### PR TITLE
Backend-aware clone() helper: collapse the HAS_TORCH clone()/copy() branches

### DIFF
--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -15,7 +15,7 @@ from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
 from .cctriples import t3c_ijk, t3c_abc, l3_ijk, l3_abc, t3c_bc, l3_bc, t3_pert_ijk, t3_pert_bc
-from .utils import zeros, zeros_like
+from .utils import zeros, zeros_like, clone
 
 if TYPE_CHECKING:
     from pycc.ccwfn import ccwfn
@@ -248,20 +248,14 @@ class ccdensity(object):
 
 
     def build_Dvo(self, l1):  # complete
-        if HAS_TORCH and isinstance(l1, torch.Tensor):
-            return l1.T.clone()
-        else:
-            return l1.T.copy()
+        return clone(l1.T)
 
     def build_Dov(self, t1, t2, l1, l2):  # complete
         contract = self.contract
         if self.ccwfn.model == 'CCD':
             Dov = zeros_like(t1)
         else:
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                Dov = 2.0 * t1.clone()
-            else:
-                Dov = 2.0 * t1.copy()
+            Dov = 2.0 * clone(t1)
 
             Dov += 2.0 * contract('me,imae->ia', l1, t2)
             Dov -= contract('me,miae->ia', l1, self.ccwfn.build_tau(t1, t2))
@@ -292,10 +286,7 @@ class ccdensity(object):
                     # Dov_1
                     t3 = t3c_ijk(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
                     if real_time is True:
-                        if HAS_TORCH and isinstance(t1, torch.Tensor):
-                            V = F - self.ccwfn.H.F.clone()
-                        else:
-                            V = F - self.ccwfn.H.F.copy()
+                        V = F - clone(self.ccwfn.H.F)
                         t3 -= t3_pert_ijk(o, v, i, j, k, t2, V, F, contract)
                     Dov[i] +=  contract('abc,bc->a', t3 - t3.swapaxes(0,1), l2[j,k])
         # Dov_2
@@ -310,10 +301,7 @@ class ccdensity(object):
             for c in range(nv):
                 t3 = t3c_bc(o, v, b, c, t2, Wvvvo, Wovoo, F, contract)
                 if real_time is True:
-                    if HAS_TORCH and isinstance(t2, torch.Tensor):
-                        V = F - self.ccwfn.H.F.clone()
-                    else:
-                        V = F - self.ccwfn.H.F.copy()
+                    V = F - clone(self.ccwfn.H.F)
                     t3 -= t3_pert_bc(o, v, b, c, t2, V, F, contract)
                 l3 = l3_bc(b, c, o, v, L, l1, l2, Fov, Wvovv, Wooov, F, contract)
                 Doo -= 0.5 * contract('lmia,lmja->ij', t3, l3)        
@@ -330,10 +318,7 @@ class ccdensity(object):
                 for k in range(no):
                     t3 = t3c_ijk(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
                     if real_time is True:
-                        if HAS_TORCH and isinstance(t2, torch.Tensor):
-                            V = F - self.ccwfn.H.F.clone()
-                        else:
-                            V = F - self.ccwfn.H.F.copy()
+                        V = F - clone(self.ccwfn.H.F)
                         t3 -= t3_pert_ijk(o, v, i, j, k, t2, V, F, contract)
                     l3 = l3_ijk(i, j, k, o, v, L, l1, l2, Fov, Wvovv, Wooov, F, contract)
                     Dvv += 0.5 * contract('bdc,adc->ab', t3, l3)
@@ -588,20 +573,14 @@ class ccdensity(object):
     # T1-transformed dipole integrals needed in CC3
     def build_Moo(self, no, nv, ints, t1):
         contract = self.contract
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            Moo = ints[:no,:no].clone()
-        else:
-            Moo = ints[:no,:no].copy()
+        Moo = clone(ints[:no,:no])
         Moo = Moo + contract('ma,ia->mi', ints[:no,-nv:], t1)
 
         return Moo
 
     def build_Mvv(self, no, nv, ints, t1):
         contract = self.contract
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            Mvv = ints[-nv:,-nv:].clone()
-        else:
-            Mvv = ints[-nv:,-nv:].copy()
+        Mvv = clone(ints[-nv:,-nv:])
         Mvv = Mvv - contract('ie,ia->ae', ints[:no,-nv:], t1)
 
         return Mvv

--- a/pycc/cchbar.py
+++ b/pycc/cchbar.py
@@ -15,6 +15,7 @@ import numpy as np
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
+from pycc.utils import clone
 
 if TYPE_CHECKING:
     from pycc.ccwfn import ccwfn
@@ -112,15 +113,9 @@ class cchbar(object):
         """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
-            if HAS_TORCH and isinstance(F, torch.Tensor):
-                Hov = F[o,v].clone()
-            else:
-                Hov = F[o,v].copy()
+            Hov = clone(F[o,v])
         else:
-            if HAS_TORCH and isinstance(F, torch.Tensor):
-                Hov = F[o,v].clone()
-            else:
-                Hov = F[o,v].copy()
+            Hov = clone(F[o,v])
             Hov = Hov + contract('nf,mnef->me', t1, L[o,o,v,v])
         return Hov
 
@@ -143,17 +138,11 @@ class cchbar(object):
         """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
-            if HAS_TORCH and isinstance(F, torch.Tensor):
-                Hvv = F[v,v].clone()
-            else:
-                Hvv = F[v,v].copy()
+            Hvv = clone(F[v,v])
             Hvv = Hvv - contract('mnfa,mnfe->ae', t2, L[o,o,v,v])
 
         else:
-            if HAS_TORCH and isinstance(F, torch.Tensor):
-                Hvv = F[v,v].clone()
-            else:
-                Hvv = F[v,v].copy()
+            Hvv = clone(F[v,v])
             Hvv = Hvv - contract('me,ma->ae', F[o,v], t1)
             Hvv = Hvv + contract('mf,amef->ae', t1, L[v,o,v,v])
             Hvv = Hvv - contract('mnfa,mnfe->ae', self.ccwfn.build_tau(t1, t2), L[o,o,v,v])
@@ -178,17 +167,11 @@ class cchbar(object):
         """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
-            if HAS_TORCH and isinstance(F, torch.Tensor):
-                Hoo = F[o,o].clone()
-            else:
-                Hoo = F[o,o].copy()
+            Hoo = clone(F[o,o])
             Hoo = Hoo + contract('inef,mnef->mi', t2, L[o,o,v,v])
 
         else:
-            if HAS_TORCH and isinstance(F, torch.Tensor):
-                Hoo = F[o,o].clone()
-            else:
-                Hoo = F[o,o].copy()
+            Hoo = clone(F[o,o])
             Hoo = Hoo + contract('ie,me->mi', t1, F[o,v])
             Hoo = Hoo + contract('ne,mnie->mi', t1, L[o,o,o,v])
             Hoo = Hoo + contract('inef,mnef->mi', self.ccwfn.build_tau(t1, t2), L[o,o,v,v])
@@ -212,17 +195,11 @@ class cchbar(object):
         """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                Hoooo = ERI[o,o,o,o].clone().to(self.ccwfn.device1)
-            else: 
-                Hoooo = ERI[o,o,o,o].copy()
+            Hoooo = clone(ERI[o,o,o,o], device=self.ccwfn.device1)
             Hoooo = Hoooo + contract('ijef,mnef->mnij', t2, ERI[o,o,v,v])
 
         else:
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hoooo = ERI[o,o,o,o].clone().to(self.ccwfn.device1)
-            else:
-                Hoooo = ERI[o,o,o,o].copy()
+            Hoooo = clone(ERI[o,o,o,o], device=self.ccwfn.device1)
             tmp = contract('je,mnie->mnij', t1, ERI[o,o,o,v])
             Hoooo = Hoooo + (tmp + tmp.swapaxes(0,1).swapaxes(2,3))
             if self.ccwfn.model == 'CC2':
@@ -250,17 +227,11 @@ class cchbar(object):
         """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hvvvv = ERI[v,v,v,v].clone().to(self.ccwfn.device1)
-            else:
-                Hvvvv = ERI[v,v,v,v].copy()
+            Hvvvv = clone(ERI[v,v,v,v], device=self.ccwfn.device1)
             Hvvvv = Hvvvv + contract('mnab,mnef->abef', t2, ERI[o,o,v,v])
 
         else:
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hvvvv = ERI[v,v,v,v].clone().to(self.ccwfn.device1)
-            else:
-                Hvvvv = ERI[v,v,v,v].copy()
+            Hvvvv = clone(ERI[v,v,v,v], device=self.ccwfn.device1)
             tmp = contract('mb,amef->abef', t1, ERI[v,o,v,v])
             Hvvvv = Hvvvv - (tmp + tmp.swapaxes(0,1).swapaxes(2,3))
             if self.ccwfn.model == 'CC2':
@@ -287,15 +258,9 @@ class cchbar(object):
         """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hvovv = ERI[v,o,v,v].clone().to(self.ccwfn.device1)
-            else:
-                Hvovv = ERI[v,o,v,v].copy()
+            Hvovv = clone(ERI[v,o,v,v], device=self.ccwfn.device1)
         else:
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hvovv = ERI[v,o,v,v].clone().to(self.ccwfn.device1)
-            else:
-                Hvovv = ERI[v,o,v,v].copy()
+            Hvovv = clone(ERI[v,o,v,v], device=self.ccwfn.device1)
             Hvovv = Hvovv - contract('na,nmef->amef', t1, ERI[o,o,v,v])
 
         return Hvovv
@@ -317,15 +282,9 @@ class cchbar(object):
         """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hooov = ERI[o,o,o,v].clone().to(self.ccwfn.device1)
-            else:
-                Hooov = ERI[o,o,o,v].copy()
+            Hooov = clone(ERI[o,o,o,v], device=self.ccwfn.device1)
         else:
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hooov = ERI[o,o,o,v].clone().to(self.ccwfn.device1)
-            else:
-                Hooov = ERI[o,o,o,v].copy()
+            Hooov = clone(ERI[o,o,o,v], device=self.ccwfn.device1)
             Hooov = Hooov + contract('if,nmef->mnie', t1, ERI[o,o,v,v])
 
         return Hooov
@@ -349,19 +308,13 @@ class cchbar(object):
         """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hovvo = ERI[o,v,v,o].clone().to(self.ccwfn.device1)
-            else:
-                Hovvo = ERI[o,v,v,o].copy()
+            Hovvo = clone(ERI[o,v,v,o], device=self.ccwfn.device1)
             # clean th== up
             Hovvo = Hovvo - contract('jnfb,mnef->mbej', t2, ERI[o,o,v,v])
             Hovvo = Hovvo + contract('njfb,mnef->mbej', t2, L[o,o,v,v])
 
         else:
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hovvo = ERI[o,v,v,o].clone().to(self.ccwfn.device1)
-            else:
-                Hovvo = ERI[o,v,v,o].copy()
+            Hovvo = clone(ERI[o,v,v,o], device=self.ccwfn.device1)
             Hovvo = Hovvo + contract('jf,mbef->mbej', t1, ERI[o,v,v,v])
             Hovvo = Hovvo - contract('nb,mnej->mbej', t1, ERI[o,o,v,o])
             if self.ccwfn.model != 'CC2':
@@ -387,16 +340,10 @@ class cchbar(object):
         """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hovov = ERI[o,v,o,v].clone().to(self.ccwfn.device1)
-            else:
-                Hovov = ERI[o,v,o,v].copy()
+            Hovov = clone(ERI[o,v,o,v], device=self.ccwfn.device1)
             Hovov = Hovov - contract('jnfb,nmef->mbje', t2, ERI[o,o,v,v])
         else:
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hovov = ERI[o,v,o,v].clone().to(self.ccwfn.device1)
-            else:
-                Hovov = ERI[o,v,o,v].copy()
+            Hovov = clone(ERI[o,v,o,v], device=self.ccwfn.device1)
             Hovov = Hovov + contract('jf,bmef->mbje', t1, ERI[v,o,v,v])
             Hovov = Hovov - contract('nb,mnje->mbje', t1, ERI[o,o,o,v])
             if self.ccwfn.model != 'CC2':
@@ -429,10 +376,7 @@ class cchbar(object):
         """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hvvvo = ERI[v,v,v,o].clone().to(self.ccwfn.device1)
-            else:
-                Hvvvo = ERI[v,v,v,o].copy()
+            Hvvvo = clone(ERI[v,v,v,o], device=self.ccwfn.device1)
             Hvvvo = Hvvvo - contract('me,miab->abei', Hov, t2)
             Hvvvo = Hvvvo + contract('mnab,mnei->abei', self.ccwfn.build_tau(t1, t2), ERI[o,o,v,o])
             Hvvvo = Hvvvo - contract('imfa,bmfe->abei', t2, ERI[v,o,v,v])
@@ -440,36 +384,24 @@ class cchbar(object):
             Hvvvo = Hvvvo + contract('mifb,amef->abei', t2, L[v,o,v,v])
 
         elif self.ccwfn.model == 'CC2':
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hvvvo = ERI[v,v,v,o].clone().to(self.ccwfn.device1)  
-            else:
-                Hvvvo = ERI[v,v,v,o].copy()
+            Hvvvo = clone(ERI[v,v,v,o], device=self.ccwfn.device1)
             Hvvvo = Hvvvo - contract('me,miab->abei', self.ccwfn.H.F[o,v], t2)
             Hvvvo = Hvvvo + contract('if,abef->abei', t1, Hvvvv)
             Hvvvo = Hvvvo + contract('nb,anei->abei', t1, contract('ma,mnei->anei', t1, ERI[o,o,v,o]))
             Hvvvo = Hvvvo - contract('mb,amei->abei', t1, ERI[v,o,v,o])
             Hvvvo = Hvvvo - contract('ma,bmie->abei', t1, ERI[v,o,o,v])
         else:
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hvvvo = ERI[v,v,v,o].clone().to(self.ccwfn.device1)
-            else:
-                Hvvvo = ERI[v,v,v,o].copy()
+            Hvvvo = clone(ERI[v,v,v,o], device=self.ccwfn.device1)
             Hvvvo = Hvvvo - contract('me,miab->abei', Hov, t2)
             Hvvvo = Hvvvo + contract('if,abef->abei', t1, Hvvvv)
             Hvvvo = Hvvvo + contract('mnab,mnei->abei', self.ccwfn.build_tau(t1, t2), ERI[o,o,v,o])
             Hvvvo = Hvvvo - contract('imfa,bmfe->abei', t2, ERI[v,o,v,v])
             Hvvvo = Hvvvo - contract('imfb,amef->abei', t2, ERI[v,o,v,v])
             Hvvvo = Hvvvo + contract('mifb,amef->abei', t2, L[v,o,v,v])   
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                tmp = ERI[v,o,v,o].clone().to(self.ccwfn.device1)
-            else: 
-                tmp = ERI[v,o,v,o].copy()
+            tmp = clone(ERI[v,o,v,o], device=self.ccwfn.device1)
             tmp = tmp - contract('infa,mnfe->amei', t2, ERI[o,o,v,v])
             Hvvvo = Hvvvo - contract('mb,amei->abei', t1, tmp)
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                tmp = ERI[v,o,o,v].clone().to(self.ccwfn.device1)
-            else:
-                tmp = ERI[v,o,o,v].copy()
+            tmp = clone(ERI[v,o,o,v], device=self.ccwfn.device1)
             tmp = tmp - contract('infb,mnef->bmie', t2, ERI[o,o,v,v])
             tmp = tmp + contract('nifb,mnef->bmie', t2, L[o,o,v,v])
             Hvvvo = Hvvvo - contract('ma,bmie->abei', t1, tmp)
@@ -503,10 +435,7 @@ class cchbar(object):
         """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hovoo = ERI[o,v,o,o].clone().to(self.ccwfn.device1)
-            else:
-                Hovoo = ERI[o,v,o,o].copy()
+            Hovoo = clone(ERI[o,v,o,o], device=self.ccwfn.device1)
             Hovoo = Hovoo + contract('me,ijeb->mbij', Hov, t2)
             Hovoo = Hovoo + contract('ijef,mbef->mbij', t2, ERI[o,v,v,v])
             Hovoo = Hovoo - contract('ineb,nmje->mbij', t2, ERI[o,o,o,v])
@@ -514,10 +443,7 @@ class cchbar(object):
             Hovoo = Hovoo + contract('njeb,mnie->mbij', t2, L[o,o,o,v])
 
         elif self.ccwfn.model == 'CC2':
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hovoo = ERI[o,v,o,o].clone().to(self.ccwfn.device1)
-            else:
-                Hovoo = ERI[o,v,o,o].copy()
+            Hovoo = clone(ERI[o,v,o,o], device=self.ccwfn.device1)
             Hovoo = Hovoo + contract('me,ijeb->mbij', self.ccwfn.H.F[o,v], t2)
             Hovoo = Hovoo - contract('nb,mnij->mbij', t1, Hoooo)
             Hovoo = Hovoo + contract('jf,mbif->mbij', t1, contract('ie,mbef->mbif', t1, ERI[o,v,v,v]))
@@ -525,26 +451,17 @@ class cchbar(object):
             Hovoo = Hovoo + contract('ie,bmje->mbij', t1, ERI[v,o,o,v])     
   
         else:
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                Hovoo = ERI[o,v,o,o].clone().to(self.ccwfn.device1)
-            else:
-                Hovoo = ERI[o,v,o,o].copy()
+            Hovoo = clone(ERI[o,v,o,o], device=self.ccwfn.device1)
             Hovoo = Hovoo + contract('me,ijeb->mbij', Hov, t2)
             Hovoo = Hovoo - contract('nb,mnij->mbij', t1, Hoooo)
             Hovoo = Hovoo + contract('ijef,mbef->mbij', self.ccwfn.build_tau(t1, t2), ERI[o,v,v,v])
             Hovoo = Hovoo - contract('ineb,nmje->mbij', t2, ERI[o,o,o,v])
             Hovoo = Hovoo - contract('jneb,mnie->mbij', t2, ERI[o,o,o,v])
             Hovoo = Hovoo + contract('njeb,mnie->mbij', t2, L[o,o,o,v])
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                tmp = ERI[o,v,o,v].clone().to(self.ccwfn.device1)
-            else:
-                tmp = ERI[o,v,o,v].copy()
+            tmp = clone(ERI[o,v,o,v], device=self.ccwfn.device1)
             tmp = tmp - contract('infb,mnfe->mbie', t2, ERI[o,o,v,v])
             Hovoo = Hovoo + contract('je,mbie->mbij', t1, tmp)
-            if HAS_TORCH and isinstance(ERI, torch.Tensor):
-                tmp = ERI[v,o,o,v].clone().to(self.ccwfn.device1)
-            else:
-                tmp = ERI[v,o,o,v].copy()
+            tmp = clone(ERI[v,o,o,v], device=self.ccwfn.device1)
             tmp = tmp - contract('jnfb,mnef->bmje', t2, ERI[o,o,v,v])
             tmp = tmp + contract('njfb,mnef->bmje', t2, L[o,o,v,v])
             Hovoo = Hovoo + contract('ie,bmje->mbij', t1, tmp)

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from opt_einsum import contract
-from .utils import helper_diis, zeros, zeros_like
+from .utils import helper_diis, zeros, zeros_like, clone
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
@@ -295,10 +295,7 @@ class cclambda(object):
                 for l in range(no):
                     t3_lmn = t3c_ijk(o, v, l, m, n, t2, Wvvvo, Wovoo, F, contract, WithDenom=True)
                     if real_time is True:
-                        if HAS_TORCH and isinstance(t1, torch.Tensor):
-                            V = F - self.ccwfn.H.F.clone()
-                        else:
-                            V = F - self.ccwfn.H.F.copy()
+                        V = F - clone(self.ccwfn.H.F)
                         t3_lmn -= t3_pert_ijk(o, v, l, m, n, t2, V, F, contract)
                     Zmndi[m,n] += contract('def,ief->di', t3_lmn, ERI[o,l,v,v])
                     Zmndi[m,n] -= contract('fed,ief->di', t3_lmn, L[o,l,v,v])
@@ -375,10 +372,7 @@ class cclambda(object):
                 for n in range(no):
                     t3_lmn = t3c_ijk(o, v, l, m, n, t2, Wvvvo, Wovoo, F, contract, WithDenom=True)
                     if real_time is True:
-                        if HAS_TORCH and isinstance(l1, torch.Tensor):
-                            V = F - self.ccwfn.H.F.clone()
-                        else:
-                            V = F - self.ccwfn.H.F.copy()
+                        V = F - clone(self.ccwfn.H.F)
                         t3_lmn -= t3_pert_ijk(o, v, l, m, n, t2, V, F, contract)
                     Znf[n] += contract('de,def->f', l2[l,m], (t3_lmn - t3_lmn.swapaxes(0,2)))
         for m in range(no):
@@ -482,10 +476,7 @@ class cclambda(object):
         if self.ccwfn.model == 'CCD':
             r_l1 = zeros_like(l1)
         else:
-            if HAS_TORCH and isinstance(l1, torch.Tensor):
-                r_l1 = 2.0 * Hov.clone()
-            else: 
-                r_l1 = 2.0 * Hov.copy()
+            r_l1 = 2.0 * clone(Hov)
 
             # Add (T) contributions to L1
             if self.ccwfn.model == 'CCSD(T)':
@@ -539,10 +530,7 @@ class cclambda(object):
         """
         contract = self.contract
         if self.ccwfn.model == 'CCD':
-            if HAS_TORCH and isinstance(l1, torch.Tensor):
-                r_l2 = L[o,o,v,v].clone().to(self.ccwfn.device1)
-            else:
-                r_l2 = L[o,o,v,v].copy()
+            r_l2 = clone(L[o,o,v,v], device=self.ccwfn.device1)
 
             r_l2 = r_l2 + contract('ijeb,ea->ijab', l2, Hvv)
             r_l2 = r_l2 - contract('mjab,im->ijab', l2, Hoo)
@@ -554,10 +542,7 @@ class cclambda(object):
             r_l2 = r_l2 + contract('ae,ijeb->ijab', Gvv, L[o,o,v,v])
             r_l2 = r_l2 - contract('mi,mjab->ijab', Goo, L[o,o,v,v])
         else:
-            if HAS_TORCH and isinstance(l1, torch.Tensor):
-                r_l2 = L[o,o,v,v].clone().to(self.ccwfn.device1)
-            else:
-                r_l2 = L[o,o,v,v].copy()
+            r_l2 = clone(L[o,o,v,v], device=self.ccwfn.device1)
 
             # Add (T) contributions to L2
             if self.ccwfn.model == 'CCSD(T)':
@@ -603,10 +588,7 @@ class cclambda(object):
                             - t_jf t_nb <mn|fe>
         """
         contract = self.contract
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            W = ERI[o,v,o,v].clone().to(self.ccwfn.device1)
-        else:
-            W = ERI[o,v,o,v].copy()
+        W = clone(ERI[o,v,o,v], device=self.ccwfn.device1)
         W = W + contract('mbfe,jf->mbje', ERI[o,v,v,v], t1)
         W = W - contract('mnje,nb->mbje', ERI[o,o,o,v], t1)
         W = W - contract('mnfe,jf,nb->mbje', ERI[o,o,v,v], t1, t1)
@@ -628,10 +610,7 @@ class cclambda(object):
                             - t_jf t_nb <mn|ef>
         """
         contract = self.contract
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            W = ERI[o,v,v,o].clone().to(self.ccwfn.device1)
-        else:
-            W = ERI[o,v,v,o].copy()
+        W = clone(ERI[o,v,v,o], device=self.ccwfn.device1)
         W = W + contract('mbef,jf->mbej', ERI[o,v,v,v], t1)
         W = W - contract('mnej,nb->mbej', ERI[o,o,v,o], t1)
         W = W - contract('mnef,jf,nb->mbej', ERI[o,o,v,v], t1, t1)
@@ -653,10 +632,7 @@ class cclambda(object):
                             + t_ma t_nb <mn|ef>
         """
         contract = self.contract
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            W = ERI[v,v,v,v].clone().to(self.ccwfn.device1)
-        else:
-            W = ERI[v,v,v,v].copy()
+        W = clone(ERI[v,v,v,v], device=self.ccwfn.device1)
         tmp = contract('mbef,ma->abef', ERI[o,v,v,v], t1)
         W = W - tmp - tmp.swapaxes(0,1).swapaxes(2,3)
         W = W + contract('mnef,ma,nb->abef', ERI[o,o,v,v], t1, t1)

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -8,7 +8,7 @@ import numpy as np
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
-from pycc.utils import zeros_like, diag
+from pycc.utils import zeros_like, diag, clone
 
 if TYPE_CHECKING:
     from pycc.ccwfn import ccwfn
@@ -400,10 +400,7 @@ def l3_ijk(i, j, k, o, v, L, l1, l2, Fov, Wvovv, Wooov, F, contract, WithDenom=T
         return l3
 
 def l3_abc(a, b, c, o, v, L, l1, l2, Fov, Wvovv, Wooov, F, contract, WithDenom=True):
-    if HAS_TORCH and isinstance(l1, torch.Tensor):
-        Loovv = L[o,o,v,v].clone()
-    else:
-        Loovv = L[o,o,v,v].copy()
+    Loovv = clone(L[o,o,v,v])
     l3 = contract('ij,k->ijk', Loovv[:,:,a,b], l1[:,c]) - contract('ij,k->ijk', Loovv[:,:,a,c], l1[:,b])
     l3 += contract('ik,j->ijk', Loovv[:,:,a,c], l1[:,b]) - contract('ik,j->ijk', Loovv[:,:,a,b], l1[:,c])
     l3 += contract('ji,k->ijk', Loovv[:,:,b,a], l1[:,c]) - contract('ji,k->ijk', Loovv[:,:,b,c], l1[:,a])
@@ -505,10 +502,7 @@ def l3_ijk_alt(i, j, k, o, v, L, l1, l2, Fov, Wvovv, Wooov, F, contract, WithDen
         return l3
 
 def l3_abc_alt(a, b, c, o, v, L, l1, l2, Fov, Wvovv, Wooov, F, contract, WithDenom=True):
-    if HAS_TORCH and isinstance(l1, torch.Tensor):
-        Loovv = L[o,o,v,v].clone()
-    else:
-        Loovv = L[o,o,v,v].copy()
+    Loovv = clone(L[o,o,v,v])
     l3 = contract('ij,k->ijk', Loovv[:,:,a,b], l1[:,c]) - contract('ij,k->ijk', Loovv[:,:,a,c], l1[:,b])
     l3 += contract('ik,j->ijk', Loovv[:,:,a,c], l1[:,b]) - contract('ik,j->ijk', Loovv[:,:,a,b], l1[:,c])
     l3 += contract('ji,k->ijk', Loovv[:,:,b,a], l1[:,c]) - contract('ji,k->ijk', Loovv[:,:,b,c], l1[:,a])
@@ -580,10 +574,7 @@ def t3c_bc(o, v, b, c, t2, Wvvvo, Wovoo, F, contract, WithDenom=True):
         return t3
 
 def l3_bc(b, c, o, v, L, l1, l2, Fov, Wvovv, Wooov, F, contract, WithDenom=True):
-    if HAS_TORCH and isinstance(l1, torch.Tensor):
-        Loovv = L[o,o,v,v].clone()
-    else:
-        Loovv = L[o,o,v,v].copy()
+    Loovv = clone(L[o,o,v,v])
     l3 = contract('ija,k->ijka', Loovv[:,:,:,b], l1[:,c]) - contract('ija,k->ijka', Loovv[:,:,:,c], l1[:,b])
     l3 += contract('ika,j->ijka', Loovv[:,:,:,c], l1[:,b]) - contract('ika,j->ijka', Loovv[:,:,:,b], l1[:,c])
     l3 += contract('jia,k->ijka', Loovv[:,:,b], l1[:,c]) - contract('ji,ka->ijka', Loovv[:,:,b,c], l1)

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -21,7 +21,7 @@ except ImportError:
 
 from typing import Any
 
-from .utils import helper_diis, cc_contract, zeros_like
+from .utils import helper_diis, cc_contract, zeros_like, clone
 from .hamiltonian import Hamiltonian
 from .local import Local
 from .cctriples import t_tjl, t3c_ijk, t3d_ijk, t3c_abc, t3d_abc, t3_pert_ijk
@@ -462,10 +462,7 @@ class ccwfn(object):
                         t3 = t3c_ijk(o, v, i, j, k, t2, Wabei_cc3, Wmbij_cc3, F, contract, WithDenom=True)
 
                         if real_time is True:
-                            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                                V = F - self.H.F.clone()
-                            else:
-                                V = F - self.H.F.copy()
+                            V = F - clone(self.H.F)
                             t3 -= t3_pert_ijk(o, v, i, j, k, t2, V, F, contract)
 
                         X1[i] += contract('abc,bc->a', t3 - t3.swapaxes(0,2), L[j,k,v,v])
@@ -535,16 +532,10 @@ class ccwfn(object):
             contract = self.ec.contract
 
         if self.model == 'CCD':
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                Fae = F[v,v].clone()
-            else:
-                Fae = F[v,v].copy()
+            Fae = clone(F[v,v])
             Fae = Fae - contract('mnaf,mnef->ae', t2, L[o,o,v,v])
         else:
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                Fae = F[v,v].clone()
-            else:
-                Fae = F[v,v].copy()
+            Fae = clone(F[v,v])
             Fae = Fae - 0.5 * contract('me,ma->ae', F[o,v], t1)
             Fae = Fae + contract('mf,mafe->ae', t1, L[o,v,v,v])
             Fae = Fae - contract('mnaf,mnef->ae', self.build_tau(t1, t2, 1.0, 0.5), L[o,o,v,v])
@@ -572,16 +563,10 @@ class ccwfn(object):
             contract = self.ec.contract
 
         if self.model == 'CCD':
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                Fmi = F[o,o].clone()
-            else:
-                Fmi = F[o,o].copy()
+            Fmi = clone(F[o,o])
             Fmi = Fmi + contract('inef,mnef->mi', t2, L[o,o,v,v])
         else:
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                Fmi = F[o,o].clone()
-            else:
-                Fmi = F[o,o].copy()
+            Fmi = clone(F[o,o])
             Fmi = Fmi + 0.5 * contract('ie,me->mi', t1, F[o,v])
             Fmi = Fmi + contract('ne,mnie->mi', t1, L[o,o,o,v])
             Fmi = Fmi + contract('inef,mnef->mi', self.build_tau(t1, t2, 1.0, 0.5), L[o,o,v,v])
@@ -610,10 +595,7 @@ class ccwfn(object):
         if self.model == 'CCD':
             return
         else:
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                Fme = F[o,v].clone()
-            else:
-                Fme = F[o,v].copy()
+            Fme = clone(F[o,v])
             Fme = Fme + contract('nf,mnef->me', t1, L[o,o,v,v])
         return Fme
 
@@ -638,16 +620,10 @@ class ccwfn(object):
             contract = self.ec.contract
 
         if self.model == 'CCD':
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                Wmnij = ERI[o,o,o,o].clone().to(self.device1)
-            else:
-                Wmnij = ERI[o,o,o,o].copy()
+            Wmnij = clone(ERI[o,o,o,o], device=self.device1)
             Wmnij = Wmnij + contract('ijef,mnef->mnij', t2, ERI[o,o,v,v])
         else:
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                Wmnij = ERI[o,o,o,o].clone().to(self.device1)
-            else:
-                Wmnij = ERI[o,o,o,o].copy()
+            Wmnij = clone(ERI[o,o,o,o], device=self.device1)
             Wmnij = Wmnij + contract('je,mnie->mnij', t1, ERI[o,o,o,v])
             Wmnij = Wmnij + contract('ie,mnej->mnij', t1, ERI[o,o,v,o])
             if self.model == 'CC2':
@@ -680,23 +656,17 @@ class ccwfn(object):
             contract = self.ec.contract
 
         if self.model == 'CCD':
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                Wmbej = ERI[o,v,v,o].clone().to(self.device1)
-            else:
-                Wmbej = ERI[o,v,v,o].copy()
+            Wmbej = clone(ERI[o,v,v,o], device=self.device1)
             Wmbej = Wmbej - contract('jnfb,mnef->mbej', 0.5*t2, ERI[o,o,v,v])
             Wmbej = Wmbej + 0.5 * contract('njfb,mnef->mbej', t2, L[o,o,v,v])
         elif self.model == 'CC2':
             return
         else:
-           if HAS_TORCH and isinstance(t1, torch.Tensor):
-                Wmbej = ERI[o,v,v,o].clone().to(self.device1)
-           else:
-                Wmbej = ERI[o,v,v,o].copy()
-           Wmbej = Wmbej + contract('jf,mbef->mbej', t1, ERI[o,v,v,v])
-           Wmbej = Wmbej - contract('nb,mnej->mbej', t1, ERI[o,o,v,o])
-           Wmbej = Wmbej - contract('jnfb,mnef->mbej', self.build_tau(t1, t2, 0.5, 1.0), ERI[o,o,v,v])
-           Wmbej = Wmbej + 0.5 * contract('njfb,mnef->mbej', t2, L[o,o,v,v])
+            Wmbej = clone(ERI[o,v,v,o], device=self.device1)
+            Wmbej = Wmbej + contract('jf,mbef->mbej', t1, ERI[o,v,v,v])
+            Wmbej = Wmbej - contract('nb,mnej->mbej', t1, ERI[o,o,v,o])
+            Wmbej = Wmbej - contract('jnfb,mnef->mbej', self.build_tau(t1, t2, 0.5, 1.0), ERI[o,o,v,v])
+            Wmbej = Wmbej + 0.5 * contract('njfb,mnef->mbej', t2, L[o,o,v,v])
         return Wmbej
 
 
@@ -721,21 +691,15 @@ class ccwfn(object):
             contract = self.ec.contract
 
         if self.model == 'CCD':
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                Wmbje = -1.0 * ERI[o,v,o,v].clone().to(self.device1)
-            else:
-                Wmbje = -1.0 * ERI[o,v,o,v].copy()
+            Wmbje = -1.0 * clone(ERI[o,v,o,v], device=self.device1)
             Wmbje = Wmbje + contract('jnfb,mnfe->mbje', 0.5*t2, ERI[o,o,v,v])
         elif self.model == 'CC2':
             return
         else:
-           if HAS_TORCH and isinstance(t1, torch.Tensor):
-                Wmbje = -1.0 * ERI[o,v,o,v].clone().to(self.device1)
-           else:
-                Wmbje = -1.0 * ERI[o,v,o,v].copy()
-           Wmbje = Wmbje - contract('jf,mbfe->mbje', t1, ERI[o,v,v,v])
-           Wmbje = Wmbje + contract('nb,mnje->mbje', t1, ERI[o,o,o,v])
-           Wmbje = Wmbje + contract('jnfb,mnfe->mbje', self.build_tau(t1, t2, 0.5, 1.0), ERI[o,o,v,v])
+            Wmbje = -1.0 * clone(ERI[o,v,o,v], device=self.device1)
+            Wmbje = Wmbje - contract('jf,mbfe->mbje', t1, ERI[o,v,v,v])
+            Wmbje = Wmbje + contract('nb,mnje->mbje', t1, ERI[o,o,o,v])
+            Wmbje = Wmbje + contract('jnfb,mnfe->mbje', self.build_tau(t1, t2, 0.5, 1.0), ERI[o,o,v,v])
         return Wmbje
 
 
@@ -794,10 +758,7 @@ class ccwfn(object):
         if self.model == 'CCD':
             r_T1 = zeros_like(t1)
         else:
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                r_T1 = F[o,v].clone()
-            else:
-                r_T1 = F[o,v].copy()
+            r_T1 = clone(F[o,v])
             r_T1 = r_T1 + contract('ie,ae->ia', t1, Fae)
             r_T1 = r_T1 - contract('mi,ma->ia', Fmi, t1)
             r_T1 = r_T1 + contract('imae,me->ia', (2.0*t2 - t2.swapaxes(2,3)), Fme)
@@ -852,10 +813,7 @@ class ccwfn(object):
         if self.einsums:
             contract = self.ec.contract
 
-        if HAS_TORCH and isinstance(t2, torch.Tensor):
-            r_T2 = 0.5 * ERI[o,o,v,v].clone().to(self.device1)
-        else:
-            r_T2 = 0.5 * ERI[o,o,v,v].copy()
+        r_T2 = 0.5 * clone(ERI[o,o,v,v], device=self.device1)
         r_T2 = r_T2 + contract('ijae,eb->ijab', t2, Fae.T)
         r_T2 = r_T2 - contract('imab,mj->ijab', t2, Fmi)
         r_T2 = r_T2 + 0.5 * contract('ijef,abef->ijab', t2, ERI[v,v,v,v])
@@ -887,10 +845,7 @@ class ccwfn(object):
         if self.einsums:
             contract = self.ec.contract
 
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            r_T2 = 0.5 * ERI[o,o,v,v].clone().to(self.device1)
-        else:
-            r_T2 = 0.5 * ERI[o,o,v,v].copy()
+        r_T2 = 0.5 * clone(ERI[o,o,v,v], device=self.device1)
 
         tmp = F[v,v] - 0.5 * contract('me,ma->ae', F[o,v], t1)
         r_T2 = r_T2 + contract('ijae,eb->ijab', t2, tmp.T)
@@ -935,10 +890,7 @@ class ccwfn(object):
         if self.einsums:
             contract = self.ec.contract
 
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            r_T2 = 0.5 * ERI[o,o,v,v].clone().to(self.device1)
-        else:
-            r_T2 = 0.5 * ERI[o,o,v,v].copy()
+        r_T2 = 0.5 * clone(ERI[o,o,v,v], device=self.device1)
         r_T2 = r_T2 + contract('ijae,eb->ijab', t2, Fae.T)
         tmp = contract('bm,me->be', t1.T, Fme)
         r_T2 = r_T2 - 0.5 * contract('ijae,eb->ijab', t2, tmp.T)
@@ -979,10 +931,7 @@ class ccwfn(object):
                             + t_ie t_jf <mn|ef>
         """
         contract = self.contract
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            W = ERI[o,o,o,o].clone().to(self.device1)
-        else:
-            W = ERI[o,o,o,o].copy()
+        W = clone(ERI[o,o,o,o], device=self.device1)
         tmp = contract('ijma,na->ijmn', ERI[o,o,o,v], t1)
         W = W + tmp + tmp.swapaxes(0,1).swapaxes(2,3)
         tmp = contract('ia,mnaf->mnif', t1, ERI[o,o,v,v])
@@ -1007,16 +956,10 @@ class ccwfn(object):
                             + t_ie ( <mb|ej> + t_jf <mb|ef> )
         """
         contract = self.contract
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            W = ERI[o,v,o,o].clone().to(self.device1)
-        else:
-            W = ERI[o,v,o,o].copy()
+        W = clone(ERI[o,v,o,o], device=self.device1)
         W = W - contract('mnij,nb->mbij', Wmnij, t1)
         W = W + contract('mbie,je->mbij', ERI[o,v,o,v], t1)
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            tmp = ERI[o,v,v,o].clone().to(self.device1) + contract('mbef,jf->mbej', ERI[o,v,v,v], t1)
-        else:
-            tmp = ERI[o,v,v,o].copy() + contract('mbef,jf->mbej', ERI[o,v,v,v], t1)
+        tmp = clone(ERI[o,v,v,o], device=self.device1) + contract('mbef,jf->mbej', ERI[o,v,v,v], t1)
         W = W + contract('ie,mbej->mbij', t1, tmp)
         return W
 
@@ -1035,10 +978,7 @@ class ccwfn(object):
             W_mnie = <mn|ie> + t_if <mn|fe>
         """
         contract = self.contract
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            W = ERI[o,o,o,v].clone().to(self.device1)
-        else:
-            W = ERI[o,o,o,v].copy()
+        W = clone(ERI[o,o,o,v], device=self.device1)
         W = W + contract('if,mnfe->mnie', t1, ERI[o,o,v,v])
         return W
 
@@ -1057,10 +997,7 @@ class ccwfn(object):
             W_amef = <am|ef> - t_na <nm|ef>
         """
         contract = self.contract
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            W = ERI[v,o,v,v].clone().to(self.device1)
-        else:
-            W = ERI[v,o,v,v].copy()
+        W = clone(ERI[v,o,v,v], device=self.device1)
         W = W - contract('na,nmef->amef', t1, ERI[o,o,v,v])
         return W
 
@@ -1082,10 +1019,7 @@ class ccwfn(object):
         """
         contract =self.contract
         # eiab
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            Z = ERI[v,o,v,v].clone().to(self.device1)
-        else:
-            Z = ERI[v,o,v,v].copy()
+        Z = clone(ERI[v,o,v,v], device=self.device1)
         tmp_ints = ERI[v,v,v,v] + ERI[v,v,v,v].swapaxes(2,3)
         Z1 = 0.5 * contract('if,abef->eiab', t1, tmp_ints)
         tmp_ints = ERI[v,v,v,v] - ERI[v,v,v,v].swapaxes(2,3)
@@ -1093,27 +1027,18 @@ class ccwfn(object):
         Z_eiab = Z + Z1 + Z2
 
         #eiab
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            Zeiam = ERI[v,o,v,o].clone().to(self.device1)
-        else:
-            Zeiam = ERI[v,o,v,o].copy()
+        Zeiam = clone(ERI[v,o,v,o], device=self.device1)
         Zamei = contract('amef,if->amei', ERI[v,o,v,v], t1)
         Zeiam = Zeiam + Zamei.swapaxes(0,2).swapaxes(1,3)
         Z_eiab = Z_eiab - contract('eiam,mb->eiab', Zeiam, t1)
 
         #eiab
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            Zmnei = ERI[o,o,v,o].clone().to(self.device1) + contract('mnef,if->mnei', ERI[o,o,v,v], t1)
-        else:
-            Zmnei = ERI[o,o,v,o].copy() + contract('mnef,if->mnei', ERI[o,o,v,v], t1)
+        Zmnei = clone(ERI[o,o,v,o], device=self.device1) + contract('mnef,if->mnei', ERI[o,o,v,v], t1)
         Zanei = contract('ma,mnei->anei', t1, Zmnei)
         Z_eiab = Z_eiab + contract('anei,nb->eiab', Zanei, t1)
 
         #abei
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            Zmbei = ERI[o,v,v,o].clone().to(self.device1)
-        else:
-            Zmbei = ERI[o,v,v,o].copy()
+        Zmbei = clone(ERI[o,v,v,o], device=self.device1)
         Zmbei = Zmbei + contract('mbef,if->mbei', ERI[o,v,v,v], t1)
         Z_abei = -1 * contract('ma,mbei->abei', t1, Zmbei)
 

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -250,6 +250,12 @@ class ccwfn(object):
         # for GPU or CPU.  
         self.contract = cc_contract(device=self.device)
 
+        # CPU/compute device handles for the GPU path. Default to None on CPU so
+        # that clone(x, device=self.device1) is a plain copy with no transfer
+        # (the device arg is ignored for NumPy arrays).
+        self.device0 = None
+        self.device1 = None
+
         # Convert the arrays to torch.Tensors if the calculation is on GPU.
         # Send the copy of F, t1, t2 to GPU.
         # ERI will be kept on GPU

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -11,7 +11,7 @@ import numpy as np
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
-from pycc.utils import zeros_like
+from pycc.utils import zeros_like, clone
 import pickle as pk
 from os.path import exists
 import opt_einsum
@@ -130,10 +130,7 @@ class rtcc(object):
         t1, t2, l1, l2, phase = self.extract_amps(y)
 
         # Add the field to the Hamiltonian
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            F = self.ccwfn.H.F.clone() + self.mu_tot * self.V(t)
-        else:
-            F = self.ccwfn.H.F.copy() + self.mu_tot * self.V(t)
+        F = clone(self.ccwfn.H.F) + self.mu_tot * self.V(t)
 
         # Compute the current residuals
         rt1, rt2 = self.ccwfn.residuals(F, t1, t2, real_time=True)
@@ -305,9 +302,8 @@ class rtcc(object):
         Doovv = self.ccdensity.build_Doovv(t1, t2, l1, l2)
         contract = self.contract
         
+        F = clone(self.ccwfn.H.F) + self.mu_tot * self.V(t)
         if HAS_TORCH and isinstance(t1, torch.Tensor):
-            F = self.ccwfn.H.F.clone() + self.mu_tot * self.V(t)
-    
             eref = 2.0 * torch.trace(F[o,o])
             # torch.trace doesn't have "axis" argument
             #eref -= torch.trace(torch.trace(tmp, axis1=1, axis2=3))
@@ -316,8 +312,6 @@ class rtcc(object):
             del tmp
 
         else:
-            F = self.ccwfn.H.F.copy() + self.mu_tot * self.V(t)
-
             eref = 2.0 * np.trace(F[o,o])
             eref -= np.trace(np.trace(self.ccwfn.H.L[o,o,o,o], axis1=1, axis2=3))
 

--- a/pycc/utils.py
+++ b/pycc/utils.py
@@ -44,20 +44,29 @@ def diag(a):
     return np.diag(a)
 
 
+def clone(a, device=None):
+    """Backend-aware deep copy: ``a.clone()`` for a torch tensor (optionally moved
+    to ``device``), else ``a.copy()``.
+
+    Collapses the ``if HAS_TORCH and isinstance(a, torch.Tensor): a.clone()
+    [.to(self.device1)] else: a.copy()`` branch that recurs throughout the CC
+    modules. ``device`` is ignored for NumPy arrays (always CPU).
+    """
+    if HAS_TORCH and isinstance(a, torch.Tensor):
+        a = a.clone()
+        return a.to(device) if device is not None else a
+    return a.copy()
+
+
 class helper_diis(object):
     def __init__(self, t1, t2, max_diis, precision='DP'):
         if HAS_TORCH and isinstance(t1, torch.Tensor):
             self.device0 = torch.device('cpu')
             self.device1 = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-            self.oldt1 = t1.clone()
-            self.oldt2 = t2.clone()
-            self.diis_vals_t1 = [t1.clone()]
-            self.diis_vals_t2 = [t2.clone()]
-        else:
-            self.oldt1 = t1.copy()
-            self.oldt2 = t2.copy()
-            self.diis_vals_t1 = [t1.copy()]
-            self.diis_vals_t2 = [t2.copy()]
+        self.oldt1 = clone(t1)
+        self.oldt2 = clone(t2)
+        self.diis_vals_t1 = [clone(t1)]
+        self.diis_vals_t2 = [clone(t2)]
 
         self.diis_errors = []
         self.diis_size = 0
@@ -65,26 +74,18 @@ class helper_diis(object):
         self.precision = precision
 
     def add_error_vector(self, t1, t2):
+        # Add DIIS vectors
+        self.diis_vals_t1.append(clone(t1))
+        self.diis_vals_t2.append(clone(t2))
+        # Add new error vectors
+        error_t1 = (self.diis_vals_t1[-1] - self.oldt1).ravel()
+        error_t2 = (self.diis_vals_t2[-1] - self.oldt2).ravel()
         if HAS_TORCH and isinstance(t1, torch.Tensor):
-            # Add DIIS vectors
-            self.diis_vals_t1.append(t1.clone())
-            self.diis_vals_t2.append(t2.clone())
-            # Add new error vectors
-            error_t1 = (self.diis_vals_t1[-1] - self.oldt1).ravel()
-            error_t2 = (self.diis_vals_t2[-1] - self.oldt2).ravel()
             self.diis_errors.append(torch.cat((error_t1, error_t2)))
-            self.oldt1 = t1.clone()
-            self.oldt2 = t2.clone()
         else:
-            # Add DIIS vectors
-            self.diis_vals_t1.append(t1.copy())
-            self.diis_vals_t2.append(t2.copy())
-            # Add new error vectors
-            error_t1 = (self.diis_vals_t1[-1] - self.oldt1).ravel()
-            error_t2 = (self.diis_vals_t2[-1] - self.oldt2).ravel()
             self.diis_errors.append(np.concatenate((error_t1, error_t2)))
-            self.oldt1 = t1.copy()
-            self.oldt2 = t2.copy()
+        self.oldt1 = clone(t1)
+        self.oldt2 = clone(t2)
 
     def extrapolate(self, t1, t2):
         
@@ -134,10 +135,6 @@ class helper_diis(object):
                 t1 += torch.real(ci[num] * self.diis_vals_t1[num + 1])
                 t2 += torch.real(ci[num] * self.diis_vals_t2[num + 1])
 
-            # Save extrapolated amplitudes to old_t amplitudes
-            self.oldt1 = t1.clone()
-            self.oldt2 = t2.clone()
-
         else:
             # Build error matrix B
             if self.precision == 'DP':
@@ -173,9 +170,9 @@ class helper_diis(object):
                 t1 += ci[num] * self.diis_vals_t1[num + 1]
                 t2 += ci[num] * self.diis_vals_t2[num + 1]
 
-            # Save extrapolated amplitudes to old_t amplitudes
-            self.oldt1 = t1.copy()
-            self.oldt2 = t2.copy()
+        # Save extrapolated amplitudes to old_t amplitudes
+        self.oldt1 = clone(t1)
+        self.oldt2 = clone(t2)
 
         return t1, t2
 


### PR DESCRIPTION
Implements smear #2 of the contraction-backend design note: replace the ~166 hand-written if HAS_TORCH and isinstance(x, 
  torch.Tensor): x.clone()[.to(self.device1)] else: x.copy() allocation branches across the torch-aware modules with a single
  helper. Each branch was a place to mistype (the same class of latent bug as the original zero_like one); this collapses
  them to one definition. Net −215 lines.

  New helper (utils.py):
  def clone(a, device=None):
      """Backend-aware deep copy: a.clone() for a torch tensor (optionally moved
      to `device`), else a.copy(). device is ignored for NumPy arrays."""
      if HAS_TORCH and isinstance(a, torch.Tensor):
          a = a.clone()
          return a.to(device) if device is not None else a
      return a.copy()
  Joins the existing array-namespace helpers (zeros/zeros_like/diag).
  
  Converted (all branches → clone(...)): cchbar (28), ccwfn (25), cclambda (8), ccdensity (7), cctriples (3), rtcc, and
  utils's own helper_diis (20) — including the arithmetic-prefix/suffix forms (0.5 * clone(...), -1.0 * clone(...), F - 
  clone(self.H.F), clone(...) + contract(...)).

  Supporting/while-here changes:
  - ccwfn.__init__ now always defines device0/device1 (= None on CPU; the GPU path still sets torch.device). Required because
  clone(x, device=self.device1) evaluates device1 eagerly, whereas the old numpy branch never referenced it — without this,
  CPU runs would AttributeError. (Caught by the full suite.)
  - Fixed pre-existing non-standard indentation in ccwfn.build_Wmbej/build_Wmbje (their CCSD else: branches used 8→11→16
  spaces; reindented to standard 8→12→16).
  - rtcc: hoisted the now-identical F = clone(self.ccwfn.H.F) + self.mu_tot*self.V(t) out of the irreducible torch.trace vs
  np.trace branch.
  
  Deliberately left: bare .copy() in numpy-only modules (ccresponse, local, lccwfn, cceom, integrators — zero torch refs);
  and the genuinely backend-divergent bodies that no copy-helper can unify (helper_diis.extrapolate's device-placed
  torch.linalg.solve vs np.linalg.solve, and rtcc's torch.trace/np.trace arms) — those await the fuller backend object.

  No numerical change. Verified in p4env after each group: full non-slow suite (einsums excluded) 50 passed / 1 skipped / 8 
  deselected / 1 xfailed, 0 failures, 0 DGEMV.

  🤖 Generated with Claude Code (https://claude.com/claude-code)