### PR TITLE
Add public-API type hints and a shared Tensor alias

### DIFF
--- a/pycc/_typing.py
+++ b/pycc/_typing.py
@@ -1,0 +1,40 @@
+"""Shared type aliases for PyCC public-API annotations.
+
+These describe the dense tensors and orbital-space selectors passed throughout
+the coupled-cluster machinery.
+
+``Tensor`` covers both the default NumPy backend and the optional PyTorch
+(GPU / mixed-precision) backend. The ``torch.Tensor`` arm is written as a
+forward reference so the alias stays importable even when PyTorch is not
+installed; the annotations that use it are themselves lazy (every annotated
+module enables ``from __future__ import annotations``), so nothing here is
+evaluated at run time.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Union
+
+import numpy as np
+
+#: A dense amplitude / integral tensor in either supported backend.
+if TYPE_CHECKING:
+    # Type-checkers always see the full union, regardless of the runtime env.
+    import torch
+    Tensor = Union[np.ndarray, "torch.Tensor"]
+else:
+    # At run time, only reference torch when it is actually importable so that
+    # ``typing.get_type_hints`` can resolve the alias even without PyTorch.
+    try:
+        import torch as _torch
+        Tensor = Union[np.ndarray, _torch.Tensor]
+    except ModuleNotFoundError:
+        Tensor = np.ndarray
+
+#: An orbital-subspace selector: the occupied/virtual ``slice`` objects
+#: (``o``/``v``), a single orbital index, or a fancy-index array.
+Slice = Union[slice, int, np.ndarray]
+
+#: A tensor-contraction callable (e.g. ``opt_einsum.contract`` or the einsums
+#: backend), invoked as ``contract(subscripts, *operands)``.
+Contract = Callable[..., Tensor]

--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -2,13 +2,21 @@
 ccdensity.py: Builds the CC density.
 """
 
+from __future__ import annotations
+
 if __name__ == "__main__":
     raise Exception("This file cannot be invoked on its own.")
 
 import time
+from typing import TYPE_CHECKING
+
 import numpy as np
 from pycc.ccwfn import HAS_TORCH
-from .cctriples import t3c_ijk, t3c_abc, l3_ijk, l3_abc, t3c_bc, l3_bc, t3_pert_ijk, t3_pert_bc 
+from .cctriples import t3c_ijk, t3c_abc, l3_ijk, l3_abc, t3c_bc, l3_bc, t3_pert_ijk, t3_pert_bc
+
+if TYPE_CHECKING:
+    from pycc.ccwfn import ccwfn
+    from pycc.cclambda import cclambda
 
 class ccdensity(object):
     """
@@ -45,7 +53,7 @@ class ccdensity(object):
     compute_onepdm() :
         Compute the one-electron density for a given set of amplitudes (useful for RTCC)
     """
-    def __init__(self, ccwfn, cclambda, onlyone=False):
+    def __init__(self, ccwfn: "ccwfn", cclambda: "cclambda", onlyone: bool = False) -> None:
         """
         Parameters
         ----------
@@ -96,7 +104,7 @@ class ccdensity(object):
 
         print("\nCCDENSITY constructed in %.3f seconds.\n" % (time.time() - time_init))
 
-    def compute_energy(self):
+    def compute_energy(self) -> float:
         """
         Compute the CC energy from the density.  If only onepdm is available, just compute the one-electron energy.
 

--- a/pycc/cceom.py
+++ b/pycc/cceom.py
@@ -1,10 +1,18 @@
+from __future__ import annotations
+
 import time
+from typing import TYPE_CHECKING
+
 import psi4
 import pycc
 import pytest
 from pycc.data.molecules import *
 import numpy as np
 import scipy.linalg
+
+if TYPE_CHECKING:
+    from pycc.ccwfn import ccwfn
+    from pycc.cchbar import cchbar
 
 class cceom(object):
     """
@@ -34,7 +42,7 @@ class cceom(object):
         Build the doubles components of the sigma = C * HBAR vector
     """
 
-    def __init__(self, ccwfn, cchbar):
+    def __init__(self, ccwfn: "ccwfn", cchbar: "cchbar") -> None:
         """
         Parameters
         ----------
@@ -61,7 +69,7 @@ class cceom(object):
         self.l1 = 2.0 * self.ccwfn.t1
         self.l2 = 2.0 * (2.0 * self.ccwfn.t2 - self.ccwfn.t2.swapaxes(2, 3))
 
-    def solve_eom(self, N=1, e_conv=1e-5, r_conv=1e-5, maxiter=100, guess='HBAR_SS', eom_type = 'RIGHT'):
+    def solve_eom(self, N: int = 1, e_conv: float = 1e-5, r_conv: float = 1e-5, maxiter: int = 100, guess: str = 'HBAR_SS', eom_type: str = 'RIGHT'):
         """
         Solves the left and right-hand EOM-CC eigenvalue problem using the Davidson algorithm
 

--- a/pycc/cchbar.py
+++ b/pycc/cchbar.py
@@ -2,13 +2,20 @@
 cchbar.py: Builds the similarity-transformed Hamiltonian (one- and two-body terms only).
 """
 
+from __future__ import annotations
+
 if __name__ == "__main__":
     raise Exception("This file cannot be invoked on its own.")
 
 
 import time
+from typing import TYPE_CHECKING
+
 import numpy as np
 from pycc.ccwfn import HAS_TORCH
+
+if TYPE_CHECKING:
+    from pycc.ccwfn import ccwfn
 
 
 class cchbar(object):
@@ -41,7 +48,7 @@ class cchbar(object):
         The occ,vir,occ,occ block of the two-body component HBAR.
 
     """
-    def __init__(self, ccwfn):
+    def __init__(self, ccwfn: "ccwfn") -> None:
         """
         Parameters
         ----------

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -2,16 +2,24 @@
 cclambda.py: Lambda-amplitude Solver
 """
 
+from __future__ import annotations
+
 if __name__ == "__main__":
     raise Exception("This file cannot be invoked on its own.")
 
 
-import numpy as np
 import time
+from typing import TYPE_CHECKING
+
+import numpy as np
 from opt_einsum import contract
 from .utils import helper_diis
 from pycc.ccwfn import HAS_TORCH
 from .cctriples import t3c_ijk, l3_ijk, l3_ijk_alt, t3_pert_ijk
+
+if TYPE_CHECKING:
+    from pycc.ccwfn import ccwfn
+    from pycc.cchbar import cchbar
 
 
 class cclambda(object):
@@ -36,7 +44,7 @@ class cclambda(object):
     residuals()
         Computes the L1 and L2 residuals for a given set of amplitudes and Fock operator
     """
-    def __init__(self, ccwfn, hbar):
+    def __init__(self, ccwfn: "ccwfn", hbar: "cchbar") -> None:
         """
         Parameters
         ----------
@@ -57,7 +65,7 @@ class cclambda(object):
         self.l1 = 2.0 * self.ccwfn.t1
         self.l2 = 2.0 * (2.0 * self.ccwfn.t2 - self.ccwfn.t2.swapaxes(2, 3))
 
-    def solve_lambda(self, e_conv=1e-7, r_conv=1e-7, maxiter=100, max_diis=8, start_diis=1):
+    def solve_lambda(self, e_conv: float = 1e-7, r_conv: float = 1e-7, maxiter: int = 100, max_diis: int = 8, start_diis: int = 1) -> float:
         """
         Parameters
         ----------

--- a/pycc/ccresponse.py
+++ b/pycc/ccresponse.py
@@ -2,13 +2,22 @@
 ccresponse.py: CC Response Functions
 """
 
+from __future__ import annotations
+
 if __name__ == "__main__":
     raise Exception("This file cannot be invoked on its own.")
 
-import numpy as np
 import time
+from typing import TYPE_CHECKING
+
+import numpy as np
 from .utils import helper_diis
 from .cclambda import cclambda
+from ._typing import Tensor
+
+if TYPE_CHECKING:
+    from pycc.ccwfn import ccwfn
+    from pycc.ccdensity import ccdensity
 
 class ccresponse(object):
     """
@@ -24,7 +33,7 @@ class ccresponse(object):
         Check first-order perturbed wave functions for all available perturbation operators.
     """
 
-    def __init__(self, ccdensity, omega1 = 0, omega2 = 0):
+    def __init__(self, ccdensity: "ccdensity", omega1: float = 0, omega2: float = 0) -> None:
         """
         Parameters
         ----------
@@ -94,7 +103,7 @@ class ccresponse(object):
         self.Dia = eps_occ.reshape(-1,1) - eps_vir
         self.Dijab = eps_occ.reshape(-1,1,1,1) + eps_occ.reshape(-1,1,1) - eps_vir.reshape(-1,1) - eps_vir
 
-    def pertcheck(self, omega, e_conv=1e-13, r_conv=1e-13, maxiter=200, max_diis=8, start_diis=1):
+    def pertcheck(self, omega: float, e_conv: float = 1e-13, r_conv: float = 1e-13, maxiter: int = 200, max_diis: int = 8, start_diis: int = 1):
         """
         Build first-order perturbed wave functions for all available perturbations and return a dict of their converged pseudoresponse values.  Primarily for testing purposes.
 
@@ -205,7 +214,7 @@ class ccresponse(object):
         return check
 
 
-    def linresp(self, A, B, omega, e_conv=1e-13, r_conv=1e-13, maxiter=200, max_diis=8, start_diis=1):
+    def linresp(self, A: str, B: str, omega: float, e_conv: float = 1e-13, r_conv: float = 1e-13, maxiter: int = 200, max_diis: int = 8, start_diis: int = 1) -> Tensor:
         """
         Calculate the CC linear-response function for one-electron perturbations A and B at field-frequency omega (w).
 
@@ -296,7 +305,7 @@ class ccresponse(object):
                     check.append(polar)
 
 
-    def linresp_asym(self, pertkey_a, X1_B, X2_B, Y1_B, Y2_B):
+    def linresp_asym(self, pertkey_a: str, X1_B: Tensor, X2_B: Tensor, Y1_B: Tensor, Y2_B: Tensor):
         """
 	Calculate the CC linear response function for polarizability at field-frequency omega(w1).
 
@@ -364,7 +373,7 @@ class ccresponse(object):
         return -1.0 * (polar1 + polar2)
 
 
-    def solve_right(self, pertbar, omega, e_conv=1e-12, r_conv=1e-12, maxiter=200, max_diis=7, start_diis=1):
+    def solve_right(self, pertbar: "pertbar", omega: float, e_conv: float = 1e-12, r_conv: float = 1e-12, maxiter: int = 200, max_diis: int = 7, start_diis: int = 1):
         solver_start = time.time()
 
         Dia = self.Dia
@@ -411,7 +420,7 @@ class ccresponse(object):
             if niter >= start_diis:
                 self.X1, self.X2 = diis.extrapolate(self.X1, self.X2)
 
-    def solve_left(self, pertbar, omega, e_conv=1e-12, r_conv=1e-12, maxiter=200, max_diis=7, start_diis=1):
+    def solve_left(self, pertbar: "pertbar", omega: float, e_conv: float = 1e-12, r_conv: float = 1e-12, maxiter: int = 200, max_diis: int = 7, start_diis: int = 1):
         """
 	Notes
 	-----
@@ -823,7 +832,7 @@ class ccresponse(object):
 
         return r_Y2
 
-    def pseudoresponse(self, pertbar, X1, X2):
+    def pseudoresponse(self, pertbar: "pertbar", X1: Tensor, X2: Tensor):
         contract = self.ccwfn.contract
         polar1 = 2.0 * contract('ai,ia->', np.conj(pertbar.Avo), X1)
 #polar2 = contract('ijab,ijab->', np.conj(pertbar.Avvoo), (2.0*X2 - X2.swapaxes(2,3)))
@@ -832,7 +841,7 @@ class ccresponse(object):
         return -2.0*(polar1 + polar2) 
         
 class pertbar(object):
-    def __init__(self, pert, ccwfn):
+    def __init__(self, pert: Tensor, ccwfn: "ccwfn") -> None:
         o = ccwfn.o
         v = ccwfn.v
         t1 = ccwfn.t1

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -1,7 +1,14 @@
 #Triples class for (T) corrections, CC3, etc.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 from pycc.ccwfn import HAS_TORCH
+
+if TYPE_CHECKING:
+    from pycc.ccwfn import ccwfn
 
 """Various triples drivers; useful for (T) corrections and CC3.  Each driver
 returns batches of triples amplitudes corresponding to the general expression:
@@ -182,7 +189,7 @@ def t3d_abc(o, v, a, b, c, t1, t2, Woovv, F, contract, WithDenom=True):
 
 
 # Lee and Rendell's formulation
-def t_tjl(ccwfn):
+def t_tjl(ccwfn: "ccwfn") -> float:
     """Compute the (T) energy correction using the efficient formulation by Rendell
     and Lee, Chem. Phys. Lett. 178, 462-470 (1991).
 
@@ -243,7 +250,7 @@ def t_tjl(ccwfn):
 
 
 # Vikings' formulation
-def t_vikings(ccwfn):
+def t_vikings(ccwfn: "ccwfn") -> float:
     """Compute the (T) energy correction using the formulation by Helgaker,
     Jørgensen, and Olsen, Molecular Electronic Structure Theory, Wiley & Sons, 
     New York, 2000, Ch.14, pp. 794-795, Eqs. (14.6.62)-(14.6.64).  This algorithm
@@ -297,7 +304,7 @@ def t_vikings(ccwfn):
 
 
 # Vikings' formulation – inverted algorithm
-def t_vikings_inverted(ccwfn):
+def t_vikings_inverted(ccwfn: "ccwfn") -> float:
     """Compute the (T) energy correction using the formulation by Helgaker,
     Jørgensen, and Olsen, Molecular Electronic Structure Theory, Wiley & Sons, 
     New York, 2000, Ch.14, pp. 794-795, Eqs. (14.6.62)-(14.6.64).  This algorithm

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -2,6 +2,8 @@
 ccwfn.py: CC T-amplitude Solver
 """
 
+from __future__ import annotations
+
 if __name__ == "__main__":
     raise Exception("This file cannot be invoked on its own.")
 
@@ -16,11 +18,14 @@ try:
 except ImportError:
     HAS_TORCH = False
 
+from typing import Any
+
 from .utils import helper_diis, cc_contract
 from .hamiltonian import Hamiltonian
 from .local import Local
 from .cctriples import t_tjl, t3c_ijk, t3d_ijk, t3c_abc, t3d_abc, t3_pert_ijk
 from .lccwfn import lccwfn
+from ._typing import Tensor
 
 try:
     import einsums as ein
@@ -71,7 +76,7 @@ class ccwfn(object):
         Computes the T1 and T2 residuals for a given set of amplitudes and Fock operator
     """
 
-    def __init__(self, scf_wfn, **kwargs):
+    def __init__(self, scf_wfn: Any, **kwargs) -> None:
         """
         Parameters
         ----------
@@ -287,7 +292,7 @@ class ccwfn(object):
         print("CCWFN object initialized in %.3f seconds." % (time.time() - time_init))
 
 
-    def solve_cc(self, e_conv=1e-7, r_conv=1e-7, maxiter=100, max_diis=8, start_diis=1):
+    def solve_cc(self, e_conv: float = 1e-7, r_conv: float = 1e-7, maxiter: int = 100, max_diis: int = 8, start_diis: int = 1) -> float:
         """
         Parameters
         ----------

--- a/pycc/hamiltonian.py
+++ b/pycc/hamiltonian.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 if __name__ == "__main__":
     raise Exception("This file cannot be invoked on its own.")
 
+
+from typing import Any
 
 import psi4
 import numpy as np
@@ -23,7 +27,7 @@ class Hamiltonian(object):
     m : NumPy array
         MO-basis magnetic dipole integrals
     """
-    def __init__(self, ref, Cp, Cr, Cq, Cs):
+    def __init__(self, ref: Any, Cp: Any, Cr: Any, Cq: Any, Cs: Any) -> None:
 
         npCp = np.asarray(Cp)
         npCr = np.asarray(Cr)

--- a/pycc/lccwfn.py
+++ b/pycc/lccwfn.py
@@ -1,7 +1,17 @@
+from __future__ import annotations
+
 import time
 #from timer import Timer
+from typing import TYPE_CHECKING
+
 import numpy as np
 from opt_einsum import contract
+
+from pycc._typing import Slice, Tensor
+
+if TYPE_CHECKING:
+    from pycc.hamiltonian import Hamiltonian
+    from pycc.local import Local as LocalObj
 
 
 class lccwfn(object):
@@ -46,7 +56,7 @@ class lccwfn(object):
     (2) time table for each intermediate?
     """
 
-    def __init__(self, o, v, no, nv, H, local, model, eref, Local):
+    def __init__(self, o: Slice, v: Slice, no: int, nv: int, H: "Hamiltonian", local: str, model: str, eref: float, Local: "LocalObj") -> None:
         self.o = o
         self.v = v
         self.no = no
@@ -77,7 +87,7 @@ class lccwfn(object):
         self.t1 = t1
         self.t2 = t2
 
-    def solve_lcc(self, e_conv=1e-7, r_conv=1e-7, maxiter=100, max_diis=8,start_diis=1):
+    def solve_lcc(self, e_conv: float = 1e-7, r_conv: float = 1e-7, maxiter: int = 100, max_diis: int = 8, start_diis: int = 1) -> float:
         """
         Parameters
         ----------

--- a/pycc/local.py
+++ b/pycc/local.py
@@ -1,7 +1,16 @@
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
 import psi4
 import numpy as np
 from opt_einsum import contract
-import time
+
+from pycc._typing import Slice, Tensor
+
+if TYPE_CHECKING:
+    from pycc.hamiltonian import Hamiltonian
 
 class Local(object):
     """
@@ -59,11 +68,11 @@ class Local(object):
      to run local MP2, uncomment the necessary lines within the _build_"local" functions which are at the end 
     """
 
-    def __init__(self, local, C, nfzc, no, nv, H, cutoff, it2_opt,
-            core_cut=5E-2,
-            lindep_cut=1E-6,
-            e_conv=1e-12,
-            r_conv=1e-12):
+    def __init__(self, local: str, C: Any, nfzc: int, no: int, nv: int, H: "Hamiltonian", cutoff: float, it2_opt: bool,
+            core_cut: float = 5E-2,
+            lindep_cut: float = 1E-6,
+            e_conv: float = 1e-12,
+            r_conv: float = 1e-12) -> None:
 
         self.cutoff = cutoff
         self.nfzc = nfzc
@@ -786,7 +795,7 @@ class Local(object):
 
             print("MP2 Iter %3d: MP2 Ecorr = %.15f dE = % .5E rmsd = % .5E" % (niter, emp2, ediff, rmsd))
     
-    def filter_t2amps(self,r2):
+    def filter_t2amps(self, r2: Tensor) -> Tensor:
         no = self.no
         nv = self.nv
         dim = self.dim
@@ -808,7 +817,7 @@ class Local(object):
 
         return t2
 
-    def filter_amps(self, r1, r2):
+    def filter_amps(self, r1: Tensor, r2: Tensor):
         no = self.no
         nv = self.nv
         dim = self.dim
@@ -843,7 +852,7 @@ class Local(object):
 
         return t1, t2
 
-    def filter_res(self, r1, r2):
+    def filter_res(self, r1: Tensor, r2: Tensor):
         no = self.no
         nv = self.nv
 
@@ -868,7 +877,7 @@ class Local(object):
 
         return t1, t2
 
-    def trans_integrals(self, o, v):
+    def trans_integrals(self, o: Slice, v: Slice):
         """
         Transforming all the necessary integrals to the semi-canonical PNO basis, stored in a list with length occ*occ
  
@@ -970,7 +979,7 @@ class Local(object):
 
         print("Integrals transformed in %.3f seconds." % (time.time() - trans_intstart))
 
-    def overlaps(self, QL): 
+    def overlaps(self, QL: list):
         """
         Generating and storing overlap terms
 

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -2,12 +2,23 @@
 rtcc.py: Real-time coupled object that provides data for an ODE propagator
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import psi4
 import numpy as np
 from pycc.ccwfn import HAS_TORCH
 import pickle as pk
 from os.path import exists
 import opt_einsum
+
+from pycc._typing import Tensor
+
+if TYPE_CHECKING:
+    from pycc.ccwfn import ccwfn
+    from pycc.cclambda import cclambda
+    from pycc.ccdensity import ccdensity
 
 
 class rtcc(object):
@@ -55,7 +66,7 @@ class rtcc(object):
     lagrangian()
         Compute the CC Lagrangian energy for a given time t
     """
-    def __init__(self, ccwfn, cclambda, ccdensity, V, magnetic = False, kick = None):
+    def __init__(self, ccwfn: "ccwfn", cclambda: "cclambda", ccdensity: "ccdensity", V: Tensor, magnetic: bool = False, kick: Any = None) -> None:
         self.ccwfn = ccwfn
         self.cclambda = cclambda
         self.ccdensity = ccdensity
@@ -98,7 +109,7 @@ class rtcc(object):
         else:
             self.magnetic = False
 
-    def f(self, t, y):
+    def f(self, t: float, y: Tensor) -> Tensor:
         """
         Parameters
         ----------
@@ -207,7 +218,7 @@ class rtcc(object):
 
         return t1, t2, l1, l2, phase
 
-    def dipole(self, t1, t2, l1, l2, magnetic = False, real_time=False):
+    def dipole(self, t1: Tensor, t2: Tensor, l1: Tensor, l2: Tensor, magnetic: bool = False, real_time: bool = False):
         """
         Parameters
         ----------
@@ -358,7 +369,7 @@ class rtcc(object):
 
         return (eref + ecc) * (-1.0j)
 
-    def autocorrelation(self, y_left, y_right):
+    def autocorrelation(self, y_left: Tensor, y_right: Tensor):
         """
         Parameters
         ----------
@@ -436,8 +447,8 @@ class rtcc(object):
             ret['m_z'] = m_z
         return y,ret
 
-    def propagate(self, ODE, yi, tf, ti=0, ref=False, chk=False, tchk=False,
-                  ofile="output.pk",tfile="t_out.pk",cfile="chk.pk",k=2):
+    def propagate(self, ODE: Any, yi: Tensor, tf: float, ti: float = 0, ref: bool = False, chk: bool = False, tchk: bool = False,
+                  ofile: str = "output.pk", tfile: str = "t_out.pk", cfile: str = "chk.pk", k: int = 2):
         """
         Propagate the function yi from time ti to time tf
 


### PR DESCRIPTION
## Summary
  
  Completes the type-hint half of the docstrings/type-hints worklist item (the docstring half merged in #95).
  
  - **New `pycc/_typing.py`** with project-wide aliases:
    - `Tensor` — `numpy.ndarray | torch.Tensor` (the torch arm is guarded so the alias imports and resolves via `typing.get_type_hints` even without PyTorch 
  installed).
    - `Slice` — orbital-subspace selector (`slice | int | ndarray`).
    - `Contract` — a tensor-contraction callable.
  - **`from __future__ import annotations`** in every touched module, so all hints are lazy (stored as strings, zero runtime cost; forward refs just work).
  - **Public API annotated:**
    - Constructors: `ccwfn`, `lccwfn`, `cchbar`, `cclambda`, `ccdensity`, `cceom`, `ccresponse`, `pertbar`, `rtcc`, `Local`, `Hamiltonian`.
    - Drivers: `solve_cc`/`solve_lcc`/`solve_lambda`/`solve_eom`, `compute_energy`, the `ccresponse` drivers, `rtcc.f`/`propagate`/`dipole`/`autocorrelation`, and 
  `Local.filter_*`/`trans_integrals`/`overlaps`.
    - `cctriples`: the three public (T)-energy drivers (`t_tjl`, `t_vikings`, `t_vikings_inverted`); batched per-index helpers left unannotated.
  - Cross-class object params use `TYPE_CHECKING`-guarded forward refs (no runtime/circular imports); foreign Psi4 objects are typed `Any`.
  
  No mypy-in-CI in this PR (deferred — Psi4 has no stubs and torch/einsums are optional).
  
  **Annotations only; no behavior change.**
  
  ## Testing
  10 tests pass across CCSD / CCD / (T) / density / RT / linresp / EOM, plus a clean package import and `get_type_hints` resolution of the runtime-resolvable 
  signatures.

## Status
- [X] Ready to go