### PR TITLE
Generalizing the triples drivers for CC3.

### DIFF
--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -33,7 +33,7 @@ class cctriples(object):
         for i in range(no):
             for j in range(no):
                 for k in range(no):
-                    t3 = self.t3c_ijk(o, v, i, j, k, t2, ERI, F)
+                    t3 = self.t3c_ijk(o, v, i, j, k, t2, ERI[v,v,v,o], ERI[o,v,o,o], F)
 
                     X1[i] += contract('abc,bc->a',(t3 - t3.swapaxes(0,2)), L[j,k,v,v])
                     X2[i,j] += contract('abc,c->ab',(t3 - t3.swapaxes(0,2)), F[k,v])
@@ -63,7 +63,7 @@ class cctriples(object):
         for a in range(nv):
             for b in range(nv):
                 for c in range(nv):
-                    t3 = self.t3c_abc(o, v, a, b, c, t2, ERI, F, True)
+                    t3 = self.t3c_abc(o, v, a, b, c, t2, ERI[v,v,v,o], ERI[o,v,o,o], F, True)
 
                     X1[a] += contract('ijk,jk->i',(t3 - t3.swapaxes(0,2)), L[o,o,b+no,c+no])
                     X2[a,b] += contract('ijk,k->ij',(t3 - t3.swapaxes(0,2)), F[o,c+no])
@@ -90,8 +90,8 @@ class cctriples(object):
         for i in range(no):
             for j in range(i+1):
                 for k in range(j+1):
-                    W3 = self.t3c_ijk(o, v, i, j, k, t2, ERI, F, False)
-                    V3 = self.t3d_ijk(o, v, i, j, k, t1, t2, ERI, F, False) + W3
+                    W3 = self.t3c_ijk(o, v, i, j, k, t2, ERI[v,v,v,o], ERI[o,v,o,o], F, False)
+                    V3 = self.t3d_ijk(o, v, i, j, k, t1, t2, ERI[o,o,v,v], F, False) + W3
 
                     for a in range(nv):
                         for b in range(nv):
@@ -125,21 +125,21 @@ class cctriples(object):
 
     # Various triples formulations; useful for (T) corrections and CC3
 
-    def t3c_ijk(self, o, v, i, j, k, t2, ERI, F, WithDenom=True):
+    def t3c_ijk(self, o, v, i, j, k, t2, Wvvvo, Wovoo, F, WithDenom=True):
         contract = self.contract 
-        t3 = contract('eab,ce->abc', ERI[i,v,v,v], t2[k,j])
-        t3 += contract('eac,be->abc', ERI[i,v,v,v], t2[j,k])
-        t3 += contract('eca,be->abc', ERI[k,v,v,v], t2[j,i])
-        t3 += contract('ecb,ae->abc', ERI[k,v,v,v], t2[i,j])
-        t3 += contract('ebc,ae->abc', ERI[j,v,v,v], t2[i,k])
-        t3 += contract('eba,ce->abc', ERI[j,v,v,v], t2[k,i])
+        t3 = contract('eab,ce->abc', Wvvvo[:,:,:,i], t2[k,j])
+        t3 += contract('eac,be->abc', Wvvvo[:,:,:,i], t2[j,k])
+        t3 += contract('eca,be->abc', Wvvvo[:,:,:,k], t2[j,i])
+        t3 += contract('ecb,ae->abc', Wvvvo[:,:,:,k], t2[i,j])
+        t3 += contract('ebc,ae->abc', Wvvvo[:,:,:,j], t2[i,k])
+        t3 += contract('eba,ce->abc', Wvvvo[:,:,:,j], t2[k,i])
 
-        t3 -= contract('mc,mab->abc', ERI[j,k,o,v], t2[i])
-        t3 -= contract('mb,mac->abc', ERI[k,j,o,v], t2[i])
-        t3 -= contract('mb,mca->abc', ERI[i,j,o,v], t2[k])
-        t3 -= contract('ma,mcb->abc', ERI[j,i,o,v], t2[k])
-        t3 -= contract('ma,mbc->abc', ERI[k,i,o,v], t2[j])
-        t3 -= contract('mc,mba->abc', ERI[i,k,o,v], t2[j])
+        t3 -= contract('mc,mab->abc', Wovoo[:,:,j,k], t2[i])
+        t3 -= contract('mb,mac->abc', Wovoo[:,:,k,j], t2[i])
+        t3 -= contract('mb,mca->abc', Wovoo[:,:,i,j], t2[k])
+        t3 -= contract('ma,mcb->abc', Wovoo[:,:,j,i], t2[k])
+        t3 -= contract('ma,mbc->abc', Wovoo[:,:,k,i], t2[j])
+        t3 -= contract('mc,mba->abc', Wovoo[:,:,i,k], t2[j])
 
         if WithDenom is True:
             Fv = np.diag(F)[v]
@@ -151,23 +151,23 @@ class cctriples(object):
             return t3
 
 
-    def t3c_abc(self, o, v, a, b, c, t2, ERI, F, WithDenom=True):
+    def t3c_abc(self, o, v, a, b, c, t2, Wvvvo, Wovoo, F, WithDenom=True):
         contract = self.contract
         no = o.stop
 
-        t3 = contract('ie,kje->ijk', ERI[o,v,a+no,b+no], t2[o,o,c])
-        t3 += contract('ie,jke->ijk', ERI[o,v,a+no,c+no], t2[o,o,b])
-        t3 += contract('ke,jie->ijk', ERI[o,v,c+no,a+no], t2[o,o,b])
-        t3 += contract('ke,ije->ijk', ERI[o,v,c+no,b+no], t2[o,o,a])
-        t3 += contract('je,ike->ijk', ERI[o,v,b+no,c+no], t2[o,o,a])
-        t3 += contract('je,kie->ijk', ERI[o,v,b+no,a+no], t2[o,o,c])
+        t3 = contract('ei,kje->ijk', Wvvvo[b,a], t2[:,:,c])
+        t3 += contract('ei,jke->ijk', Wvvvo[c,a], t2[:,:,b])
+        t3 += contract('ek,jie->ijk', Wvvvo[a,c], t2[:,:,b])
+        t3 += contract('ek,ije->ijk', Wvvvo[b,c], t2[:,:,a])
+        t3 += contract('ej,ike->ijk', Wvvvo[c,b], t2[:,:,a])
+        t3 += contract('ej,kie->ijk', Wvvvo[a,b], t2[:,:,c])
 
-        t3 -= contract('jkm,im->ijk', ERI[o,o,o,c+no], t2[o,o,a,b])
-        t3 -= contract('kjm,im->ijk', ERI[o,o,o,b+no], t2[o,o,a,c])
-        t3 -= contract('ijm,km->ijk', ERI[o,o,o,b+no], t2[o,o,c,a])
-        t3 -= contract('jim,km->ijk', ERI[o,o,o,a+no], t2[o,o,c,b])
-        t3 -= contract('kim,jm->ijk', ERI[o,o,o,a+no], t2[o,o,b,c])
-        t3 -= contract('ikm,jm->ijk', ERI[o,o,o,c+no], t2[o,o,b,a])
+        t3 -= contract('mjk,im->ijk', Wovoo[:,c,:,:], t2[:,:,a,b])
+        t3 -= contract('mkj,im->ijk', Wovoo[:,b,:,:], t2[:,:,a,c])
+        t3 -= contract('mij,km->ijk', Wovoo[:,b,:,:], t2[:,:,c,a])
+        t3 -= contract('mji,km->ijk', Wovoo[:,a,:,:], t2[:,:,c,b])
+        t3 -= contract('mki,jm->ijk', Wovoo[:,a,:,:], t2[:,:,b,c])
+        t3 -= contract('mik,jm->ijk', Wovoo[:,c,:,:], t2[:,:,b,a])
 
         if WithDenom is True:
             Fo = np.diag(F)[o]
@@ -179,11 +179,11 @@ class cctriples(object):
             return t3
 
 
-    def t3d_ijk(self, o, v, i, j, k, t1, t2, ERI, F, WithDenom=True):
+    def t3d_ijk(self, o, v, i, j, k, t1, t2, Woovv, F, WithDenom=True):
         contract = self.contract
-        t3 = contract('ab,c->abc', ERI[i,j,v,v], t1[k])
-        t3 += contract('ac,b->abc', ERI[i,k,v,v], t1[j])
-        t3 += contract('bc,a->abc', ERI[j,k,v,v], t1[i])
+        t3 = contract('ab,c->abc', Woovv[i,j], t1[k])
+        t3 += contract('ac,b->abc', Woovv[i,k], t1[j])
+        t3 += contract('bc,a->abc', Woovv[j,k], t1[i])
         t3 += contract('ab,c->abc', t2[i,j], F[k,v])
         t3 += contract('ac,b->abc', t2[i,k], F[j,v])
         t3 += contract('bc,a->abc', t2[j,k], F[i,v])

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -127,12 +127,12 @@ class cctriples(object):
 
     def t3c_ijk(self, o, v, i, j, k, t2, Wvvvo, Wovoo, F, WithDenom=True):
         contract = self.contract 
-        t3 = contract('eab,ce->abc', Wvvvo[:,:,:,i], t2[k,j])
-        t3 += contract('eac,be->abc', Wvvvo[:,:,:,i], t2[j,k])
-        t3 += contract('eca,be->abc', Wvvvo[:,:,:,k], t2[j,i])
-        t3 += contract('ecb,ae->abc', Wvvvo[:,:,:,k], t2[i,j])
-        t3 += contract('ebc,ae->abc', Wvvvo[:,:,:,j], t2[i,k])
-        t3 += contract('eba,ce->abc', Wvvvo[:,:,:,j], t2[k,i])
+        t3 = contract('bae,ce->abc', Wvvvo[:,:,:,i], t2[k,j])
+        t3 += contract('cae,be->abc', Wvvvo[:,:,:,i], t2[j,k])
+        t3 += contract('ace,be->abc', Wvvvo[:,:,:,k], t2[j,i])
+        t3 += contract('bce,ae->abc', Wvvvo[:,:,:,k], t2[i,j])
+        t3 += contract('cbe,ae->abc', Wvvvo[:,:,:,j], t2[i,k])
+        t3 += contract('abe,ce->abc', Wvvvo[:,:,:,j], t2[k,i])
 
         t3 -= contract('mc,mab->abc', Wovoo[:,:,j,k], t2[i])
         t3 -= contract('mb,mac->abc', Wovoo[:,:,k,j], t2[i])


### PR DESCRIPTION
## Description
The triples drivers in `cctriples.py` assume that the two-electron array is the ERIs, with all of its usual permutational symmetries.  This PR removes this assumption by requiring two two-electron quantities with shapes `[v,v,v,o]` and `[o,v,o,o]`.  This should allow CC3 and related codes to use this triples driver.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [X] Generalize `t3c_ijk()`, `t3d_ijk()`, and `t3c_abc()` functions to use new array structures.
  - [X] Correct API in (T) functions `t_vikings()`, `t_vikings_inverted()`, and `t_tjl()`.

## Status
- [X] Ready to go