### PR TITLE
Removing pubchem call for ethylene due to CI http instabilities.

### DIFF
--- a/pycc/tests/test_036_lr.py
+++ b/pycc/tests/test_036_lr.py
@@ -10,6 +10,7 @@ import pycc
 from ..data.molecules import *
 
 def test_linresp():
+    psi4.core.clean()
     psi4.core.clean_options()
     psi4.set_memory('2 GiB')
     psi4.set_output_file('output.dat', False)

--- a/pycc/tests/test_037_rtcc3.py
+++ b/pycc/tests/test_037_rtcc3.py
@@ -12,6 +12,7 @@ from ..data.molecules import *
 
 def test_rtcc_he_cc_pvdz():
     """H2O cc-pVDZ"""
+    psi4.core.clean()
     psi4.set_memory('2 GiB')
     psi4.core.set_output_file('output.dat', False)
     psi4.set_options({'basis': 'cc-pVDZ',

--- a/pycc/tests/test_043_eomccsd.py
+++ b/pycc/tests/test_043_eomccsd.py
@@ -112,8 +112,15 @@ def test_eomccsd_c2h4_fc():
                       'd_convergence': 1e-12,
                       'r_convergence': 1e-12,
                       'diis': 1})
-    mol = psi4.geometry("pubchem:ethylene")
-    mol.reset_point_group("c1")
+    mol = psi4.geometry("""
+C            0.000000000000     0.667203595356     0.000000000000
+C            0.000000000000    -0.667196404644     0.000000000000
+H           -0.931693962629     1.221303595356     0.000000000000
+H            0.931693962629     1.221203595356     0.000000000000
+H            0.931693962629    -1.221296404644     0.000000000000
+H           -0.931693962629    -1.221296404644     0.000000000000
+units angstrom
+""")
     rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
 
     maxiter = 75


### PR DESCRIPTION
## Description
CI was failing because connections to pubchem to get the ethylene geometry were unreliable.  This removes that requirement and changes the name of the test case file to avoid a conflict with test_035_cpnoppcc.py.

## Todos
  - [X] Removes pubchem call and replaces it with static ethylene geometry.
  - [X] Changes test case file name.

## Status
- [X] Ready to go