### PR TITLE
Extract CC3 t3 block from ccwfn.residuals; drop unused r_T2 L arg

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -20,14 +20,22 @@ in the **Critique** section.
       branching with one callable that owns library/device/precision. (Root cause of
       the `zero_like` bug.) _Design drafted below — see "Design note:
       contraction-backend abstraction"; decision is to grow `cc_contract`._
-      _Started (smear #3, the array-namespace helpers):_ added shared `zeros_like(a)` and
-      `zeros(shape, like)` to `utils.py` as free functions (free, not `cc_contract`
-      methods, because `cctriples`' triples kernels are module-level and have no
-      `self.contract`), and applied them in `cclambda` and `ccdensity` — collapsing the
-      `if HAS_TORCH … torch.zeros_like … else np.zeros_like` branches and removing every
-      `zeros_like`+`pad` idiom. Remaining modules (`ccwfn`, `cctriples`, `cchbar`,
-      `cceom`, `rt/rtcc`, `lccwfn`) adopt the helpers one-per-PR. The library-dispatch
-      (smear #1) and `.clone()/.copy()` (smear #2) collapses are still open.
+      **Smear #3 (array-namespace helpers) DONE.** Added shared free functions to
+      `utils.py` — `zeros_like(a)`, `zeros(shape, like)`, `diag(a)`, `clone(a, device=None)`
+      (free, not `cc_contract` methods, because `cctriples`' triples kernels are
+      module-level and have no `self.contract`) — and adopted them across the torch-aware
+      modules (`cclambda`/`ccdensity` PR #102, `ccwfn`/`cctriples`/`rtcc` PR #103),
+      collapsing the `if HAS_TORCH … torch.zeros_like … else np.zeros_like` branches and
+      removing every `zeros_like`+`pad` idiom. **Smear #2 (`.clone()/.copy()`) DONE (PR
+      #105):** `clone(a, device=None)` collapsed ~166 branched copy sites across
+      `cchbar`/`ccwfn`/`cclambda`/`ccdensity`/`cctriples`/`rtcc` + `utils`'s `helper_diis`
+      (−215 lines); bare `.copy()` in the numpy-only modules (`ccresponse`/`local`/
+      `lccwfn`/`cceom`/`integrators`) was left as-is. _Still open:_ **smear #1** — the
+      per-method `contract = self.ec.contract if self.einsums` library re-dispatch (paused;
+      the einsums path is not in CI, so it needs a manual run before collapsing). The
+      genuinely backend-divergent bodies that no copy/alloc helper can unify
+      (`helper_diis.extrapolate`'s `torch.linalg.solve` vs `np.linalg.solve`; `rtcc`'s
+      `torch.trace`/`np.trace` arms) await the fuller backend object.
 - [x] **Test fixtures** — added `pycc/tests/conftest.py` (`psi4_environment` +
       `rhf_wfn` factory); converted 32 test modules off the copied psi4-setup block
       (~570 fewer lines). Branch `refactor/test-fixtures`, commit `2cfe825`. A
@@ -35,7 +43,7 @@ in the **Critique** section.
       reference energies are method-specific and stay inline in each test. Note:
       `test_040` (einsums CC2) hangs locally with or without this change; einsums
       isn't in CI so those tests skip there.
-- [~] **Break up god methods** — _`cclambda` half DONE (PR #101)._
+- [x] **Break up god methods** — DONE. _`cclambda` half (PR #101)._
       `cclambda.solve_lambda` (221→122) and `cclambda.residuals` (169→56) each carried a
       near-verbatim ~120-line CC3 lambda-triples block; extracted to shared helpers
       `_build_cc3_lambda_intermediates` + `_cc3_lambda_triples` (a `real_time` flag is the
@@ -45,10 +53,16 @@ in the **Critique** section.
       from this item. A mirror **t3** dedup in `ccwfn.py` was considered but is a
       **non-issue**: unlike `cclambda`, `ccwfn.solve_cc` already delegates to
       `ccwfn.residuals` (it does not inline its own copy of the CC3 t3 block), so there is
-      nothing duplicated to extract. _Still open:_ the `ccwfn.r_T2` (~100-line) deep
-      CCD/CC2/CCSD/CC3 conditional tree (the genuine remaining god method); optionally,
-      pulling the single-instance CC3 t3 block out of `ccwfn.residuals` into a helper for
-      parallelism with `cclambda._cc3_lambda_triples` (readability only, not dedup).
+      nothing duplicated to extract. **`ccwfn.r_T2` split DONE (PR #104):** the ~100-line
+      CCD/CC2/CCSD/CC3 conditional tree became a thin dispatcher over per-model builders
+      `_r_T2_ccd`/`_r_T2_cc2`/`_r_T2_ccsd` (each with its own tensor-expression docstring),
+      and a double `self.build_tau` call in the CCSD branch was fixed. (The CC2 builder is
+      currently a modified-CCSD form; the user may later rewrite it to a true CC2
+      formulation.) Finally, the single-instance CC3 t3 block was pulled out of
+      `ccwfn.residuals` (79→52 lines) into `_cc3_t_residual`, parallel to
+      `cclambda._cc3_lambda_triples` (readability, not dedup). No remaining god methods
+      from the original review; `ccwfn.__init__` (~226 lines of linear setup) is long but
+      out of scope here (no deep conditional tree or duplication).
 - [x] **Custom exception types** + `.upper()` the string kwargs — DONE. New
       `pycc/exceptions.py` with `PyCCError` base and `InvalidKeywordError(PyCCError,
       ValueError)` (carries `keyword`/`value`/`allowed`, standardized message,

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -438,47 +438,81 @@ class ccwfn(object):
         Zmbij = self.build_Zmbij(o, v, ERI, t1, t2)
 
         r1 = self.r_T1(o, v, F, ERI, L, t1, t2, Fae, Fme, Fmi)
-        r2 = self.r_T2(o, v, F, ERI, L, t1, t2, Fae, Fme, Fmi, Wmnij, Wmbej, Wmbje, Zmbij)
+        r2 = self.r_T2(o, v, F, ERI, t1, t2, Fae, Fme, Fmi, Wmnij, Wmbej, Wmbje, Zmbij)
 
         if HAS_TORCH and isinstance(Fae, torch.Tensor):
             del Fae, Fmi, Wmnij, Wmbej, Wmbje, Zmbij
 
         if self.model == 'CC3':
-            Wmnij_cc3 = self.build_cc3_Wmnij(o, v, ERI, t1)
-            Wmbij_cc3 = self.build_cc3_Wmbij(o, v, ERI, t1, Wmnij_cc3)
-            Wmnie_cc3 = self.build_cc3_Wmnie(o, v, ERI, t1)
-            Wamef_cc3 = self.build_cc3_Wamef(o, v, ERI, t1)
-            Wabei_cc3 = self.build_cc3_Wabei(o, v, ERI, t1)
-
-            X1 = zeros_like(t1)
-            X2 = zeros_like(t2)
-
-            contract = self.contract
-            for i in range(no):
-                for j in range(no):
-                    for k in range(no):
-                        if self.einsums:
-                            contract = self.ec.contract
-                        t3 = t3c_ijk(o, v, i, j, k, t2, Wabei_cc3, Wmbij_cc3, F, contract, WithDenom=True)
-
-                        if real_time is True:
-                            V = F - clone(self.H.F)
-                            t3 -= t3_pert_ijk(o, v, i, j, k, t2, V, F, contract)
-
-                        X1[i] += contract('abc,bc->a', t3 - t3.swapaxes(0,2), L[j,k,v,v])
-
-                        X2[i,j] += contract('abc,dbc->ad', 2 * t3 - t3.swapaxes(1,2) - t3.swapaxes(0,2), Wamef_cc3.swapaxes(0,1)[k])
-                        X2[i] -= contract('lc,abc->lab', Wmnie_cc3[j,k], (2 * t3 - t3.swapaxes(1,2) - t3.swapaxes(0,2)))
-                        contract = self.contract
-                        X2[i,j] += contract('abc,c->ab', t3 - t3.swapaxes(0,2), Fme[k])
-
+            X1, X2 = self._cc3_t_residual(o, v, F, ERI, L, t1, t2, Fme, real_time=real_time)
             r1 += X1
             r2 += X2 + X2.swapaxes(0,1).swapaxes(2,3)
 
-            if HAS_TORCH and isinstance(t3, torch.Tensor):
-                del Fme, Wmnij_cc3, Wmbij_cc3, Wmnie_cc3, Wamef_cc3, Wabei_cc3
+            if HAS_TORCH and isinstance(r1, torch.Tensor):
+                del Fme
 
         return r1, r2
+
+    def _cc3_t_residual(self, o, v, F, ERI, L, t1, t2, Fme, real_time=False):
+        """Compute the CC3 connected-triples contributions (X1, X2) to the T residuals.
+
+        Builds the T1-dressed CC3 W-intermediates, then accumulates the connected
+        triples' contribution to the T1 and T2 residuals. Single-instance helper
+        that parallels cclambda._cc3_lambda_triples (the t3 side of the l3 work).
+
+        Parameters
+        ----------
+        o, v : slice
+            occupied/virtual orbital slices
+        F, ERI, L : ndarray or torch.Tensor
+            Fock matrix, two-electron integrals, and L = 2*ERI - ERI.swapaxes
+        t1, t2 : ndarray or torch.Tensor
+            current T1/T2 amplitudes
+        Fme : ndarray or torch.Tensor
+            the one-body H_me intermediate (already built by residuals)
+        real_time : bool
+            if True, subtract the explicit time-dependent perturbation from the
+            connected triples (real-time CC3 path)
+
+        Returns
+        -------
+        X1, X2 : ndarray or torch.Tensor
+            the CC3 triples contributions to the T1 and T2 residuals
+        """
+        no = self.no
+
+        Wmnij_cc3 = self.build_cc3_Wmnij(o, v, ERI, t1)
+        Wmbij_cc3 = self.build_cc3_Wmbij(o, v, ERI, t1, Wmnij_cc3)
+        Wmnie_cc3 = self.build_cc3_Wmnie(o, v, ERI, t1)
+        Wamef_cc3 = self.build_cc3_Wamef(o, v, ERI, t1)
+        Wabei_cc3 = self.build_cc3_Wabei(o, v, ERI, t1)
+
+        X1 = zeros_like(t1)
+        X2 = zeros_like(t2)
+
+        contract = self.contract
+        for i in range(no):
+            for j in range(no):
+                for k in range(no):
+                    if self.einsums:
+                        contract = self.ec.contract
+                    t3 = t3c_ijk(o, v, i, j, k, t2, Wabei_cc3, Wmbij_cc3, F, contract, WithDenom=True)
+
+                    if real_time is True:
+                        V = F - clone(self.H.F)
+                        t3 -= t3_pert_ijk(o, v, i, j, k, t2, V, F, contract)
+
+                    X1[i] += contract('abc,bc->a', t3 - t3.swapaxes(0,2), L[j,k,v,v])
+
+                    X2[i,j] += contract('abc,dbc->ad', 2 * t3 - t3.swapaxes(1,2) - t3.swapaxes(0,2), Wamef_cc3.swapaxes(0,1)[k])
+                    X2[i] -= contract('lc,abc->lab', Wmnie_cc3[j,k], (2 * t3 - t3.swapaxes(1,2) - t3.swapaxes(0,2)))
+                    contract = self.contract
+                    X2[i,j] += contract('abc,c->ab', t3 - t3.swapaxes(0,2), Fme[k])
+
+        if HAS_TORCH and isinstance(t3, torch.Tensor):
+            del Wmnij_cc3, Wmbij_cc3, Wmnie_cc3, Wamef_cc3, Wabei_cc3
+
+        return X1, X2
 
     def build_tau(self, t1, t2, fact1=1.0, fact2=1.0):
         """Build the effective doubles amplitude tau = fact1*t2 + fact2*(t1 t1).
@@ -768,7 +802,7 @@ class ccwfn(object):
         return r_T1
 
 
-    def r_T2(self, o, v, F, ERI, L, t1, t2, Fae, Fme, Fmi, Wmnij, Wmbej, Wmbje, Zmbij):
+    def r_T2(self, o, v, F, ERI, t1, t2, Fae, Fme, Fmi, Wmnij, Wmbej, Wmbje, Zmbij):
         """Compute the T2 (doubles) amplitude residual.
 
         solve_cc drives this residual to zero. This method dispatches on the CC


### PR DESCRIPTION
Completes the "break up god methods" worklist item.

  - Extract the CC3 t3 block (~35 lines) out of ccwfn.residuals into a new _cc3_t_residual(o, v, F, ERI, L, t1, t2, Fme, 
  real_time) helper that returns (X1, X2); residuals just adds them and symmetrizes (79 → 52 lines). This parallels
  cclambda._cc3_lambda_triples (the t3 side of the l3 work). It's a single-instance extraction for readability/consistency,
  not a dedup — unlike cclambda, ccwfn.solve_cc already delegates to residuals, so there was never a second copy.
  - Remove the unused L parameter from r_T2 and its sole call site; none of the per-model builders reference it. (lccwfn.r_T2
  is a separate method, unaffected.)
  - Refresh CODE_REVIEW.md: mark "break up god methods" done ([x]); record the r_T2 split (PR #104) and the smear-#2 clone()
  (PR #105) / smear-#3 array-helper (PRs #102/#103) completions; narrow the contraction-backend item to smear #1
  (self.einsums dispatch, paused) plus the deeper backend object for the irreducible solve/trace branches.

  No numerical change. Verified in p4env: full non-slow suite (einsums excluded) 50 passed / 1 skipped / 8 deselected / 1 
  xfailed, 0 failures.

  🤖 Generated with Claude Code (https://claude.com/claude-code)