### PR TITLE
Add shared backend-aware zeros helpers; apply in cclambda and ccdensity

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -15,11 +15,19 @@ in the **Critique** section.
 - [x] `.gitignore` — Psi4 scratch (`psi.*.clean`), `ijk.dat`, `profile.txt`, `.DS_Store`
 - [ ] **Shared CC solver base** — extract a `_CCSolver` (or composition) shared by
       `ccwfn` and `lccwfn` to kill the ~800–960-line duplication. _Highest leverage._
-- [ ] **Contraction-backend abstraction** — replace the ~50×/module
+- [~] **Contraction-backend abstraction** — replace the ~50×/module
       `contract = self.ec.contract if self.einsums ...` + `.clone()/.copy()` device
       branching with one callable that owns library/device/precision. (Root cause of
       the `zero_like` bug.) _Design drafted below — see "Design note:
       contraction-backend abstraction"; decision is to grow `cc_contract`._
+      _Started (smear #3, the array-namespace helpers):_ added shared `zeros_like(a)` and
+      `zeros(shape, like)` to `utils.py` as free functions (free, not `cc_contract`
+      methods, because `cctriples`' triples kernels are module-level and have no
+      `self.contract`), and applied them in `cclambda` and `ccdensity` — collapsing the
+      `if HAS_TORCH … torch.zeros_like … else np.zeros_like` branches and removing every
+      `zeros_like`+`pad` idiom. Remaining modules (`ccwfn`, `cctriples`, `cchbar`,
+      `cceom`, `rt/rtcc`, `lccwfn`) adopt the helpers one-per-PR. The library-dispatch
+      (smear #1) and `.clone()/.copy()` (smear #2) collapses are still open.
 - [x] **Test fixtures** — added `pycc/tests/conftest.py` (`psi4_environment` +
       `rhf_wfn` factory); converted 32 test modules off the copied psi4-setup block
       (~570 fewer lines). Branch `refactor/test-fixtures`, commit `2cfe825`. A
@@ -27,9 +35,16 @@ in the **Critique** section.
       reference energies are method-specific and stay inline in each test. Note:
       `test_040` (einsums CC2) hangs locally with or without this change; einsums
       isn't in CI so those tests skip there.
-- [ ] **Break up god methods** — `cclambda.solve_lambda` (~220), `cclambda.residuals`
-      (~170), `ccwfn.t3_density` (~134, incl. dead debug block at 912–958),
-      `ccwfn.r_T2`/`residuals` deep model conditional trees.
+- [~] **Break up god methods** — _`cclambda` half DONE (PR #101)._
+      `cclambda.solve_lambda` (221→122) and `cclambda.residuals` (169→56) each carried a
+      near-verbatim ~120-line CC3 lambda-triples block; extracted to shared helpers
+      `_build_cc3_lambda_intermediates` + `_cc3_lambda_triples` (a `real_time` flag is the
+      only difference between the two former copies). `ccwfn.t3_density`'s flagged dead
+      debug block was **already gone** (removed before this effort; the "912–958" line
+      ref was stale) and the method is now a clean 86-line (T)-density kernel — dropped
+      from this item. _Still open:_ the mirror **t3** dedup in `ccwfn.py` (its `residuals`
+      vs the `solve_cc` per-iteration block), and the `ccwfn.r_T2`/`residuals` deep
+      CCD/CC2/CCSD/CC3 conditional trees.
 - [x] **Custom exception types** + `.upper()` the string kwargs — DONE. New
       `pycc/exceptions.py` with `PyCCError` base and `InvalidKeywordError(PyCCError,
       ValueError)` (carries `keyword`/`value`/`allowed`, standardized message,
@@ -169,9 +184,11 @@ Sphinx docs. As a research scaffold it's in good shape.
   `if HAS_TORCH and isinstance(t1, torch.Tensor): .clone() else .copy()` appears ~50+ times per
   module. Should be one contraction-backend abstraction (a callable that already knows
   device/precision/library). This smearing is exactly what produced the `zero_like` bug.
-- **God methods.** `cclambda.solve_lambda` (~220 lines) and `residuals` (~170),
-  `ccwfn.t3_density` (~134, with a 47-line commented-out debug block at 912–958),
-  `residuals`/`r_T2` with deep CCD/CC2/CCSD/CC3 conditional trees. Hard to test and review.
+- **God methods.** `cclambda.solve_lambda` (~220 lines) and `residuals` (~170) — both
+  cut roughly in half by extracting the shared CC3 lambda-triples block (PR #101);
+  `ccwfn.t3_density` (now ~86 lines; the once-flagged commented-out debug block is already
+  gone); `ccwfn.residuals`/`r_T2` with deep CCD/CC2/CCSD/CC3 conditional trees (still
+  open). Hard to test and review.
 
 ### Quality / maintainability
 

--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -15,6 +15,7 @@ from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
 from .cctriples import t3c_ijk, t3c_abc, l3_ijk, l3_abc, t3c_bc, l3_bc, t3_pert_ijk, t3_pert_bc
+from .utils import zeros, zeros_like
 
 if TYPE_CHECKING:
     from pycc.ccwfn import ccwfn
@@ -209,10 +210,7 @@ class ccdensity(object):
             opdm[o,v] += self.build_cc3_Dov(o, v, no, nv, F, L, t1, t2, l1, l2, Wvvvo, Wovoo, Fov, Wvovv, Wooov, real_time=real_time)
 
             # Density matrix blocks in contractions with T1-transformed dipole integrals
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                opdm_cc3 = torch.zeros_like(opdm)
-            else:
-                opdm_cc3 = np.zeros_like(opdm)
+            opdm_cc3 = zeros_like(opdm)
             opdm_cc3[o,o] += self.build_cc3_Doo(o, v, no, nv, F, L, t2, l1, l2, Fov, Wvvvo, Wovoo, Wvovv, Wooov)
             opdm_cc3[v,v] += self.build_cc3_Dvv(o, v, no, nv, F, L, t2, l1, l2, Fov, Wvvvo, Wovoo, Wvovv, Wooov)
 
@@ -258,10 +256,7 @@ class ccdensity(object):
     def build_Dov(self, t1, t2, l1, l2):  # complete
         contract = self.contract
         if self.ccwfn.model == 'CCD':
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                Dov = torch.zeros_like(t1)
-            else:
-                Dov = np.zeros_like(t1)
+            Dov = zeros_like(t1)
         else:
             if HAS_TORCH and isinstance(t1, torch.Tensor):
                 Dov = 2.0 * t1.clone()
@@ -285,13 +280,9 @@ class ccdensity(object):
 
     # CC3 contributions to the one electron densities
     def build_cc3_Dov(self, o, v, no, nv, F, L, t1, t2, l1, l2, Wvvvo, Wovoo, Fov, Wvovv, Wooov, real_time=False):
-        contract = self.contract  
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            Dov = torch.zeros_like(t1)   
-            Zlmdi = torch.zeros_like(t2[:,:,:,:no])
-        else:
-            Dov = np.zeros_like(t1)    
-            Zlmdi = np.zeros_like(t2[:,:,:,:no])    
+        contract = self.contract
+        Dov = zeros_like(t1)
+        Zlmdi = zeros_like(t2[:,:,:,:no])
         for i in range(no):
             for j in range(no):
                 for k in range(no):                    
@@ -314,11 +305,8 @@ class ccdensity(object):
                                     
     def build_cc3_Doo(self, o, v, no, nv, F, L, t2, l1, l2, Fov, Wvvvo, Wovoo, Wvovv, Wooov, real_time=False):
         contract = self.contract
-        if HAS_TORCH and isinstance(l1, torch.Tensor):
-            Doo = torch.zeros_like(l1[:,:no])
-        else:
-            Doo = np.zeros_like(l1[:,:no])        
-        for b in range(nv): 
+        Doo = zeros_like(l1[:,:no])
+        for b in range(nv):
             for c in range(nv):
                 t3 = t3c_bc(o, v, b, c, t2, Wvvvo, Wovoo, F, contract)
                 if real_time is True:
@@ -334,12 +322,9 @@ class ccdensity(object):
 
     def build_cc3_Dvv(self, o, v, no, nv, F, L, t2, l1, l2, Fov, Wvvvo, Wovoo, Wvovv, Wooov, real_time=False):
         contract = self.contract
-        if HAS_TORCH and isinstance(l1, torch.Tensor):
-            Dvv = torch.zeros_like(l1)
-            Dvv = torch.nn.functional.pad(Dvv, (0,0,0,nv-no))
-        else:
-            Dvv = np.zeros_like(l1)
-            Dvv = np.pad(Dvv, ((0,nv-no), (0,0)))
+        # Dvv's leading axis is virtual (shape nv,nv), so allocate it directly
+        # rather than zeros_like(l1) (no,nv) + pad.
+        Dvv = zeros((nv, nv), like=l1)
         for i in range(no):
             for j in range(no):
                 for k in range(no):

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from opt_einsum import contract
-from .utils import helper_diis
+from .utils import helper_diis, zeros, zeros_like
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
@@ -245,21 +245,6 @@ class cclambda(object):
                                              
         return r1, r2
 
-    def _zeros(self, shape, like):
-        """Allocate a zero tensor of ``shape`` matching ``like``'s backend/dtype/device.
-
-        A small file-local version of the ``zeros(shape, like=x)`` primitive
-        described in the contraction-backend design note: it dispatches on the
-        runtime type of ``like`` (NumPy vs torch) and inherits its dtype — and,
-        for torch, its device — so single/mixed precision and GPU placement ride
-        along automatically. Used to allocate the CC3 Z-intermediates, whose
-        shapes mix occupied and virtual dimensions and so are not ``zeros_like``
-        of any single amplitude array.
-        """
-        if HAS_TORCH and isinstance(like, torch.Tensor):
-            return torch.zeros(shape, dtype=like.dtype, device=like.device)
-        return np.zeros(shape, dtype=like.dtype)
-
     def _build_cc3_lambda_intermediates(self, o, v, t1, t2, F, ERI, L, real_time=False):
         """Build the T-dependent CC3 intermediates shared by the Lambda equations.
 
@@ -303,8 +288,8 @@ class cclambda(object):
 
         # Building intermediates in t3l1. Zmdfa's second axis is virtual
         # (shape no,nv,nv,nv), so it is allocated directly rather than padded.
-        Zmndi = self._zeros((no, no, nv, no), like=t2)
-        Zmdfa = self._zeros((no, nv, nv, nv), like=t2)
+        Zmndi = zeros((no, no, nv, no), like=t2)
+        Zmdfa = zeros((no, nv, nv, nv), like=t2)
         for m in range(no):
             for n in range(no):
                 for l in range(no):
@@ -373,17 +358,17 @@ class cclambda(object):
         # a Lambda array's shape; Zbide/Zblad_* have a virtual leading axis
         # (nv,no,nv,nv) and Zjlma/Zjlid_* an all-but-last occupied shape
         # (no,no,no,nv), so they are allocated by explicit shape.
-        Y1 = self._zeros(l1.shape, like=l1)
-        Y2 = self._zeros(l2.shape, like=l2)
+        Y1 = zeros_like(l1)
+        Y2 = zeros_like(l2)
         # t3l1
-        Znf = self._zeros(l1.shape, like=l1)
+        Znf = zeros_like(l1)
         #l3l1+l3l2
-        Zbide = self._zeros((nv, no, nv, nv), like=l2)
-        Zblad_1 = self._zeros((nv, no, nv, nv), like=l2)
-        Zblad_2 = self._zeros((nv, no, nv, nv), like=l2)
-        Zjlma = self._zeros((no, no, no, nv), like=l2)
-        Zjlid_1 = self._zeros((no, no, no, nv), like=l2)
-        Zjlid_2 = self._zeros((no, no, no, nv), like=l2)
+        Zbide = zeros((nv, no, nv, nv), like=l2)
+        Zblad_1 = zeros((nv, no, nv, nv), like=l2)
+        Zblad_2 = zeros((nv, no, nv, nv), like=l2)
+        Zjlma = zeros((no, no, no, nv), like=l2)
+        Zjlid_1 = zeros((no, no, no, nv), like=l2)
+        Zjlid_2 = zeros((no, no, no, nv), like=l2)
         # t3l1
         for l in range(no):
             for m in range(no):
@@ -495,10 +480,7 @@ class cclambda(object):
         """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
-            if HAS_TORCH and isinstance(l1, torch.Tensor):
-                r_l1 = torch.zeros_like(l1)
-            else:
-                r_l1 = np.zeros_like(l1)
+            r_l1 = zeros_like(l1)
         else:
             if HAS_TORCH and isinstance(l1, torch.Tensor):
                 r_l1 = 2.0 * Hov.clone()

--- a/pycc/utils.py
+++ b/pycc/utils.py
@@ -5,6 +5,33 @@ if HAS_TORCH:
 import opt_einsum
 
 
+def zeros_like(a):
+    """Backend-aware ``zeros_like``: ``torch.zeros_like`` for a torch tensor,
+    else ``np.zeros_like``.
+
+    Collapses the ``if HAS_TORCH and isinstance(a, torch.Tensor): ... else: ...``
+    allocation branch that recurs throughout the CC modules into a single call.
+    """
+    if HAS_TORCH and isinstance(a, torch.Tensor):
+        return torch.zeros_like(a)
+    return np.zeros_like(a)
+
+
+def zeros(shape, like):
+    """Allocate a zero tensor of ``shape`` matching ``like``'s backend/dtype/device.
+
+    Dispatches on the runtime type of ``like`` (NumPy vs torch) and inherits its
+    dtype — and, for torch, its device — so single/mixed precision and GPU
+    placement ride along automatically. Use this in place of the
+    ``zeros_like(x)`` + ``np.pad``/``torch.nn.functional.pad`` idiom when the
+    target shape mixes occupied and virtual dimensions and so is not
+    ``zeros_like`` of any single amplitude array.
+    """
+    if HAS_TORCH and isinstance(like, torch.Tensor):
+        return torch.zeros(shape, dtype=like.dtype, device=like.device)
+    return np.zeros(shape, dtype=like.dtype)
+
+
 class helper_diis(object):
     def __init__(self, t1, t2, max_diis, precision='DP'):
         if HAS_TORCH and isinstance(t1, torch.Tensor):


### PR DESCRIPTION
Follow-up to PR #101. The CC modules repeat an if HAS_TORCH and isinstance(x, torch.Tensor): torch.zeros_like(…) else: 
  np.zeros_like(…) allocation branch dozens of times, plus a roundabout zeros_like + pad idiom where the target shape mixes
  occupied and virtual dimensions. PR #101 introduced a private _zeros in cclambda for the latter; this generalizes it into
  shared helpers and starts the rollout.

  New helpers in utils.py (which already imports HAS_TORCH/torch):
  - zeros_like(a) — backend-aware torch/np zeros_like, collapsing the branch to one call.
  - zeros(shape, like) — zeros of an explicit shape inheriting like's dtype (and torch device); the replacement for
  zeros_like+pad. This is cclambda's former _zeros, promoted to shared.
  
  Why free functions, not cc_contract methods: cctriples's triples kernels (t3c_ijk, l3_ijk, …) are module-level functions
  with no self.contract to hang a method on. Free functions reach both call styles. They're also the first installment of the
  "array-namespace helpers" from the contraction-backend design note (smear #3: zeros_like ×47 → one definition).

  Applied:
  - cclambda — drop the private _zeros, import/use the shared helpers (incl. the r_L1 CCD branch).
  - ccdensity — convert all five allocation blocks (12 zeros_like sites) and the last pad site (build_cc3_Dvv →
  zeros((nv,nv), like=l1)). 
  
  Also updates CODE_REVIEW.md: marks the cclambda god-methods half done (PR #101) and the array-namespace-helpers smear (#3)
  as started; records that t3_density's flagged dead debug block was already gone (the 912–958 line ref was stale) and the
  method is now a clean ~86-line kernel; fixes the matching stale mention in the structural-issues section.

  No numerical change. Verified in p4env:
  - Full non-slow suite — 53 passed, 1 skipped (gpu), 8 deselected (slow), 1 xfailed; every ccdensity consumer included
  (CCSD/CCD/CC2/CCSD(T)/CC3 densities, RT-CC variants, dipole/field, linear response, autocorrelation, checkpoint,
  single-precision, local-RT PNO/PAO, EOM-CCSD, and the einsums tests that ran).
  - Re-run with all einsums tests excluded — 50 passed, 0 DGEMV warnings, confirming those pre-existing BLAS warnings are
  einsums-only and unrelated to this change.

  CC3 and both backends are in CI, so the PR's suite re-confirms.

  Remaining modules (ccwfn, cctriples, cchbar, cceom, rt/rtcc, lccwfn) can adopt the same helpers one-per-PR, per the design
  note.

  🤖 Generated with Claude Code (https://claude.com/claude-code)