### PR TITLE
Adding Einsums-capable energy codes

### DIFF
--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -104,6 +104,10 @@ def t3d_abc(o, v, a, b, c, t1, t2, Woovv, F, contract, WithDenom=True):
 
 # Lee and Rendell's formulation
 def t_tjl(ccwfn):
+    contract = ccwfn.contract
+    if ccwfn.einsums:
+        contract = ccwfn.ec.contract
+
     o = ccwfn.o
     v = ccwfn.v
     no = ccwfn.no
@@ -112,7 +116,6 @@ def t_tjl(ccwfn):
     ERI = ccwfn.H.ERI
     t1 = ccwfn.t1
     t2 = ccwfn.t2
-    contract = ccwfn.contract
 
     ET = 0.0
     for i in range(no):
@@ -155,6 +158,9 @@ def t_tjl(ccwfn):
 # Vikings' formulation
 def t_vikings(ccwfn):
     contract = ccwfn.contract
+    if ccwfn.einsums:
+        contract = ccwfn.ec.contract
+
     o = ccwfn.o
     v = ccwfn.v
     no = ccwfn.no
@@ -173,12 +179,20 @@ def t_vikings(ccwfn):
     for i in range(no):
         for j in range(no):
             for k in range(no):
+                if ccwfn.einsums:
+                    contract = ccwfn.ec.contract
+
                 t3 = t3c_ijk(o, v, i, j, k, t2, ERI[v,v,v,o], ERI[o,v,o,o], F, contract)
 
                 X1[i] += contract('abc,bc->a',(t3 - t3.swapaxes(0,2)), L[j,k,v,v])
-                X2[i,j] += contract('abc,c->ab',(t3 - t3.swapaxes(0,2)), F[k,v])
                 X2[i,j] += contract('abc,dbc->ad', (2.0*t3 - t3.swapaxes(1,2) - t3.swapaxes(0,2)),ERI[v,k,v,v])
                 X2[i] -= contract('abc,lc->lab', (2.0*t3 - t3.swapaxes(1,2) - t3.swapaxes(0,2)),ERI[j,k,o,v])
+
+#                contract = ccwfn.contract
+                X2[i,j] += contract('abc,c->ab',(t3 - t3.swapaxes(0,2)), F[k,v])
+
+    if ccwfn.einsums:
+        contract = ccwfn.ec.contract
 
     ET = 2.0 * contract('ia,ia->', t1, X1)
     ET += contract('ijab,ijab->', (4.0*t2 - 2.0*t2.swapaxes(2,3)), X2)
@@ -189,6 +203,9 @@ def t_vikings(ccwfn):
 # Vikings' formulation – inverted algorithm
 def t_vikings_inverted(ccwfn):
     contract = ccwfn.contract
+    if ccwfn.einsums:
+        contract = ccwfn.ec.contract
+
     o = ccwfn.o
     v = ccwfn.v
     no = ccwfn.no
@@ -204,12 +221,19 @@ def t_vikings_inverted(ccwfn):
     for a in range(nv):
         for b in range(nv):
             for c in range(nv):
+                if ccwfn.einsums:
+                    contract = ccwfn.ec.contract
                 t3 = t3c_abc(o, v, a, b, c, t2, ERI[v,v,v,o], ERI[o,v,o,o], F, contract, True)
 
                 X1[a] += contract('ijk,jk->i',(t3 - t3.swapaxes(0,2)), L[o,o,b+no,c+no])
-                X2[a,b] += contract('ijk,k->ij',(t3 - t3.swapaxes(0,2)), F[o,c+no])
                 X2[a] += contract('ijk,dk->dij', (2.0*t3 - t3.swapaxes(1,2) - t3.swapaxes(0,2)),ERI[v,o,b+no,c+no])
                 X2[a,b] -= contract('ijk,jkl->il', (2.0*t3 - t3.swapaxes(1,2) - t3.swapaxes(0,2)),ERI[o,o,o,c+no])
+
+#                contract = ccwfn.contract
+                X2[a,b] += contract('ijk,k->ij',(t3 - t3.swapaxes(0,2)), F[o,c+no])
+
+    if ccwfn.einsums:
+        contract = ccwfn.ec.contract
 
     ET = 2.0 * contract('ia,ia->', t1, X1.T)
     ET += contract('ijab,ijab->', (4.0*t2 - 2.0*t2.swapaxes(2,3)), X2.T)

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -9,16 +9,24 @@ if __name__ == "__main__":
 import psi4
 import time
 import numpy as np
+
 try:
     import torch
     HAS_TORCH = True
 except ImportError:
     HAS_TORCH = False
+
 from .utils import helper_diis, cc_contract
 from .hamiltonian import Hamiltonian
 from .local import Local
 from .cctriples import t_tjl, t3c_ijk, t3d_ijk, t3c_abc, t3d_abc, t3_pert_ijk
 from .lccwfn import lccwfn
+
+try:
+    import einsums as ein
+    HAS_EINSUMS = True
+except ImportError:
+    HAS_EINSUMS = False
 
 class ccwfn(object):
     """
@@ -235,6 +243,22 @@ class ccwfn(object):
                 self.H.ERI = torch.tensor(self.H.ERI, dtype=torch.complex64, device=self.device0)
                 self.H.L = torch.tensor(self.H.L, dtype=torch.complex64, device=self.device0)
                 
+        self.einsums = kwargs.pop('einsums', False)
+        if self.einsums and HAS_EINSUMS:
+            self.ec = ein.einsums_contract()
+            print('Contractions will use the C++ Einsums library where implemented...')
+        elif self.einsums and not HAS_EINSUMS:
+            self.einsums = False
+            print('C++ Einsums library requested but not available.')
+
+        # Compute MP2 energy as einsums test
+        if self.einsums:
+            t2 = 2*self.t2 - self.t2.swapaxes(2,3)
+            emp2 = self.contract('ijab,ijab->', t2, self.H.ERI[o,o,v,v])
+            print("E(MP2) = %20.15f (opt_einsums)" % (emp2))
+            emp2 = self.ec.contract('ijab,ijab->', t2, self.H.ERI[o,o,v,v])
+            print("E(MP2) = %20.15f (einsums)" % (emp2))
+
         print("CCWFN object initialized in %.3f seconds." % (time.time() - time_init))
 
 
@@ -268,6 +292,8 @@ class ccwfn(object):
         Dijab = self.Dijab
 
         contract = self.contract
+        if self.einsums:
+            contract = self.ec.contract
 
         ecc = self.cc_energy(o, v, F, L, self.t1, self.t2)
         print("CC Iter %3d: CC Ecorr = %.15f  dE = % .5E  MP2" % (0, ecc, -ecc))
@@ -284,8 +310,7 @@ class ccwfn(object):
                 inc1, inc2 = self.Local.filter_amps(r1, r2)
                 self.t1 += inc1
                 self.t2 += inc2
-                rms = contract('ia,ia->', inc1, inc1)
-                rms += contract('ijab,ijab->', inc2, inc2)
+                rms = contract('ia,ia->', inc1, inc1) + contract('ijab,ijab->', inc2, inc2)
                 if HAS_TORCH and isinstance(r1, torch.Tensor):
                     rms = torch.sqrt(rms)
                 else:
@@ -293,8 +318,8 @@ class ccwfn(object):
             else:
                 self.t1 += r1/Dia
                 self.t2 += r2/Dijab
-                rms = contract('ia,ia->', r1/Dia, r1/Dia)
-                rms += contract('ijab,ijab->', r2/Dijab, r2/Dijab)
+                rms = contract('ia,ia->', r1/Dia, r1/Dia) + contract('ijab,ijab->', r2/Dijab, r2/Dijab)
+#rms = ec.contract('ia,ia->', r1/Dia, r1/Dia) + ec.contract('ijab,ijab->', r2/Dijab, r2/Dijab)
                 if HAS_TORCH and isinstance(r1, torch.Tensor):
                     rms = torch.sqrt(rms)
                 else:
@@ -353,6 +378,8 @@ class ccwfn(object):
         """
 
         contract = self.contract
+        if self.einsums:
+            contract = self.ec.contract
 
         o = self.o
         v = self.v
@@ -389,20 +416,27 @@ class ccwfn(object):
                 X1 = np.zeros_like(t1)
                 X2 = np.zeros_like(t2)
 
+            contract = self.contract
             for i in range(no):
                 for j in range(no):
                     for k in range(no):
+                        if self.einsums:
+                            contract = self.ec.contract
                         t3 = t3c_ijk(o, v, i, j, k, t2, Wabei_cc3, Wmbij_cc3, F, contract, WithDenom=True)
+
                         if real_time is True:
                             if HAS_TORCH and isinstance(t1, torch.Tensor):
                                 V = F - self.H.F.clone()
                             else:
                                 V = F - self.H.F.copy()
                             t3 -= t3_pert_ijk(o, v, i, j, k, t2, V, F, contract)
+
                         X1[i] += contract('abc,bc->a', t3 - t3.swapaxes(0,2), L[j,k,v,v])
-                        X2[i,j] += contract('abc,c->ab', t3 - t3.swapaxes(0,2), Fme[k])
+
                         X2[i,j] += contract('abc,dbc->ad', 2 * t3 - t3.swapaxes(1,2) - t3.swapaxes(0,2), Wamef_cc3.swapaxes(0,1)[k])
-                        X2[i] -= contract('abc,lc->lab', 2 * t3 - t3.swapaxes(1,2) - t3.swapaxes(0,2), Wmnie_cc3[j,k])
+                        X2[i] -= contract('lc,abc->lab', Wmnie_cc3[j,k], (2 * t3 - t3.swapaxes(1,2) - t3.swapaxes(0,2)))
+                        contract = self.contract
+                        X2[i,j] += contract('abc,c->ab', t3 - t3.swapaxes(0,2), Fme[k])
 
             r1 += X1
             r2 += X2 + X2.swapaxes(0,1).swapaxes(2,3)
@@ -414,11 +448,18 @@ class ccwfn(object):
 
     def build_tau(self, t1, t2, fact1=1.0, fact2=1.0):
         contract = self.contract
-        return fact1 * t2 + fact2 * contract('ia,jb->ijab', t1, t1)
+        if self.einsums:
+            tau = fact1 * np.transpose(t2, (3,2,1,0)) + fact2 * self.ec.contract('ai,bj->baji', t1.T, t1.T)
+            return np.transpose(tau, (3,2,1,0))
+        else:
+            return fact1 * t2 + fact2 * contract('ia,jb->ijab', t1, t1)
 
 
     def build_Fae(self, o, v, F, L, t1, t2):
         contract = self.contract
+        if self.einsums:
+            contract = self.ec.contract
+
         if self.model == 'CCD':
             if HAS_TORCH and isinstance(t1, torch.Tensor):
                 Fae = F[v,v].clone()
@@ -438,6 +479,9 @@ class ccwfn(object):
 
     def build_Fmi(self, o, v, F, L, t1, t2):
         contract = self.contract
+        if self.einsums:
+            contract = self.ec.contract
+
         if self.model == 'CCD':
             if HAS_TORCH and isinstance(t1, torch.Tensor):
                 Fmi = F[o,o].clone()
@@ -457,6 +501,9 @@ class ccwfn(object):
 
     def build_Fme(self, o, v, F, L, t1):
         contract = self.contract
+        if self.einsums:
+            contract = self.ec.contract
+
         if self.model == 'CCD':
             return
         else:
@@ -470,6 +517,9 @@ class ccwfn(object):
 
     def build_Wmnij(self, o, v, ERI, t1, t2):
         contract = self.contract
+        if self.einsums:
+            contract = self.ec.contract
+
         if self.model == 'CCD':
             if HAS_TORCH and isinstance(t1, torch.Tensor):
                 Wmnij = ERI[o,o,o,o].clone().to(self.device1)
@@ -484,7 +534,8 @@ class ccwfn(object):
             Wmnij = Wmnij + contract('je,mnie->mnij', t1, ERI[o,o,o,v])
             Wmnij = Wmnij + contract('ie,mnej->mnij', t1, ERI[o,o,v,o])
             if self.model == 'CC2':
-                Wmnij = Wmnij + contract('jf, mnif->mnij', t1, contract('ie,mnef->mnif', t1, ERI[o,o,v,v]))
+                tmp = contract('mnef,ei->mnif', ERI[o,o,v,v], t1.T)
+                Wmnij = Wmnij + contract('mnif,fj->mnij', tmp, t1.T)
             else:
                 Wmnij = Wmnij + contract('ijef,mnef->mnij', self.build_tau(t1, t2), ERI[o,o,v,v])
         return Wmnij
@@ -492,6 +543,9 @@ class ccwfn(object):
 
     def build_Wmbej(self, o, v, ERI, L, t1, t2):
         contract = self.contract
+        if self.einsums:
+            contract = self.ec.contract
+
         if self.model == 'CCD':
             if HAS_TORCH and isinstance(t1, torch.Tensor):
                 Wmbej = ERI[o,v,v,o].clone().to(self.device1)
@@ -515,6 +569,9 @@ class ccwfn(object):
 
     def build_Wmbje(self, o, v, ERI, t1, t2):
         contract = self.contract
+        if self.einsums:
+            contract = self.ec.contract
+
         if self.model == 'CCD':
             if HAS_TORCH and isinstance(t1, torch.Tensor):
                 Wmbje = -1.0 * ERI[o,v,o,v].clone().to(self.device1)
@@ -536,16 +593,23 @@ class ccwfn(object):
 
     def build_Zmbij(self, o, v, ERI, t1, t2):
         contract = self.contract
+        if self.einsums:
+            contract = self.ec.contract
+
         if self.model == 'CCD':
             return
         elif self.model == 'CC2':
-            return contract('mbif,jf->mbij', contract('mbef,ie->mbif', ERI[o,v,v,v], t1), t1)
+            tmp = contract('mbef,ie->mbif', ERI[o,v,v,v], t1)
+            return contract('mbif,fj->mbij', tmp, t1.T)
         else:
             return contract('mbef,ijef->mbij', ERI[o,v,v,v], self.build_tau(t1, t2))
 
 
     def r_T1(self, o, v, F, ERI, L, t1, t2, Fae, Fme, Fmi):
         contract = self.contract
+        if self.einsums:
+            contract = self.ec.contract
+
         if self.model == 'CCD':
             if HAS_TORCH and isinstance(t1, torch.Tensor):
                 r_T1 = torch.zero_like(t1)
@@ -557,7 +621,7 @@ class ccwfn(object):
             else:
                 r_T1 = F[o,v].copy()
             r_T1 = r_T1 + contract('ie,ae->ia', t1, Fae)
-            r_T1 = r_T1 - contract('ma,mi->ia', t1, Fmi)
+            r_T1 = r_T1 - contract('mi,ma->ia', Fmi, t1)
             r_T1 = r_T1 + contract('imae,me->ia', (2.0*t2 - t2.swapaxes(2,3)), Fme)
             r_T1 = r_T1 + contract('nf,nafi->ia', t1, L[o,v,v,o])
             r_T1 = r_T1 + contract('mief,maef->ia', (2.0*t2 - t2.swapaxes(2,3)), ERI[o,v,v,v])
@@ -567,15 +631,18 @@ class ccwfn(object):
 
     def r_T2(self, o, v, F, ERI, L, t1, t2, Fae, Fme, Fmi, Wmnij, Wmbej, Wmbje, Zmbij):
         contract = self.contract
+        if self.einsums:
+            contract = self.ec.contract
+
         if self.model == 'CCD':
             if HAS_TORCH and isinstance(t1, torch.Tensor):
                 r_T2 = 0.5 * ERI[o,o,v,v].clone().to(self.device1)
             else:
                 r_T2 = 0.5 * ERI[o,o,v,v].copy()
-            r_T2 = r_T2 + contract('ijae,be->ijab', t2, Fae)
+            r_T2 = r_T2 + contract('ijae,eb->ijab', t2, Fae.T)
             r_T2 = r_T2 - contract('imab,mj->ijab', t2, Fmi)
-            r_T2 = r_T2 + 0.5 * contract('mnab,mnij->ijab', t2, Wmnij)
             r_T2 = r_T2 + 0.5 * contract('ijef,abef->ijab', t2, ERI[v,v,v,v])
+            r_T2 = r_T2 + 0.5 * contract('mnij,mnab->ijab', Wmnij, t2)
             r_T2 = r_T2 + contract('imae,mbej->ijab', (t2 - t2.swapaxes(2,3)), Wmbej)
             r_T2 = r_T2 + contract('imae,mbej->ijab', t2, (Wmbej + Wmbje.swapaxes(2,3)))
             r_T2 = r_T2 + contract('mjae,mbie->ijab', t2, Wmbje)
@@ -584,10 +651,13 @@ class ccwfn(object):
                 r_T2 = 0.5 * ERI[o,o,v,v].clone().to(self.device1)
             else:
                 r_T2 = 0.5 * ERI[o,o,v,v].copy()
-            r_T2 = r_T2 + contract('ijae,be->ijab', t2, (F[v,v] - 0.5 * contract('me,ma->ae', F[o,v], t1)))
+
+            tmp = F[v,v] - 0.5 * contract('me,ma->ae', F[o,v], t1)
+            r_T2 = r_T2 + contract('ijae,eb->ijab', t2, tmp.T)
             tmp = contract('mb,me->be', t1, F[o,v])
-            r_T2 = r_T2 - 0.5 * contract('ijae,be->ijab', t2, tmp)
-            r_T2 = r_T2 - contract('imab,mj->ijab', t2, (F[o,o] + 0.5 * contract('ie,me->mi', t1, F[o,v])))
+            r_T2 = r_T2 - 0.5 * contract('ijae,eb->ijab', t2, tmp.T)
+            tmp = F[o,o] + 0.5 * contract('ie,me->mi', t1, F[o,v])
+            r_T2 = r_T2 - contract('imab,mj->ijab', t2, tmp)
             tmp = contract('je,me->jm', t1, F[o,v])
             r_T2 = r_T2 - 0.5 * contract('imab,jm->ijab', t2, tmp)
             r_T2 = r_T2 + 0.5 * contract('ma,mbij->ijab', t1, contract('nb,mnij->mbij', t1, Wmnij))
@@ -597,6 +667,7 @@ class ccwfn(object):
             r_T2 = r_T2 - contract('mb,maji->ijab', t1, contract('ie,maje->maji', t1, ERI[o,v,o,v]))
             r_T2 = r_T2 + contract('ie,abej->ijab', t1, ERI[v,v,v,o])
             r_T2 = r_T2 - contract('ma,mbij->ijab', t1, ERI[o,v,o,o])
+            contract = self.contract
             if HAS_TORCH and isinstance(tmp, torch.Tensor):
                 del tmp
         else:
@@ -604,21 +675,21 @@ class ccwfn(object):
                 r_T2 = 0.5 * ERI[o,o,v,v].clone().to(self.device1)
             else:
                 r_T2 = 0.5 * ERI[o,o,v,v].copy()
-            r_T2 = r_T2 + contract('ijae,be->ijab', t2, Fae)
-            tmp = contract('mb,me->be', t1, Fme)
-            r_T2 = r_T2 - 0.5 * contract('ijae,be->ijab', t2, tmp)
+            r_T2 = r_T2 + contract('ijae,eb->ijab', t2, Fae.T)
+            tmp = contract('bm,me->be', t1.T, Fme)
+            r_T2 = r_T2 - 0.5 * contract('ijae,eb->ijab', t2, tmp.T)
             r_T2 = r_T2 - contract('imab,mj->ijab', t2, Fmi)
-            tmp = contract('je,me->jm', t1, Fme)
-            r_T2 = r_T2 - 0.5 * contract('imab,jm->ijab', t2, tmp)
+            tmp = contract('je,em->jm', t1, Fme.T)
+            r_T2 = r_T2 - 0.5 * contract('imab,mj->ijab', t2, tmp.T)
             r_T2 = r_T2 + 0.5 * contract('mnab,mnij->ijab', self.build_tau(t1, t2), Wmnij)
             r_T2 = r_T2 + 0.5 * contract('ijef,abef->ijab', self.build_tau(t1, t2), ERI[v,v,v,v])
             r_T2 = r_T2 - contract('ma,mbij->ijab', t1, Zmbij)
             r_T2 = r_T2 + contract('imae,mbej->ijab', (t2 - t2.swapaxes(2,3)), Wmbej)
             r_T2 = r_T2 + contract('imae,mbej->ijab', t2, (Wmbej + Wmbje.swapaxes(2,3)))
             r_T2 = r_T2 + contract('mjae,mbie->ijab', t2, Wmbje)
-            tmp = contract('ie,ma->imea', t1, t1)
-            r_T2 = r_T2 - contract('imea,mbej->ijab', tmp, ERI[o,v,v,o])
-            r_T2 = r_T2 - contract('imeb,maje->ijab', tmp, ERI[o,v,o,v])
+            tmp = contract('ei,am->aemi', t1.T, t1.T)
+            r_T2 = r_T2 - contract('imea,mbej->ijab', np.transpose(tmp, (3,2,1,0)), ERI[o,v,v,o])
+            r_T2 = r_T2 - contract('imeb,maje->ijab', np.transpose(tmp, (3,2,1,0)), ERI[o,v,o,v])
             r_T2 = r_T2 + contract('ie,abej->ijab', t1, ERI[v,v,v,o])
             r_T2 = r_T2 - contract('ma,mbij->ijab', t1, ERI[o,v,o,o])
 
@@ -718,6 +789,8 @@ class ccwfn(object):
 
     def cc_energy(self, o, v, F, L, t1, t2):
         contract = self.contract
+        if self.einsums:
+            contract = self.ec.contract
         if self.model == 'CCD':
             ecc = contract('ijab,ijab->', t2, L[o,o,v,v])
         else:

--- a/pycc/tests/test_038_ccsd_einsums.py
+++ b/pycc/tests/test_038_ccsd_einsums.py
@@ -1,0 +1,43 @@
+"""
+Test CCSD equation solution using various molecule test cases.
+"""
+
+# Import package, test suite, and other packages as needed
+import psi4
+import pycc
+import pytest
+from ..data.molecules import *
+from pycc.ccwfn import HAS_EINSUMS
+
+@pytest.mark.skipif(not HAS_EINSUMS, reason="Einsums not installed")
+def test_ccsd_h2o():
+    # Psi4 Setup
+    psi4.set_memory('2 GB')
+    psi4.core.set_output_file('output.dat', False)
+    psi4.set_options({'basis': 'STO-3G',
+                      'scf_type': 'pk',
+                      'mp2_type': 'conv',
+                      'freeze_core': 'true',
+                      'e_convergence': 1e-12,
+                      'd_convergence': 1e-12,
+                      'r_convergence': 1e-12,
+                      'diis': 1})
+    mol = psi4.geometry(moldict["H2O"])
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+
+    maxiter = 75
+    e_conv = 1e-12
+    r_conv = 1e-12
+    
+    ccsd = pycc.ccwfn(rhf_wfn, einsums=True)
+    eccsd = ccsd.solve_cc(e_conv,r_conv,maxiter)
+    epsi4 = -0.070616830152761  
+    assert (abs(epsi4 - eccsd) < 1e-11)
+
+    # cc-pVDZ basis set
+    psi4.set_options({'basis': 'cc-pVDZ'})
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+    ccsd = pycc.ccwfn(rhf_wfn, einsums=True)
+    eccsd = ccsd.solve_cc(e_conv,r_conv,maxiter)
+    epsi4 = -0.222029814166783
+    assert (abs(epsi4 - eccsd) < 1e-11)

--- a/pycc/tests/test_039_ccd_einsums.py
+++ b/pycc/tests/test_039_ccd_einsums.py
@@ -1,0 +1,44 @@
+"""
+Test CCD equation solution using various molecule test cases.
+"""
+
+# Import package, test suite, and other packages as needed
+import psi4
+import pycc
+import pytest
+from ..data.molecules import *
+from pycc.ccwfn import HAS_EINSUMS
+
+@pytest.mark.skipif(not HAS_EINSUMS, reason="Einsums not installed")
+def test_ccd_h2o():
+    # Psi4 Setup
+    psi4.set_memory('2 GB')
+    psi4.core.set_output_file('output.dat', False)
+    psi4.set_options({'basis': 'cc-pVDZ',
+                      'scf_type': 'pk',
+                      'mp2_type': 'conv',
+                      'freeze_core': 'false',
+                      'e_convergence': 1e-12,
+                      'd_convergence': 1e-12,
+                      'r_convergence': 1e-12,
+                      'diis': 1})
+    mol = psi4.geometry(moldict["H2O"])
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+
+    maxiter = 75
+    e_conv = 1e-12
+    r_conv = 1e-12
+    cc = pycc.ccwfn(rhf_wfn, model='CCD', einsums=True)
+    ecc = cc.solve_cc(e_conv,r_conv,maxiter)
+    epsi4 = -0.222559319034  # Checked against CFOUR
+    assert (abs(epsi4 - ecc) < 1e-11)
+
+    hbar = pycc.cchbar(cc)
+    cclambda = pycc.cclambda(cc, hbar)
+    lcc = cclambda.solve_lambda(e_conv, r_conv)
+    lcc_cfour = -0.218758826700
+    assert (abs(lcc - lcc_cfour) < 1e-11)
+
+    ccdensity = pycc.ccdensity(cc, cclambda)
+    ecc = ccdensity.compute_energy()
+    assert (abs(epsi4 - ecc) < 1e-11)

--- a/pycc/tests/test_040_cc2_einsums.py
+++ b/pycc/tests/test_040_cc2_einsums.py
@@ -1,0 +1,78 @@
+"""
+Test CC2 equation solution using various molecule test cases.
+"""
+
+# Import package, test suite, and other packages as needed
+import psi4
+import pycc
+import pytest
+from ..data.molecules import *
+from pycc.ccwfn import HAS_EINSUMS
+
+@pytest.mark.skipif(not HAS_EINSUMS, reason="Einsums not installed")
+def test_cc2_h2o():
+    # Psi4 Setup
+    psi4.set_memory('2 GB')
+    psi4.core.set_output_file('output.dat', False)
+    psi4.set_options({'basis': 'cc-pVDZ',
+                      'scf_type': 'pk',
+                      'mp2_type': 'conv',
+                      'freeze_core': 'false',
+                      'e_convergence': 1e-12,
+                      'd_convergence': 1e-12,
+                      'r_convergence': 1e-12,
+                      'diis': 1})
+    mol = psi4.geometry(moldict["H2O"])
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+
+    maxiter = 75
+    e_conv = 1e-12
+    r_conv = 1e-12
+    cc = pycc.ccwfn(rhf_wfn, model='CC2', einsums=True)
+    ecc = cc.solve_cc(e_conv,r_conv,maxiter)
+    epsi4 = -0.215857544656
+    assert (abs(epsi4 - ecc) < 1e-11)
+
+    hbar = pycc.cchbar(cc)
+    cclambda = pycc.cclambda(cc, hbar)
+    lcc = cclambda.solve_lambda(e_conv, r_conv)
+    lcc_psi4 = -0.215765740373555
+    assert(abs(lcc - lcc_psi4) < 1e-11)
+
+    ccdensity = pycc.ccdensity(cc, cclambda)
+    ecc = ccdensity.compute_energy()
+    assert (abs(epsi4 - ecc) < 1e-11)
+
+@pytest.mark.skipif(not HAS_EINSUMS, reason="Einsums not installed")
+def test_cc2_h2():
+    # Psi4 Setup
+    psi4.set_memory('2 GB')
+    psi4.core.set_output_file('output.dat', False)
+    psi4.set_options({'basis': 'cc-pVDZ',
+                      'scf_type': 'pk',
+                      'mp2_type': 'conv',
+                      'freeze_core': 'false',
+                      'e_convergence': 1e-12,
+                      'd_convergence': 1e-12,
+                      'r_convergence': 1e-12,
+                      'diis': 1})
+    mol = psi4.geometry(moldict["H2"])
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+
+    maxiter = 75
+    e_conv = 1e-12
+    r_conv = 1e-12
+    cc = pycc.ccwfn(rhf_wfn, model='CC2', einsums=True)
+    ecc = cc.solve_cc(e_conv,r_conv,maxiter)
+    epsi4 = -0.026445902512140185
+    assert (abs(epsi4 - ecc) < 1e-11)
+
+    hbar = pycc.cchbar(cc)
+    cclambda = pycc.cclambda(cc, hbar)
+    lcc = cclambda.solve_lambda(e_conv, r_conv)
+    lcc_psi4 = -0.026443139737993
+    assert(abs(lcc - lcc_psi4) < 1e-11)
+
+    ccdensity = pycc.ccdensity(cc, cclambda)
+    ecc = ccdensity.compute_energy()
+    assert (abs(epsi4 - ecc) < 1e-11)

--- a/pycc/tests/test_041_ccsd_t_einsums.py
+++ b/pycc/tests/test_041_ccsd_t_einsums.py
@@ -1,0 +1,62 @@
+"""
+Test CCSD equation solution using various molecule test cases.
+"""
+
+# Import package, test suite, and other packages as needed
+import psi4
+import pycc
+import pytest
+from ..data.molecules import *
+from ..cctriples import t_vikings, t_vikings_inverted, t_tjl
+from pycc.ccwfn import HAS_EINSUMS
+
+@pytest.mark.skipif(not HAS_EINSUMS, reason="Einsums not installed")
+def test_ccsd_t_h2o():
+    """H2O cc-pVDZ"""
+    # Psi4 Setup
+    psi4.set_memory('2 GB')
+    psi4.core.set_output_file('output.dat', False)
+    psi4.set_options({'basis': 'STO-3G',
+                      'scf_type': 'pk',
+                      'mp2_type': 'conv',
+                      'freeze_core': 'true',
+                      'e_convergence': 1e-12,
+                      'd_convergence': 1e-12,
+                      'r_convergence': 1e-12,
+                      'diis': 1})
+    mol = psi4.geometry(moldict["H2O"])
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+
+    maxiter = 75
+    e_conv = 1e-12
+    r_conv = 1e-12
+
+    cc = pycc.ccwfn(rhf_wfn, model='ccsd(t)', einsums=True)
+    eccsd = cc.solve_cc(e_conv,r_conv,maxiter)
+    et_vik_ijk = t_vikings(cc)
+    et_vik_abc = t_vikings_inverted(cc)
+    et_tjl = t_tjl(cc)
+    epsi4 = -0.000099957499645
+    print("E(T) = %20.15f (Vikings' IJK)" % (et_vik_ijk))
+    print("E(T) = %20.15f (Vikings' ABC)" % (et_vik_abc))
+    print("E(T) = %20.15f (Lee/Rendell IJK)" % (et_tjl))
+    print("E(T) = %20.15f (Psi4)" % (epsi4))
+    assert (abs(epsi4 - et_vik_ijk) < 1e-11)
+    assert (abs(epsi4 - et_vik_abc) < 1e-11)
+    assert (abs(epsi4 - et_tjl) < 1e-11)
+
+    psi4.set_options({'basis': 'cc-pVDZ'})
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+    cc = pycc.ccwfn(rhf_wfn, model='ccsd(t)', einsums=True)
+    eccsd = cc.solve_cc(e_conv,r_conv,maxiter)
+    et_vik_ijk = t_vikings(cc)
+    et_vik_abc = t_vikings_inverted(cc)
+    et_tjl = t_tjl(cc)
+    epsi4 = -0.003861236558801
+    print("E(T) = %20.15f (Vikings' IJK)" % (et_vik_ijk))
+    print("E(T) = %20.15f (Vikings' ABC)" % (et_vik_abc))
+    print("E(T) = %20.15f (Lee/Rendell IJK)" % (et_tjl))
+    print("E(T) = %20.15f (Psi4)" % (epsi4))
+    assert (abs(epsi4 - et_vik_ijk) < 1e-11)
+    assert (abs(epsi4 - et_vik_abc) < 1e-11)
+    assert (abs(epsi4 - et_tjl) < 1e-11)

--- a/pycc/tests/test_042_cc3_einsums.py
+++ b/pycc/tests/test_042_cc3_einsums.py
@@ -1,0 +1,38 @@
+"""
+Test CC3 equation solution using various molecule test cases.
+"""
+
+# Import package, test suite, and other packages as needed
+import psi4
+import pycc
+import pytest
+from ..data.molecules import *
+import numpy as np
+from pycc.ccwfn import HAS_EINSUMS
+
+# H2O/cc-pVDZ
+@pytest.mark.skipif(not HAS_EINSUMS, reason="Einsums not installed")
+def test_cc3_h2o():
+    # Psi4 Setup
+    psi4.set_memory('2 GB')
+    psi4.core.set_output_file('output.dat', False)
+    psi4.set_options({'basis': 'cc-pVDZ',
+                      'scf_type': 'pk',
+                      'mp2_type': 'conv',
+                      'freeze_core': 'false',
+                      'e_convergence': 1e-12,
+                      'd_convergence': 1e-12,
+                      'r_convergence': 1e-12,
+                      'diis': 1})
+    mol = psi4.geometry(moldict["H2O_Teach"])
+    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+
+    maxiter = 75
+    e_conv = 1e-12
+    r_conv = 1e-12
+    cc = pycc.ccwfn(rhf_wfn, model='CC3', einsums=True)
+    ecc = cc.solve_cc(e_conv,r_conv,maxiter)
+    epsi4 = -0.227888246840310
+    ecfour = -0.2278882468404231
+    assert (abs(epsi4 - ecc) < 1e-11)
+


### PR DESCRIPTION
Adding Einsums-capable energy codes, including CCSD, CCSD(T), CCD, CC2, and CC3

## Description
This PR adds CCD, CC2, CCSD, CCSD(T), and CC3 energies using Einsums (pyeinsums) contractions.  An additional argument to the `ccwfn` class of `einsums=True` turns the contractions on.  Otherwise, it defaults to `opt_einsum`.

## Todos
  - [x] CCD energies
  - [x] CC2 energies
  - [x] CCSD energies
  - [x] CCSD(T) energies
  - [x] CC3 energies
  - [x] Test cases for all of the above.  (These will not run if the user hasn't installed pyeinsums.)

## Questions
- [x] One contraction in the triples codes for (T) and CC3 does not convert properly from `opt_einsum` to Einsums.  The reason for this is not clear, but I've marked it in the code (`cctriples` and `ccwfn`).

## Status
- [x] Ready to go