### PR TITLE
Adding the missing term in T3 equation for RT-CC3

### DIFF
--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -290,7 +290,7 @@ class ccdensity(object):
                     Zlmdi[i,j] += contract('def,ife->di', l3, t2[k])
                     # Dov_1
                     t3 = t3c_ijk(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
-		    if real_time is True:
+                    if real_time is True:
                         if isinstance(t1, torch.Tensor):
                             V = F - self.ccwfn.H.F.clone()
                         else:
@@ -311,7 +311,7 @@ class ccdensity(object):
         for b in range(nv): 
             for c in range(nv):
                 t3 = t3c_bc(o, v, b, c, t2, Wvvvo, Wovoo, F, contract)
-		if real_time is True:
+                if real_time is True:
                     if isinstance(t2, torch.Tensor):
                         V = F - self.ccwfn.H.F.clone()
                     else:
@@ -334,7 +334,7 @@ class ccdensity(object):
             for j in range(no):
                 for k in range(no):
                     t3 = t3c_ijk(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
-		    if real_time is True:
+                    if real_time is True:
                         if isinstance(t2, torch.Tensor):
                             V = F - self.ccwfn.H.F.clone()
                         else:
@@ -399,7 +399,7 @@ class ccdensity(object):
                 tmp = contract('imea,kmef->iakf', t2, l2)
                 Dooov += contract('iakf,jf->ijka', tmp, t1)
 	
-	        if isinstance(tmp, torch.Tensor):
+                if isinstance(tmp, torch.Tensor):
                     del tmp, Goo
 
             tmp = contract('kmef,jf->kmej', l2, t1)
@@ -452,7 +452,7 @@ class ccdensity(object):
                 tmp = contract('mibe,nmce->ibnc', t2, l2)
                 Dvvvo -= contract('ibnc,na->abci', tmp, t1)
 		
-		if isinstance(tmp, torch.Tensor):
+                if isinstance(tmp, torch.Tensor):
                     del tmp, Gvv
 
             tmp = contract('nmce,ie->nmci', l2, t1)
@@ -573,7 +573,7 @@ class ccdensity(object):
                 tmp = contract('mnei,njae->mija', tmp, t2)
                 Doovv += contract('mb,mija->ijab', t1, tmp)
 		
-		if isinstance(tmp, torch.Tensor):
+                if isinstance(tmp, torch.Tensor):
                     del tmp, tmp1, tmp2, Goo, Gvv
 
             tmp = contract('jf,mnef->mnej', t1, l2)

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -11,7 +11,7 @@ import time
 from opt_einsum import contract
 from .utils import helper_diis
 import torch
-from .cctriples import t3c_ijk, l3_ijk, l3_ijk_alt
+from .cctriples import t3c_ijk, l3_ijk, l3_ijk_alt, t3_pert_ijk
 
 
 class cclambda(object):
@@ -346,6 +346,12 @@ class cclambda(object):
                 for n in range(no):
                     for l in range(no):
                         t3_lmn = t3c_ijk(o, v, l, m, n, t2, Wvvvo, Wovoo, F, contract, WithDenom=True)
+			if self.ccwfn.real_time is True:
+                            if isinstance(t1, torch.Tensor):
+                                V = F - self.ccwfn.H.F.clone()
+                            else:
+                                V = F - self.ccwfn.H.F.copy()
+                            t3_lmn -= t3_pert_ijk(o, v, l, m, n, t2, V, F, contract)
                         Zmndi[m,n] += contract('def,ief->di', t3_lmn, ERI[o,l,v,v])
                         Zmndi[m,n] -= contract('fed,ief->di', t3_lmn, L[o,l,v,v])
                         Zmdfa[m] += contract('def,ea->dfa', t3_lmn, ERI[n,l,v,v])
@@ -386,7 +392,13 @@ class cclambda(object):
             for l in range(no):
                 for m in range(no):
                     for n in range(no):
-                        t3_lmn = t3c_ijk(o, v, l, m, n, t2, Wvvvo, Wovoo, F, contract, WithDenom=True)        
+                        t3_lmn = t3c_ijk(o, v, l, m, n, t2, Wvvvo, Wovoo, F, contract, WithDenom=True)
+			if self.ccwfn.real_time is True:
+                            if isinstance(t1, torch.Tensor):
+                                V = F - self.ccwfn.H.F.clone()
+                            else:
+                                V = F - self.ccwfn.H.F.copy()
+                            t3_lmn -= t3_pert_ijk(o, v, l, m, n, t2, V, F, contract)
                         Znf[n] += contract('de,def->f', l2[l,m], (t3_lmn - t3_lmn.swapaxes(0,2)))          
             for m in range(no):
                 Y1 += contract('idf,dfa->ia', l2[:,m], Zmdfa[m])

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -346,7 +346,7 @@ class cclambda(object):
                 for n in range(no):
                     for l in range(no):
                         t3_lmn = t3c_ijk(o, v, l, m, n, t2, Wvvvo, Wovoo, F, contract, WithDenom=True)
-			if self.ccwfn.real_time is True:
+                        if self.ccwfn.real_time is True:
                             if isinstance(t1, torch.Tensor):
                                 V = F - self.ccwfn.H.F.clone()
                             else:
@@ -393,7 +393,7 @@ class cclambda(object):
                 for m in range(no):
                     for n in range(no):
                         t3_lmn = t3c_ijk(o, v, l, m, n, t2, Wvvvo, Wovoo, F, contract, WithDenom=True)
-			if self.ccwfn.real_time is True:
+                        if self.ccwfn.real_time is True:
                             if isinstance(t1, torch.Tensor):
                                 V = F - self.ccwfn.H.F.clone()
                             else:

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -88,7 +88,7 @@ class ccwfn(object):
         self.make_t3_density = kwargs.pop('make_t3_density', False)
 
         # RT-CC3 calculations requiring additional terms when an external perturbation is present 
-	self.real_time = kwargs.pop('real_time', False)
+        self.real_time = kwargs.pop('real_time', False)
 
         valid_local_models = [None, 'PNO', 'PAO','CPNO++','PNO++']
         local = kwargs.pop('local', None)

--- a/pycc/rt/lasers.py
+++ b/pycc/rt/lasers.py
@@ -58,3 +58,34 @@ class delta_pulse_laser:
             pulse = 0
         return pulse
 
+# ramped continuous wave (RCW)
+# set nr=0 for a regular cosine wave
+class lrcw_laser:
+    def __init__(self, F_str, omega, nr):
+        self.F_str = F_str
+        self.omega = omega
+        self.nr = nr
+    def __call__(self, t):
+        tc = 2 * np.pi / self.omega * self.nr
+        if t <= tc:            
+            pulse = t / tc * self.F_str * np.cos(self.omega * t)
+        else:
+            pulse = self.F_str * np.cos(self.omega * t)
+        return pulse
+
+class qrcw_laser:
+    def __init__(self, F_str, omega, nr):
+        self.F_str = F_str
+        self.omega = omega
+        self.nr = nr
+    def __call__(self, t):
+        tc = 2 * np.pi / self.omega * self.nr
+        if t <= 0.5 * tc:            
+            pulse = 2 * t ** 2 / tc ** 2 * self.F_str * np.cos(self.omega * t)
+        elif t <= tc:
+            pulse = (1 - 2 * (t - tc) ** 2 / tc ** 2)* self.F_str * np.cos(self.omega * t)
+        else:
+            pulse = self.F_str * np.cos(self.omega * t)
+        return pulse
+
+

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -122,7 +122,7 @@ class rtcc(object):
             F = self.ccwfn.H.F.copy() + self.mu_tot * self.V(t)
 
         # Compute the current residuals
-        rt1, rt2 = self.ccwfn.residuals(F, t1, t2)
+        rt1, rt2 = self.ccwfn.residuals(F, t1, t2, real_time=True)
         rt1 = rt1 * (-1.0j)
         rt2 = rt2 * (-1.0j)
         if self.ccwfn.local is not None:
@@ -207,7 +207,7 @@ class rtcc(object):
 
         return t1, t2, l1, l2, phase
 
-    def dipole(self, t1, t2, l1, l2, magnetic = False):
+    def dipole(self, t1, t2, l1, l2, magnetic = False, real_time=False):
         """
         Parameters
         ----------
@@ -222,7 +222,7 @@ class rtcc(object):
             Cartesian components of the correlated dipole moment
         """
         if self.ccwfn.model == 'CC3':
-            (opdm, opdm_cc3) = self.ccdensity.compute_onepdm(t1, t2, l1, l2)
+            (opdm, opdm_cc3) = self.ccdensity.compute_onepdm(t1, t2, l1, l2, real_time=real_time)
         else:
             opdm = self.ccdensity.compute_onepdm(t1, t2, l1, l2)
 

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -240,6 +240,10 @@ class rtcc(object):
             else:
                 ints_cc3 = np.zeros_like(ints)
             for i in range(3):
+                if isinstance(t1, torch.Tensor):                    
+                    ints_cc3 = ints_cc3.type_as(t1)
+                else:
+                    ints_cc3 = ints_cc3.astype(t1.dtype)
                 ints_cc3[i][:no,:no] = self.ccdensity.build_Moo(no, nv, ints[i], t1)     
                 ints_cc3[i][-nv:,-nv:] = self.ccdensity.build_Mvv(no, nv, ints[i], t1)      
      

--- a/pycc/tests/test_037_rtcc3.py
+++ b/pycc/tests/test_037_rtcc3.py
@@ -1,0 +1,70 @@
+"""
+Test RT-CC3 propagation on water molecule.
+"""
+
+# Import package, test suite, and other packages as needed
+import psi4
+import pycc
+import pytest
+from pycc.rt.integrators import rk4
+from pycc.rt.lasers import qrcw_laser
+from ..data.molecules import *
+
+def test_rtcc_he_cc_pvdz():
+    """H2O cc-pVDZ"""
+    psi4.set_memory('2 GiB')
+    psi4.core.set_output_file('output.dat', False)
+    psi4.set_options({'basis': 'cc-pVDZ',
+                      'scf_type': 'pk',
+                      'mp2_type': 'conv',
+                      'freeze_core': 'false',
+                      'e_convergence': 1e-12,
+                      'd_convergence': 1e-12,
+                      'r_convergence': 1e-12,
+                      'diis': 1})
+    mol = psi4.geometry(moldict["H2O_Teach"])
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+
+    e_conv = 1e-12
+    r_conv = 1e-12
+
+    cc = pycc.ccwfn(rhf_wfn, model='CC3', real_time=True)
+    ecc = cc.solve_cc(e_conv, r_conv)
+
+    hbar = pycc.cchbar(cc)
+
+    cclambda = pycc.cclambda(cc, hbar)
+    lecc = cclambda.solve_lambda(e_conv, r_conv)
+
+    ccdensity = pycc.ccdensity(cc, cclambda)
+
+    # quadratic ramped continuous wave (QRCW)
+    F_str = 0.002
+    omega = 0.078
+    nr = 1
+    V = qrcw_laser(F_str, omega, nr)
+
+    # RT-CC Setup
+    phase = 0
+    t0 = 0
+    tf = 0.05
+    h = 0.01
+    t = t0
+    rtcc = pycc.rtcc(cc, cclambda, ccdensity, V, kick='x')
+    y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2, phase)
+    y = y0
+    ODE = rk4(h)
+    t1, t2, l1, l2, phase = rtcc.extract_amps(y0)
+    mu0_x, mu0_y, mu0_z = rtcc.dipole(t1, t2, l1, l2)
+
+    mu_z_ref = -0.0859645691 #CFOUR
+
+    while t < tf:
+        y = ODE(rtcc.f, t, y)
+        t += h
+        t1, t2, l1, l2, phase = rtcc.extract_amps(y)
+        mu_x, mu_y, mu_z = rtcc.dipole(t1, t2, l1, l2, real_time=True)
+        
+    print(mu_z)
+    assert (abs(mu_z_ref - mu_z.real) < 1e-10)
+


### PR DESCRIPTION
## Description
Add the missing term in T3 equation for RT-CC3. (Required when an external perturbation is present, also useful for CC3 linear response for future reference.) 

Add linear and quadratic ramped continuous wave (LRCW&QRCW) to the types of lasers available in PyCC. (Useful for calculating polarizabilities, G', etc. with RT methods.)

**'real_time' parameter is added to specify if the term is required in CC3 calculations. The default value is 'False', only need to specify and set to 'True' when running RT-CC3 calculations. The usage of all other methods or levels of theory will not be affected. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add the missing term in T3 equation.
  - [x] Modify residuals and densities involving the corrected triples.  
  - [x] Add LRCW and QRCW to lasers.py.
  - [x] Add test for RT-CC3.

## Status
- [x] Ready to go