### PR TITLE
Add integrators and test case

### DIFF
--- a/pycc/rt/integrators.py
+++ b/pycc/rt/integrators.py
@@ -1,0 +1,154 @@
+"""
+integrators.py: various ordinary differential equation solvers for time-domain propagation
+"""
+
+import numpy as np
+
+class rk2(object):
+    """
+    Integrator object for 2nd-order Runge-Kutta ODE propagation.
+    """
+    def __init__(self, h):
+        self.h = float(h)
+
+    def __call__(self, f, t, y):
+        # time step i
+        k1 = f(t, y)
+        k2 = f(t + 2 / 3 * self.h, y + self.h * 2 / 3 * k1)
+
+        # time step i + h
+        y_new = y + self.h * (0.25 * k1 + 0.75 * k2)
+
+        return y_new
+
+class rk3(object):
+    """
+    Integrator object for 3rd-order Runge-Kutta ODE propagation.
+    """
+    def __init__(self, h):
+        self.h = float(h)
+
+    def __call__(self, f, t, y):
+        # time step i
+        k1 = f(t, y)
+        k2 = f(t + 0.5 * self.h, y + 0.5 * self.h * k1)
+        k3 = f(t + self.h, y + self.h * (-1.0 * k1 + 2.0 * k2))
+
+        # time step i + h
+        y_new = y + self.h * (k1 + 4 * k2 + k3) / 6.0
+
+        return y_new
+
+class rk38(object):
+    """
+    Integrator object for "corrected" 3rd-order Runge-Kutta ODE propagation.
+    """
+    def __init__(self, h):
+        self.h = float(h)
+
+    def __call__(self, f, t, y):
+        # For time step i
+        # time step i
+        k1 = f(t, y)
+        k2 = f(t + 1 / 3 * self.h, y + 1 / 3 * self.h * k1)
+        k3 = f(t + 2 / 3 * self.h, y + self.h * (-1 / 3 * k1 + k2))
+        k4 = f(t + self.h, y + self.h * (k1 - k2 + k3))
+
+        # time step i + h
+        y_new = y + self.h * (k1 + 3 * k2 + 3 * k3 + k4) / 8.0
+    
+        return y_new
+
+class rk4(object):
+    """
+    Integrator object for 4th-order Runge-Kutta ODE propagation.
+    """
+    def __init__(self,h):
+        self.h = float(h)
+
+    def __call__(self, f, t, y):
+        # time step i
+        k1 = f(t, y)
+        k2 = f(t + 0.5 * self.h, y + 0.5 * self.h * k1)
+        k3 = f(t + 0.5 * self.h, y + 0.5 * self.h * k2)
+        k4 = f(t + self.h, y + self.h * k3)
+
+        # time step i + h
+        y_new = y + self.h * (k1 + 2 * k2 + 2 * k3 + k4) / 6.0
+
+        return y_new
+
+class gl6(object):
+    """
+    Integrator object for 6th-order Gauss-Legendre ODE propagation.
+    """
+    def __init__(self, h, Z_conv=1e-7):
+        self.h = float(h)
+        self.Z_conv = float(Z_conv)
+
+    def __call__(self, f, t, y):
+        # Order 2s = 6
+        s = 3
+    
+        # input coefficients
+        A = np.array([[5 / 36, 2 / 9 - np.sqrt(15) / 15, 5 / 36 - np.sqrt(15) / 30],
+                      [5 / 36 + np.sqrt(15) / 24, 2 / 9, 5 / 36 - np.sqrt(15) / 24],
+                      [5 / 36 + np.sqrt(15) / 30, 2 / 9 + np.sqrt(15) / 15, 5 / 36]])
+        B = np.array([5 / 18, 4 / 9, 5 / 18])
+        C = np.array([1 / 2 - np.sqrt(15) / 10, 1 / 2, 1 / 2 + np.sqrt(15) / 10])
+    
+        # check the coeffecients
+        """
+        a = [0, 0, 0]
+        b = 0
+        for i in range(3):
+            aa = 0
+            for j in range(3):
+                aa += A[i][j]
+            a[i] = aa
+            b += B[i]
+        for i in range(3):
+            if a[i] - C[i] < 1E-10:
+                pass
+                # print("coefficients a%d, c%d pass!"% (i, i))
+            else:
+                print("check a, c again!")
+        if b == 1:
+            pass
+            # print("coefficients b pass!")
+        else:
+            print("check c again!")
+        """
+
+        # gl6
+        # Calculate Z
+        # Maxiter for Z
+        nk = 10
+        # Initial guess of Z
+        F = np.array([f(t + C[0] * self.h, y), f(t + C[1] * self.h, y), f(t + C[2] * self.h, y)])
+        Z = self.h * (C.T * F.T).T * 0.0
+        # print(Z.shape)
+        # Z = np.zeros((3, 18240)) + 0.0j
+        Z_new = Z.copy()
+        k = 0
+        for k in range(nk):
+            F = np.array([f(t + C[0] * self.h, y + Z[0]), f(t + C[1] * self.h, y + Z[1]),
+                          f(t + C[2] * self.h, y + Z[2])])
+            for m in range(s):
+                Z_new[m] = self.h * np.dot(A[m], F)
+            if np.linalg.norm(Z_new - Z) < self.Z_conv:
+                Z = Z_new
+                F = np.array([f(t + C[0] * self.h, y + Z[0]), f(t + C[1] * self.h, y + Z[1]),
+                              f(t + C[2] * self.h, y + Z[2])])
+#                print("Z has converged in %d iterations." % (k + 1))
+                break
+            else:
+                Z = Z_new
+    
+        if k == nk - 1:
+            print("Z has not convered in %d iterations, please choose a larger nk." % nk)
+
+        # time step i + h
+        y_new = y + self.h * np.dot(B, F)
+    
+        return y_new

--- a/pycc/tests/test_015_ints.py
+++ b/pycc/tests/test_015_ints.py
@@ -1,0 +1,64 @@
+"""
+Test integrators with simple ODE
+dx/dy = 3x^2y given x0 = 1, y0 = 2
+ANALYTIC SOLUTION: 
+y = e^{x^3 + c}, c = ln(2) - 1
+y(1,1.1,1.2,1.3,1.4) = [2,2.78471958461639,4.141869187709196,6.6203429951303265,11.440356871885081]
+"""
+
+# Import package, test suite, and other packages as needed
+import numpy as np
+from pycc.rt import integrators as ints
+
+def f(x,y):
+    """dy/dx = f(x,y) = 3x^2y"""
+    Y = 3.*x**2. * y
+    return Y
+
+def chk_ode(ode):
+    h = 0.1
+    ODE = ode(h)
+    t0 = 1
+    y0 = 2
+    
+    y1 = ODE(f,t0,y0)
+    y2 = ODE(f,t0+h,y1)
+    y3 = ODE(f,t0+2*h,y2)
+    y4 = ODE(f,t0+3*h,y3)
+
+    return np.array([y0,y1,y2,y3,y4])
+
+def test_rk4():
+    """Test 4th-order Runge-Kutta"""
+    rk4 = chk_ode(ints.rk4)
+    ref = np.array([2,2.7846419118859376,4.141490537335979,6.618844434974082,11.434686303979237])
+
+    assert np.allclose(rk4,ref)
+
+def test_rk38():
+    """Test "corrected" 3rd-order Runge-Kutta"""
+    rk38 = chk_ode(ints.rk38)
+    ref = np.array([2,2.7846719015333337,4.141594947022453,6.619134913159302,11.435455703714204])
+
+    assert np.allclose(rk38,ref)
+
+def test_rk3():
+    """Test 3rd-order Runge-Kutta"""
+    rk3 = chk_ode(ints.rk3)
+    ref = np.array([2,2.783897725,4.137908208354427,6.60545045860959,11.38808439342214])
+
+    assert np.allclose(rk3,ref)
+
+def test_rk2():
+    """Test 2nd-order Runge-Kutta"""
+    rk2 = chk_ode(ints.rk2)
+    ref = np.array([2,2.7643999999999997,4.066743395,6.396857224546359,10.804576512405294])
+
+    assert np.allclose(rk2,ref)
+
+def test_gl6():
+    """Test 6th-order Gauss-Legendre"""
+    gl6 = chk_ode(ints.gl6)
+    ref = np.array([2,2.78364923694925,4.1371512621094695,6.603613786914487,11.383853535021142])
+
+    assert np.allclose(gl6,ref)


### PR DESCRIPTION
## Description
Adding native integrators for 2nd-, 3rd-, 4th-, and corrected 3rd-order Runge-Kutta class of ODE solvers to the `rt` subpackage, plus the implicit 6th-order Gauss-Legendre solver. These can be loaded similar to the `vode` integrator - they store the stepsize, and you simply pass it a residual function, a vector, and the current timestep. Returns the new vector (you must keep track of the time yourself, unlike with the `scipy` integrators). 

Integrators are tested by approximating a simple differential equation with initial conditions,
```dx/dy = 3x^{2}y, where x0 = 1 and y0 = 2```
for which the analytic solution has been checked.

This PR reduces the scope of #11 to just the propagation and checkpointing systems. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add integrators
  - [x] Test integrators

## Status
- [x] Ready to go