### PR TITLE
No ref

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -70,7 +70,7 @@ jobs:
         python -m pip install .
         python -m pip install opt_einsum
         python -m pip install scipy
-        python -m pip install torch==1.11
+        python -m pip install torch
         conda list
 
     - name: PyTest

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -53,7 +53,7 @@ jobs:
       run: |
         conda info
         conda list --show-channel-urls
-        conda install psi4 python=${{ matrix.python-version }} -c conda-forge/label/libint_dev -c conda-forge 
+        conda install psi4 python=${{ matrix.python-version }} -c conda-forge 
         ls -l $CONDA
 
     - name: Test Psi4 Python Loading

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -70,7 +70,7 @@ jobs:
         python -m pip install .
         python -m pip install opt_einsum
         python -m pip install scipy
-        python -m pip install torch
+        python -m pip install torch==1.11
         conda list
 
     - name: PyTest

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -53,7 +53,7 @@ jobs:
       run: |
         conda info
         conda list --show-channel-urls
-        conda install psi4 python=${{ matrix.python-version }} -c conda-forge
+        conda install psi4 python=${{ matrix.python-version }} -c conda-forge/label/libint_dev -c conda-forge 
         ls -l $CONDA
 
     - name: Test Psi4 Python Loading

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -1,5 +1,6 @@
 name: p4dev
 channels:
+  - conda-forge/label/libint_dev
   - conda-forge
 dependencies:
   - psi4

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -1,6 +1,5 @@
 name: p4dev
 channels:
-  - conda-forge/label/libint_dev
   - conda-forge
 dependencies:
   - psi4
@@ -13,7 +12,6 @@ dependencies:
   - psutil
   - qcelemental >=0.19.0  # test minimum stated version.
   - pydantic >=1.0.0  # test minimun stated version. actually min is 1.0 but no py38 builds
-  - conda-forge/label/libint_dev::libint=2.7.3dev1
   - msgpack-python
 
     # Testing

--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -152,14 +152,12 @@ class ccdensity(object):
 
         return ecc
 
-    def compute_onepdm(self, t1, t2, l1, l2, withref=False):
+    def compute_onepdm(self, t1, t2, l1, l2):
         """
         Parameters
         ----------
         t1, t2, l1, l2 : NumPy arrays
             current cluster amplitudes
-        withref : Boolean (default: False)
-            include the reference contribution if True
 
         Returns
         -------
@@ -186,18 +184,6 @@ class ccdensity(object):
             elif self.ccwfn.precision == 'SP':
                 opdm = np.zeros((nt, nt), dtype='complex64')
         opdm[o,o] = self.build_Doo(t1, t2, l1, l2)
-        if withref is True:
-            if isinstance(t1, torch.Tensor):
-                if self.ccwfn.precision == 'DP':
-                    opdm[o,o] += 2.0 * torch.eye(no, dtype=torch.complex128, device=self.ccwfn.device1)  # Reference contribution
-                elif self.ccwfn.precision == 'SP':
-                    opdm[o,o] += 2.0 * torch.eye(no, dtype=torch.complex64, device=self.ccwfn.device1)
-            else:
-                if self.ccwfn.precision == 'DP':
-                    opdm[o,o] += 2.0 * np.eye(no)  # Reference contribution
-                elif self.ccwfn.precision == 'SP':
-                    opdm[o,o] += 2.0 * np.eye(no, dtype=np.complex64)
-
         opdm[v,v] = self.build_Dvv(t1, t2, l1, l2)
         opdm[o,v] = self.build_Dov(t1, t2, l1, l2)
         opdm[v,o] = self.build_Dvo(l1)

--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -162,7 +162,7 @@ class ccdensity(object):
         Returns
         -------
         onepdm : NumPy array
-            the CC one-electron density as a single, full matrix
+            the CC one-electron density as a single, full matrix (only the correlated contribution)
         """
         o = self.ccwfn.o
         v = self.ccwfn.v

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -219,7 +219,7 @@ class rtcc(object):
         Returns
         -------
         x, y, z : scalars
-            Cartesian components of the dipole moment
+            Cartesian components of the correlated dipole moment
         """
         if self.ccwfn.model == 'CC3':
             (opdm, opdm_cc3) = self.ccdensity.compute_onepdm(t1, t2, l1, l2)

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -207,14 +207,12 @@ class rtcc(object):
 
         return t1, t2, l1, l2, phase
 
-    def dipole(self, t1, t2, l1, l2, withref = True, magnetic = False):
+    def dipole(self, t1, t2, l1, l2, magnetic = False):
         """
         Parameters
         ----------
         t1, t2, l1, l2 : NumPy arrays
             current cluster amplitudes
-        withref        : Bool (default = True)
-            include reference contribution to the OPDM
         magnetic       : Bool (default = False)
             compute magnetic dipole rather than electric
 
@@ -224,9 +222,9 @@ class rtcc(object):
             Cartesian components of the dipole moment
         """
         if self.ccwfn.model == 'CC3':
-            (opdm, opdm_cc3) = self.ccdensity.compute_onepdm(t1, t2, l1, l2, withref=withref)
+            (opdm, opdm_cc3) = self.ccdensity.compute_onepdm(t1, t2, l1, l2)
         else:
-            opdm = self.ccdensity.compute_onepdm(t1, t2, l1, l2, withref=withref)
+            opdm = self.ccdensity.compute_onepdm(t1, t2, l1, l2)
 
         if magnetic:
             ints = self.m
@@ -423,12 +421,12 @@ class rtcc(object):
         ret = {}
         t1, t2, l1, l2, phase = self.extract_amps(y)
         ret['ecc'] = self.lagrangian(t,t1,t2,l1,l2)
-        mu_x, mu_y, mu_z = self.dipole(t1,t2,l1,l2,withref=ref,magnetic=False)
+        mu_x, mu_y, mu_z = self.dipole(t1,t2,l1,l2,magnetic=False)
         ret['mu_x'] = mu_x
         ret['mu_y'] = mu_y
         ret['mu_z'] = mu_z
         if self.magnetic:
-            m_x, m_y, m_z = self.dipole(t1,t2,l1,l2,withref=ref,magnetic=True)
+            m_x, m_y, m_z = self.dipole(t1,t2,l1,l2,magnetic=True)
             ret['m_x'] = m_x
             ret['m_y'] = m_y
             ret['m_z'] = m_z
@@ -509,12 +507,12 @@ class rtcc(object):
         # initial properties
         t1, t2, l1, l2, phase = self.extract_amps(yi)
         ret[key]['ecc'] = self.lagrangian(ti,t1,t2,l1,l2)
-        mu_x, mu_y, mu_z = self.dipole(t1,t2,l1,l2,withref=ref,magnetic=False)
+        mu_x, mu_y, mu_z = self.dipole(t1,t2,l1,l2,magnetic=False)
         ret[key]['mu_x'] = mu_x
         ret[key]['mu_y'] = mu_y
         ret[key]['mu_z'] = mu_z
         if self.magnetic:
-            m_x, m_y, m_z = self.dipole(t1,t2,l1,l2,withref=ref,magnetic=True)
+            m_x, m_y, m_z = self.dipole(t1,t2,l1,l2,magnetic=True)
             ret[key]['m_x'] = m_x
             ret[key]['m_y'] = m_y
             ret[key]['m_z'] = m_z

--- a/pycc/tests/test_007_dipole.py
+++ b/pycc/tests/test_007_dipole.py
@@ -43,7 +43,6 @@ def test_dipole_h2_2_cc_pvdz():
 
     ref = [0, 0, 0.005371586416860086] # au
     mu_x, mu_y, mu_z = rtcc.dipole(t1, t2, l1, l2)
-    opdm = rtcc.ccdensity.compute_onepdm(t1, t2, l1, l2, withref = True)
 
     assert (abs(ref[0] - mu_x) < 1E-10)
     assert (abs(ref[1] - mu_y) < 1E-10)

--- a/pycc/tests/test_007_dipole.py
+++ b/pycc/tests/test_007_dipole.py
@@ -6,10 +6,11 @@ Test CCSD electric and magnetic dipole on H2 dimer.
 import psi4
 import pycc
 import pytest
+import numpy as np
 from ..data.molecules import *
 
 def test_dipole_h2_2_cc_pvdz():
-    """He cc-pVDZ"""
+    """H4 cc-pVDZ"""
     psi4.set_memory('2 GiB')
     psi4.core.set_output_file('output.dat', False)
     psi4.set_options({'basis': 'cc-pVDZ',
@@ -41,7 +42,8 @@ def test_dipole_h2_2_cc_pvdz():
     y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2, ecc).astype('complex128')
     t1, t2, l1, l2, phase = rtcc.extract_amps(y0)
 
-    ref = [0, 0, 0.005371586416860086] # au
+    ref = np.array([0, 0, -0.0007395036977002]) # computed by removing SCF from original ref
+
     mu_x, mu_y, mu_z = rtcc.dipole(t1, t2, l1, l2)
 
     assert (abs(ref[0] - mu_x) < 1E-10)

--- a/pycc/tests/test_021_rk4.py
+++ b/pycc/tests/test_021_rk4.py
@@ -87,7 +87,7 @@ def test_rtcc_water_cc_pvdz():
         """
         
     print(mu_z)
-    mu_z_ref = -0.34894577
+    mu_z_ref = -0.0780067603267549 # computed by removing SCF from original ref
     assert (abs(mu_z_ref - mu_z.real) < 1e-4)
     
     #return (dip_x, dip_y, dip_z, time_points)

--- a/pycc/tests/test_022_adap_int.py
+++ b/pycc/tests/test_022_adap_int.py
@@ -90,7 +90,7 @@ def test_rtcc_water_cc_pvdz():
         """
         
     print(mu_z)
-    mu_z_ref = -0.34894577
+    mu_z_ref = -0.0780067603267549 # computed by removing SCF from original ref
     assert (abs(mu_z_ref - mu_z.real) < 1e-3)
     
     #return (dip_x, dip_y, dip_z, time_points)

--- a/pycc/tests/test_023_ms_int.py
+++ b/pycc/tests/test_023_ms_int.py
@@ -102,7 +102,7 @@ def test_rtcc_water_cc_pvdz():
         """
         
     print(mu_z)
-    mu_z_ref = -0.34894577
+    mu_z_ref = -0.0780067603267549 # computed by removing SCF from original ref
     assert (abs(mu_z_ref - mu_z.real) < 1e-1)
     
     #return (dip_x, dip_y, dip_z, time_points)

--- a/pycc/tests/test_024_contract_cpu.py
+++ b/pycc/tests/test_024_contract_cpu.py
@@ -90,7 +90,7 @@ def test_rtcc_water_cc_pvdz():
         """
         
     print(mu_z)
-    mu_z_ref = -0.34894577
+    mu_z_ref = -0.0780067603267549 # computed by removing SCF from original ref
     assert (abs(mu_z_ref - mu_z.real) < 1e-4)
     
     #return (dip_x, dip_y, dip_z, time_points)

--- a/pycc/tests/test_030_sp.py
+++ b/pycc/tests/test_030_sp.py
@@ -74,7 +74,7 @@ def test_rtcc_water_cc_pvdz():
     ecc0 = rtcc.lagrangian(t0, t1, t2, l1, l2)
    
     # Check dipole moment 
-    mu0_z_ref = -0.3489459218340155 
+    mu0_z_ref = -0.0780069121607703 # computed by removing SCF from original ref
     assert(abs(mu0_z_ref - mu0_z) < 1e-6)
     
     while t < tf:
@@ -87,6 +87,6 @@ def test_rtcc_water_cc_pvdz():
     print(mu_z)
    
     # Check the dipole value at time step 1
-    mu_z_ref = -0.3489459204749751
+    mu_z_ref = -0.0780069121607703 # computed by removing SCF from original ref
     assert (abs(mu_z_ref - mu_z.real) < 1e-6)    
 

--- a/pycc/tests/test_031_cc3.py
+++ b/pycc/tests/test_031_cc3.py
@@ -50,7 +50,7 @@ def test_cc3_h2o():
     # Total dipole from CFOUR: [0, 0, 0.7703875967] au
     ref = [0, 0, -0.3569035158] # au
 
-    mu_x, mu_y, mu_z = rtcc.dipole(cc.t1, cc.t2, cclambda.l1, cclambda.l2, withref=True)
+    mu_x, mu_y, mu_z = rtcc.dipole(cc.t1, cc.t2, cclambda.l1, cclambda.l2)
 
     assert (abs(ref[0] - np.real(mu_x)) < 1E-10)
     assert (abs(ref[1] - np.real(mu_y)) < 1E-10)

--- a/pycc/tests/test_031_cc3.py
+++ b/pycc/tests/test_031_cc3.py
@@ -45,14 +45,12 @@ def test_cc3_h2o():
     # no laser
     rtcc = pycc.rtcc(cc, cclambda, ccdensity, None, magnetic = False)
     
-    # Nuclear dipole from Psi4: 1.12729111248 au
-    #nuc_dipole = mol.nuclear_dipole()
-    # Total dipole from CFOUR: [0, 0, 0.7703875967] au
-    ref = [0, 0, -0.3569035158] # au
+    CFOUR = [0, 0, 0.7703875967] # CFOUR total dipole (CC3 + SCF + nuclear)
+    scf = rhf_wfn.variable('SCF DIPOLE') # PSI4 reference dipole (SCF + nuclear)
+    ref = CFOUR - scf # Final reference: CC3 only
 
     mu_x, mu_y, mu_z = rtcc.dipole(cc.t1, cc.t2, cclambda.l1, cclambda.l2)
 
-    assert (abs(ref[0] - np.real(mu_x)) < 1E-10)
     assert (abs(ref[1] - np.real(mu_y)) < 1E-10)
     assert (abs(ref[2] - np.real(mu_z)) < 1E-10)
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     license='BSD-3-Clause',
-    python_requires='<3.12',
     install_requires=[
         "numpy",
         "opt_einsum",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "numpy",
         "opt_einsum",
         "scipy",
-        "torch<=1.11"
+        "torch"
     ],
 
     # Which Python importable modules should be included when your package is installed

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "numpy",
         "opt_einsum",
         "scipy",
-        "torch"
+        "torch<=1.11"
     ],
 
     # Which Python importable modules should be included when your package is installed

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     license='BSD-3-Clause',
+    python_requires='<3.12',
     install_requires=[
         "numpy",
         "opt_einsum",

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
## Description
Removes the option to include the reference contribution in densities and dipoles. This avoids incorrectly computing the reference contributions due to frozen core electrons. Closes #65 and edits tests to match. 

Also updates `Versioneer`, which had some conflicts, and removes all references to `libint` in `.yaml` files, since those are now included with `psi4` conda packages. 

Originally this PR set out to remove the limitation on pytorch version (see #44 ). `pytorch` currently only supports up to python 3.11, but even with that pinned, Github CI fails (MacOS specifically for some reason). If there is a need, this issue can be readdressed in a separate PR. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Remove `withref` option
  - [x] Update tests
  ~~- [ ] Unpin Pytorch version 1.11~~
  ~~- [ ] Pin Python version?~~


## Questions
~~- [ ] Should we pin python<=3.11?~~ 
- [x] Could someone recompute the data from test 31? It looks like CFOUR was used.

## Status
- [x] Ready to go