### PR TITLE
Pytorch ver

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -70,7 +70,7 @@ jobs:
         python -m pip install .
         python -m pip install opt_einsum
         python -m pip install scipy
-        python -m pip install torch
+        python -m pip install torch==1.11
         conda list
 
     - name: PyTest

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ PyCC
 [//]: # (Badges)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![GitHub Actions Build
-Status](https://github.com/CrawfordGroup/pycc/workflows/CI/badge.svg)](https://github.com/lothian/pycc/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/CrawfordGroup/pycc/branch/main/graph/badge.svg)](https://codecov.io/gh/lothian/pycc/branch/main)
+Status](https://github.com/CrawfordGroup/pycc/workflows/CI/badge.svg)](https://github.com/CrawfordGroup/pycc/actions?query=workflow%3ACI)
+[![codecov](https://codecov.io/gh/CrawfordGroup/pycc/branch/main/graph/badge.svg)](https://codecov.io/gh/CrawfordGroup/pycc/branch/main)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/lothian/pycc.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/lothian/pycc/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/lothian/pycc.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/lothian/pycc/context:python)
 

--- a/README.md
+++ b/README.md
@@ -12,17 +12,18 @@ A Python-based coupled cluster implementation.  Current capabilities include:
   - Spin-adapted RHF-CCD, RHF-CC2, RHF-CCSD, and RHF-CCSD(T) energies
   - Triples-drivers for (T), CC3, and other approximate triples
   - RHF-CCSD densities
+  - GPU implementation
+  - Single- and mixed-precision arithmetic
   - Real-time CCSD with a selection of integrators
-  - LPNO-CCSD energies and RT-CC
   - PAO-CCSD energies and RT-CC
+  - PNO-CCSD energies and RT-CC
+  - PNO++-CCSD energies and RT-CC
 
 Future plans:
   - CC3
   - Linear and quadratic response functions
   - EOM-CC
   - Single- and mixed-precision arithmetic
-  - Analytic gradients
-  - GPU implementation
 
 This repository is currently under development. To do a developmental install, download this repository and type `pip install -e .` in the repository directory.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Future plans:
   - CC3
   - Linear and quadratic response functions
   - EOM-CC
-  - Single- and mixed-precision arithmetic
+  - Analytic gradients
 
 This repository is currently under development. To do a developmental install, download this repository and type `pip install -e .` in the repository directory.
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "numpy",
         "opt_einsum",
         "scipy",
-        "torch"
+        "torch<=1.11"
     ],
 
     # Which Python importable modules should be included when your package is installed


### PR DESCRIPTION
## Description
Force `pytorch` version to 1.11 for the moment to avoid a package conflict. 

Small README edits: move GPU and single/double-precision implementations to current capabilities, change LPNO to PNO, and add PNO++-CCSD energies and RT-CC. Also change the badges to pull from `CrawfordGroup/pycc` instead of `lothian/pycc`. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Check github CI
  - [x] Add version to dependency in `setup.py`

## Status
- [x] Ready to go