### PR TITLE
Add shared rhf_wfn pytest fixture; de-duplicate test setup

### DIFF
--- a/pycc/tests/conftest.py
+++ b/pycc/tests/conftest.py
@@ -1,0 +1,90 @@
+"""Shared pytest fixtures for the PyCC test suite.
+
+Centralizes the Psi4 boilerplate (scratch memory, output file, SCF options,
+geometry + SCF call) that was previously copy-pasted into every test module.
+
+A test now obtains its reference wavefunction through the ``rhf_wfn`` factory::
+
+    def test_ccsd_h2o(rhf_wfn):
+        wfn = rhf_wfn("H2O", "STO-3G")
+        ccsd = pycc.ccwfn(wfn)
+        ...
+
+The ``pycc.ccwfn(...)`` call (model, local, einsums, ... kwargs) legitimately
+varies per test and intentionally stays in the test body.
+"""
+
+import psi4
+import pytest
+
+from pycc.data.molecules import moldict
+
+# Psi4 SCF options shared by essentially every test in the suite. Individual
+# tests override any of these (most commonly 'basis' and 'freeze_core') by
+# passing keyword arguments to the rhf_wfn factory.
+DEFAULT_SCF_OPTIONS = {
+    'scf_type': 'pk',
+    'mp2_type': 'conv',
+    'freeze_core': 'true',
+    'e_convergence': 1e-12,
+    'd_convergence': 1e-12,
+    'r_convergence': 1e-12,
+    'diis': 1,
+}
+
+
+@pytest.fixture
+def psi4_environment():
+    """Put Psi4 in a clean, quiet state around a test.
+
+    Sets scratch memory, redirects output to ``output.dat``, and clears global
+    options so settings do not leak between test modules; cleans scratch files
+    on teardown. Not autouse: it only affects tests that opt in, either by
+    requesting it directly or (more commonly) via the ``rhf_wfn`` factory, so
+    tests that manage their own Psi4 state are untouched.
+    """
+    psi4.set_memory('2 GB')
+    psi4.core.set_output_file('output.dat', False)
+    psi4.core.clean_options()
+    yield
+    psi4.core.clean()
+
+
+@pytest.fixture
+def rhf_wfn(psi4_environment):
+    """Factory fixture that builds an RHF reference wavefunction.
+
+    Returns a callable so a single test can build several references (e.g. the
+    same molecule in different bases)::
+
+        def test_x(rhf_wfn):
+            wfn  = rhf_wfn("H2O", "STO-3G")
+            wfn2 = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false")
+
+    Parameters
+    ----------
+    molecule : str
+        Either a key into ``pycc.data.molecules.moldict`` (e.g. "H2O",
+        "H2O_Teach") or a literal Psi4 geometry string (for the one-off
+        geometries some tests define inline).
+    basis : str, optional
+        Psi4 basis-set name. Defaults to "cc-pVDZ", the suite's most common basis.
+    geom_extra : str, optional
+        Extra lines appended to the geometry block, e.g. ``"\\nnoreorient\\nnocom"``
+        or ``"\\nsymmetry c1"``.
+    **options
+        Additional Psi4 options, overriding (or extending) DEFAULT_SCF_OPTIONS.
+
+    Returns
+    -------
+    psi4.core.Wavefunction
+        The converged RHF wavefunction (the ``return_wfn=True`` object).
+    """
+    def _build(molecule, basis="cc-pVDZ", geom_extra="", **options):
+        opts = {**DEFAULT_SCF_OPTIONS, 'basis': basis, **options}
+        psi4.set_options(opts)
+        geometry = moldict.get(molecule, molecule)  # moldict key, else literal geometry
+        psi4.geometry(geometry + geom_extra)
+        _, wfn = psi4.energy('SCF', return_wfn=True)
+        return wfn
+    return _build

--- a/pycc/tests/test_002_ccsd_energy.py
+++ b/pycc/tests/test_002_ccsd_energy.py
@@ -8,34 +8,21 @@ import pycc
 import pytest
 from ..data.molecules import *
 
-def test_ccsd_h2o():
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'STO-3G',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'true',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
+def test_ccsd_h2o(rhf_wfn):
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    
-    ccsd = pycc.ccwfn(rhf_wfn)
+
+    # STO-3G basis set
+    wfn = rhf_wfn("H2O", "STO-3G")
+    ccsd = pycc.ccwfn(wfn)
     eccsd = ccsd.solve_cc(e_conv,r_conv,maxiter)
-    epsi4 = -0.070616830152761  
+    epsi4 = -0.070616830152761
     assert (abs(epsi4 - eccsd) < 1e-11)
 
     # cc-pVDZ basis set
-    psi4.set_options({'basis': 'cc-pVDZ'})
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-    ccsd = pycc.ccwfn(rhf_wfn)
+    wfn = rhf_wfn("H2O", "cc-pVDZ")
+    ccsd = pycc.ccwfn(wfn)
     eccsd = ccsd.solve_cc(e_conv,r_conv,maxiter)
     epsi4 = -0.222029814166783
     assert (abs(epsi4 - eccsd) < 1e-11)

--- a/pycc/tests/test_003_ccsd_lambda.py
+++ b/pycc/tests/test_003_ccsd_lambda.py
@@ -9,27 +9,14 @@ import pytest
 from ..data.molecules import *
 
 
-def test_lambda_ccsd_h2o():
+def test_lambda_ccsd_h2o(rhf_wfn):
     """H2O STO-3G"""
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'STO-3G',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'true',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    
-    ccsd = pycc.ccwfn(rhf_wfn)
+
+    wfn = rhf_wfn("H2O", "STO-3G")
+    ccsd = pycc.ccwfn(wfn)
     eccsd = ccsd.solve_cc(e_conv, r_conv)
     hbar = pycc.cchbar(ccsd)
     cclambda = pycc.cclambda(ccsd, hbar)
@@ -40,9 +27,8 @@ def test_lambda_ccsd_h2o():
     assert (abs(lpsi4 - lccsd) < 1e-11)
 
     # cc-pVDZ basis set
-    psi4.set_options({'basis': 'cc-pVDZ'})
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-    ccsd = pycc.ccwfn(rhf_wfn)
+    wfn = rhf_wfn("H2O", "cc-pVDZ")
+    ccsd = pycc.ccwfn(wfn)
     eccsd = ccsd.solve_cc(e_conv,r_conv,maxiter)
     hbar = pycc.cchbar(ccsd)
     cclambda = pycc.cclambda(ccsd, hbar)

--- a/pycc/tests/test_004_ccsd_density.py
+++ b/pycc/tests/test_004_ccsd_density.py
@@ -10,27 +10,14 @@ import pytest
 from ..data.molecules import *
 
 
-def test_density_ccsd_h2o():
+def test_density_ccsd_h2o(rhf_wfn):
     """H2O"""
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'STO-3G',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'true',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    
-    ccsd = pycc.ccwfn(rhf_wfn)
+
+    wfn = rhf_wfn("H2O", "STO-3G")
+    ccsd = pycc.ccwfn(wfn)
     eccsd = ccsd.solve_cc(e_conv, r_conv)
     hbar = pycc.cchbar(ccsd)
     cclambda = pycc.cclambda(ccsd, hbar)
@@ -43,9 +30,8 @@ def test_density_ccsd_h2o():
     assert (abs(lpsi4 - lccsd) < 1e-11)
     assert (abs(epsi4 - ecc_density) < 1e-11)
 
-    psi4.set_options({'basis': 'cc-pVDZ'})
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-    ccsd = pycc.ccwfn(rhf_wfn)
+    wfn = rhf_wfn("H2O", "cc-pVDZ")
+    ccsd = pycc.ccwfn(wfn)
     eccsd = ccsd.solve_cc(e_conv, r_conv)
     hbar = pycc.cchbar(ccsd)
     cclambda = pycc.cclambda(ccsd, hbar)

--- a/pycc/tests/test_005_ccsd_t_energy.py
+++ b/pycc/tests/test_005_ccsd_t_energy.py
@@ -9,27 +9,14 @@ import pytest
 from ..data.molecules import *
 from ..cctriples import t_vikings, t_vikings_inverted, t_tjl
 
-def test_ccsd_t_h2o():
+def test_ccsd_t_h2o(rhf_wfn):
     """H2O cc-pVDZ"""
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'STO-3G',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'true',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
 
-    cc = pycc.ccwfn(rhf_wfn, model='ccsd(t)')
+    wfn = rhf_wfn("H2O", "STO-3G")
+    cc = pycc.ccwfn(wfn, model='ccsd(t)')
     eccsd = cc.solve_cc(e_conv,r_conv,maxiter)
     et_vik_ijk = t_vikings(cc)
     et_vik_abc = t_vikings_inverted(cc)
@@ -39,9 +26,8 @@ def test_ccsd_t_h2o():
     assert (abs(epsi4 - et_vik_abc) < 1e-11)
     assert (abs(epsi4 - et_tjl) < 1e-11)
 
-    psi4.set_options({'basis': 'cc-pVDZ'})
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-    cc = pycc.ccwfn(rhf_wfn, model='ccsd(t)')
+    wfn = rhf_wfn("H2O", "cc-pVDZ")
+    cc = pycc.ccwfn(wfn, model='ccsd(t)')
     eccsd = cc.solve_cc(e_conv,r_conv,maxiter)
     et_vik_ijk = t_vikings(cc)
     et_vik_abc = t_vikings_inverted(cc)

--- a/pycc/tests/test_006_rtccsd.py
+++ b/pycc/tests/test_006_rtccsd.py
@@ -10,25 +10,14 @@ from scipy.integrate import complex_ode as ode
 from pycc.rt.lasers import sine_square_laser
 from ..data.molecules import *
 
-def test_rtcc_he_cc_pvdz():
+def test_rtcc_he_cc_pvdz(rhf_wfn):
     """He cc-pVDZ"""
-    psi4.set_memory('2 GiB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["He"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     e_conv = 1e-13
     r_conv = 1e-13
 
-    cc = pycc.ccwfn(rhf_wfn)
+    wfn = rhf_wfn("He", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+    cc = pycc.ccwfn(wfn)
     ecc = cc.solve_cc(e_conv, r_conv)
 
     hbar = pycc.cchbar(cc)

--- a/pycc/tests/test_007_dipole.py
+++ b/pycc/tests/test_007_dipole.py
@@ -9,25 +9,14 @@ import pytest
 import numpy as np
 from ..data.molecules import *
 
-def test_dipole_h2_2_cc_pvdz():
+def test_dipole_h2_2_cc_pvdz(rhf_wfn):
     """H4 cc-pVDZ"""
-    psi4.set_memory('2 GiB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["(H2)_2"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     e_conv = 1e-13
     r_conv = 1e-13
-    
-    cc = pycc.ccwfn(rhf_wfn)
+
+    wfn = rhf_wfn("(H2)_2", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+    cc = pycc.ccwfn(wfn)
     ecc = cc.solve_cc(e_conv, r_conv)
 
     hbar = pycc.cchbar(cc)

--- a/pycc/tests/test_013_pnocc.py
+++ b/pycc/tests/test_013_pnocc.py
@@ -8,28 +8,16 @@ import pycc
 import pytest
 from ..data.molecules import *
 
-def test_pno_ccsd():
+def test_pno_ccsd(rhf_wfn):
     """H2O PNO-CCSD Test"""
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
     max_diis = 8
 
-    ccsd = pycc.ccwfn(rhf_wfn, local='PNO', local_cutoff=1e-5, it2_opt=False)
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+    ccsd = pycc.ccwfn(wfn, local='PNO', local_cutoff=1e-5, it2_opt=False)
     eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter)
 
     hbar = pycc.cchbar(ccsd)
@@ -42,28 +30,16 @@ def test_pno_ccsd():
     assert (abs(epsi4 - eccsd) < 1e-7)
     assert (abs(lpsi4 - lccsd) < 1e-7)
 
-def test_pno_ccsd_opt():
+def test_pno_ccsd_opt(rhf_wfn):
     """H2O PNO-CCSD Test with Optimized Initial T2 Amplitudes"""
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
     max_diis = 8
 
-    ccsd = pycc.ccwfn(rhf_wfn, local='PNO', local_cutoff=1e-5)
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+    ccsd = pycc.ccwfn(wfn, local='PNO', local_cutoff=1e-5)
     eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter)
 
     hbar = pycc.cchbar(ccsd)

--- a/pycc/tests/test_014_field.py
+++ b/pycc/tests/test_014_field.py
@@ -10,25 +10,14 @@ import numpy as np
 from ..data.molecules import *
 from pycc.rt.lasers import gaussian_laser
 
-def test_dipole_h2_2_field():
+def test_dipole_h2_2_field(rhf_wfn):
     """H2 dimer"""
-    psi4.set_memory('2 GiB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': '6-31G',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["(H2)_2"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     e_conv = 1e-13
     r_conv = 1e-13
 
-    cc = pycc.ccwfn(rhf_wfn)
+    wfn = rhf_wfn("(H2)_2", "6-31G", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+    cc = pycc.ccwfn(wfn)
     ecc = cc.solve_cc(e_conv, r_conv)
 
     hbar = pycc.cchbar(cc)

--- a/pycc/tests/test_017_ccd.py
+++ b/pycc/tests/test_017_ccd.py
@@ -8,25 +8,13 @@ import pycc
 import pytest
 from ..data.molecules import *
 
-def test_ccd_h2o():
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
+def test_ccd_h2o(rhf_wfn):
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    cc = pycc.ccwfn(rhf_wfn, model='CCD')
+
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false")
+    cc = pycc.ccwfn(wfn, model='CCD')
     ecc = cc.solve_cc(e_conv,r_conv,maxiter)
     epsi4 = -0.222559319034  # Checked against CFOUR
     assert (abs(epsi4 - ecc) < 1e-11)

--- a/pycc/tests/test_018_paocc.py
+++ b/pycc/tests/test_018_paocc.py
@@ -3,21 +3,14 @@ import pycc
 import numpy as np
 from ..data.molecules import moldict
 
-def test_pao_H8():
+def test_pao_H8(rhf_wfn):
     """PAO-CCSD Test"""
-    # Psi4 Setup
-    psi4.set_memory('1 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'DZ',
-                      'scf_type': 'pk',
-                      'guess': 'core',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'False',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 8})
-    mol = psi4.geometry("""
+    maxiter = 75
+    e_conv = 1e-12
+    r_conv = 1e-12
+    max_diis = 8
+
+    geom = """
         H 0.000000 0.000000 0.000000
         H 0.750000 0.000000 0.000000
         H 0.000000 1.500000 0.000000
@@ -29,15 +22,9 @@ def test_pao_H8():
         symmetry c1
         noreorient
         nocom
-        """)
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-    
-    maxiter = 75
-    e_conv = 1e-12
-    r_conv = 1e-12
-    max_diis = 8
-    
-    ccsd = pycc.ccwfn(rhf_wfn, local='PAO', local_cutoff=2e-2)
+        """
+    wfn = rhf_wfn(geom, "DZ", freeze_core="False", guess="core", diis=8)
+    ccsd = pycc.ccwfn(wfn, local='PAO', local_cutoff=2e-2)
     
     eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter, max_diis)
     
@@ -46,29 +33,16 @@ def test_pao_H8():
 
     assert (abs(psi3_ref - eccsd) < 1e-7)
 
-def test_pao_h2o():
+def test_pao_h2o(rhf_wfn):
     """PAO-CCSD Test 2"""
-    # Psi4 Setup
-    psi4.set_memory('1 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': '6-31g',
-                      'scf_type': 'pk',
-                      'guess': 'core',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'False',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 8})
-    mol = psi4.geometry(moldict["H2O_Teach"] + "\nnoreorient\nnocom\nsymmetry c1")
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-    
     maxiter = 75
     e_conv = 1e-7
     r_conv = 1e-7
     max_diis = 8
-    
-    ccsd = pycc.ccwfn(rhf_wfn, local='PAO', local_cutoff=2e-2)
+
+    wfn = rhf_wfn("H2O_Teach", "6-31g", geom_extra="\nnoreorient\nnocom\nsymmetry c1",
+                  freeze_core="False", guess="core", diis=8)
+    ccsd = pycc.ccwfn(wfn, local='PAO', local_cutoff=2e-2)
     
     eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter, max_diis)
     
@@ -77,29 +51,16 @@ def test_pao_h2o():
     psi3_ref = -0.149361947815815
     assert (abs(psi3_ref - eccsd) < 1e-7)
 
-def test_pao_h2o_frzc():
+def test_pao_h2o_frzc(rhf_wfn):
     """PAO-CCSD Frozen Core Test"""
-    # Psi4 Setup
-    psi4.set_memory('1 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': '6-31g',
-                      'scf_type': 'pk',
-                      'guess': 'core',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'True',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 8})
-    mol = psi4.geometry(moldict["H2O_Teach"] + "\nnoreorient\nnocom\nsymmetry c1")
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-    
     maxiter = 75
     e_conv = 1e-7
     r_conv = 1e-7
     max_diis = 8
-    
-    ccsd = pycc.ccwfn(rhf_wfn, local='PAO', local_cutoff=2e-2)
+
+    wfn = rhf_wfn("H2O_Teach", "6-31g", geom_extra="\nnoreorient\nnocom\nsymmetry c1",
+                  freeze_core="True", guess="core", diis=8)
+    ccsd = pycc.ccwfn(wfn, local='PAO', local_cutoff=2e-2)
     
     eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter, max_diis)
     

--- a/pycc/tests/test_020_cc2.py
+++ b/pycc/tests/test_020_cc2.py
@@ -8,25 +8,13 @@ import pycc
 import pytest
 from ..data.molecules import *
 
-def test_cc2_h2o():
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
+def test_cc2_h2o(rhf_wfn):
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    cc = pycc.ccwfn(rhf_wfn, model='CC2')
+
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false")
+    cc = pycc.ccwfn(wfn, model='CC2')
     ecc = cc.solve_cc(e_conv,r_conv,maxiter)
     epsi4 = -0.215857544656
     assert (abs(epsi4 - ecc) < 1e-11)
@@ -41,25 +29,13 @@ def test_cc2_h2o():
     ecc = ccdensity.compute_energy()
     assert (abs(epsi4 - ecc) < 1e-11)
 
-def test_cc2_h2():
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
+def test_cc2_h2(rhf_wfn):
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    cc = pycc.ccwfn(rhf_wfn, model='CC2')
+
+    wfn = rhf_wfn("H2", "cc-pVDZ", freeze_core="false")
+    cc = pycc.ccwfn(wfn, model='CC2')
     ecc = cc.solve_cc(e_conv,r_conv,maxiter)
     epsi4 = -0.026445902512140185
     assert (abs(epsi4 - ecc) < 1e-11)

--- a/pycc/tests/test_021_rk4.py
+++ b/pycc/tests/test_021_rk4.py
@@ -12,25 +12,14 @@ from pycc.rt.lasers import gaussian_laser
 from ..data.molecules import *
 
 
-def test_rtcc_water_cc_pvdz():
+def test_rtcc_water_cc_pvdz(rhf_wfn):
     """H2O cc-pVDZ"""
-    psi4.set_memory('2 GiB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     e_conv = 1e-13
     r_conv = 1e-13
 
-    cc = pycc.ccwfn(rhf_wfn)
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+    cc = pycc.ccwfn(wfn)
     ecc = cc.solve_cc(e_conv, r_conv)
 
     hbar = pycc.cchbar(cc)

--- a/pycc/tests/test_022_adap_int.py
+++ b/pycc/tests/test_022_adap_int.py
@@ -12,25 +12,14 @@ from pycc.rt.lasers import gaussian_laser
 from ..data.molecules import *
 
 
-def test_rtcc_water_cc_pvdz():
+def test_rtcc_water_cc_pvdz(rhf_wfn):
     """H2O cc-pVDZ"""
-    psi4.set_memory('2 GiB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     e_conv = 1e-13
     r_conv = 1e-13
 
-    cc = pycc.ccwfn(rhf_wfn)
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+    cc = pycc.ccwfn(wfn)
     ecc = cc.solve_cc(e_conv, r_conv)
 
     hbar = pycc.cchbar(cc)

--- a/pycc/tests/test_023_ms_int.py
+++ b/pycc/tests/test_023_ms_int.py
@@ -13,25 +13,14 @@ from pycc.rt.lasers import gaussian_laser
 from ..data.molecules import *
 
 
-def test_rtcc_water_cc_pvdz():
+def test_rtcc_water_cc_pvdz(rhf_wfn):
     """H2O cc-pVDZ"""
-    psi4.set_memory('2 GiB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     e_conv = 1e-13
     r_conv = 1e-13
 
-    cc = pycc.ccwfn(rhf_wfn)
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+    cc = pycc.ccwfn(wfn)
     ecc = cc.solve_cc(e_conv, r_conv)
 
     hbar = pycc.cchbar(cc)

--- a/pycc/tests/test_024_contract_cpu.py
+++ b/pycc/tests/test_024_contract_cpu.py
@@ -12,28 +12,18 @@ from pycc.rt.lasers import gaussian_laser
 from ..data.molecules import *
 
 
-def test_rtcc_water_cc_pvdz():
+def test_rtcc_water_cc_pvdz(rhf_wfn):
     """H2O cc-pVDZ"""
-    psi4.set_memory('2 GiB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     e_conv = 1e-13
     r_conv = 1e-13
-    
+
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+
     # The device for the calculation (CPU/GPU) can be specified.
     # Option: 'CPU', 'GPU'
     # Default: 'CPU'
-    cc = pycc.ccwfn(rhf_wfn)
+    cc = pycc.ccwfn(wfn)
     ecc = cc.solve_cc(e_conv, r_conv)
     
     hbar = pycc.cchbar(cc)

--- a/pycc/tests/test_025_contract_gpu.py
+++ b/pycc/tests/test_025_contract_gpu.py
@@ -14,28 +14,18 @@ from pycc.ccwfn import HAS_TORCH
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not HAS_TORCH, reason="PyTorch not installed")
-def test_rtcc_water_cc_pvdz():
+def test_rtcc_water_cc_pvdz(rhf_wfn):
     """H2O cc-pVDZ"""
-    psi4.set_memory('2 GiB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     e_conv = 1e-13
     r_conv = 1e-13
-    
+
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+
     # The device for the calculation (CPU/GPU) can be specified.
     # Option: 'CPU', 'GPU'
     # Default: 'CPU'
-    cc = pycc.ccwfn(rhf_wfn, device='GPU')
+    cc = pycc.ccwfn(wfn, device='GPU')
     ecc = cc.solve_cc(e_conv, r_conv)
     
     hbar = pycc.cchbar(cc)

--- a/pycc/tests/test_026_autocorrelation.py
+++ b/pycc/tests/test_026_autocorrelation.py
@@ -10,25 +10,14 @@ from scipy.integrate import complex_ode as ode
 from pycc.rt.lasers import sine_square_laser
 from ..data.molecules import *
 
-def test_rtcc_he_cc_pvdz_auto():
+def test_rtcc_he_cc_pvdz_auto(rhf_wfn):
     """He cc-pVDZ"""
-    psi4.set_memory('2 GiB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["He"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     e_conv = 1e-13
     r_conv = 1e-13
 
-    cc = pycc.ccwfn(rhf_wfn)
+    wfn = rhf_wfn("He", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+    cc = pycc.ccwfn(wfn)
     ecc = cc.solve_cc(e_conv, r_conv)
 
     hbar = pycc.cchbar(cc)

--- a/pycc/tests/test_027_linresp.py
+++ b/pycc/tests/test_027_linresp.py
@@ -9,25 +9,14 @@ import pytest
 from ..data.molecules import *
 
 
-def test_polar_h2o_cc_pvdz():
+def test_polar_h2o_cc_pvdz(rhf_wfn):
     """H2O cc-pVDZ"""
-    psi4.set_memory('2 GiB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'STO-3G',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-14,
-                      'd_convergence': 1e-14,
-                      'r_convergence': 1e-14,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     e_conv = 1e-13
     r_conv = 1e-13
 
-    cc = pycc.ccwfn(rhf_wfn)
+    wfn = rhf_wfn("H2O", "STO-3G", freeze_core="false",
+                  e_convergence=1e-14, d_convergence=1e-14, r_convergence=1e-14)
+    cc = pycc.ccwfn(wfn)
     ecc = cc.solve_cc(e_conv, r_conv)
     hbar = pycc.cchbar(cc)
     cclambda = pycc.cclambda(cc, hbar)

--- a/pycc/tests/test_028_pnoppcc.py
+++ b/pycc/tests/test_028_pnoppcc.py
@@ -9,28 +9,16 @@ import pytest
 from ..data.molecules import *
 
 
-def test_pnopp_ccsd():
+def test_pnopp_ccsd(rhf_wfn):
     """H2O PNO++-CCSD Test"""
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 8})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
     max_diis = 8
 
-    ccsd = pycc.ccwfn(rhf_wfn, local='PNO++', local_cutoff=1e-7, it2_opt=False)
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false", diis=8,
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+    ccsd = pycc.ccwfn(wfn, local='PNO++', local_cutoff=1e-7, it2_opt=False)
     eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter)
     
     hbar = pycc.cchbar(ccsd)
@@ -43,28 +31,16 @@ def test_pnopp_ccsd():
     assert (abs(esim - eccsd) < 1e-7)
     assert (abs(lsim - lccsd) < 1e-7)   
 
-def test_pnopp_ccsd_opt():
+def test_pnopp_ccsd_opt(rhf_wfn):
     """H2O PNO++-CCSD with Optimized Initial T2 Amplitudes"""
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 8})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
     max_diis = 8
 
-    ccsd = pycc.ccwfn(rhf_wfn, local='PNO++', local_cutoff=1e-9)
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false", diis=8,
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+    ccsd = pycc.ccwfn(wfn, local='PNO++', local_cutoff=1e-9)
     eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter)
 
     hbar = pycc.cchbar(ccsd)

--- a/pycc/tests/test_030_sp.py
+++ b/pycc/tests/test_030_sp.py
@@ -11,30 +11,19 @@ from pycc.rt.integrators import rk4
 from pycc.rt.lasers import gaussian_laser
 from ..data.molecules import *
 
-def test_rtcc_water_cc_pvdz():
+def test_rtcc_water_cc_pvdz(rhf_wfn):
     """H2O cc-pVDZ"""
-    psi4.set_memory('2 GiB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pvdz',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     e_conv = 1e-7
     r_conv = 1e-7
-    
+
+    wfn = rhf_wfn("H2O", "cc-pvdz", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+
     # The precision for the calculation (single-precision (sp)
     # /double-precision (dp)) can be specified.
     # Option: 'SP', 'DP'
     # Default: 'DP'
-    #cc = pycc.ccwfn(rhf_wfn)
-    cc = pycc.ccwfn(rhf_wfn, precision='SP')
+    cc = pycc.ccwfn(wfn, precision='SP')
     ecc = cc.solve_cc(e_conv, r_conv)
     
     # Check CCSD energy

--- a/pycc/tests/test_031_cc3.py
+++ b/pycc/tests/test_031_cc3.py
@@ -10,25 +10,13 @@ from ..data.molecules import *
 import numpy as np
 
 # H2O/cc-pVDZ
-def test_cc3_h2o():
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O_Teach"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
+def test_cc3_h2o(rhf_wfn):
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    cc = pycc.ccwfn(rhf_wfn, model='CC3')
+
+    wfn = rhf_wfn("H2O_Teach", "cc-pVDZ", freeze_core="false")
+    cc = pycc.ccwfn(wfn, model='CC3')
     ecc = cc.solve_cc(e_conv,r_conv,maxiter)
     epsi4 = -0.227888246840310
     ecfour = -0.2278882468404231
@@ -46,7 +34,7 @@ def test_cc3_h2o():
     rtcc = pycc.rtcc(cc, cclambda, ccdensity, None, magnetic = False)
     
     CFOUR = [0, 0, 0.7703875967] # CFOUR total dipole (CC3 + SCF + nuclear)
-    scf = rhf_wfn.variable('SCF DIPOLE') # PSI4 reference dipole (SCF + nuclear)
+    scf = wfn.variable('SCF DIPOLE') # PSI4 reference dipole (SCF + nuclear)
     ref = CFOUR - scf # Final reference: CC3 only
 
     mu_x, mu_y, mu_z = rtcc.dipole(cc.t1, cc.t2, cclambda.l1, cclambda.l2)

--- a/pycc/tests/test_032_localccd.py
+++ b/pycc/tests/test_032_localccd.py
@@ -8,121 +8,81 @@ import pytest
 from ..data.molecules import *
 
 @pytest.mark.slow
-def test_pno_ccd():
+def test_pno_ccd(rhf_wfn):
     """H2O PNO-CCD Test"""
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-    
     maxiter = 100
     e_conv = 1e-12
     r_conv = 1e-12
-    
+
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+
     #simulation code of pno-ccd
-    ccd_sim = pycc.ccwfn(rhf_wfn, model='CCD',local='PNO', local_cutoff=1e-5,it2_opt=False,filter=True)
+    ccd_sim = pycc.ccwfn(wfn, model='CCD',local='PNO', local_cutoff=1e-5,it2_opt=False,filter=True)
     eccd_sim = ccd_sim.solve_cc(e_conv, r_conv, maxiter)
-    
+
     #pno-ccd
-    lccd = pycc.ccwfn(rhf_wfn,model='CCD', local='PNO', local_cutoff=1e-5,it2_opt=False)
+    lccd = pycc.ccwfn(wfn,model='CCD', local='PNO', local_cutoff=1e-5,it2_opt=False)
     elccd = lccd.lccwfn.solve_lcc(e_conv, r_conv, maxiter) 
 
     assert(abs(eccd_sim - elccd) < 1e-12) 
 
 @pytest.mark.slow
-def test_pnopp_ccd():
+def test_pnopp_ccd(rhf_wfn):
     """H2O PNO++ CCD Test"""
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': '6-31G',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 100
     e_conv = 1e-12
     r_conv = 1e-12
 
+    wfn = rhf_wfn("H2O", "6-31G", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+
     #simulation code of pno++-ccd
-    ccd_sim = pycc.ccwfn(rhf_wfn, model='CCD',local='PNO++', local_cutoff=1e-7,it2_opt=False,filter=True)
+    ccd_sim = pycc.ccwfn(wfn, model='CCD',local='PNO++', local_cutoff=1e-7,it2_opt=False,filter=True)
     eccd_sim = ccd_sim.solve_cc(e_conv, r_conv, maxiter)
 
     #pno++-ccd
-    lccd = pycc.ccwfn(rhf_wfn,model='CCD', local='PNO++', local_cutoff=1e-7,it2_opt=False)
+    lccd = pycc.ccwfn(wfn,model='CCD', local='PNO++', local_cutoff=1e-7,it2_opt=False)
     elccd = lccd.lccwfn.solve_lcc(e_conv, r_conv, maxiter)
 
     assert(abs(eccd_sim - elccd) < 1e-12) 
 
 @pytest.mark.slow
-def test_pno_ccd_opt():
+def test_pno_ccd_opt(rhf_wfn):
     """H2O PNO-CCD with Optimized Initial T2 Amplitudes"""
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 100
     e_conv = 1e-12
     r_conv = 1e-12
 
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+
     #simulation code of pno-ccd
-    ccd_sim = pycc.ccwfn(rhf_wfn, model='CCD',local='PNO', local_cutoff=1e-7,filter=True)
+    ccd_sim = pycc.ccwfn(wfn, model='CCD',local='PNO', local_cutoff=1e-7,filter=True)
     eccd_sim = ccd_sim.solve_cc(e_conv, r_conv, maxiter)
 
     #pno-ccd
-    lccd = pycc.ccwfn(rhf_wfn,model='CCD', local='PNO', local_cutoff=1e-7)
+    lccd = pycc.ccwfn(wfn,model='CCD', local='PNO', local_cutoff=1e-7)
     elccd = lccd.lccwfn.solve_lcc(e_conv, r_conv, maxiter)
 
     assert(abs(eccd_sim - elccd) < 1e-12)
 
 @pytest.mark.slow
-def test_pao_ccd_opt():
+def test_pao_ccd_opt(rhf_wfn):
     """H2O PAO-CCD with Optimized Initial T2 Amplitudes"""
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',   
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 100
     e_conv = 1e-12
     r_conv = 1e-12
 
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+
     #simulation code of pao-ccd
-    ccd_sim = pycc.ccwfn(rhf_wfn, model='CCD',local='PAO', local_cutoff=2e-2,filter=True)
+    ccd_sim = pycc.ccwfn(wfn, model='CCD',local='PAO', local_cutoff=2e-2,filter=True)
     eccd_sim = ccd_sim.solve_cc(e_conv, r_conv, maxiter)
 
     #pao-ccd
-    lccd = pycc.ccwfn(rhf_wfn,model='CCD', local='PAO', local_cutoff=2e-2)
+    lccd = pycc.ccwfn(wfn,model='CCD', local='PAO', local_cutoff=2e-2)
     elccd = lccd.lccwfn.solve_lcc(e_conv, r_conv, maxiter)
 
     assert(abs(eccd_sim - elccd) < 1e-12)

--- a/pycc/tests/test_033_localccsd.py
+++ b/pycc/tests/test_033_localccsd.py
@@ -8,121 +8,81 @@ import pytest
 from ..data.molecules import *
 
 @pytest.mark.slow
-def test_pno_ccsd():
+def test_pno_ccsd(rhf_wfn):
     """H2O PNO-CCSD Test"""
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-    
     maxiter = 100
     e_conv = 1e-12
     r_conv = 1e-12
-    
+
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+
     #simulation code of pno-ccsd
-    ccsd_sim = pycc.ccwfn(rhf_wfn, model='CCSD',local='PNO', local_cutoff=1e-5,it2_opt=False,filter=True)
+    ccsd_sim = pycc.ccwfn(wfn, model='CCSD',local='PNO', local_cutoff=1e-5,it2_opt=False,filter=True)
     eccsd_sim = ccsd_sim.solve_cc(e_conv, r_conv, maxiter)
-    
+
     #pno-ccsd
-    lccsd = pycc.ccwfn(rhf_wfn,model='CCSD', local='PNO', local_cutoff=1e-5,it2_opt=False)
+    lccsd = pycc.ccwfn(wfn,model='CCSD', local='PNO', local_cutoff=1e-5,it2_opt=False)
     elccsd = lccsd.lccwfn.solve_lcc(e_conv, r_conv, maxiter) 
 
     assert(abs(eccsd_sim - elccsd) < 1e-12) 
 
 @pytest.mark.slow
-def test_pnopp_ccsd():
+def test_pnopp_ccsd(rhf_wfn):
     """H2O PNO++ CCSD Test"""
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': '6-31G',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 100
     e_conv = 1e-12
     r_conv = 1e-12
 
+    wfn = rhf_wfn("H2O", "6-31G", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+
     #simulation code of pno++-ccsd
-    ccsd_sim = pycc.ccwfn(rhf_wfn, model='CCSD',local='PNO++', local_cutoff=1e-7,it2_opt=False,filter=True)
+    ccsd_sim = pycc.ccwfn(wfn, model='CCSD',local='PNO++', local_cutoff=1e-7,it2_opt=False,filter=True)
     eccsd_sim = ccsd_sim.solve_cc(e_conv, r_conv, maxiter)
 
     #pno++-ccsd
-    lccsd = pycc.ccwfn(rhf_wfn,model='CCSD', local='PNO++', local_cutoff=1e-7,it2_opt=False)
+    lccsd = pycc.ccwfn(wfn,model='CCSD', local='PNO++', local_cutoff=1e-7,it2_opt=False)
     elccsd = lccsd.lccwfn.solve_lcc(e_conv, r_conv, maxiter)
 
     assert(abs(eccsd_sim - elccsd) < 1e-12) 
 
 @pytest.mark.slow
-def test_pno_ccsd_opt():
+def test_pno_ccsd_opt(rhf_wfn):
     """H2O PNO-CCSD with Optimized Initial T2 Amplitudes"""
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 100
     e_conv = 1e-12
     r_conv = 1e-12
 
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+
     #simulation code of pno-ccsd
-    ccsd_sim = pycc.ccwfn(rhf_wfn, model='CCSD',local='PNO', local_cutoff=1e-5,filter=True)
+    ccsd_sim = pycc.ccwfn(wfn, model='CCSD',local='PNO', local_cutoff=1e-5,filter=True)
     eccsd_sim = ccsd_sim.solve_cc(e_conv, r_conv, maxiter)
 
     #pno-ccsd
-    lccsd = pycc.ccwfn(rhf_wfn,model='CCSD', local='PNO', local_cutoff=1e-5)
+    lccsd = pycc.ccwfn(wfn,model='CCSD', local='PNO', local_cutoff=1e-5)
     elccsd = lccsd.lccwfn.solve_lcc(e_conv, r_conv, maxiter)
 
     assert(abs(eccsd_sim - elccsd) < 1e-12)
 
 @pytest.mark.slow
-def test_pao_ccsd_opt():
+def test_pao_ccsd_opt(rhf_wfn):
     """H2O PAO-CCSD with Optimized Initial T2 Amplitudes"""
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',   
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 100
     e_conv = 1e-12
     r_conv = 1e-12
 
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+
     #simulation code of pao-ccsd
-    ccsd_sim = pycc.ccwfn(rhf_wfn, model='CCSD',local='PAO', local_cutoff=2e-2,filter=True)
+    ccsd_sim = pycc.ccwfn(wfn, model='CCSD',local='PAO', local_cutoff=2e-2,filter=True)
     eccsd_sim = ccsd_sim.solve_cc(e_conv, r_conv, maxiter)
 
     #pao-ccsd
-    lccsd = pycc.ccwfn(rhf_wfn,model='CCSD', local='PAO', local_cutoff=2e-2)
+    lccsd = pycc.ccwfn(wfn,model='CCSD', local='PAO', local_cutoff=2e-2)
     elccsd = lccsd.lccwfn.solve_lcc(e_conv, r_conv, maxiter)
 
     assert(abs(eccsd_sim - elccsd) < 1e-12)

--- a/pycc/tests/test_034_ccsd_t_density.py
+++ b/pycc/tests/test_034_ccsd_t_density.py
@@ -9,38 +9,25 @@ import pytest
 from ..data.molecules import *
 from ..cctriples import t_vikings, t_vikings_inverted, t_tjl
 
-def test_ccsd_t_h2o():
+def test_ccsd_t_h2o(rhf_wfn):
     """H2O cc-pVDZ"""
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'STO-3G',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(
-"""
+    maxiter = 75
+    e_conv = 1e-12
+    r_conv = 1e-12
+
+    geom = """
 O 0.000000000000000   0.000000000000000   0.143225857166674
 H 0.000000000000000  -1.638037301628121  -1.136549142277225
 H 0.000000000000000   1.638037301628121  -1.136549142277225
 symmetry c1
 units bohr
 """
-)
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
-    maxiter = 75
-    e_conv = 1e-12
-    r_conv = 1e-12
+    wfn = rhf_wfn(geom, "STO-3G", freeze_core="false")
 
     etot = psi4.energy('CCSD(T)')
     ecc_psi4 = psi4.variable('CCSD(T) CORRELATION ENERGY')
 
-    cc = pycc.ccwfn(rhf_wfn, model='ccsd(t)', make_t3_density=True)
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', make_t3_density=True)
     ecc = cc.solve_cc(e_conv, r_conv, maxiter, max_diis=0)
     assert (abs(ecc_psi4 - ecc) < 1e-11)
     hbar = pycc.cchbar(cc)
@@ -60,13 +47,12 @@ units bohr
 
     psi4.core.clean()
 
-    psi4.set_options({'basis': 'cc-pVDZ'})
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+    wfn = rhf_wfn(geom, "cc-pVDZ", freeze_core="false")
 
     etot = psi4.energy('CCSD(T)')
     ecc_psi4 = psi4.variable('CCSD(T) CORRELATION ENERGY')
 
-    cc = pycc.ccwfn(rhf_wfn, model='ccsd(t)', make_t3_density=True)
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', make_t3_density=True)
     ecc = cc.solve_cc(e_conv, r_conv, maxiter)
     assert (abs(ecc_psi4 - ecc) < 1e-11)
     hbar = pycc.cchbar(cc)

--- a/pycc/tests/test_035_cpnoppcc.py
+++ b/pycc/tests/test_035_cpnoppcc.py
@@ -9,28 +9,16 @@ import pytest
 from ..data.molecules import *
 
 
-def test_cpnopp_ccsd():
+def test_cpnopp_ccsd(rhf_wfn):
     """H2O CPNO++-CCSD Test"""
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 8})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
     max_diis = 8
 
-    ccsd = pycc.ccwfn(rhf_wfn, local='CPNO++', local_cutoff=1e-7, it2_opt=False)
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false", diis=8,
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+    ccsd = pycc.ccwfn(wfn, local='CPNO++', local_cutoff=1e-7, it2_opt=False)
     eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter)
     
     hbar = pycc.cchbar(ccsd)
@@ -44,28 +32,16 @@ def test_cpnopp_ccsd():
     assert (abs(esim - eccsd) < 1e-7)
     assert (abs(lsim - lccsd) < 1e-7)   
 
-def test_pnopp_ccsd_opt():
+def test_pnopp_ccsd_opt(rhf_wfn):
     """H2O CPNO++-CCSD with Optimized Initial T2 Amplitudes"""
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-13,
-                      'd_convergence': 1e-13,
-                      'r_convergence': 1e-13,
-                      'diis': 8})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
     max_diis = 8
 
-    ccsd = pycc.ccwfn(rhf_wfn, local='CPNO++', local_cutoff=1e-7)
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false", diis=8,
+                  e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
+    ccsd = pycc.ccwfn(wfn, local='CPNO++', local_cutoff=1e-7)
     eccsd = ccsd.solve_cc(e_conv, r_conv, maxiter)
 
     hbar = pycc.cchbar(ccsd)

--- a/pycc/tests/test_036_lr.py
+++ b/pycc/tests/test_036_lr.py
@@ -9,24 +9,12 @@ import pytest
 import pycc
 from ..data.molecules import *
 
-def test_linresp():
-    psi4.core.clean()
-    psi4.core.clean_options()
-    psi4.set_memory('2 GiB')
-    psi4.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'aug-cc-pvdz',
-                      'scf_type': 'pk',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12
-    })
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
+def test_linresp(rhf_wfn):
     e_conv = 1e-12
     r_conv = 1e-12
 
-    cc = pycc.ccwfn(rhf_wfn)
+    wfn = rhf_wfn("H2O", "aug-cc-pvdz", freeze_core="false")
+    cc = pycc.ccwfn(wfn)
     ecc = cc.solve_cc(e_conv, r_conv)
     hbar = pycc.cchbar(cc)
     cclambda = pycc.cclambda(cc, hbar)

--- a/pycc/tests/test_037_rtcc3.py
+++ b/pycc/tests/test_037_rtcc3.py
@@ -10,26 +10,13 @@ from pycc.rt.integrators import rk4
 from pycc.rt.lasers import qrcw_laser
 from ..data.molecules import *
 
-def test_rtcc_he_cc_pvdz():
+def test_rtcc_he_cc_pvdz(rhf_wfn):
     """H2O cc-pVDZ"""
-    psi4.core.clean()
-    psi4.set_memory('2 GiB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O_Teach"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     e_conv = 1e-12
     r_conv = 1e-12
 
-    cc = pycc.ccwfn(rhf_wfn, model='CC3', real_time=True)
+    wfn = rhf_wfn("H2O_Teach", "cc-pVDZ", freeze_core="false")
+    cc = pycc.ccwfn(wfn, model='CC3', real_time=True)
     ecc = cc.solve_cc(e_conv, r_conv)
 
     hbar = pycc.cchbar(cc)

--- a/pycc/tests/test_038_ccsd_einsums.py
+++ b/pycc/tests/test_038_ccsd_einsums.py
@@ -10,34 +10,21 @@ from ..data.molecules import *
 from pycc.ccwfn import HAS_EINSUMS
 
 @pytest.mark.skipif(not HAS_EINSUMS, reason="Einsums not installed")
-def test_ccsd_h2o():
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'STO-3G',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'true',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
+def test_ccsd_h2o(rhf_wfn):
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    
-    ccsd = pycc.ccwfn(rhf_wfn, einsums=True)
+
+    # STO-3G basis set
+    wfn = rhf_wfn("H2O", "STO-3G")
+    ccsd = pycc.ccwfn(wfn, einsums=True)
     eccsd = ccsd.solve_cc(e_conv,r_conv,maxiter)
-    epsi4 = -0.070616830152761  
+    epsi4 = -0.070616830152761
     assert (abs(epsi4 - eccsd) < 1e-11)
 
     # cc-pVDZ basis set
-    psi4.set_options({'basis': 'cc-pVDZ'})
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-    ccsd = pycc.ccwfn(rhf_wfn, einsums=True)
+    wfn = rhf_wfn("H2O", "cc-pVDZ")
+    ccsd = pycc.ccwfn(wfn, einsums=True)
     eccsd = ccsd.solve_cc(e_conv,r_conv,maxiter)
     epsi4 = -0.222029814166783
     assert (abs(epsi4 - eccsd) < 1e-11)

--- a/pycc/tests/test_039_ccd_einsums.py
+++ b/pycc/tests/test_039_ccd_einsums.py
@@ -10,25 +10,13 @@ from ..data.molecules import *
 from pycc.ccwfn import HAS_EINSUMS
 
 @pytest.mark.skipif(not HAS_EINSUMS, reason="Einsums not installed")
-def test_ccd_h2o():
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
+def test_ccd_h2o(rhf_wfn):
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    cc = pycc.ccwfn(rhf_wfn, model='CCD', einsums=True)
+
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false")
+    cc = pycc.ccwfn(wfn, model='CCD', einsums=True)
     ecc = cc.solve_cc(e_conv,r_conv,maxiter)
     epsi4 = -0.222559319034  # Checked against CFOUR
     assert (abs(epsi4 - ecc) < 1e-11)

--- a/pycc/tests/test_040_cc2_einsums.py
+++ b/pycc/tests/test_040_cc2_einsums.py
@@ -10,25 +10,13 @@ from ..data.molecules import *
 from pycc.ccwfn import HAS_EINSUMS
 
 @pytest.mark.skipif(not HAS_EINSUMS, reason="Einsums not installed")
-def test_cc2_h2o():
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
+def test_cc2_h2o(rhf_wfn):
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    cc = pycc.ccwfn(rhf_wfn, model='CC2', einsums=True)
+
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false")
+    cc = pycc.ccwfn(wfn, model='CC2', einsums=True)
     ecc = cc.solve_cc(e_conv,r_conv,maxiter)
     epsi4 = -0.215857544656
     assert (abs(epsi4 - ecc) < 1e-11)
@@ -44,25 +32,13 @@ def test_cc2_h2o():
     assert (abs(epsi4 - ecc) < 1e-11)
 
 @pytest.mark.skipif(not HAS_EINSUMS, reason="Einsums not installed")
-def test_cc2_h2():
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
+def test_cc2_h2(rhf_wfn):
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    cc = pycc.ccwfn(rhf_wfn, model='CC2', einsums=True)
+
+    wfn = rhf_wfn("H2", "cc-pVDZ", freeze_core="false")
+    cc = pycc.ccwfn(wfn, model='CC2', einsums=True)
     ecc = cc.solve_cc(e_conv,r_conv,maxiter)
     epsi4 = -0.026445902512140185
     assert (abs(epsi4 - ecc) < 1e-11)

--- a/pycc/tests/test_041_ccsd_t_einsums.py
+++ b/pycc/tests/test_041_ccsd_t_einsums.py
@@ -11,27 +11,14 @@ from ..cctriples import t_vikings, t_vikings_inverted, t_tjl
 from pycc.ccwfn import HAS_EINSUMS
 
 @pytest.mark.skipif(not HAS_EINSUMS, reason="Einsums not installed")
-def test_ccsd_t_h2o():
+def test_ccsd_t_h2o(rhf_wfn):
     """H2O cc-pVDZ"""
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'STO-3G',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'true',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
 
-    cc = pycc.ccwfn(rhf_wfn, model='ccsd(t)', einsums=True)
+    wfn = rhf_wfn("H2O", "STO-3G")
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', einsums=True)
     eccsd = cc.solve_cc(e_conv,r_conv,maxiter)
     et_vik_ijk = t_vikings(cc)
     et_vik_abc = t_vikings_inverted(cc)
@@ -45,9 +32,8 @@ def test_ccsd_t_h2o():
     assert (abs(epsi4 - et_vik_abc) < 1e-11)
     assert (abs(epsi4 - et_tjl) < 1e-11)
 
-    psi4.set_options({'basis': 'cc-pVDZ'})
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-    cc = pycc.ccwfn(rhf_wfn, model='ccsd(t)', einsums=True)
+    wfn = rhf_wfn("H2O", "cc-pVDZ")
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', einsums=True)
     eccsd = cc.solve_cc(e_conv,r_conv,maxiter)
     et_vik_ijk = t_vikings(cc)
     et_vik_abc = t_vikings_inverted(cc)

--- a/pycc/tests/test_042_cc3_einsums.py
+++ b/pycc/tests/test_042_cc3_einsums.py
@@ -12,25 +12,13 @@ from pycc.ccwfn import HAS_EINSUMS
 
 # H2O/cc-pVDZ
 @pytest.mark.skipif(not HAS_EINSUMS, reason="Einsums not installed")
-def test_cc3_h2o():
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O_Teach"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
+def test_cc3_h2o(rhf_wfn):
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    cc = pycc.ccwfn(rhf_wfn, model='CC3', einsums=True)
+
+    wfn = rhf_wfn("H2O_Teach", "cc-pVDZ", freeze_core="false")
+    cc = pycc.ccwfn(wfn, model='CC3', einsums=True)
     ecc = cc.solve_cc(e_conv,r_conv,maxiter)
     epsi4 = -0.227888246840310
     ecfour = -0.2278882468404231

--- a/pycc/tests/test_043_eomccsd.py
+++ b/pycc/tests/test_043_eomccsd.py
@@ -13,25 +13,13 @@ import sys
 np.set_printoptions(precision=10, linewidth=300, threshold=sys.maxsize, suppress=True)
 
 # H2O/cc-pVDZ
-def test_eomccsd_h2o():
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O_Teach"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+def test_eomccsd_h2o(rhf_wfn):
+    wfn = rhf_wfn("H2O_Teach", "cc-pVDZ", freeze_core="false")
 
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    cc = pycc.ccwfn(rhf_wfn)
+    cc = pycc.ccwfn(wfn)
     ecc = cc.solve_cc(e_conv,r_conv,maxiter)
     hbar = pycc.cchbar(cc)
     eom = pycc.cceom(cc, hbar)
@@ -56,25 +44,13 @@ def test_eomccsd_h2o():
     assert(abs(eom_E_guess_3[2] - psi_E[2]) < 1e-5)
 
 # Test frozen core
-def test_eomccsd_h2o_fc():
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'true',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2O_Teach"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+def test_eomccsd_h2o_fc(rhf_wfn):
+    wfn = rhf_wfn("H2O_Teach", "cc-pVDZ")
 
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    cc = pycc.ccwfn(rhf_wfn)
+    cc = pycc.ccwfn(wfn)
     ecc = cc.solve_cc(e_conv,r_conv,maxiter)
     hbar = pycc.cchbar(cc)
     eom = pycc.cceom(cc, hbar)
@@ -99,20 +75,8 @@ def test_eomccsd_h2o_fc():
     assert(abs(eom_E_guess_3[2] - psi_E[2]) < 1e-5)
 
 
-def test_eomccsd_c2h4_fc():
-    # Psi4 Setup
-    psi4.core.clean()
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'true',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry("""
+def test_eomccsd_c2h4_fc(rhf_wfn):
+    wfn = rhf_wfn("""
 C            0.000000000000     0.667203595356     0.000000000000
 C            0.000000000000    -0.667196404644     0.000000000000
 H           -0.931693962629     1.221303595356     0.000000000000
@@ -120,13 +84,12 @@ H            0.931693962629     1.221203595356     0.000000000000
 H            0.931693962629    -1.221296404644     0.000000000000
 H           -0.931693962629    -1.221296404644     0.000000000000
 units angstrom
-""")
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
+""", "cc-pVDZ")
 
     maxiter = 75
     e_conv = 1e-12
     r_conv = 1e-12
-    cc = pycc.ccwfn(rhf_wfn)
+    cc = pycc.ccwfn(wfn)
     ecc = cc.solve_cc(e_conv,r_conv,maxiter)
     hbar = pycc.cchbar(cc)
     eom = pycc.cceom(cc, hbar)
@@ -144,11 +107,6 @@ units angstrom
 
     guess = 'unit'
     eom_E_guess_3, _ = eom.solve_eom(N, e_conv, r_conv, maxiter, guess, "right")
-
-    psi4.set_options({'cceom__e_convergence': e_conv,
-                      'cceom__r_convergence': r_conv,
-                      'roots_per_irrep': [N],
-                      'restart': 'false'})
 
     psi_E = [0.3260065052, 0.3298285196, 0.3345771530]
     assert(abs(eom_E_guess_1[0] - psi_E[0]) < 1e-5)


### PR DESCRIPTION
Introduce pycc/tests/conftest.py with:
- psi4_environment: sets scratch memory + output file and clears global options around a test (non-autouse, so only opted-in tests are affected; tests that load a reference wfn from disk are untouched).
- rhf_wfn: a factory fixture that builds an RHF reference from a moldict key (or a literal geometry string), with basis/geom-suffix/option overrides. Shared SCF options live in DEFAULT_SCF_OPTIONS.

Convert 32 test modules from the copy-pasted
set_memory/set_output_file/set_options/geometry/energy block to `wfn = rhf_wfn(...)`. Net ~570 fewer lines. The per-test pycc.ccwfn(...) call (model/local/einsums/precision kwargs) intentionally stays in the body. Also drop a dead trailing set_options in test_043 and an orphaned wfn-var rename in test_031.

Not converted (by design): test_016, test_019 load the reference wfn from a saved .npy via Wavefunction.from_file, and the pure-math tests (FFT, Pade, denoise, FWHM, ints, delta) build no wavefunction.

Verified: full non-slow, non-einsums suite = 50 passed, 1 skipped, 8 deselected (slow), 1 xfailed. einsums tests 038/039/041/042 pass individually. test_040 (einsums CC2) hangs locally, but does so with or without this change (pre-existing); einsums is not installed in CI, where these tests skip.

- [X] Ready to go