### PR TITLE
Warn on GPU fallback instead of falling back silently

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -41,8 +41,16 @@ in the **Critique** section.
       errors — `.upper()` never applied — and were removed rather than "fixed".
       Verified in `p4env`: error path raises with the new message; lowercase
       `local`/`local_mos` accepted and drive localization correctly.
-- [ ] **GPU-fallback warning** — emit a warning when GPU is requested but Torch is
-      missing instead of silently falling back to CPU.
+- [x] **GPU-fallback warning** — DONE. New `PyCCWarning(UserWarning)` base in
+      `pycc/exceptions.py` (filterable/escalatable). In `ccwfn.__init__`, the
+      torch-missing `print` became a `warnings.warn(..., PyCCWarning)` and a *second*
+      warning was added for the genuinely-silent case — torch present but
+      `torch.cuda.is_available()` False, where `device` stays `'GPU'` while tensors
+      silently run on CPU (the elif at the device block; tensor routing unchanged).
+      Verified in `p4env` (no torch installed → exercises the torch-missing path:
+      one `PyCCWarning`, `device` falls back to `'CPU'`). The CUDA-unavailable elif is
+      verified by inspection only — testing it needs torch installed, which we declined
+      to add to `p4env`; it's safe because it's only reachable when `HAS_TORCH` is True.
 - [x] **Type hints + method docstrings** — DONE (both halves):
       shape/index + CCSD-equation docstrings on the intermediate builders and
       residual/energy methods in `ccwfn.py`, `cchbar.py`, `cclambda.py`

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -10,6 +10,7 @@ if __name__ == "__main__":
 
 import psi4
 import time
+import warnings
 import numpy as np
 
 try:
@@ -26,7 +27,7 @@ from .local import Local
 from .cctriples import t_tjl, t3c_ijk, t3d_ijk, t3c_abc, t3d_abc, t3_pert_ijk
 from .lccwfn import lccwfn
 from ._typing import Tensor
-from .exceptions import InvalidKeywordError
+from .exceptions import InvalidKeywordError, PyCCWarning
 
 try:
     import einsums as ein
@@ -227,9 +228,14 @@ class ccwfn(object):
         if device.upper() not in valid_device:
             raise InvalidKeywordError('device', device, valid_device)
         self.device = device.upper()
-        if self.device == 'GPU' and HAS_TORCH == False:
+        if self.device == 'GPU' and not HAS_TORCH:
+            warnings.warn("GPU requested, but PyTorch is not available; "
+                          "falling back to CPU.", PyCCWarning, stacklevel=2)
             self.device = 'CPU'
-            print('GPU requested, but torch not available.  Using CPU instead.')
+        elif self.device == 'GPU' and not torch.cuda.is_available():
+            warnings.warn("GPU requested, but no CUDA device is available; "
+                          "PyTorch tensors will run on CPU.", PyCCWarning,
+                          stacklevel=2)
 
         if self.precision == 'SP':
             self.H.F = np.float32(self.H.F)

--- a/pycc/exceptions.py
+++ b/pycc/exceptions.py
@@ -14,6 +14,15 @@ class PyCCError(Exception):
     """Base class for all PyCC-specific errors."""
 
 
+class PyCCWarning(UserWarning):
+    """Base class for all PyCC-specific warnings.
+
+    Subclassing :class:`UserWarning` lets callers silence or escalate PyCC
+    warnings selectively, e.g. ``warnings.filterwarnings('error',
+    category=PyCCWarning)``.
+    """
+
+
 class InvalidKeywordError(PyCCError, ValueError):
     """A keyword argument was given an unrecognized or invalid value.
 


### PR DESCRIPTION
## Summary

  Replaces silent CPU fallbacks with proper, filterable warnings when GPU execution can't actually happen.

  ### Changes
  - **`pycc/exceptions.py`** — new `PyCCWarning(UserWarning)` base, so callers can silence or escalate PyCC warnings
  selectively (e.g. `warnings.filterwarnings('error', category=PyCCWarning)`).
  - **`ccwfn.__init__`** — two cases, both now warn via `warnings.warn(..., PyCCWarning)`:
    1. **Torch missing** — was a `print`; now a real warning. Falls back to CPU as before.
    2. **CUDA unavailable** (torch present, `torch.cuda.is_available()` False) — previously *fully silent*: `device` stayed 
  `'GPU'` while tensors actually ran on CPU. Now warns. Tensor routing is unchanged — only the warning is new.
  - Tidied `HAS_TORCH == False` → `not HAS_TORCH`.

  ## Verification
  Confirmed in the `p4env` conda env (which has no torch installed, so it exercises the torch-missing path):
  - `ccwfn(wfn, device='GPU')` emits exactly one `PyCCWarning` ("GPU requested, but PyTorch is not available; falling back to
  CPU.") and `cc.device == 'CPU'`.

  The CUDA-unavailable `elif` is verified by inspection (testing it needs torch installed, which we opted not to add to 
  `p4env`). It's safe because it's only reachable when `HAS_TORCH` is True, so `torch.cuda` is always defined there.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Status
- [X] Ready to go