### PR TITLE
PAO

### DIFF
--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -86,7 +86,8 @@ class ccwfn(object):
 
         valid_local_models = [None, 'LPNO', 'PAO']
         local = kwargs.pop('local', None)
-        if local.upper() not in valid_local_models:
+        # TODO: case-protect this kwarg
+        if local not in valid_local_models:
             raise Exception("%s is not an allowed local-CC model." % (local))
         self.local = local
         self.local_cutoff = kwargs.pop('lpno_cutoff', 1e-5)

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -84,9 +84,9 @@ class ccwfn(object):
         # models requiring T1-transformed integrals
         self.need_t1_transform = ['CC2', 'CC3']
 
-        valid_local_models = [None, 'LPNO']
+        valid_local_models = [None, 'LPNO', 'PAO']
         local = kwargs.pop('local', None)
-        if local not in valid_local_models:
+        if local.upper() not in valid_local_models:
             raise Exception("%s is not an allowed local-CC model." % (local))
         self.local = local
         self.local_cutoff = kwargs.pop('lpno_cutoff', 1e-5)
@@ -133,7 +133,7 @@ class ccwfn(object):
         self.H = Hamiltonian(self.ref, self.C, self.C, self.C, self.C)
 
         if local is not None:
-            self.Local = Local(local, self.no, self.nv, self.H, self.local_cutoff)
+            self.Local = Local(local, C, self.no, self.nv, self.H, self.local_cutoff)
 
         # denominators
         eps_occ = np.diag(self.H.F)[o]

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -90,7 +90,7 @@ class ccwfn(object):
         if local not in valid_local_models:
             raise Exception("%s is not an allowed local-CC model." % (local))
         self.local = local
-        self.local_cutoff = kwargs.pop('lpno_cutoff', 1e-5)
+        self.local_cutoff = kwargs.pop('local_cutoff', 1e-5)
 
         valid_local_MOs = ['PIPEK_MEZEY', 'BOYS']
         local_MOs = kwargs.pop('local_mos', 'PIPEK_MEZEY')
@@ -134,7 +134,7 @@ class ccwfn(object):
         self.H = Hamiltonian(self.ref, self.C, self.C, self.C, self.C)
 
         if local is not None:
-            self.Local = Local(local, C, self.no, self.nv, self.H, self.local_cutoff)
+            self.Local = Local(local, self.C, self.nfzc, self.no, self.nv, self.H, self.local_cutoff)
 
         # denominators
         eps_occ = np.diag(self.H.F)[o]

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -133,7 +133,7 @@ class ccwfn(object):
         self.H = Hamiltonian(self.ref, self.C, self.C, self.C, self.C)
 
         if local is not None:
-            self.Local = Local(self.no, self.nv, self.H, self.local_cutoff)
+            self.Local = Local(local, self.no, self.nv, self.H, self.local_cutoff)
 
         # denominators
         eps_occ = np.diag(self.H.F)[o]

--- a/pycc/hamiltonian.py
+++ b/pycc/hamiltonian.py
@@ -22,3 +22,5 @@ class Hamiltonian(object):
         self.ERI = np.asarray(mints.mo_eri(Cp, Cr, Cq, Cs))  # (pr|qs)
         self.ERI = self.ERI.swapaxes(1,2)                    # <pq|rs>
         self.L = 2.0 * self.ERI - self.ERI.swapaxes(2,3)     # 2 <pq|rs> - <pq|sr>
+
+        self.mints = mints

--- a/pycc/hamiltonian.py
+++ b/pycc/hamiltonian.py
@@ -25,3 +25,4 @@ class Hamiltonian(object):
 
         self.mol = ref.molecule()
         self.basisset = ref.basisset()
+        self.Fao = np.asarray(ref.Fa())

--- a/pycc/hamiltonian.py
+++ b/pycc/hamiltonian.py
@@ -23,4 +23,5 @@ class Hamiltonian(object):
         self.ERI = self.ERI.swapaxes(1,2)                    # <pq|rs>
         self.L = 2.0 * self.ERI - self.ERI.swapaxes(2,3)     # 2 <pq|rs> - <pq|sr>
 
-        self.mints = mints
+        self.mol = ref.molecule()
+        self.basisset = ref.basisset()

--- a/pycc/hamiltonian.py
+++ b/pycc/hamiltonian.py
@@ -25,4 +25,5 @@ class Hamiltonian(object):
 
         self.mol = ref.molecule()
         self.basisset = ref.basisset()
-        self.Fao = np.asarray(ref.Fa())
+        self.C_all = ref.Ca().to_array() # includes frozen core
+        self.F_ao = ref.Fa().to_array()

--- a/pycc/local.py
+++ b/pycc/local.py
@@ -265,7 +265,7 @@ class Local(object):
             print("Pair domain (%1d,%1d) contains %3d/%3d orbitals." 
                                 % (i,j,dim[-1],nao))
 
-        print("Average PAO dimension: %d" % (np.average(dim)))
+        print("Average PAO dimension: %.2f" % (np.average(dim)))
         print("Number of canonical VMOs: %d" % (self.nv))
 
         self.Q = Q  # transform between canonical VMO and PAO spaces

--- a/pycc/local.py
+++ b/pycc/local.py
@@ -4,20 +4,44 @@ from opt_einsum import contract
 
 class Local(object):
 
-    def __init__(self, no, nv, H, cutoff):
+    def __init__(self, local, no, nv, H, cutoff):
 
-        o = slice(0, no)
-        v = slice(no, no+nv)
+        self.cutoff = cutoff
+        self.no = no
+        self.nv = nv
+        self.H = H
+
+        self._build(local)
+    
+    def _build(self,local):
+        if local.upper() in ["LPNO","PNO"]:
+            self._build_LPNO()
+        elif local.upper() in ["PAO"]:
+            self._build_PAO()
+        else:
+            raise Exception("Not a valid local type!")
+
+    def _build_PAO(self):
+        D = self.H.Cp[:,:self.no] @ self.H.Cp[:,:self.no].T
+        S = self.H.mints.ao_overlap().to_array()
+
+        R = np.eye(D.shape[0]) - D @ S
+        pass
+
+    def _build_LPNO(self):
+
+        o = slice(0, self.no)
+        v = slice(self.no, self.no+self.nv)
 
         # Compute MP2 amplitudes in non-canonical MO basis
-        eps_occ = np.diag(H.F)[o]
-        eps_vir = np.diag(H.F)[v]
+        eps_occ = np.diag(self.H.F)[o]
+        eps_vir = np.diag(self.H.F)[v]
         Dijab = eps_occ.reshape(-1,1,1,1) + eps_occ.reshape(-1,1,1) - eps_vir.reshape(-1,1) - eps_vir
 
         # initial guess amplitudes
-        t2 = H.ERI[o,o,v,v]/Dijab
+        t2 = self.H.ERI[o,o,v,v]/Dijab
 
-        emp2 = contract('ijab,ijab->', t2, H.L[o,o,v,v])
+        emp2 = contract('ijab,ijab->', t2, self.H.L[o,o,v,v])
         print("MP2 Iter %3d: MP2 Ecorr = %.15f  dE = % .5E" % (0, emp2, -emp2))
 
         e_conv = 1e-7
@@ -30,34 +54,34 @@ class Local(object):
         while ((abs(ediff) > e_conv) or (abs(rmsd) > r_conv)) and (niter <= maxiter):
             elast = emp2
 
-            r2 = 0.5 * H.ERI[o,o,v,v].copy()
-            r2 += contract('ijae,be->ijab', t2, H.F[v,v])
-            r2 -= contract('imab,mj->ijab', t2, H.F[o,o])
+            r2 = 0.5 * self.H.ERI[o,o,v,v].copy()
+            r2 += contract('ijae,be->ijab', t2, self.H.F[v,v])
+            r2 -= contract('imab,mj->ijab', t2, self.H.F[o,o])
             r2 = r2 + r2.swapaxes(0,1).swapaxes(2,3)
 
             t2 += r2/Dijab
 
             rmsd = np.sqrt(contract('ijab,ijab->', r2/Dijab, r2/Dijab))
 
-            emp2 = contract('ijab,ijab->', t2, H.L[o,o,v,v])
+            emp2 = contract('ijab,ijab->', t2, self.H.L[o,o,v,v])
             ediff = emp2 - elast
 
             print("MP2 Iter %3d: MP2 Ecorr = %.15f  dE = % .5E  rmsd = % .5E" % (niter, emp2, ediff, rmsd))
 
         # Build LPNOs and store transformation matrices
-        print("Computing PNOs.  Canonical VMO dim: %d" % (nv))
-        T_ij = t2.copy().reshape((no*no, nv, nv))
+        print("Computing PNOs.  Canonical VMO dim: %d" % (self.nv))
+        T_ij = t2.copy().reshape((self.no*self.no, self.nv, self.nv))
         Tt_ij = 2.0 * T_ij - T_ij.swapaxes(1,2)
         D = np.zeros_like(T_ij)
         Q_full = np.zeros_like(T_ij)
         Q = []  # truncated LPNO list
-        occ = np.zeros((no*no, nv))
-        dim = np.zeros((no*no), dtype=int)  # dimension of LPNO space for each pair
+        occ = np.zeros((self.no*self.no, self.nv))
+        dim = np.zeros((self.no*self.no), dtype=int)  # dimension of LPNO space for each pair
         L = []
         eps = []
-        for ij in range(no*no):
-            i = ij // no
-            j = ij % no
+        for ij in range(self.no*self.no):
+            i = ij // self.no
+            j = ij % self.no
 
             # Compute pair density
             D[ij] = contract('ab,bc->ac', T_ij[ij], Tt_ij[ij].T) + contract('ab,bc->ac', T_ij[ij].T, Tt_ij[ij])
@@ -69,11 +93,11 @@ class Local(object):
                 neg = occ[ij][(occ[ij]<0)].min()
                 print("Warning! Negative occupation numbers up to {} detected. \
                         Using absolute values - please check if your input is correct.".format(neg))
-            dim[ij] = (np.abs(occ[ij]) > cutoff).sum()
-            Q.append(Q_full[ij, :, (nv-dim[ij]):])
+            dim[ij] = (np.abs(occ[ij]) > self.cutoff).sum()
+            Q.append(Q_full[ij, :, (self.nv-dim[ij]):])
 
             # Compute semicanonical virtual space
-            F = Q[ij].T @ H.F[v,v] @ Q[ij]  # Fock matrix in PNO basis
+            F = Q[ij].T @ self.H.F[v,v] @ Q[ij]  # Fock matrix in PNO basis
             eval, evec = np.linalg.eigh(F)
             eps.append(eval)
             L.append(evec)
@@ -81,12 +105,8 @@ class Local(object):
             print("PNO dimension of pair %d = %d" % (ij, dim[ij]))
 
         print("Average PNO dimension: %d" % (np.average(dim)))
-        print("Number of canonical VMOs: %d" % (nv))
+        print("Number of canonical VMOs: %d" % (self.nv))
 
-        self.cutoff = cutoff
-        self.no = no
-        self.nv = nv
-        self.H = H
         self.Q = Q  # transform between canonical VMO and LPNO spaces
         self.dim = dim  # dimension of LPNO space
         self.eps = eps  # semicananonical LPNO energies

--- a/pycc/local.py
+++ b/pycc/local.py
@@ -42,6 +42,7 @@ class Local(object):
         for i in range(natom): # store basis indices for each atom
             bsi = [b+sum(a2nao[:i]) for b in range(a2nao[i])]
             a2ao[str(i)] = bsi
+
         # now, a2ao is a dict (keys str(0-natom)) w/ vals as indices
         # of AOs on each atom
 
@@ -153,8 +154,9 @@ class Local(object):
 
             # MO -> PAO (redundant)
             # called the "Local residual vector" in psi3
-            # U in Eq 73, used to transform the LMO-basis residual matrix
-            # into the projected local basis
+            # U in Hampel/Werner Eq 73 
+            # used to transform the LMO-basis residual matrix into the
+            # projected (redundant, non-canonical) PAO basis
             V = np.einsum('ap,pq->aq',RS,Rt)
             Q.append(V)
 
@@ -183,6 +185,7 @@ class Local(object):
             # diagonalize to get semi-canonical space
             Fbar = np.einsum('pq,pr,rs->qs',Xt,Ft,Xt)
             evals,evecs = np.linalg.eigh(Fbar)
+            # TESTED: evecs does, in fact, diagonalize Fbar
 
             # form W, which rotates the redundant PAO-basis amplitudes 
             # directly into the into the non-redundant, semi-canonical basis
@@ -191,10 +194,16 @@ class Local(object):
             eps.append(evals)
             L.append(W)
 
+            print('Pair domain (%1d,%1d) contains %3d/%3d orbitals\n'
+                    'after semi-canonicalization.' % (i,j,dim[-1],nao))
+
+        print("Average PAO dimension: %d" % (np.average(dim)))
+        print("Number of canonical VMOs: %d" % (self.nv))
+
         self.Q = Q  # transform between canonical VMO and PAO spaces
-        self.eps = eps  # semicananonical PAO energies
         self.L = L  # transform between PAO and semicanonical PAO spaces
         self.dim = dim  # dimension of PAO space
+        self.eps = eps  # semicananonical PAO energies
 
     def _build_LPNO(self):
 

--- a/pycc/local.py
+++ b/pycc/local.py
@@ -297,6 +297,7 @@ class Local(object):
         niter = 0
 
         while ((abs(ediff) > e_conv) or (abs(rmsd) > r_conv)) and (niter <= maxiter):
+            niter += 1
             elast = emp2
 
             r2 = 0.5 * self.H.ERI[o,o,v,v].copy()

--- a/pycc/local.py
+++ b/pycc/local.py
@@ -263,7 +263,7 @@ class Local(object):
             L.append(W)
 
             print("Pair domain (%1d,%1d) contains %3d/%3d orbitals." 
-                                % (i,j,len(ij_domain),nao))
+                                % (i,j,dim[-1],nao))
 
         print("Average PAO dimension: %d" % (np.average(dim)))
         print("Number of canonical VMOs: %d" % (self.nv))

--- a/pycc/local.py
+++ b/pycc/local.py
@@ -165,7 +165,6 @@ class Local(object):
     
                 # Eq 9, completeness check
                 chk = 1 - contract('m,mn,n->',Rp,SB,self.C[:,i])
-                print("BP completeness check: %.3f" % chk)
 
                 if chk > self.cutoff:
                     try:
@@ -175,9 +174,16 @@ class Local(object):
                         AOi = sorted(AOi) 
                     except IndexError:
                         print("Ran out of atoms. How did that happen?")
-                        raise IndexError
+                        if self.cutoff == 0:
+                            print("Current BP value: {}".format(chk))
+                            print("Cutoff = 0 ... continuing with full space")
+                            chk = 0
+                            continue
+                        else:
+                            raise IndexError
                 else:
                     print("Completeness threshold fulfilled.")
+                    print("BP completeness check: %.3f" % chk)
                     print("PAO domain %3d contains %3d/%3d orbitals." 
                             % (i,len(AOi),self.no+self.nv))
             AO_domains.append(AOi)
@@ -229,6 +235,8 @@ class Local(object):
             St = contract('pq,pr,rs->qs',Rt,S,Rt) 
             evals,evecs = np.linalg.eigh(St)
             toss = np.abs(evals) < self.lindep_cut 
+            if sum(toss) > 0:
+                print("%1d linearly dependent orbitals removed." % (sum(toss)))
 
             # Eq 53, normalized nonredundant transform 
             # (still not semi-canonical)

--- a/pycc/local.py
+++ b/pycc/local.py
@@ -126,10 +126,10 @@ class Local(object):
             print(np.round(charges,2))
 
             atoms = [i for i in range(natom)]
-            zipped = zip(charges,atoms)
+            zipped = zip(np.abs(np.array(charges)),atoms)
             sort = sorted(zipped, reverse=True)
             tups = zip(*sort)
-            charges,atoms = [list(t) for t in tups] # sorted!
+            charges,atoms = [list(t) for t in tups] # sorted by abs(charge)
 
             # choose which atoms belong to the domain based on charge
             atom_domains.append([])
@@ -232,7 +232,7 @@ class Local(object):
 
             # Eq 5, PAO -> semicanonical PAO
             # check for linear dependencies 
-            St = contract('pq,pr,rs->qs',Rt,S,Rt) 
+            St = contract('pq,pr,rs->qs',Rt,S,Rt)
             evals,evecs = np.linalg.eigh(St)
             toss = np.abs(evals) < self.lindep_cut 
             if sum(toss) > 0:

--- a/pycc/local.py
+++ b/pycc/local.py
@@ -193,7 +193,6 @@ class Local(object):
         # remove PAOs with negligible norms
         for i in range(nao):
             norm = np.linalg.norm(Rt_full[:,i]) # column-norm
-            print("NORM {} = {}".format(i,norm))
             if norm < self.core_cut:
                 print("Norm of orbital %4d = %20.12f... deleting" % (i,norm))
                 Rt_full[:,i] = 0

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -80,6 +80,8 @@ class rtcc(object):
             for axis in range(3):
                 m = (C.T @ (np.asarray(m_ints[axis])*-0.5) @ C)
                 self.m.append(m*1.0j)
+        else:
+            self.magnetic = False
 
     def f(self, t, y):
         """

--- a/pycc/tests/test_018_paocc.py
+++ b/pycc/tests/test_018_paocc.py
@@ -3,12 +3,12 @@ import pycc
 import numpy as np
 from ..data.molecules import moldict
 
-def test_pao_H4():
+def test_pao_H8():
     """PAO-CCSD Test"""
     # Psi4 Setup
     psi4.set_memory('1 GB')
     psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': '6-31g',
+    psi4.set_options({'basis': 'DZ',
                       'scf_type': 'pk',
                       'guess': 'core',
                       'mp2_type': 'conv',
@@ -18,27 +18,31 @@ def test_pao_H4():
                       'r_convergence': 1e-12,
                       'diis': 8})
     mol = psi4.geometry("""
-        H         0.000000000000     0.000000000000     0.000000000000
-        H         0.000000000000     0.000000000000     1.417294491434
-        H         2.834588982868     0.000000000000     1.417294491434
-        H         2.834588982868     1.227413034226     0.708647245717
-        units au
+        H 0.000000 0.000000 0.000000
+        H 0.750000 0.000000 0.000000
+        H 0.000000 1.500000 0.000000
+        H 0.375000 1.500000 -0.649520
+        H 0.000000 3.000000 0.000000
+        H -0.375000 3.000000 -0.649520
+        H 0.000000 4.500000 -0.000000
+        H -0.750000 4.500000 -0.000000
+        symmetry c1
         noreorient
         nocom
         """)
     rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
     
     maxiter = 75
-    e_conv = 1e-7
-    r_conv = 1e-7
+    e_conv = 1e-12
+    r_conv = 1e-12
     max_diis = 8
     
     ccsd = pycc.ccwfn(rhf_wfn, local='PAO', local_cutoff=2e-2)
     
     eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter, max_diis)
     
-    # (H2)_2 REFERENCE:
-    psi3_ref = -0.052863089856486
+    # (H2)_4 REFERENCE:
+    psi3_ref = -0.108914240219735
 
     assert (abs(psi3_ref - eccsd) < 1e-7)
 

--- a/pycc/tests/test_018_paocc.py
+++ b/pycc/tests/test_018_paocc.py
@@ -1,6 +1,7 @@
 import psi4
 import pycc
 import numpy as np
+from ..data.molecules import moldict
 
 def test_pao_H4():
     """PAO-CCSD Test"""
@@ -36,7 +37,7 @@ def test_pao_H4():
     
     eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter, max_diis)
     
-    # (H2)_2 REFERENCES:
+    # (H2)_2 REFERENCE:
     psi3_ref = -0.052863089856486
 
     assert (abs(psi3_ref - eccsd) < 1e-7)
@@ -55,20 +56,7 @@ def test_pao_metox():
                       'd_convergence': 1e-12,
                       'r_convergence': 1e-12,
                       'diis': 8})
-    mol = psi4.geometry("""
-        C  26.580000  26.520000  27.119999
-        O  26.580000  26.520000  28.520000
-        C  27.840000  26.520000  27.840000
-        C  26.500000  27.700001  26.289999
-        H  25.559999  27.700001  25.739998
-        H  26.559999  28.590000  26.910000
-        H  27.330000  27.700001  25.580002
-        H  26.070002  25.629999  26.760002
-        H  28.410000  25.629999  27.579998
-        H  28.410000  27.410000  27.579998
-        noreorient
-        nocom
-        """)
+    mol = psi4.geometry(moldict["H2O_Teach"] + "\nnoreorient\nnocom")
     rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
     
     maxiter = 75
@@ -80,8 +68,9 @@ def test_pao_metox():
     
     eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter, max_diis)
     
-    psi3_ref = -0.426259408543049
-
+    # NOTE: the following reference was generated with a custom build of Psi3
+    # which removed PAOs based on their norm EVEN IF freeze_core = false
+    psi3_ref = -0.149361947815815
     assert (abs(psi3_ref - eccsd) < 1e-7)
 
 def test_pao_metox_frzc():
@@ -98,20 +87,7 @@ def test_pao_metox_frzc():
                       'd_convergence': 1e-12,
                       'r_convergence': 1e-12,
                       'diis': 8})
-    mol = psi4.geometry("""
-        C  26.580000  26.520000  27.119999
-        O  26.580000  26.520000  28.520000
-        C  27.840000  26.520000  27.840000
-        C  26.500000  27.700001  26.289999
-        H  25.559999  27.700001  25.739998
-        H  26.559999  28.590000  26.910000
-        H  27.330000  27.700001  25.580002
-        H  26.070002  25.629999  26.760002
-        H  28.410000  25.629999  27.579998
-        H  28.410000  27.410000  27.579998
-        noreorient
-        nocom
-        """)
+    mol = psi4.geometry(moldict["H2O_Teach"] + "\nnoreorient\nnocom")
     rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
     
     maxiter = 75
@@ -123,7 +99,6 @@ def test_pao_metox_frzc():
     
     eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter, max_diis)
     
-    psi3_ref = -0.421904536004824
-    #psi3_ref = -0.421226226923507 # this is WITH cutting-by-norm!
+    psi3_ref = -0.148485522656349
 
     assert (abs(psi3_ref - eccsd) < 1e-7)

--- a/pycc/tests/test_018_paocc.py
+++ b/pycc/tests/test_018_paocc.py
@@ -42,7 +42,7 @@ def test_pao_H4():
 
     assert (abs(psi3_ref - eccsd) < 1e-7)
 
-def test_pao_metox():
+def test_pao_h2o():
     """PAO-CCSD Test 2"""
     # Psi4 Setup
     psi4.set_memory('1 GB')
@@ -73,7 +73,7 @@ def test_pao_metox():
     psi3_ref = -0.149361947815815
     assert (abs(psi3_ref - eccsd) < 1e-7)
 
-def test_pao_metox_frzc():
+def test_pao_h2o_frzc():
     """PAO-CCSD Frozen Core Test"""
     # Psi4 Setup
     psi4.set_memory('1 GB')

--- a/pycc/tests/test_018_paocc.py
+++ b/pycc/tests/test_018_paocc.py
@@ -1,65 +1,129 @@
 import psi4
 import pycc
 import numpy as np
-import pickle as pk
-from pycc.data.molecules import *
 
-"""PAO-CCSD Test"""
-# Psi4 Setup
-psi4.set_memory('2 GB')
-psi4.core.set_output_file('output.dat', False)
-psi4.set_options({'basis': '6-31g',
-                  'scf_type': 'pk',
-                  'guess': 'core',
-                  'mp2_type': 'conv',
-                  'freeze_core': 'True',
-                  'e_convergence': 1e-12,
-                  'd_convergence': 1e-12,
-                  'r_convergence': 1e-12,
-                  'diis': 8})
-# explicit units in au so matching w/ psi3 is easier
-#    H         0.000000000000     0.000000000000     0.000000000000
-#    H         0.000000000000     0.000000000000     1.417294491434
-#    H         2.834588982868     0.000000000000     1.417294491434
-#    H         2.834588982868     1.227413034226     0.708647245717
-# units au
-mol = psi4.geometry("""
-    C  26.580000  26.520000  27.119999
-    O  26.580000  26.520000  28.520000
-    C  27.840000  26.520000  27.840000
-    C  26.500000  27.700001  26.289999
-    H  25.559999  27.700001  25.739998
-    H  26.559999  28.590000  26.910000
-    H  27.330000  27.700001  25.580002
-    H  26.070002  25.629999  26.760002
-    H  28.410000  25.629999  27.579998
-    H  28.410000  27.410000  27.579998
-    noreorient
-    nocom
-    """)
-rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-print("RHF_E: {}".format(rhf_e))
+def test_pao_H4():
+    """PAO-CCSD Test"""
+    # Psi4 Setup
+    psi4.set_memory('1 GB')
+    psi4.core.set_output_file('output.dat', False)
+    psi4.set_options({'basis': '6-31g',
+                      'scf_type': 'pk',
+                      'guess': 'core',
+                      'mp2_type': 'conv',
+                      'freeze_core': 'False',
+                      'e_convergence': 1e-12,
+                      'd_convergence': 1e-12,
+                      'r_convergence': 1e-12,
+                      'diis': 8})
+    mol = psi4.geometry("""
+        H         0.000000000000     0.000000000000     0.000000000000
+        H         0.000000000000     0.000000000000     1.417294491434
+        H         2.834588982868     0.000000000000     1.417294491434
+        H         2.834588982868     1.227413034226     0.708647245717
+        units au
+        noreorient
+        nocom
+        """)
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+    
+    maxiter = 75
+    e_conv = 1e-7
+    r_conv = 1e-7
+    max_diis = 8
+    
+    ccsd = pycc.ccwfn(rhf_wfn, local='PAO', local_cutoff=2e-2)
+    
+    eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter, max_diis)
+    
+    # (H2)_2 REFERENCES:
+    psi3_ref = -0.052863089856486
 
-maxiter = 75
-e_conv = 1e-7
-r_conv = 1e-7
-max_diis = 8
+    assert (abs(psi3_ref - eccsd) < 1e-7)
 
-#ccsd = pycc.ccwfn(rhf_wfn)
-ccsd = pycc.ccwfn(rhf_wfn, local='PAO', local_cutoff=2e-2)
+def test_pao_metox():
+    """PAO-CCSD Test 2"""
+    # Psi4 Setup
+    psi4.set_memory('1 GB')
+    psi4.core.set_output_file('output.dat', False)
+    psi4.set_options({'basis': '6-31g',
+                      'scf_type': 'pk',
+                      'guess': 'core',
+                      'mp2_type': 'conv',
+                      'freeze_core': 'False',
+                      'e_convergence': 1e-12,
+                      'd_convergence': 1e-12,
+                      'r_convergence': 1e-12,
+                      'diis': 8})
+    mol = psi4.geometry("""
+        C  26.580000  26.520000  27.119999
+        O  26.580000  26.520000  28.520000
+        C  27.840000  26.520000  27.840000
+        C  26.500000  27.700001  26.289999
+        H  25.559999  27.700001  25.739998
+        H  26.559999  28.590000  26.910000
+        H  27.330000  27.700001  25.580002
+        H  26.070002  25.629999  26.760002
+        H  28.410000  25.629999  27.579998
+        H  28.410000  27.410000  27.579998
+        noreorient
+        nocom
+        """)
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+    
+    maxiter = 75
+    e_conv = 1e-7
+    r_conv = 1e-7
+    max_diis = 8
+    
+    ccsd = pycc.ccwfn(rhf_wfn, local='PAO', local_cutoff=2e-2)
+    
+    eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter, max_diis)
+    
+    psi3_ref = -0.426259408543049
 
-eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter, max_diis)
-print("PAO energy    : {}".format(eccsd))
+    assert (abs(psi3_ref - eccsd) < 1e-7)
 
-# (H2)_2 REFERENCES:
-#print("6-31g psi3 PAO: -0.052863089856486")
-#print("6-31g ref     : -0.052863084256471564")
+def test_pao_metox_frzc():
+    """PAO-CCSD Frozen Core Test"""
+    # Psi4 Setup
+    psi4.set_memory('1 GB')
+    psi4.core.set_output_file('output.dat', False)
+    psi4.set_options({'basis': '6-31g',
+                      'scf_type': 'pk',
+                      'guess': 'core',
+                      'mp2_type': 'conv',
+                      'freeze_core': 'True',
+                      'e_convergence': 1e-12,
+                      'd_convergence': 1e-12,
+                      'r_convergence': 1e-12,
+                      'diis': 8})
+    mol = psi4.geometry("""
+        C  26.580000  26.520000  27.119999
+        O  26.580000  26.520000  28.520000
+        C  27.840000  26.520000  27.840000
+        C  26.500000  27.700001  26.289999
+        H  25.559999  27.700001  25.739998
+        H  26.559999  28.590000  26.910000
+        H  27.330000  27.700001  25.580002
+        H  26.070002  25.629999  26.760002
+        H  28.410000  25.629999  27.579998
+        H  28.410000  27.410000  27.579998
+        noreorient
+        nocom
+        """)
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+    
+    maxiter = 75
+    e_conv = 1e-7
+    r_conv = 1e-7
+    max_diis = 8
+    
+    ccsd = pycc.ccwfn(rhf_wfn, local='PAO', local_cutoff=2e-2)
+    
+    eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter, max_diis)
+    
+    psi3_ref = -0.421904536004824
+    #psi3_ref = -0.421226226923507 # this is WITH cutting-by-norm!
 
-# METOX REFERENCES:
-#print("6-31g psi3 PAO: -0.426259408543049")
-#print("6-31g ref     : -0.43714625109972294")
-# FRZC
-print("6-31g psi3 PAO: -0.421904536004824")
-#print("6-31g psi3 PAO: -0.421226226923507") # this is WITH cutting-by-norm!
-print("6-31g ref     : -0.4324193006718509")
-
+    assert (abs(psi3_ref - eccsd) < 1e-7)

--- a/pycc/tests/test_018_paocc.py
+++ b/pycc/tests/test_018_paocc.py
@@ -1,0 +1,65 @@
+import psi4
+import pycc
+import numpy as np
+import pickle as pk
+from pycc.data.molecules import *
+
+"""PAO-CCSD Test"""
+# Psi4 Setup
+psi4.set_memory('2 GB')
+psi4.core.set_output_file('output.dat', False)
+psi4.set_options({'basis': '6-31g',
+                  'scf_type': 'pk',
+                  'guess': 'core',
+                  'mp2_type': 'conv',
+                  'freeze_core': 'True',
+                  'e_convergence': 1e-12,
+                  'd_convergence': 1e-12,
+                  'r_convergence': 1e-12,
+                  'diis': 8})
+# explicit units in au so matching w/ psi3 is easier
+#    H         0.000000000000     0.000000000000     0.000000000000
+#    H         0.000000000000     0.000000000000     1.417294491434
+#    H         2.834588982868     0.000000000000     1.417294491434
+#    H         2.834588982868     1.227413034226     0.708647245717
+# units au
+mol = psi4.geometry("""
+    C  26.580000  26.520000  27.119999
+    O  26.580000  26.520000  28.520000
+    C  27.840000  26.520000  27.840000
+    C  26.500000  27.700001  26.289999
+    H  25.559999  27.700001  25.739998
+    H  26.559999  28.590000  26.910000
+    H  27.330000  27.700001  25.580002
+    H  26.070002  25.629999  26.760002
+    H  28.410000  25.629999  27.579998
+    H  28.410000  27.410000  27.579998
+    noreorient
+    nocom
+    """)
+rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+print("RHF_E: {}".format(rhf_e))
+
+maxiter = 75
+e_conv = 1e-7
+r_conv = 1e-7
+max_diis = 8
+
+#ccsd = pycc.ccwfn(rhf_wfn)
+ccsd = pycc.ccwfn(rhf_wfn, local='PAO', local_cutoff=2e-2)
+
+eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter, max_diis)
+print("PAO energy    : {}".format(eccsd))
+
+# (H2)_2 REFERENCES:
+#print("6-31g psi3 PAO: -0.052863089856486")
+#print("6-31g ref     : -0.052863084256471564")
+
+# METOX REFERENCES:
+#print("6-31g psi3 PAO: -0.426259408543049")
+#print("6-31g ref     : -0.43714625109972294")
+# FRZC
+print("6-31g psi3 PAO: -0.421904536004824")
+#print("6-31g psi3 PAO: -0.421226226923507") # this is WITH cutting-by-norm!
+print("6-31g ref     : -0.4324193006718509")
+


### PR DESCRIPTION
## Description
Adds PAO's to the list of available virtual-space localization methods. `local_cutoff` controls the [Boughton-Pulay completeness check](doi.org/10.1002/jcc.540140615).

Note that the `Hamiltonian` class now stores the `psi4.core.Molecule` object (for Z-values), the `psi4.core.BasisSet` object, the full set of MO coefficients `C_all` (including frozen core for projection out of the AO space), and the AO-basis Fock matrix (for determining the new semi-canonical orbital energies). 

Also note that the `lpno_cutoff` kwarg has been swapped to `local_cutoff` in `ccwfn`, and `Local` now receives the `local` type as a string, the (active) MO coefficients, and the number of frozen core orbitals.

Finally, two small patches that I've been meaning to get pushed into `main`: set `rtcc.magnetic=False` properly when no magnetic dipoles are required, and update the iteration number in the LPNO MP2 loop. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Check all domains (singles and pairs) against Psi3
  - [x] Check standard and frozen-core energies against Psi3
  - [x] Tests
  - [x] Docs / output / notation pass
  - [x] Probably swap methyloxirane test case for water in a big basis set to cut down test time.
  - [x] Additional options: norm-cutting? variable linear dependance check?

## Questions
- [x] Currently, I'm not cutting the pair domains down by the norm as described in [Hampel & Werner 1996](10.1063/1.471289). Psi3 strangely does this only when frozen core is on -- I believe it should be when frozen core is _off_, since that is when you are probably most likely to see very similar orbital norms around the core. Currently the code is checked against a locally-modified Psi3 which skips this step. Should I add this in, and should it be `if frozen_core` or `if not frozen_core`? 
- - I added `core_cut`, which cuts the PAOs by their norm, regardless of `freeze_core` status
- [x] 1e-6 seems to be a relatively stable choice for the linear dependence check on the redundant pair domains. Should this be included as an extra optional? (The function call to `Local` is getting rather complicated...)
- - Added `lindep_cut` with a default of 1E-6 in case we want it later, but `ccwfn.py` doesn't take/pass the argument. 

## Status
- [x] Ready to go