### PR TITLE
Adopt the shared array-namespace helpers across ccwfn, cctriples, rtcc

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -42,9 +42,13 @@ in the **Critique** section.
       only difference between the two former copies). `ccwfn.t3_density`'s flagged dead
       debug block was **already gone** (removed before this effort; the "912–958" line
       ref was stale) and the method is now a clean 86-line (T)-density kernel — dropped
-      from this item. _Still open:_ the mirror **t3** dedup in `ccwfn.py` (its `residuals`
-      vs the `solve_cc` per-iteration block), and the `ccwfn.r_T2`/`residuals` deep
-      CCD/CC2/CCSD/CC3 conditional trees.
+      from this item. A mirror **t3** dedup in `ccwfn.py` was considered but is a
+      **non-issue**: unlike `cclambda`, `ccwfn.solve_cc` already delegates to
+      `ccwfn.residuals` (it does not inline its own copy of the CC3 t3 block), so there is
+      nothing duplicated to extract. _Still open:_ the `ccwfn.r_T2` (~100-line) deep
+      CCD/CC2/CCSD/CC3 conditional tree (the genuine remaining god method); optionally,
+      pulling the single-instance CC3 t3 block out of `ccwfn.residuals` into a helper for
+      parallelism with `cclambda._cc3_lambda_triples` (readability only, not dedup).
 - [x] **Custom exception types** + `.upper()` the string kwargs — DONE. New
       `pycc/exceptions.py` with `PyCCError` base and `InvalidKeywordError(PyCCError,
       ValueError)` (carries `keyword`/`value`/`allowed`, standardized message,

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -8,6 +8,7 @@ import numpy as np
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
+from pycc.utils import zeros_like, diag
 
 if TYPE_CHECKING:
     from pycc.ccwfn import ccwfn
@@ -55,12 +56,8 @@ def t3c_ijk(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract, WithDenom=True):
     t3 -= contract('mc,mba->abc', Wovoo[:,:,i,k], t2[j])
 
     if WithDenom is True:
-        if HAS_TORCH and isinstance(t2, torch.Tensor):
-            Fv = torch.diag(F)[v]
-            denom = torch.zeros_like(t3)
-        else:
-            Fv = np.diag(F)[v]
-            denom = np.zeros_like(t3)
+        Fv = diag(F)[v]
+        denom = zeros_like(t3)
         denom -= Fv.reshape(-1,1,1) + Fv.reshape(-1,1) + Fv
         denom += F[i,i] + F[j,j] + F[k,k]
         return t3/denom
@@ -102,12 +99,8 @@ def t3c_abc(o, v, a, b, c, t2, Wvvvo, Wovoo, F, contract, WithDenom=True):
 
     if WithDenom is True:
         no = o.stop
-        if HAS_TORCH and isinstance(t2, torch.Tensor):
-            Fo = torch.diag(F)[o]
-            denom = torch.zeros_like(t3)
-        else:
-            Fo = np.diag(F)[o]
-            denom = np.zeros_like(t3)
+        Fo = diag(F)[o]
+        denom = zeros_like(t3)
         denom += Fo.reshape(-1,1,1) + Fo.reshape(-1,1) + Fo
         denom -= F[a+no,a+no] + F[b+no,b+no] + F[c+no,c+no]
         return t3/denom
@@ -275,12 +268,8 @@ def t_vikings(ccwfn: "ccwfn") -> float:
     L = ccwfn.H.L
     t1 = ccwfn.t1
     t2 = ccwfn.t2
-    if HAS_TORCH and isinstance(t1, torch.Tensor):
-        X1 = torch.zeros_like(ccwfn.t1)
-        X2 = torch.zeros_like(ccwfn.t2)
-    else:
-        X1 = np.zeros_like(ccwfn.t1)
-        X2 = np.zeros_like(ccwfn.t2)
+    X1 = zeros_like(ccwfn.t1)
+    X2 = zeros_like(ccwfn.t2)
 
     for i in range(no):
         for j in range(no):
@@ -402,12 +391,8 @@ def l3_ijk(i, j, k, o, v, L, l1, l2, Fov, Wvovv, Wooov, F, contract, WithDenom=T
     l3 += W
 
     if WithDenom is True:
-        if HAS_TORCH and isinstance(l2, torch.Tensor):
-            Fv = torch.diag(F)[v]
-            denom = torch.zeros_like(l3)
-        else:
-            Fv = np.diag(F)[v]
-            denom = np.zeros_like(l3)
+        Fv = diag(F)[v]
+        denom = zeros_like(l3)
         denom -= Fv.reshape(-1,1,1) + Fv.reshape(-1,1) + Fv
         denom += F[i,i] + F[j,j] + F[k,k]
         return l3/denom
@@ -468,12 +453,8 @@ def l3_abc(a, b, c, o, v, L, l1, l2, Fov, Wvovv, Wooov, F, contract, WithDenom=T
 
     if WithDenom is True:
         no = o.stop
-        if HAS_TORCH and isinstance(l2, torch.Tensor):
-            Fo = torch.diag(F)[o]
-            denom = torch.zeros_like(l3)
-        else:
-            Fo = np.diag(F)[o]
-            denom = np.zeros_like(l3)
+        Fo = diag(F)[o]
+        denom = zeros_like(l3)
         denom += Fo.reshape(-1,1,1) + Fo.reshape(-1,1) + Fo
         denom -= F[a+no,a+no] + F[b+no,b+no] + F[c+no,c+no]
         return l3/denom
@@ -515,12 +496,8 @@ def l3_ijk_alt(i, j, k, o, v, L, l1, l2, Fov, Wvovv, Wooov, F, contract, WithDen
     l3 += 2 * W - W.swapaxes(0,1) - W.swapaxes(0,2)
 
     if WithDenom is True:
-        if HAS_TORCH and isinstance(l2, torch.Tensor):
-            Fv = torch.diag(F)[v]
-            denom = torch.zeros_like(l3)
-        else:
-            Fv = np.diag(F)[v]
-            denom = np.zeros_like(l3)
+        Fv = diag(F)[v]
+        denom = zeros_like(l3)
         denom -= Fv.reshape(-1,1,1) + Fv.reshape(-1,1) + Fv
         denom += F[i,i] + F[j,j] + F[k,k]
         return l3/denom
@@ -564,12 +541,8 @@ def l3_abc_alt(a, b, c, o, v, L, l1, l2, Fov, Wvovv, Wooov, F, contract, WithDen
 
     if WithDenom is True:
         no = o.stop
-        if HAS_TORCH and isinstance(l2, torch.Tensor):
-            Fo = torch.diag(F)[o]
-            denom = torch.zeros_like(l3)
-        else:
-            Fo = np.diag(F)[o]
-            denom = np.zeros_like(l3)
+        Fo = diag(F)[o]
+        denom = zeros_like(l3)
         denom += Fo.reshape(-1,1,1) + Fo.reshape(-1,1) + Fo
         denom -= F[a+no,a+no] + F[b+no,b+no] + F[c+no,c+no]
         return l3/denom
@@ -596,14 +569,9 @@ def t3c_bc(o, v, b, c, t2, Wvvvo, Wovoo, F, contract, WithDenom=True):
 
     if WithDenom is True:
         no = o.stop
-        if HAS_TORCH and isinstance(t2, torch.Tensor):
-            Fo = torch.diag(F)[o]
-            Fv = torch.diag(F)[v]
-            denom = torch.zeros_like(t3)
-        else:
-            Fo = np.diag(F)[o]
-            Fv = np.diag(F)[v]
-            denom = np.zeros_like(t3)
+        Fo = diag(F)[o]
+        Fv = diag(F)[v]
+        denom = zeros_like(t3)
         denom += Fo.reshape(-1,1,1,1) + Fo.reshape(-1,1,1) + Fo.reshape(-1,1)
         denom -= Fv.reshape(1,1,1,-1)
         denom -= F[b+no,b+no] + F[c+no,c+no]
@@ -665,14 +633,9 @@ def l3_bc(b, c, o, v, L, l1, l2, Fov, Wvovv, Wooov, F, contract, WithDenom=True)
 
     if WithDenom is True:
         no = o.stop
-        if HAS_TORCH and isinstance(l2, torch.Tensor):
-            Fo = torch.diag(F)[o]
-            Fv = torch.diag(F)[v]
-            denom = torch.zeros_like(l3)
-        else:
-            Fo = np.diag(F)[o]
-            Fv = np.diag(F)[v]
-            denom = np.zeros_like(l3)
+        Fo = diag(F)[o]
+        Fv = diag(F)[v]
+        denom = zeros_like(l3)
         denom += Fo.reshape(-1,1,1,1) + Fo.reshape(-1,1,1) + Fo.reshape(-1,1)
         denom -= Fv.reshape(1,1,1,-1)
         denom -= F[b+no,b+no] + F[c+no,c+no]
@@ -687,12 +650,8 @@ def t3_pert_ijk(o, v, i, j, k, t2, V, F, contract, WithDenom=True):
     t3 = contract('al,lcb->abc', tmp, t2[k])
 
     if WithDenom is True:
-        if HAS_TORCH and isinstance(t2, torch.Tensor):
-            Fv = torch.diag(F)[v]
-            denom = torch.zeros_like(t3)
-        else:
-            Fv = np.diag(F)[v]
-            denom = np.zeros_like(t3)
+        Fv = diag(F)[v]
+        denom = zeros_like(t3)
         denom -= Fv.reshape(-1,1,1) + Fv.reshape(-1,1) + Fv
         denom += F[i,i] + F[j,j] + F[k,k]
         return t3/denom
@@ -705,12 +664,8 @@ def t3_pert_abc(o, v, a, b, c, t2, V, F, contract, WithDenom=True):
 
     if WithDenom is True:
         no = o.stop
-        if HAS_TORCH and isinstance(t2, torch.Tensor):
-            Fo = torch.diag(F)[o]
-            denom = torch.zeros_like(t3)
-        else:
-            Fo = np.diag(F)[o]
-            denom = np.zeros_like(t3)
+        Fo = diag(F)[o]
+        denom = zeros_like(t3)
         denom += Fo.reshape(-1,1,1) + Fo.reshape(-1,1) + Fo
         denom -= F[a+no,a+no] + F[b+no,b+no] + F[c+no,c+no]
         return t3/denom
@@ -723,14 +678,9 @@ def t3_pert_bc(o, v, b, c, t2, V, F, contract, WithDenom=True):
 
     if WithDenom is True:
         no = o.stop
-        if HAS_TORCH and isinstance(t2, torch.Tensor):
-            Fo = torch.diag(F)[o]
-            Fv = torch.diag(F)[v]
-            denom = torch.zeros_like(t3)
-        else:
-            Fo = np.diag(F)[o]
-            Fv = np.diag(F)[v]
-            denom = np.zeros_like(t3)
+        Fo = diag(F)[o]
+        Fv = diag(F)[v]
+        denom = zeros_like(t3)
         denom += Fo.reshape(-1,1,1,1) + Fo.reshape(-1,1,1) + Fo.reshape(-1,1)
         denom -= Fv.reshape(1,1,1,-1)
         denom -= F[b+no,b+no] + F[c+no,c+no]

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -21,7 +21,7 @@ except ImportError:
 
 from typing import Any
 
-from .utils import helper_diis, cc_contract
+from .utils import helper_diis, cc_contract, zeros_like
 from .hamiltonian import Hamiltonian
 from .local import Local
 from .cctriples import t_tjl, t3c_ijk, t3d_ijk, t3c_abc, t3d_abc, t3_pert_ijk
@@ -444,12 +444,8 @@ class ccwfn(object):
             Wamef_cc3 = self.build_cc3_Wamef(o, v, ERI, t1)
             Wabei_cc3 = self.build_cc3_Wabei(o, v, ERI, t1)
 
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                X1 = torch.zeros_like(t1)
-                X2 = torch.zeros_like(t2)
-            else:
-                X1 = np.zeros_like(t1)
-                X2 = np.zeros_like(t2)
+            X1 = zeros_like(t1)
+            X2 = zeros_like(t2)
 
             contract = self.contract
             for i in range(no):
@@ -790,10 +786,7 @@ class ccwfn(object):
             contract = self.ec.contract
 
         if self.model == 'CCD':
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                r_T1 = torch.zeros_like(t1)
-            else:
-                r_T1 = np.zeros_like(t1)
+            r_T1 = zeros_like(t1)
         else:
             if HAS_TORCH and isinstance(t1, torch.Tensor):
                 r_T1 = F[o,v].clone()

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -11,6 +11,7 @@ import numpy as np
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
+from pycc.utils import zeros_like
 import pickle as pk
 from os.path import exists
 import opt_einsum
@@ -248,10 +249,7 @@ class rtcc(object):
             # Calculating T1-transformed dipole integral  
             no = self.ccwfn.no
             nv = self.ccwfn.nv
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                ints_cc3 = torch.zeros_like(ints)
-            else:
-                ints_cc3 = np.zeros_like(ints)
+            ints_cc3 = zeros_like(ints)
             for i in range(3):
                 if HAS_TORCH and isinstance(t1, torch.Tensor):                    
                     ints_cc3 = ints_cc3.type_as(t1)

--- a/pycc/utils.py
+++ b/pycc/utils.py
@@ -32,6 +32,18 @@ def zeros(shape, like):
     return np.zeros(shape, dtype=like.dtype)
 
 
+def diag(a):
+    """Backend-aware ``diag``: ``torch.diag`` for a torch tensor, else ``np.diag``.
+
+    Collapses the ``if HAS_TORCH and isinstance(a, torch.Tensor): torch.diag(a)
+    else: np.diag(a)`` branch (paired with ``zeros_like`` in the triples-denominator
+    construction throughout cctriples).
+    """
+    if HAS_TORCH and isinstance(a, torch.Tensor):
+        return torch.diag(a)
+    return np.diag(a)
+
+
 class helper_diis(object):
     def __init__(self, t1, t2, max_diis, precision='DP'):
         if HAS_TORCH and isinstance(t1, torch.Tensor):


### PR DESCRIPTION
  Continues the array-namespace-helper rollout from PR #102 (smear #3 of the contraction-backend design note). Collapses the
  per-site if HAS_TORCH and isinstance(x, torch.Tensor): torch.zeros_like(…) else: np.zeros_like(…) allocation branches to
  the shared utils helpers.
  
  cctriples's triples-denominator branches dispatch torch.diag/np.diag together with zeros_like, so this adds a companion
  diag(a) helper to utils.py (also in the design note's helper set); the two collapse those denom blocks fully.

  - utils.py — add diag(a) (backend-aware torch.diag/np.diag).
  - cctriples — collapse all 11 {diag, zeros_like} denominator branches and the t_vikings X1/X2 allocation (−60 lines).
  - ccwfn — collapse the two pure-zeros_like branches (CC3 X1/X2; CCD r_T1).
  - rtcc — collapse the ints_cc3 branch.

  Left untouched on purpose: bare single-backend np.zeros_like calls in numpy-only function bodies
  (t3d_ijk/t3d_abc/t_tjl/t_vikings_inverted, and the cceom/lccwfn modules, which have zero torch references) — converting
  them would falsely imply backend support the surrounding code lacks; and the three clone()/copy() branches in cctriples
  (smear #2, a separate item).

  No numerical change. Verified in p4env: full non-slow suite (einsums excluded) 50 passed / 1 skipped / 8 deselected / 1 
  xfailed, 0 DGEMV.

Also corrects CODE_REVIEW.md: records that the "mirror t3 dedup" in ccwfn is a non-issue (solve_cc already delegates to residuals — no inlined t3 copy, unlike cclambda); the genuine remaining ccwfn god method is r_T2's deep model-conditional tree.


  🤖 Generated with Claude Code (https://claude.com/claude-code)