### PR TITLE
CC2 - Optimizing lambda equations

### DIFF
--- a/pycc/cchbar.py
+++ b/pycc/cchbar.py
@@ -175,8 +175,6 @@ class cchbar(object):
             Hovvo = ERI[o,v,v,o].copy()
             Hovvo = Hovvo + contract('jf,mbef->mbej', t1, ERI[o,v,v,v])
             Hovvo = Hovvo - contract('nb,mnej->mbej', t1, ERI[o,o,v,o])
-            #Hovvo = Hovvo - contract('jf,mbef->mbej', self.ccwfn.t1, contract('nb,mnef->mbef', self.ccwfn.t1, ERI[o,o,v,v]))
-            #Hovvo = Hovvo - contract('jnfb,mnef->mbej', self.ccwfn.build_tau(t1, t2, fact2=0), ERI[o,o,v,v])
             if self.ccwfn.model != 'CC2':
                 Hovvo = Hovvo - contract('jnfb,mnef->mbej', self.ccwfn.build_tau(t1, t2), ERI[o,o,v,v])
                 Hovvo = Hovvo + contract('njfb,mnef->mbej', t2, L[o,o,v,v])
@@ -191,7 +189,6 @@ class cchbar(object):
             Hovov = ERI[o,v,o,v].copy()
             Hovov = Hovov + contract('jf,bmef->mbje', t1, ERI[v,o,v,v])
             Hovov = Hovov - contract('nb,mnje->mbje', t1, ERI[o,o,o,v])
-            #Hovov = Hovov - contract('jnfb,nmef->mbje', self.ccwfn.build_tau(t1, t2), ERI[o,o,v,v])
             if self.ccwfn.model != 'CC2':
                 Hovov = Hovov - contract('jnfb,nmef->mbje', self.ccwfn.build_tau(t1, t2), ERI[o,o,v,v])
         return Hovov

--- a/pycc/cchbar.py
+++ b/pycc/cchbar.py
@@ -175,8 +175,11 @@ class cchbar(object):
             Hovvo = ERI[o,v,v,o].copy()
             Hovvo = Hovvo + contract('jf,mbef->mbej', t1, ERI[o,v,v,v])
             Hovvo = Hovvo - contract('nb,mnej->mbej', t1, ERI[o,o,v,o])
-            Hovvo = Hovvo - contract('jnfb,mnef->mbej', self.ccwfn.build_tau(t1, t2), ERI[o,o,v,v])
-            Hovvo = Hovvo + contract('njfb,mnef->mbej', t2, L[o,o,v,v])
+            #Hovvo = Hovvo - contract('jf,mbef->mbej', self.ccwfn.t1, contract('nb,mnef->mbef', self.ccwfn.t1, ERI[o,o,v,v]))
+            #Hovvo = Hovvo - contract('jnfb,mnef->mbej', self.ccwfn.build_tau(t1, t2, fact2=0), ERI[o,o,v,v])
+            if self.ccwfn.model != 'CC2':
+                Hovvo = Hovvo - contract('jnfb,mnef->mbej', self.ccwfn.build_tau(t1, t2), ERI[o,o,v,v])
+                Hovvo = Hovvo + contract('njfb,mnef->mbej', t2, L[o,o,v,v])
         return Hovvo
 
 
@@ -188,7 +191,9 @@ class cchbar(object):
             Hovov = ERI[o,v,o,v].copy()
             Hovov = Hovov + contract('jf,bmef->mbje', t1, ERI[v,o,v,v])
             Hovov = Hovov - contract('nb,mnje->mbje', t1, ERI[o,o,o,v])
-            Hovov = Hovov - contract('jnfb,nmef->mbje', self.ccwfn.build_tau(t1, t2), ERI[o,o,v,v])
+            #Hovov = Hovov - contract('jnfb,nmef->mbje', self.ccwfn.build_tau(t1, t2), ERI[o,o,v,v])
+            if self.ccwfn.model != 'CC2':
+                Hovov = Hovov - contract('jnfb,nmef->mbje', self.ccwfn.build_tau(t1, t2), ERI[o,o,v,v])
         return Hovov
 
 

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -198,17 +198,22 @@ class cclambda(object):
         else:
             r_l1 = 2.0 * Hov.copy()
             r_l1 = r_l1 + contract('ie,ea->ia', l1, Hvv)
-            r_l1 = r_l1 - contract('ma,im->ia', l1, Hoo)
-            r_l1 = r_l1 + contract('me,ieam->ia', l1, (2.0 * Hovvo - Hovov.swapaxes(2,3)))
+            r_l1 = r_l1 - contract('ma,im->ia', l1, Hoo)          
             r_l1 = r_l1 + contract('imef,efam->ia', l2, Hvvvo)
             r_l1 = r_l1 - contract('mnae,iemn->ia', l2, Hovoo)
-            if self.ccwfn.model != 'CC2':
+            r_l1 = r_l1 + contract('me,ieam->ia', l1, (2.0 * Hovvo - Hovov.swapaxes(2,3)))
+            if self.ccwfn.model == 'CC2':
+                tmp = contract('me,nmfe->nf', l1, self.ccwfn.t2)
+                r_l1 = r_l1 + contract('nf,inaf->ia', tmp, (2 * self.ccwfn.H.L[o,o,v,v]))
+                tmp = contract('me,mnfe->nf', l1, self.ccwfn.build_tau(self.ccwfn.t1, self.ccwfn.t2))
+                r_l1 = r_l1 - contract('nf,inaf->ia', tmp, (2 * self.ccwfn.H.ERI[o,o,v,v]))
+                r_l1 = r_l1 + contract('nf,inaf->ia', tmp, self.ccwfn.H.ERI[o,o,v,v].swapaxes(2,3))
+            else:
                 r_l1 = r_l1 - 2.0 * contract('ef,eifa->ia', Gvv, Hvovv)
                 r_l1 = r_l1 + contract('ef,eiaf->ia', Gvv, Hvovv)
                 r_l1 = r_l1 - 2.0 * contract('mn,mina->ia', Goo, Hooov)
                 r_l1 = r_l1 + contract('mn,imna->ia', Goo, Hooov)
         return r_l1
-
 
     def r_L2(self, o, v, l1, l2, L, Hov, Hvv, Hoo, Hoooo, Hvvvv, Hovvo, Hovov, Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo):
         if self.ccwfn.model == 'CCD':

--- a/pycc/tests/test_020_cc2.py
+++ b/pycc/tests/test_020_cc2.py
@@ -40,3 +40,36 @@ def test_cc2_h2o():
     ccdensity = pycc.ccdensity(cc, cclambda)
     ecc = ccdensity.compute_energy()
     assert (abs(epsi4 - ecc) < 1e-11)
+
+def test_cc2_h2():
+    # Psi4 Setup
+    psi4.set_memory('2 GB')
+    psi4.core.set_output_file('output.dat', False)
+    psi4.set_options({'basis': 'cc-pVDZ',
+                      'scf_type': 'pk',
+                      'mp2_type': 'conv',
+                      'freeze_core': 'false',
+                      'e_convergence': 1e-12,
+                      'd_convergence': 1e-12,
+                      'r_convergence': 1e-12,
+                      'diis': 1})
+    mol = psi4.geometry(moldict["H2"])
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+
+    maxiter = 75
+    e_conv = 1e-12
+    r_conv = 1e-12
+    cc = pycc.ccwfn(rhf_wfn, model='CC2')
+    ecc = cc.solve_cc(e_conv,r_conv,maxiter)
+    epsi4 = -0.026445902512140185
+    assert (abs(epsi4 - ecc) < 1e-11)
+
+    hbar = pycc.cchbar(cc)
+    cclambda = pycc.cclambda(cc, hbar)
+    lcc = cclambda.solve_lambda(e_conv, r_conv)
+    lcc_psi4 = -0.026443139737993
+    assert(abs(lcc - lcc_psi4) < 1e-11)
+
+    ccdensity = pycc.ccdensity(cc, cclambda)
+    ecc = ccdensity.compute_energy()
+    assert (abs(epsi4 - ecc) < 1e-11)


### PR DESCRIPTION
## Description
The current implementation of the lambda equations for CC2 still contains some N<sup>6</sup>-terms.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Rewrite the code to calculate the CC2 lambda amplitudes in order to avoid N<sup>6</sup>-terms.
  - [x] Add H2 as a test case

## Status
- [x] Ready to go