### PR TITLE
Correcting GPU/sp magnetic dipoles calculation

### DIFF
--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -78,7 +78,12 @@ class rtcc(object):
                 self.mu = torch.tensor(self.mu, dtype=torch.complex128, device=self.ccwfn.device1)
             elif self.ccwfn.precision == 'SP':
                 self.mu = torch.tensor(self.mu, dtype=torch.complex64, device=self.ccwfn.device1)
-            self.mu_tot = sum(self.mu) / (torch.sqrt(torch.tensor(3.0)).item())
+            
+            if kick:
+                s_to_i = {"x":0, "y":1, "z":2}
+                self.mu_tot = self.mu[s_to_i[kick.lower()]]
+            else:
+                self.mu_tot = sum(self.mu) / (torch.sqrt(torch.tensor(3.0)).item())
 
         if magnetic:
             self.magnetic = True

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -83,6 +83,13 @@ class rtcc(object):
         if magnetic:
             self.magnetic = True
             self.m = self.ccwfn.H.m
+            if self.ccwfn.precision == 'SP':
+                self.m = np.complex64(self.m)
+            if isinstance(self.ccwfn.t1, torch.Tensor):
+                if self.ccwfn.precision == 'DP':
+                    self.m = torch.tensor(self.m, dtype=torch.complex128, device=self.ccwfn.device1)
+                elif self.ccwfn.precision == 'SP':
+                    self.m = torch.tensor(self.m, dtype=torch.complex64, device=self.ccwfn.device1)
         else:
             self.magnetic = False
 


### PR DESCRIPTION
## Description
Modifying the code for GPU/sp magnetic dipoles calculation with laser pulse xyz kicks. 

## Todos
  - [x] Adding magnetic dipoles when external field is x, y, z kicks for GPU and/or single-precision calculations. 

## Status
- [x] Ready to go