### PR TITLE
Document CC intermediates with shapes and equations

### DIFF
--- a/pycc/cchbar.py
+++ b/pycc/cchbar.py
@@ -88,6 +88,19 @@ class cchbar(object):
     4-index tensors are stored on CPU
     """
     def build_Hov(self, o, v, F, L, t1):
+        """Build the occupied-virtual block H_me of the one-body HBAR.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, nv)
+            Indexed [m, e]. For CCD this is just f_me (no singles term).
+
+        Notes
+        -----
+        CCSD form (repeated indices summed)::
+
+            H_me = f_me + t_nf L_mnef
+        """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
             if HAS_TORCH and isinstance(F, torch.Tensor):
@@ -104,6 +117,21 @@ class cchbar(object):
 
 
     def build_Hvv(self, o, v, F, L, t1, t2):
+        """Build the virtual-virtual block H_ae of the one-body HBAR.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (nv, nv)
+            Indexed [a, e].
+
+        Notes
+        -----
+        CCSD form (repeated indices summed; CCD keeps only f_ae and the final
+        t2 term)::
+
+            H_ae = f_ae - f_me t_ma + t_mf L_amef
+                        - (t2_mnfa + t_mf t_na) L_mnfe
+        """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
             if HAS_TORCH and isinstance(F, torch.Tensor):
@@ -124,6 +152,21 @@ class cchbar(object):
 
 
     def build_Hoo(self, o, v, F, L, t1, t2):
+        """Build the occupied-occupied block H_mi of the one-body HBAR.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, no)
+            Indexed [m, i].
+
+        Notes
+        -----
+        CCSD form (repeated indices summed; CCD keeps only f_mi and the final
+        t2 term)::
+
+            H_mi = f_mi + t_ie f_me + t_ne L_mnie
+                        + (t2_inef + t_ie t_nf) L_mnef
+        """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
             if HAS_TORCH and isinstance(F, torch.Tensor):
@@ -144,6 +187,20 @@ class cchbar(object):
 
 
     def build_Hoooo(self, o, v, ERI, t1, t2):
+        """Build the occ-occ-occ-occ block H_mnij of the two-body HBAR.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, no, no, no)
+            Indexed [m, n, i, j]. ERI is in Dirac order <pq|rs>.
+
+        Notes
+        -----
+        CCSD form (repeated indices summed)::
+
+            H_mnij = <mn|ij> + t_je <mn|ie> + t_ie <nm|je>
+                            + (t2_ijef + t_ie t_jf) <mn|ef>
+        """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
             if HAS_TORCH and isinstance(t1, torch.Tensor):
@@ -168,6 +225,20 @@ class cchbar(object):
 
 
     def build_Hvvvv(self, o, v, ERI, t1, t2):
+        """Build the vir-vir-vir-vir block H_abef of the two-body HBAR.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (nv, nv, nv, nv)
+            Indexed [a, b, e, f].
+
+        Notes
+        -----
+        CCSD form (repeated indices summed)::
+
+            H_abef = <ab|ef> - t_mb <am|ef> - t_ma <bm|fe>
+                            + (t2_mnab + t_ma t_nb) <mn|ef>
+        """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
             if HAS_TORCH and isinstance(ERI, torch.Tensor):
@@ -192,6 +263,19 @@ class cchbar(object):
 
 
     def build_Hvovv(self, o, v, ERI, t1):
+        """Build the vir-occ-vir-vir block H_amef of the two-body HBAR.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (nv, no, nv, nv)
+            Indexed [a, m, e, f]. For CCD this is just <am|ef>.
+
+        Notes
+        -----
+        CCSD form (repeated indices summed)::
+
+            H_amef = <am|ef> - t_na <nm|ef>
+        """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
             if HAS_TORCH and isinstance(ERI, torch.Tensor):
@@ -209,6 +293,19 @@ class cchbar(object):
 
 
     def build_Hooov(self, o, v, ERI, t1):
+        """Build the occ-occ-occ-vir block H_mnie of the two-body HBAR.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, no, no, nv)
+            Indexed [m, n, i, e]. For CCD this is just <mn|ie>.
+
+        Notes
+        -----
+        CCSD form (repeated indices summed)::
+
+            H_mnie = <mn|ie> + t_if <nm|ef>
+        """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
             if HAS_TORCH and isinstance(ERI, torch.Tensor):
@@ -226,6 +323,21 @@ class cchbar(object):
 
 
     def build_Hovvo(self, o, v, ERI, L, t1, t2):
+        """Build the occ-vir-vir-occ block H_mbej of the two-body HBAR.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, nv, nv, no)
+            Indexed [m, b, e, j].
+
+        Notes
+        -----
+        CCSD form (repeated indices summed; CC2 drops the t2 terms)::
+
+            H_mbej = <mb|ej> + t_jf <mb|ef> - t_nb <mn|ej>
+                            - (t2_jnfb + t_jf t_nb) <mn|ef>
+                            + t2_njfb L_mnef
+        """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
             if HAS_TORCH and isinstance(ERI, torch.Tensor):
@@ -250,6 +362,20 @@ class cchbar(object):
 
 
     def build_Hovov(self, o, v, ERI, t1, t2):
+        """Build the occ-vir-occ-vir block H_mbje of the two-body HBAR.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, nv, no, nv)
+            Indexed [m, b, j, e].
+
+        Notes
+        -----
+        CCSD form (repeated indices summed; CC2 drops the t2 term)::
+
+            H_mbje = <mb|je> + t_jf <bm|ef> - t_nb <mn|je>
+                            - (t2_jnfb + t_jf t_nb) <nm|ef>
+        """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
             if HAS_TORCH and isinstance(ERI, torch.Tensor):
@@ -270,6 +396,28 @@ class cchbar(object):
 
 
     def build_Hvvvo(self, o, v, ERI, L, Hov, Hvvvv, t1, t2):
+        """Build the vir-vir-vir-occ block H_abei of the two-body HBAR.
+
+        Reuses the already-built Hov and Hvvvv blocks.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (nv, nv, nv, no)
+            Indexed [a, b, e, i].
+
+        Notes
+        -----
+        CCSD form (repeated indices summed; the parenthesized groups are the
+        nested intermediates assembled in the code)::
+
+            H_abei = <ab|ei> - H_me t2_miab + t_if H_abef
+                            + (t2_mnab + t_ma t_nb) <mn|ei>
+                            - t2_imfa <bm|fe> - t2_imfb <am|ef>
+                            + t2_mifb L_amef
+                            - t_mb ( <am|ei> - t2_infa <mn|fe> )
+                            - t_ma ( <bm|ie> - t2_infb <mn|ef>
+                                              + t2_nifb L_mnef )
+        """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
             if HAS_TORCH and isinstance(ERI, torch.Tensor):
@@ -322,6 +470,28 @@ class cchbar(object):
 
 
     def build_Hovoo(self, o, v, ERI, L, Hov, Hoooo, t1, t2):
+        """Build the occ-vir-occ-occ block H_mbij of the two-body HBAR.
+
+        Reuses the already-built Hov and Hoooo blocks.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, nv, no, no)
+            Indexed [m, b, i, j].
+
+        Notes
+        -----
+        CCSD form (repeated indices summed; the parenthesized groups are the
+        nested intermediates assembled in the code)::
+
+            H_mbij = <mb|ij> + H_me t2_ijeb - t_nb H_mnij
+                            + (t2_ijef + t_ie t_jf) <mb|ef>
+                            - t2_ineb <nm|je> - t2_jneb <mn|ie>
+                            + t2_njeb L_mnie
+                            + t_je ( <mb|ie> - t2_infb <mn|fe> )
+                            + t_ie ( <bm|je> - t2_jnfb <mn|ef>
+                                              + t2_njfb L_mnef )
+        """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
             if HAS_TORCH and isinstance(ERI, torch.Tensor):

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -448,17 +448,65 @@ class cclambda(object):
         return r1, r2
 
     def build_Goo(self, t2, l2):
+        """Build the G_mi occupied density intermediate (t2-weighted lambda).
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, no)
+            Indexed [m, i].
+
+        Notes
+        -----
+        ::
+
+            G_mi = t2_mjab l2_ijab
+        """
         contract = self.contract
         return contract('mjab,ijab->mi', t2, l2)
 
 
     def build_Gvv(self, t2, l2):
-        contract = self.contract 
+        """Build the G_ae virtual density intermediate (t2-weighted lambda).
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (nv, nv)
+            Indexed [a, e].
+
+        Notes
+        -----
+        ::
+
+            G_ae = - t2_ijeb l2_ijab
+        """
+        contract = self.contract
         return -1.0 * contract('ijeb,ijab->ae', t2, l2)
 
 
     def r_L1(self, o, v, l1, l2, Hov, Hvv, Hoo, Hovvo, Hovov, Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo):
-        contract = self.contract 
+        """Compute the L1 (lambda singles) residual.
+
+        The lambda equations are linear; solve_lambda drives this residual to
+        zero. H_* are the HBAR blocks, G_* the t2-weighted lambda densities.
+        Returns zeros for CCD (no singles); CC2 and CCSD(T) modify/extend the
+        terms below.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, nv)
+            L1 residual indexed [i, a].
+
+        Notes
+        -----
+        CCSD form (repeated indices summed)::
+
+            r_l1_ia = 2 H_ia + l1_ie H_ea - l1_ma H_im
+                    + l2_imef H_efam - l2_mnae H_iemn
+                    + l1_me (2 H_ieam - H_iema)
+                    - G_ef (2 H_eifa - H_eiaf)
+                    - G_mn (2 H_mina - H_imna)
+        """
+        contract = self.contract
         if self.ccwfn.model == 'CCD':
             if HAS_TORCH and isinstance(l1, torch.Tensor):
                 r_l1 = torch.zeros_like(l1)
@@ -493,7 +541,34 @@ class cclambda(object):
         return r_l1
 
     def r_L2(self, o, v, l1, l2, L, Hov, Hvv, Hoo, Hoooo, Hvvvv, Hovvo, Hovov, Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo):
-        contract = self.contract 
+        """Compute the L2 (lambda doubles) residual.
+
+        The lambda equations are linear; solve_lambda drives this residual to
+        zero. The expression below is symmetrized as r_l2_ijab += r_l2_jiba on
+        return. H_* are the HBAR blocks, G_* the t2-weighted lambda densities.
+        CCD drops the l1 terms; CC2 and CCSD(T) modify/extend the terms below.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, no, nv, nv)
+            L2 residual indexed [i, j, a, b].
+
+        Notes
+        -----
+        CCSD form, before the i<->j / a<->b symmetrization (repeated indices
+        summed)::
+
+            r_l2_ijab = L_ijab
+                      + 2 l1_ia H_jb - l1_ja H_ib
+                      + 2 l1_ie H_ejab - l1_ie H_ejba
+                      - 2 l1_mb H_jima + l1_mb H_ijma
+                      + l2_ijeb H_ea - l2_mjab H_im
+                      + 1/2 l2_mnab H_ijmn + 1/2 l2_ijef H_efab
+                      + l2_mjeb (2 H_ieam - H_iema)
+                      - l2_mibe H_jema - l2_mieb H_jeam
+                      + G_ae L_ijeb - G_mi L_mjab
+        """
+        contract = self.contract
         if self.ccwfn.model == 'CCD':
             if HAS_TORCH and isinstance(l1, torch.Tensor):
                 r_l2 = L[o,o,v,v].clone().to(self.ccwfn.device1)
@@ -544,6 +619,20 @@ class cclambda(object):
 
     # Additional intermediates needed for CC3 lambda equations
     def build_cc3_Wmbje(self, o, v, ERI, t1):
+        """Build the CC3 W_mbje intermediate (T1-dressed integrals).
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, nv, no, nv)
+            Indexed [m, b, j, e].
+
+        Notes
+        -----
+        Repeated indices summed::
+
+            W_mbje = <mb|je> + t_jf <mb|fe> - t_nb <mn|je>
+                            - t_jf t_nb <mn|fe>
+        """
         contract = self.contract
         if HAS_TORCH and isinstance(t1, torch.Tensor):
             W = ERI[o,v,o,v].clone().to(self.ccwfn.device1)
@@ -555,6 +644,20 @@ class cclambda(object):
         return W
 
     def build_cc3_Wmbej(self, o, v, ERI, t1):
+        """Build the CC3 W_mbej intermediate (T1-dressed integrals).
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, nv, nv, no)
+            Indexed [m, b, e, j].
+
+        Notes
+        -----
+        Repeated indices summed::
+
+            W_mbej = <mb|ej> + t_jf <mb|ef> - t_nb <mn|ej>
+                            - t_jf t_nb <mn|ef>
+        """
         contract = self.contract
         if HAS_TORCH and isinstance(t1, torch.Tensor):
             W = ERI[o,v,v,o].clone().to(self.ccwfn.device1)
@@ -566,6 +669,20 @@ class cclambda(object):
         return W
 
     def build_cc3_Wabef(self, o, v, ERI, t1):
+        """Build the CC3 W_abef intermediate (T1-dressed integrals).
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (nv, nv, nv, nv)
+            Indexed [a, b, e, f].
+
+        Notes
+        -----
+        Repeated indices summed::
+
+            W_abef = <ab|ef> - t_ma <mb|ef> - t_mb <ma|fe>
+                            + t_ma t_nb <mn|ef>
+        """
         contract = self.contract
         if HAS_TORCH and isinstance(t1, torch.Tensor):
             W = ERI[v,v,v,v].clone().to(self.ccwfn.device1)
@@ -577,5 +694,12 @@ class cclambda(object):
         return W
                                          
     def pseudoenergy(self, o, v, ERI, l2):
-        contract = self.contract 
+        """Compute the CC pseudoenergy from the L2 amplitudes.
+
+        Returns
+        -------
+        float
+            The lambda pseudoenergy 1/2 <ij|ab> l2_ijab.
+        """
+        contract = self.contract
         return 0.5 * contract('ijab,ijab->',ERI[o,o,v,v], l2)

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -471,6 +471,21 @@ class ccwfn(object):
         return r1, r2
 
     def build_tau(self, t1, t2, fact1=1.0, fact2=1.0):
+        """Build the effective doubles amplitude tau = fact1*t2 + fact2*(t1 t1).
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, no, nv, nv)
+            tau indexed [i, j, a, b]; t1 is [i, a], t2 is [i, j, a, b].
+
+        Notes
+        -----
+        ::
+
+            tau_ijab = fact1 * t2_ijab + fact2 * t_ia t_jb
+
+        (defaults fact1 = fact2 = 1).
+        """
         contract = self.contract
         if self.einsums:
             tau = fact1 * np.transpose(t2, (3,2,1,0)) + fact2 * self.ec.contract('ai,bj->baji', t1.T, t1.T)
@@ -480,6 +495,28 @@ class ccwfn(object):
 
 
     def build_Fae(self, o, v, F, L, t1, t2):
+        """Build the F_ae similarity-transformed one-body intermediate.
+
+        Parameters
+        ----------
+        o, v : slice
+            Occupied and virtual orbital subspaces.
+        F, L : ndarray or torch.Tensor
+            Fock matrix and spin-adapted ERIs (L = 2<pq|rs> - <pq|sr>).
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (nv, nv)
+            Virtual-virtual intermediate indexed [a, e].
+
+        Notes
+        -----
+        CCSD form (repeated indices summed; CCD keeps only the f_ae and final
+        t2 terms)::
+
+            F_ae = f_ae - 1/2 f_me t_ma + t_mf L_mafe
+                        - (t2_mnaf + 1/2 t_ma t_nf) L_mnef
+        """
         contract = self.contract
         if self.einsums:
             contract = self.ec.contract
@@ -502,6 +539,21 @@ class ccwfn(object):
 
 
     def build_Fmi(self, o, v, F, L, t1, t2):
+        """Build the F_mi similarity-transformed one-body intermediate.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, no)
+            Occupied-occupied intermediate indexed [m, i].
+
+        Notes
+        -----
+        CCSD form (repeated indices summed; CCD keeps only the f_mi and final
+        t2 terms)::
+
+            F_mi = f_mi + 1/2 t_ie f_me + t_ne L_mnie
+                        + (t2_inef + 1/2 t_ie t_nf) L_mnef
+        """
         contract = self.contract
         if self.einsums:
             contract = self.ec.contract
@@ -524,6 +576,20 @@ class ccwfn(object):
 
 
     def build_Fme(self, o, v, F, L, t1):
+        """Build the F_me similarity-transformed one-body intermediate.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, nv)
+            Occupied-virtual intermediate indexed [m, e]. Returns None for the
+            CCD model, which has no singles.
+
+        Notes
+        -----
+        Repeated indices summed::
+
+            F_me = f_me + t_nf L_mnef
+        """
         contract = self.contract
         if self.einsums:
             contract = self.ec.contract
@@ -540,6 +606,20 @@ class ccwfn(object):
 
 
     def build_Wmnij(self, o, v, ERI, t1, t2):
+        """Build the W_mnij similarity-transformed two-body intermediate.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, no, no, no)
+            Intermediate indexed [m, n, i, j]. ERI is in Dirac order <pq|rs>.
+
+        Notes
+        -----
+        CCSD form (repeated indices summed)::
+
+            W_mnij = <mn|ij> + t_je <mn|ie> + t_ie <mn|ej>
+                            + (t2_ijef + t_ie t_jf) <mn|ef>
+        """
         contract = self.contract
         if self.einsums:
             contract = self.ec.contract
@@ -566,6 +646,22 @@ class ccwfn(object):
 
 
     def build_Wmbej(self, o, v, ERI, L, t1, t2):
+        """Build the W_mbej similarity-transformed two-body intermediate.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, nv, nv, no)
+            Intermediate indexed [m, b, e, j]. Returns None for the CC2 model,
+            which omits this intermediate.
+
+        Notes
+        -----
+        CCSD form (repeated indices summed)::
+
+            W_mbej = <mb|ej> + t_jf <mb|ef> - t_nb <mn|ej>
+                            - (1/2 t2_jnfb + t_jf t_nb) <mn|ef>
+                            + 1/2 t2_njfb L_mnef
+        """
         contract = self.contract
         if self.einsums:
             contract = self.ec.contract
@@ -592,6 +688,21 @@ class ccwfn(object):
 
 
     def build_Wmbje(self, o, v, ERI, t1, t2):
+        """Build the W_mbje similarity-transformed two-body intermediate.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, nv, no, nv)
+            Intermediate indexed [m, b, j, e]. Returns None for the CC2 model,
+            which omits this intermediate.
+
+        Notes
+        -----
+        CCSD form (repeated indices summed)::
+
+            W_mbje = -<mb|je> - t_jf <mb|fe> + t_nb <mn|je>
+                             + (1/2 t2_jnfb + t_jf t_nb) <mn|fe>
+        """
         contract = self.contract
         if self.einsums:
             contract = self.ec.contract
@@ -616,6 +727,19 @@ class ccwfn(object):
 
 
     def build_Zmbij(self, o, v, ERI, t1, t2):
+        """Build the Z_mbij similarity-transformed intermediate.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, nv, no, no)
+            Intermediate indexed [m, b, i, j]. Returns None for the CCD model.
+
+        Notes
+        -----
+        CCSD form (repeated indices summed)::
+
+            Z_mbij = <mb|ef> (t2_ijef + t_ie t_jf)
+        """
         contract = self.contract
         if self.einsums:
             contract = self.ec.contract
@@ -630,6 +754,26 @@ class ccwfn(object):
 
 
     def r_T1(self, o, v, F, ERI, L, t1, t2, Fae, Fme, Fmi):
+        """Compute the T1 (singles) amplitude residual.
+
+        solve_cc drives this residual to zero. Fae/Fme/Fmi are the precomputed
+        one-body intermediates. Returns zeros for CCD (no singles).
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, nv)
+            T1 residual indexed [i, a].
+
+        Notes
+        -----
+        CCSD form (repeated indices summed)::
+
+            r_t1_ia = f_ia + t_ie F_ae - F_mi t_ma
+                    + (2 t2_imae - t2_imea) F_me
+                    + t_nf L_nafi
+                    + (2 t2_mief - t2_mife) <ma|ef>
+                    - t2_mnae L_nmei
+        """
         contract = self.contract
         if self.einsums:
             contract = self.ec.contract
@@ -654,6 +798,35 @@ class ccwfn(object):
 
 
     def r_T2(self, o, v, F, ERI, L, t1, t2, Fae, Fme, Fmi, Wmnij, Wmbej, Wmbje, Zmbij):
+        """Compute the T2 (doubles) amplitude residual.
+
+        solve_cc drives this residual to zero. The expression below is the
+        spin-adapted "half" residual, symmetrized as r_t2_ijab += r_t2_jiba on
+        return. Fae/Fmi/Fme and Wmnij/Wmbej/Wmbje/Zmbij are the precomputed
+        intermediates; tau = build_tau(t1, t2). CCD drops the singles terms;
+        CC2 replaces the Fae/Fmi terms with bare-Fock forms (see code).
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, no, nv, nv)
+            T2 residual indexed [i, j, a, b].
+
+        Notes
+        -----
+        CCSD form, before the i<->j / a<->b symmetrization (repeated indices
+        summed; W_mbje[e<->j] is Wmbje with its last two axes swapped)::
+
+            r_t2_ijab = 1/2 <ij|ab>
+                      + t2_ijae F_be  - 1/2 t2_ijae t_mb F_me
+                      - t2_imab F_mj  - 1/2 t2_imab t_je F_me
+                      + 1/2 tau_mnab W_mnij + 1/2 tau_ijef <ab|ef>
+                      - t_ma Z_mbij
+                      + (t2_imae - t2_imea) W_mbej
+                      + t2_imae (W_mbej + W_mbje[e<->j])
+                      + t2_mjae W_mbie
+                      - t_ie t_ma <mb|ej> - t_ie t_mb <ma|je>
+                      + t_ie <ab|ej> - t_ma <mb|ij>
+        """
         contract = self.contract
         if self.einsums:
             contract = self.ec.contract
@@ -725,6 +898,20 @@ class ccwfn(object):
 
     # Intermedeates needed for CC3
     def build_cc3_Wmnij(self, o, v, ERI, t1):
+        """Build the CC3 W_mnij intermediate (T1-dressed integrals).
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, no, no, no)
+            Indexed [m, n, i, j].
+
+        Notes
+        -----
+        Repeated indices summed::
+
+            W_mnij = <mn|ij> + t_ja <mn|ia> + t_ia <nm|ja>
+                            + t_ie t_jf <mn|ef>
+        """
         contract = self.contract
         if HAS_TORCH and isinstance(t1, torch.Tensor):
             W = ERI[o,o,o,o].clone().to(self.device1)
@@ -737,6 +924,22 @@ class ccwfn(object):
         return W
 
     def build_cc3_Wmbij(self, o, v, ERI, t1, Wmnij):
+        """Build the CC3 W_mbij intermediate (T1-dressed integrals).
+
+        Reuses the CC3 W_mnij intermediate.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, nv, no, no)
+            Indexed [m, b, i, j].
+
+        Notes
+        -----
+        Repeated indices summed::
+
+            W_mbij = <mb|ij> - W_mnij t_nb + t_je <mb|ie>
+                            + t_ie ( <mb|ej> + t_jf <mb|ef> )
+        """
         contract = self.contract
         if HAS_TORCH and isinstance(t1, torch.Tensor):
             W = ERI[o,v,o,o].clone().to(self.device1)
@@ -752,6 +955,19 @@ class ccwfn(object):
         return W
 
     def build_cc3_Wmnie(self, o, v, ERI, t1):
+        """Build the CC3 W_mnie intermediate (T1-dressed integrals).
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (no, no, no, nv)
+            Indexed [m, n, i, e].
+
+        Notes
+        -----
+        Repeated indices summed::
+
+            W_mnie = <mn|ie> + t_if <mn|fe>
+        """
         contract = self.contract
         if HAS_TORCH and isinstance(t1, torch.Tensor):
             W = ERI[o,o,o,v].clone().to(self.device1)
@@ -761,6 +977,19 @@ class ccwfn(object):
         return W
 
     def build_cc3_Wamef(self, o, v, ERI, t1):
+        """Build the CC3 W_amef intermediate (T1-dressed integrals).
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (nv, no, nv, nv)
+            Indexed [a, m, e, f].
+
+        Notes
+        -----
+        Repeated indices summed::
+
+            W_amef = <am|ef> - t_na <nm|ef>
+        """
         contract = self.contract
         if HAS_TORCH and isinstance(t1, torch.Tensor):
             W = ERI[v,o,v,v].clone().to(self.device1)
@@ -770,6 +999,21 @@ class ccwfn(object):
         return W
 
     def build_cc3_Wabei(self, o, v, ERI, t1):
+        """Build the CC3 W_abei intermediate (T1-dressed integrals).
+
+        The most involved CC3 intermediate. It is assembled in two parts that
+        are combined as W_abei = Z_abei + Z_eiab[swap (a,e) and (b,i)]:
+
+        - Z_eiab: <ei|ab> dressed by t1 through the vir-vir-vir-vir integrals
+          (symmetric + antisymmetric pieces) and ladder/ring corrections;
+        - Z_abei: the -t_ma (<mb|ei> + t_if <mb|ef>) particle-attachment term.
+
+        Returns
+        -------
+        ndarray or torch.Tensor, shape (nv, nv, nv, no)
+            Indexed [a, b, e, i]. See the inline construction for the exact
+            term-by-term T1 dressing.
+        """
         contract =self.contract
         # eiab
         if HAS_TORCH and isinstance(t1, torch.Tensor):
@@ -812,6 +1056,16 @@ class ccwfn(object):
         return W
 
     def cc_energy(self, o, v, F, L, t1, t2):
+        """Compute the CC correlation energy from the current amplitudes.
+
+        Returns
+        -------
+        float
+            The CC correlation energy (repeated indices summed)::
+
+                CCD:   E = t2_ijab L_ijab
+                else:  E = 2 f_ia t_ia + tau_ijab L_ijab   (tau = t2 + t1 t1)
+        """
         contract = self.contract
         if self.einsums:
             contract = self.ec.contract


### PR DESCRIPTION
Add numpydoc docstrings to the intermediate builders and residual/energy methods in ccwfn.py, cchbar.py, and cclambda.py. Each gives a Returns line (tensor shape + index order) and a Notes block with the CCSD equation transcribed directly from the contract(...) calls, with tau factors expanded inline and model-specific (CCD/CC2/(T)) deviations and None-returns noted.

- ccwfn.py: build_tau, build_Fae/Fmi/Fme, build_Wmnij/Wmbej/Wmbje, build_Zmbij, r_T1, r_T2, build_cc3_Wmnij/Wmbij/Wmnie/Wamef/Wabei, cc_energy.
- cchbar.py: all 11 HBAR blocks (Hov, Hvv, Hoo, Hoooo, Hvvvv, Hvovv, Hooov, Hovvo, Hovov, Hvvvo, Hovoo).
- cclambda.py: build_Goo, build_Gvv, r_L1, r_L2, build_cc3_Wmbje/Wmbej/Wabef, pseudoenergy.

Docstrings only; no behavior change. The longest assembled intermediates (Hvvvo, Hovoo, build_cc3_Wabei) are described structurally rather than as a single closed-form expression. Verified: CCSD/CCD/CC2/CC3 energy, lambda, and density tests pass.

## Status
- [X] Ready to go