### PR TITLE
Revised DIIS code to be somewhat simpler and more general.

### DIFF
--- a/pycc/utils.py
+++ b/pycc/utils.py
@@ -3,67 +3,47 @@ import torch
 import opt_einsum
 
 
-class helper_diis(object):
-    def __init__(self, t1, t2, max_diis, precision='DP'):
-        if isinstance(t1, torch.Tensor):
+class DIIS(object):
+    def __init__(self, T, max_diis, precision='DP'):
+        if isinstance(T, torch.Tensor):
             self.device0 = torch.device('cpu')
             self.device1 = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-            self.oldt1 = t1.clone()
-            self.oldt2 = t2.clone()
-            self.diis_vals_t1 = [t1.clone()]
-            self.diis_vals_t2 = [t2.clone()]
+            self.diis_T = [T.clone()]
         else:
-            self.oldt1 = t1.copy()
-            self.oldt2 = t2.copy()
-            self.diis_vals_t1 = [t1.copy()]
-            self.diis_vals_t2 = [t2.copy()]
+            self.diis_T = [T.copy()]
 
         self.diis_errors = []
         self.diis_size = 0
         self.max_diis = max_diis
         self.precision = precision
 
-    def add_error_vector(self, t1, t2):
-        if isinstance(t1, torch.Tensor):
-            # Add DIIS vectors
-            self.diis_vals_t1.append(t1.clone())
-            self.diis_vals_t2.append(t2.clone())
-            # Add new error vectors
-            error_t1 = (self.diis_vals_t1[-1] - self.oldt1).ravel()
-            error_t2 = (self.diis_vals_t2[-1] - self.oldt2).ravel()
-            self.diis_errors.append(torch.cat((error_t1, error_t2)))
-            self.oldt1 = t1.clone()
-            self.oldt2 = t2.clone()
+    def add_error_vector(self, T, e):
+        if isinstance(T, torch.Tensor):
+            self.diis_T.append(T.clone())
+            self.diis_errors.append(e.ravel().clone())
         else:
-            # Add DIIS vectors
-            self.diis_vals_t1.append(t1.copy())
-            self.diis_vals_t2.append(t2.copy())
-            # Add new error vectors
-            error_t1 = (self.diis_vals_t1[-1] - self.oldt1).ravel()
-            error_t2 = (self.diis_vals_t2[-1] - self.oldt2).ravel()
-            self.diis_errors.append(np.concatenate((error_t1, error_t2)))
-            self.oldt1 = t1.copy()
-            self.oldt2 = t2.copy()
+            self.diis_T.append(T.copy())
+            self.diis_errors.append(e.ravel())
 
-    def extrapolate(self, t1, t2):
+    def extrapolate(self, T):
         
         if (self.max_diis == 0):
-            return t1, t2
+            return T
 
         # Limit size of DIIS vector
         if (len(self.diis_errors) > self.max_diis):
-            del self.diis_vals_t1[0]
-            del self.diis_vals_t2[0]
+            del self.diis_T[0]
             del self.diis_errors[0]
 
         self.diis_size = len(self.diis_errors)
 
-        if isinstance(t1, torch.Tensor):
+        if isinstance(T, torch.Tensor):
             # Build error matrix B
             if self.precision == 'DP':
-                B = torch.ones((self.diis_size + 1, self.diis_size + 1), dtype=torch.float64, device=self.device1) * -1
+                B = -1 * torch.ones((self.diis_size + 1, self.diis_size + 1), dtype=torch.float64, device=self.device1)
             elif self.precision == 'SP':
-                B = torch.ones((self.diis_size + 1, self.diis_size + 1), dtype=torch.float32, device=self.device1) * -1
+                B = -1 * torch.ones((self.diis_size + 1, self.diis_size + 1), dtype=torch.float32, device=self.device1)
+
             B[-1, -1] = 0
 
             for n1, e1 in enumerate(self.diis_errors):
@@ -87,15 +67,9 @@ class helper_diis(object):
             ci = torch.linalg.solve(B, resid)
 
             # Calculate new amplitudes
-            t1 = torch.zeros_like(self.oldt1)
-            t2 = torch.zeros_like(self.oldt2)
+            T *= 0
             for num in range(self.diis_size):
-                t1 += torch.real(ci[num] * self.diis_vals_t1[num + 1])
-                t2 += torch.real(ci[num] * self.diis_vals_t2[num + 1])
-
-            # Save extrapolated amplitudes to old_t amplitudes
-            self.oldt1 = t1.clone()
-            self.oldt2 = t2.clone()
+                T += torch.real(ci[num] * self.diis_T[num + 1])
 
         else:
             # Build error matrix B
@@ -126,17 +100,11 @@ class helper_diis(object):
             ci = np.linalg.solve(B, resid)
 
             # Calculate new amplitudes
-            t1 = np.zeros_like(self.oldt1)
-            t2 = np.zeros_like(self.oldt2)
+            T *= 0
             for num in range(self.diis_size):
-                t1 += ci[num] * self.diis_vals_t1[num + 1]
-                t2 += ci[num] * self.diis_vals_t2[num + 1]
+                T += ci[num] * self.diis_T[num + 1]
 
-            # Save extrapolated amplitudes to old_t amplitudes
-            self.oldt1 = t1.copy()
-            self.oldt2 = t2.copy()
-
-        return t1, t2
+        return T
 
 class cc_contract(object):
     """


### PR DESCRIPTION
## Description
Modifying DIIS code to be somewhat simpler internally, though the interface will now require the caller to create the error vectors.

## Todos
  - [X] Modify the DIIS class to use residuals as error vectors and avoid T1- and T2-type tensors as separate arguments.
  - [X] Modify the calling codes to create their own error vectors and to 'np.hstack' their amplitudes for extrapolation.

## Status
- [X] Ready to go