### PR TITLE
Specify dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,11 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     license='BSD-3-Clause',
+    install_requires=[
+        "numpy",
+        "opt_einsum",
+        "scipy",
+    ],
 
     # Which Python importable modules should be included when your package is installed
     # Handled automatically by setuptools. Use 'exclude' to prevent some specific


### PR DESCRIPTION
Specify packages which are required for PyCC in `setup.py`. 
They are automatically installed when PyCC is installed.

Note: I did not include psi4 since it cannot be installed by pip (form what I know). 

## Status
- Ready to go