### PR TITLE
Adding autocorrelation function to RTCC.

### DIFF
--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -164,7 +164,7 @@ class rtcc(object):
         Parameters
         ----------
         y : NumPy array
-            flattened array of wave function phase and cluster amplitudes or residuals
+            amplitudes or residuals and phase as a vector (flattened array)
 
         Returns
         -------
@@ -183,15 +183,15 @@ class rtcc(object):
             t1 = torch.reshape(y[:len1], (no, nv))
             t2 = torch.reshape(y[len1:(len1+len2)], (no, no, nv, nv))
             l1 = torch.reshape(y[(len1+len2):(len1+len2+len1)], (no, nv))
-            l2 = torch.reshape(y[(len1+len2+len1):(2*len1+2*len2)], (no, no, nv, nv))
+            l2 = torch.reshape(y[(len1+len2+len1):-1], (no, no, nv, nv))
         else:
             t1 = np.reshape(y[:len1], (no, nv))
             t2 = np.reshape(y[len1:(len1+len2)], (no, no, nv, nv))
             l1 = np.reshape(y[(len1+len2):(len1+len2+len1)], (no, nv))
-            l2 = np.reshape(y[(len1+len2+len1):(2*len1+2*len2)], (no, no, nv, nv))
+            l2 = np.reshape(y[(len1+len2+len1):-1], (no, no, nv, nv))
 
         # Extract the phase
-        phase = y[y.size-1]
+        phase = y[-1]
 
         return t1, t2, l1, l2, phase
 
@@ -313,6 +313,17 @@ class rtcc(object):
         return (eref + ecc) * (-1.0j)
 
     def autocorrelation(self, y_left, y_right):
+        """
+        Parameters
+        ----------
+        y_left, y_right : Numpy arrays
+            amplitudes or residuals and phase as a vector (flattened array) for two different time steps
+
+        Returns
+        -------
+        float
+            the autocorrelation function, A(t1, t2) as defined in Eq. (18) of J. Chem. Phys. 150, 144106 (2019)
+        """
         contract = opt_einsum.contract
 
         t1_l, t2_l, l1_l, l2_l, phase_l = self.extract_amps(y_left)

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -406,7 +406,8 @@ class rtcc(object):
             ret_t[key] = {"t1":t1,
                     "t2":t2,
                     "l1":l1,
-                    "l2":l2}
+                    "l2":l2,
+                    "phase":phase}
         else:
             save_t = False
 

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -173,7 +173,7 @@ class rtcc(object):
         nv = self.ccwfn.nv
 
         # Extract the phase
-        phase = y[[0]]
+        phase = y[0]
 
         # Extract the amplitudes
         len1 = no*nv

--- a/pycc/tests/test_006_rtccsd.py
+++ b/pycc/tests/test_006_rtccsd.py
@@ -45,7 +45,7 @@ def test_rtcc_he_cc_pvdz():
     V = sine_square_laser(F_str, omega, tprime)
 
     # RT-CC Setup
-    phase = ecc
+    phase = 0
     t0 = 0
     tf = 1.0
     h = 0.01

--- a/pycc/tests/test_006_rtccsd.py
+++ b/pycc/tests/test_006_rtccsd.py
@@ -45,15 +45,16 @@ def test_rtcc_he_cc_pvdz():
     V = sine_square_laser(F_str, omega, tprime)
 
     # RT-CC Setup
+    phase = ecc
     t0 = 0
     tf = 1.0
     h = 0.01
     rtcc = pycc.rtcc(cc, cclambda, ccdensity, V)
-    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2).astype('complex128')
+    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2, phase).astype('complex128')
     ODE = ode(rtcc.f).set_integrator('vode',atol=1e-13,rtol=1e-13)
     ODE.set_initial_value(y0, t0)
 
-    t1, t2, l1, l2 = rtcc.extract_amps(y0)
+    t1, t2, l1, l2, phase = rtcc.extract_amps(y0)
     mu0_x, mu0_y, mu0_z = rtcc.dipole(t1, t2, l1, l2)
     ecc0 = rtcc.lagrangian(t0, t1, t2, l1, l2)
 
@@ -62,7 +63,7 @@ def test_rtcc_he_cc_pvdz():
     while ODE.successful() and ODE.t < tf:
         y = ODE.integrate(ODE.t+h)
         t = ODE.t
-        t1, t2, l1, l2 = rtcc.extract_amps(y)
+        t1, t2, l1, l2, phase = rtcc.extract_amps(y)
         mu_x, mu_y, mu_z = rtcc.dipole(t1, t2, l1, l2)
         ecc = rtcc.lagrangian(t, t1, t2, l1, l2)
 

--- a/pycc/tests/test_007_dipole.py
+++ b/pycc/tests/test_007_dipole.py
@@ -38,8 +38,8 @@ def test_dipole_h2_2_cc_pvdz():
 
     # no laser
     rtcc = pycc.rtcc(cc, cclambda, ccdensity, None, magnetic = True)
-    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2).astype('complex128')
-    t1, t2, l1, l2 = rtcc.extract_amps(y0)
+    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2, ecc).astype('complex128')
+    t1, t2, l1, l2, phase = rtcc.extract_amps(y0)
 
     ref = [0, 0, 0.005371586416860086] # au
     mu_x, mu_y, mu_z = rtcc.dipole(t1, t2, l1, l2)

--- a/pycc/tests/test_016_chk.py
+++ b/pycc/tests/test_016_chk.py
@@ -67,6 +67,7 @@ def test_chk(datadir):
     V = gaussian_laser(F_str, 0, sigma, center=center)
 
     # RTCC setup
+    phase = ecc
     h = 0.1
     tf = 10
     rtcc = pycc.rtcc(cc,cclambda,ccdensity,V,magnetic=True,kick='z')
@@ -79,6 +80,7 @@ def test_chk(datadir):
     # propagate to 10au
     ODE = rk2(h)
     y0 = chk['y']
+    y0 = np.append(y0, phase)
     ti = chk['time']
     ofile = datadir.join(f"output.pk")
     tfile = datadir.join(f"t_out.pk")

--- a/pycc/tests/test_016_chk.py
+++ b/pycc/tests/test_016_chk.py
@@ -67,7 +67,7 @@ def test_chk(datadir):
     V = gaussian_laser(F_str, 0, sigma, center=center)
 
     # RTCC setup
-    phase = ecc
+    phase = 0
     h = 0.1
     tf = 10
     rtcc = pycc.rtcc(cc,cclambda,ccdensity,V,magnetic=True,kick='z')

--- a/pycc/tests/test_019_localrt.py
+++ b/pycc/tests/test_019_localrt.py
@@ -68,7 +68,7 @@ def test_rtpno(datadir):
     V = gaussian_laser(F_str, omega, sigma, center=center)
 
     # RT-CC Setup
-    phase = ecc
+    phase = 0
     t0 = 0
     tf = 0.5
     h = 0.02

--- a/pycc/tests/test_019_localrt.py
+++ b/pycc/tests/test_019_localrt.py
@@ -68,11 +68,12 @@ def test_rtpno(datadir):
     V = gaussian_laser(F_str, omega, sigma, center=center)
 
     # RT-CC Setup
+    phase = ecc
     t0 = 0
     tf = 0.5
     h = 0.02
     rtcc = pycc.rtcc(cc, cclambda, ccdensity, V)
-    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2).astype('complex128')
+    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2, phase).astype('complex128')
     ODE = rk4(h)
     
     # Propagate
@@ -123,11 +124,12 @@ def test_rtpao(datadir):
     V = gaussian_laser(F_str, omega, sigma, center=center)
 
     # RT-CC Setup
+    phase = ecc
     t0 = 0
     tf = 0.5
     h = 0.02
     rtcc = pycc.rtcc(cc, cclambda, ccdensity, V)
-    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2).astype('complex128')
+    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2, phase).astype('complex128')
     ODE = rk4(h)
     
     # Propagate

--- a/pycc/tests/test_019_localrt.py
+++ b/pycc/tests/test_019_localrt.py
@@ -124,7 +124,7 @@ def test_rtpao(datadir):
     V = gaussian_laser(F_str, omega, sigma, center=center)
 
     # RT-CC Setup
-    phase = ecc
+    phase = 0
     t0 = 0
     tf = 0.5
     h = 0.02

--- a/pycc/tests/test_021_rk4.py
+++ b/pycc/tests/test_021_rk4.py
@@ -48,15 +48,16 @@ def test_rtcc_water_cc_pvdz():
     V = gaussian_laser(F_str, omega, sigma, center)
 
     # RT-CC Setup
+    phase = ecc
     t0 = 0
     tf = 0.1
     h = 0.01
     t = t0
     rtcc = pycc.rtcc(cc, cclambda, ccdensity, V)
-    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2).astype('complex128')
+    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2, phase).astype('complex128')
     y = y0
     ODE = rk4(h)
-    t1, t2, l1, l2 = rtcc.extract_amps(y0)
+    t1, t2, l1, l2, phase = rtcc.extract_amps(y0)
     mu0_x, mu0_y, mu0_z = rtcc.dipole(t1, t2, l1, l2)
     ecc0 = rtcc.lagrangian(t0, t1, t2, l1, l2)
 
@@ -75,7 +76,7 @@ def test_rtcc_water_cc_pvdz():
     while t < tf:
         y = ODE(rtcc.f, t, y)
         t += h 
-        t1, t2, l1, l2 = rtcc.extract_amps(y)
+        t1, t2, l1, l2, phase = rtcc.extract_amps(y)
         mu_x, mu_y, mu_z = rtcc.dipole(t1, t2, l1, l2)
         ecc = rtcc.lagrangian(t, t1, t2, l1, l2)
         """

--- a/pycc/tests/test_021_rk4.py
+++ b/pycc/tests/test_021_rk4.py
@@ -48,7 +48,7 @@ def test_rtcc_water_cc_pvdz():
     V = gaussian_laser(F_str, omega, sigma, center)
 
     # RT-CC Setup
-    phase = ecc
+    phase = 0
     t0 = 0
     tf = 0.1
     h = 0.01

--- a/pycc/tests/test_022_adap_int.py
+++ b/pycc/tests/test_022_adap_int.py
@@ -48,7 +48,7 @@ def test_rtcc_water_cc_pvdz():
     V = gaussian_laser(F_str, omega, sigma, center)
 
     # RT-CC Setup
-    phase = ecc
+    phase = 0
     t0 = 0
     tf = 1
     h = 0.01

--- a/pycc/tests/test_022_adap_int.py
+++ b/pycc/tests/test_022_adap_int.py
@@ -48,18 +48,19 @@ def test_rtcc_water_cc_pvdz():
     V = gaussian_laser(F_str, omega, sigma, center)
 
     # RT-CC Setup
+    phase = ecc
     t0 = 0
     tf = 1
     h = 0.01
     t = t0
     rtcc = pycc.rtcc(cc, cclambda, ccdensity, V)
-    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2).astype('complex128')
+    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2, phase).astype('complex128')
     y = y0
     # Setting for the adaptive integrator
     maxiter = 10
     yconv = 1e-7
     ODE = ck(maxiter, yconv)
-    t1, t2, l1, l2 = rtcc.extract_amps(y0)
+    t1, t2, l1, l2, phase = rtcc.extract_amps(y0)
     mu0_x, mu0_y, mu0_z = rtcc.dipole(t1, t2, l1, l2)
     ecc0 = rtcc.lagrangian(t0, t1, t2, l1, l2)
 
@@ -78,7 +79,7 @@ def test_rtcc_water_cc_pvdz():
     while t < tf:
         (y, h_old, h) = ODE(rtcc.f, t, y, h)
         t += h_old
-        t1, t2, l1, l2 = rtcc.extract_amps(y)
+        t1, t2, l1, l2, phase = rtcc.extract_amps(y)
         mu_x, mu_y, mu_z = rtcc.dipole(t1, t2, l1, l2)
         ecc = rtcc.lagrangian(t, t1, t2, l1, l2)
         """

--- a/pycc/tests/test_023_ms_int.py
+++ b/pycc/tests/test_023_ms_int.py
@@ -52,7 +52,7 @@ def test_rtcc_water_cc_pvdz():
     e_field = 1e-7
 
     # RT-CC Setup
-    phase = ecc
+    phase = 0
     t0 = 0
     tf = 0.1
     h_small = 1e-5

--- a/pycc/tests/test_023_ms_int.py
+++ b/pycc/tests/test_023_ms_int.py
@@ -52,17 +52,18 @@ def test_rtcc_water_cc_pvdz():
     e_field = 1e-7
 
     # RT-CC Setup
+    phase = ecc
     t0 = 0
     tf = 0.1
     h_small = 1e-5
     h = 0.01
     t = t0
     rtcc = pycc.rtcc(cc, cclambda, ccdensity, V)
-    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2).astype('complex128')
+    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2, phase).astype('complex128')
     y = y0
     ODE1 = rk4(h_small)
     ODE2 = rk4(h)
-    t1, t2, l1, l2 = rtcc.extract_amps(y0)
+    t1, t2, l1, l2, phase = rtcc.extract_amps(y0)
     mu0_x, mu0_y, mu0_z = rtcc.dipole(t1, t2, l1, l2)
     ecc0 = rtcc.lagrangian(t0, t1, t2, l1, l2)
 
@@ -90,7 +91,7 @@ def test_rtcc_water_cc_pvdz():
             y = ODE2(rtcc.f, t, y) 
             h_i = h
         t += h_i
-        t1, t2, l1, l2 = rtcc.extract_amps(y)
+        t1, t2, l1, l2, phase = rtcc.extract_amps(y)
         mu_x, mu_y, mu_z = rtcc.dipole(t1, t2, l1, l2)
         ecc = rtcc.lagrangian(t, t1, t2, l1, l2)
         """

--- a/pycc/tests/test_024_contract_cpu.py
+++ b/pycc/tests/test_024_contract_cpu.py
@@ -51,15 +51,16 @@ def test_rtcc_water_cc_pvdz():
     V = gaussian_laser(F_str, omega, sigma, center)
 
     # RT-CC Setup
+    phase = ecc
     t0 = 0
     tf = 0.1
     h = 0.01
     t = t0
     rtcc = pycc.rtcc(cc, cclambda, ccdensity, V)
-    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2).astype('complex128')
+    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2, phase).astype('complex128')
     y = y0
     ODE = rk4(h)
-    t1, t2, l1, l2 = rtcc.extract_amps(y0)
+    t1, t2, l1, l2, phase = rtcc.extract_amps(y0)
     mu0_x, mu0_y, mu0_z = rtcc.dipole(t1, t2, l1, l2)
     ecc0 = rtcc.lagrangian(t0, t1, t2, l1, l2)
 
@@ -78,7 +79,7 @@ def test_rtcc_water_cc_pvdz():
     while t < tf:
         y = ODE(rtcc.f, t, y)
         t += h 
-        t1, t2, l1, l2 = rtcc.extract_amps(y)
+        t1, t2, l1, l2, phase = rtcc.extract_amps(y)
         mu_x, mu_y, mu_z = rtcc.dipole(t1, t2, l1, l2)
         ecc = rtcc.lagrangian(t, t1, t2, l1, l2)
         """

--- a/pycc/tests/test_024_contract_cpu.py
+++ b/pycc/tests/test_024_contract_cpu.py
@@ -51,7 +51,7 @@ def test_rtcc_water_cc_pvdz():
     V = gaussian_laser(F_str, omega, sigma, center)
 
     # RT-CC Setup
-    phase = ecc
+    phase = 0
     t0 = 0
     tf = 0.1
     h = 0.01

--- a/pycc/tests/test_025_contract_gpu.py
+++ b/pycc/tests/test_025_contract_gpu.py
@@ -52,15 +52,16 @@ def test_rtcc_water_cc_pvdz():
     V = gaussian_laser(F_str, omega, sigma, center)
 
     # RT-CC Setup
+    phase = ecc
     t0 = 0
     tf = 0.1
     h = 0.01
     t = t0
     rtcc = pycc.rtcc(cc, cclambda, ccdensity, V)
-    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2).type(torch.complex128)
+    y0 = rtcc.collect_amps(phase, cc.t1, cc.t2, cclambda.l1, cclambda.l2).type(torch.complex128)
     y = y0
     ODE = rk4(h)
-    t1, t2, l1, l2 = rtcc.extract_amps(y0)
+    phase, t1, t2, l1, l2 = rtcc.extract_amps(y0)
     mu0_x, mu0_y, mu0_z = rtcc.dipole(t1, t2, l1, l2)
     ecc0 = rtcc.lagrangian(t0, t1, t2, l1, l2)
 
@@ -79,7 +80,7 @@ def test_rtcc_water_cc_pvdz():
     while t < tf:
         y = ODE(rtcc.f, t, y)
         t += h 
-        t1, t2, l1, l2 = rtcc.extract_amps(y)
+        phase, t1, t2, l1, l2 = rtcc.extract_amps(y)
         mu_x, mu_y, mu_z = rtcc.dipole(t1, t2, l1, l2)
         ecc = rtcc.lagrangian(t, t1, t2, l1, l2)
         """

--- a/pycc/tests/test_025_contract_gpu.py
+++ b/pycc/tests/test_025_contract_gpu.py
@@ -52,7 +52,7 @@ def test_rtcc_water_cc_pvdz():
     V = gaussian_laser(F_str, omega, sigma, center)
 
     # RT-CC Setup
-    phase = ecc
+    phase = 0
     t0 = 0
     tf = 0.1
     h = 0.01

--- a/pycc/tests/test_026_autocorrelation.py
+++ b/pycc/tests/test_026_autocorrelation.py
@@ -1,0 +1,78 @@
+"""
+Test RT-CCSD propagation on He atom.
+"""
+
+# Import package, test suite, and other packages as needed
+import psi4
+import pycc
+import pytest
+from scipy.integrate import complex_ode as ode
+from pycc.rt.lasers import sine_square_laser
+from ..data.molecules import *
+
+def test_rtcc_he_cc_pvdz_auto():
+    """He cc-pVDZ"""
+    psi4.set_memory('2 GiB')
+    psi4.core.set_output_file('output.dat', False)
+    psi4.set_options({'basis': 'cc-pVDZ',
+                      'scf_type': 'pk',
+                      'mp2_type': 'conv',
+                      'freeze_core': 'false',
+                      'e_convergence': 1e-13,
+                      'd_convergence': 1e-13,
+                      'r_convergence': 1e-13,
+                      'diis': 1})
+    mol = psi4.geometry(moldict["He"])
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+
+    e_conv = 1e-13
+    r_conv = 1e-13
+
+    cc = pycc.ccwfn(rhf_wfn)
+    ecc = cc.solve_cc(e_conv, r_conv)
+
+    hbar = pycc.cchbar(cc)
+
+    cclambda = pycc.cclambda(cc, hbar)
+    lecc = cclambda.solve_lambda(e_conv, r_conv)
+
+    ccdensity = pycc.ccdensity(cc, cclambda)
+
+    # Sine squared pulse (a.u.)
+    F_str = 1.0
+    omega = 2.87
+    tprime = 5.0
+    V = sine_square_laser(F_str, omega, tprime)
+
+    # RT-CC Setup
+    phase = 0
+    t0 = 0
+    tf = 1.0
+    h = 0.01
+    rtcc = pycc.rtcc(cc, cclambda, ccdensity, V)
+    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2, phase).astype('complex128')
+    ODE = ode(rtcc.f).set_integrator('vode',atol=1e-13,rtol=1e-13)
+    ODE.set_initial_value(y0, t0)
+
+    t1, t2, l1, l2, phase = rtcc.extract_amps(y0)
+    mu0_x, mu0_y, mu0_z = rtcc.dipole(t1, t2, l1, l2)
+    ecc0 = rtcc.lagrangian(t0, t1, t2, l1, l2)
+    auto = rtcc.autocorrelation(y0, y0)
+
+    # From Håkon's He test case
+    A_t_t0_ref = -0.967109840555436 + 0.250976568630115j
+
+    while ODE.successful() and ODE.t < tf:
+        y = ODE.integrate(ODE.t+h)
+        t = ODE.t
+        t1, t2, l1, l2, phase = rtcc.extract_amps(y)
+        mu_x, mu_y, mu_z = rtcc.dipole(t1, t2, l1, l2)
+        ecc = rtcc.lagrangian(t, t1, t2, l1, l2)
+        auto = rtcc.autocorrelation(y0, y)
+
+    print(f"{auto:.15f}")
+    print(f"{A_t_t0_ref:.15f}")
+
+    assert (abs(A_t_t0_ref.real - auto.real) < 1e-10)
+    assert (abs(A_t_t0_ref.imag - auto.imag) < 1e-10)
+


### PR DESCRIPTION
## Description
This PR will add the autocorrelation function to RTCC to compute the population of the ground state as a function of time.

## Todos
  - [X] Add phase factor calculation to main RK f() function.
  - [x] Add function to compute autocorrelation function in each step
  - [x] Add test case comparing to Pedersen and Kvaal's results from [J. Chem. Phys. 150, 144106 (2019)](https://doi.org/10.1063/1.5085390).

## Other
  - [X] Removed the `energy` function from `rtcc.py` because it is unused and untested.
 
## Status
- [x] Ready to go