### PR TITLE
Fix packaging, GPU CCD residual bug, and repo hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,14 @@ pycc/tests/ref_t1.pk
 pycc/tests/ref_t2.pk
 pycc/tests/t1.pk
 pycc/tests/t2.pk
+
+# Psi4 scratch / cleanup files (named psi.<pid>.clean, etc.)
+psi.*.clean
+psi.*
+
+# Misc leftover test/profiling output
+ijk.dat
+profile.txt
+
+# macOS
+.DS_Store

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -344,7 +344,6 @@ class ccwfn(object):
                 self.t1 += r1/Dia
                 self.t2 += r2/Dijab
                 rms = contract('ia,ia->', r1/Dia, r1/Dia) + contract('ijab,ijab->', r2/Dijab, r2/Dijab)
-#rms = ec.contract('ia,ia->', r1/Dia, r1/Dia) + ec.contract('ijab,ijab->', r2/Dijab, r2/Dijab)
                 if HAS_TORCH and isinstance(r1, torch.Tensor):
                     rms = torch.sqrt(rms)
                 else:
@@ -637,7 +636,7 @@ class ccwfn(object):
 
         if self.model == 'CCD':
             if HAS_TORCH and isinstance(t1, torch.Tensor):
-                r_T1 = torch.zero_like(t1)
+                r_T1 = torch.zeros_like(t1)
             else:
                 r_T1 = np.zeros_like(t1)
         else:

--- a/pycc/data/__init__.py
+++ b/pycc/data/__init__.py
@@ -1,0 +1,1 @@
+"""Reference data for PyCC (molecule geometries, etc.)."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ test = [
 branch = true
 omit = ["*/tests/*", "*site-packages*", "*__init__.py"]
 
-[tool.setuptools]
-packages = ["pycc"]
+[tool.setuptools.packages.find]
+include = ["pycc*"]
 
 # [tool.setuptools.aliases]
 # can't be done in pyproject.toml so use `pytest` itself


### PR DESCRIPTION
- pyproject.toml: discover subpackages via setuptools find (include pycc*) so pycc.rt, pycc.data, and pycc.tests are shipped in a non-editable install instead of only the top-level package.
- pycc/data: add __init__.py so it is a real subpackage (tests import from ..data.molecules; find_packages skips dirs without __init__).
- ccwfn.py: fix torch.zero_like -> torch.zeros_like on the GPU CCD residual path (AttributeError when running CCD on Torch tensors).
- ccwfn.py: remove orphaned de-indented commented-out line.
- .gitignore: ignore Psi4 scratch (psi.*.clean), ijk.dat, profile.txt, and .DS_Store leftovers.

## Status
- [X] Ready to go