### PR TITLE
Moving property integrals into the Hamiltonian.

### DIFF
--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -34,7 +34,7 @@ class ccwfn(object):
     nmo : int
         the number of active orbitals
     H : Hamiltonian object
-        the normal-ordered Hamiltonian, which includes the Fock matrix, the ERIs, and the spin-adapted ERIs (L)
+        the normal-ordered Hamiltonian, which includes the Fock matrix, the ERIs, the spin-adapted ERIs (L), and various property integrals
     o : NumPy slice
         occupied orbital subspace
     v : NumPy slice


### PR DESCRIPTION
## Description
In order to avoid redundancy and inconsistencies, this PR moves all property integrals (so far just electric and magnetic dipoles) into the Hamiltonian object.  This will be helpful as we add response and other properties beyond RTCC simulations.

## Todos
  - [x] Add relevant `mintshelper` calls and MO transformations to the Hamiltonian.
  - [x] Remove corresponding calls from `rtcc.py` and replace with assignments to attributes of `self.ccwfn.H`.

## Status
- [x] Ready to go