### PR TITLE
axe psi4 dev channel

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -53,7 +53,7 @@ jobs:
       run: |
         conda info
         conda list --show-channel-urls
-        conda install psi4 python=${{ matrix.python-version }} -c psi4/label/dev
+        conda install psi4 python=${{ matrix.python-version }} -c conda-forge
         ls -l $CONDA
 
     - name: Test Psi4 Python Loading

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -1,6 +1,5 @@
 name: p4dev
 channels:
-  - psi4/label/dev
   - conda-forge
 dependencies:
   - psi4
@@ -13,6 +12,7 @@ dependencies:
   - psutil
   - qcelemental >=0.19.0  # test minimum stated version.
   - pydantic >=1.0.0  # test minimun stated version. actually min is 1.0 but no py38 builds
+  - conda-forge/label/libint_dev::libint=2.7.3dev1
   - msgpack-python
 
     # Testing


### PR DESCRIPTION
## Description
remove psi4/label/dev channel, per loriab: 
```
any need for the high AM? if not, just nix all psi4 channel references. you can go plain c-f except that you will need this line explicitly 
https://github.com/psi4/psi4/blob/master/devtools/conda-envs/Linux-buildrun-maxeco.yaml#L22
. . .
psi4 channel is to become the home of select nighly builds  and high AM releases. other than that, straight c-f
```

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] remove psi4/label/dev channel from `psi.yaml`
  - [x] update `CI.yaml` to pull from c-f
  - [x] pin specific libint 
  - [ ] make sure CI tests pass on this PR  

## Status
- [ ] Ready to go