### PR TITLE
Relegate remaining HAS_TORCH branches in DIIS/rtcc to backend helpers

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -207,6 +207,16 @@ Sphinx docs. As a research scaffold it's in good shape.
   PNO/PNO++ opt paths converge fine, so this is PAO-specific (possibly the `local_cutoff=2e-2`
   domain construction or a sign/projection error on the PAO path) — a genuine numerical bug,
   NOT the `np.zeros` issue above. Needs investigation.
+- **`ccwfn.py:solve_cc` — the torch/GPU convergence branch silently skips the `(T)`
+  correction (open).** In the convergence block the `if HAS_TORCH and isinstance(self.t1,
+  torch.Tensor):` arm prints/returns the bare `ecc` (CCSD energy), while only the NumPy
+  `else` arm has the `if self.model == 'CCSD(T)': et = t3_density()/t_tjl(self); ecc += et`
+  step. So **`model='CCSD(T)'` run on a torch tensor returns the CCSD energy with no `(T)`
+  correction** — a wrong result, not a crash. Latent because torch/GPU isn't in CI (the
+  CPU-torch lane added in PR #99 *would* catch it if a `CCSD(T)` torch test existed). Fix:
+  hoist the `(T)` step out of the backend branch so both paths compute it. Surfaced while
+  auditing remaining `HAS_TORCH` branches for the backend-helper sweep; left as a separate
+  behavior fix (untestable locally — no torch in `p4env`).
 
 ### Structural issues (the expensive ones)
 

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -36,6 +36,23 @@ in the **Critique** section.
       genuinely backend-divergent bodies that no copy/alloc helper can unify
       (`helper_diis.extrapolate`'s `torch.linalg.solve` vs `np.linalg.solve`; `rtcc`'s
       `torch.trace`/`np.trace` arms) await the fuller backend object.
+- [ ] **Real-valued response amplitudes for imaginary perturbations.** The magnetic-dipole
+      (`H.m`) and linear-momentum (`H.p`) integrals are stored pure-imaginary (`* 1.0j`),
+      so for those perturbations `ccresponse`'s `X1`/`X2` come out **pure imaginary** —
+      verified empirically: real part is *exactly* `0.0`, only the imaginary half is used
+      (the electric-dipole `MU` amplitudes are real). They are nonetheless carried as
+      `complex128`. Factoring the `i` out and storing them as **real** arrays would halve
+      their memory, drop the complex arithmetic, and remove a benign `ComplexWarning` in
+      DIIS (`np.dot` of two pure-imaginary vectors returns a complex-dtype scalar whose
+      imaginary part is exactly zero, which is then cast into the real DIIS `B` matrix —
+      no information lost; the warning is **pre-existing on `main`**, not from the
+      backend-helper refactor). A focused `ccresponse` change, independent of the
+      contraction-backend work. **Caveat:** the `* 1.0j` integral arrays `H.m`/`H.p`
+      themselves **cannot** simply be made real — they are shared with the RT-CC code
+      (`rtcc` consumes `self.ccwfn.H.m` for the magnetic-field coupling), which relies on
+      their imaginary character. So any "store real" change must factor the `i` out
+      *locally inside `ccresponse`*'s amplitude/perturbation handling, leaving the
+      `hamiltonian` integral storage untouched.
 - [x] **Test fixtures** — added `pycc/tests/conftest.py` (`psi4_environment` +
       `rhf_wfn` factory); converted 32 test modules off the copied psi4-setup block
       (~570 fewer lines). Branch `refactor/test-fixtures`, commit `2cfe825`. A

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from opt_einsum import contract
-from .utils import helper_diis, zeros, zeros_like, clone
+from .utils import helper_diis, zeros, zeros_like, clone, sqrt
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
@@ -152,19 +152,13 @@ class cclambda(object):
                 self.l2 += inc2
                 rms = contract('ia,ia->', inc1, inc1)
                 rms += contract('ijab,ijab->', inc2, inc2)
-                if HAS_TORCH and isinstance(l1, torch.Tensor):
-                    rms = torch.sqrt(rms)
-                else: 
-                    rms = np.sqrt(rms)
+                rms = sqrt(rms)
             else:
                 self.l1 += r1/Dia
                 self.l2 += r2/Dijab
                 rms = contract('ia,ia->', r1/Dia, r1/Dia)
                 rms += contract('ijab,ijab->', r2/Dijab, r2/Dijab)
-                if HAS_TORCH and isinstance(l1, torch.Tensor):
-                    rms = torch.sqrt(rms)
-                else:
-                    rms = np.sqrt(rms)
+                rms = sqrt(rms)
 
             lecc = self.pseudoenergy(o, v, ERI, self.l2)
             ediff = lecc - lecc_last

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -21,7 +21,7 @@ except ImportError:
 
 from typing import Any
 
-from .utils import helper_diis, cc_contract, zeros_like, clone
+from .utils import helper_diis, cc_contract, zeros_like, clone, sqrt
 from .hamiltonian import Hamiltonian
 from .local import Local
 from .cctriples import t_tjl, t3c_ijk, t3d_ijk, t3c_abc, t3d_abc, t3_pert_ijk
@@ -353,18 +353,12 @@ class ccwfn(object):
                 self.t1 += inc1
                 self.t2 += inc2
                 rms = contract('ia,ia->', inc1, inc1) + contract('ijab,ijab->', inc2, inc2)
-                if HAS_TORCH and isinstance(r1, torch.Tensor):
-                    rms = torch.sqrt(rms)
-                else:
-                    rms = np.sqrt(rms)
+                rms = sqrt(rms)
             else:
                 self.t1 += r1/Dia
                 self.t2 += r2/Dijab
                 rms = contract('ia,ia->', r1/Dia, r1/Dia) + contract('ijab,ijab->', r2/Dijab, r2/Dijab)
-                if HAS_TORCH and isinstance(r1, torch.Tensor):
-                    rms = torch.sqrt(rms)
-                else:
-                    rms = np.sqrt(rms)
+                rms = sqrt(rms)
 
             ecc = self.cc_energy(o, v, F, L, self.t1, self.t2)
             ediff = ecc - ecc_last

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -11,7 +11,7 @@ import numpy as np
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
-from pycc.utils import zeros_like, clone, conj
+from pycc.utils import zeros_like, clone, conj, reshape
 import pickle as pk
 from os.path import exists
 import opt_einsum
@@ -202,18 +202,14 @@ class rtcc(object):
         # Extract the amplitudes
         len1 = no*nv
         len2 = no*no*nv*nv
+        t1 = reshape(y[:len1], (no, nv))
+        t2 = reshape(y[len1:(len1+len2)], (no, no, nv, nv))
+        l1 = reshape(y[(len1+len2):(len1+len2+len1)], (no, nv))
+        l2 = reshape(y[(len1+len2+len1):-1], (no, no, nv, nv))
+        # Extract the phase; .item() returns a Python scalar from a torch tensor
         if HAS_TORCH and isinstance(y, torch.Tensor):
-            t1 = torch.reshape(y[:len1], (no, nv))
-            t2 = torch.reshape(y[len1:(len1+len2)], (no, no, nv, nv))
-            l1 = torch.reshape(y[(len1+len2):(len1+len2+len1)], (no, nv))
-            l2 = torch.reshape(y[(len1+len2+len1):-1], (no, no, nv, nv))
             phase = y[-1].item()
         else:
-            t1 = np.reshape(y[:len1], (no, nv))
-            t2 = np.reshape(y[len1:(len1+len2)], (no, no, nv, nv))
-            l1 = np.reshape(y[(len1+len2):(len1+len2+len1)], (no, nv))
-            l2 = np.reshape(y[(len1+len2+len1):-1], (no, no, nv, nv))
-            # Extract the phase
             phase = y[-1]
 
         return t1, t2, l1, l2, phase

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -11,7 +11,7 @@ import numpy as np
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
-from pycc.utils import zeros_like, clone
+from pycc.utils import zeros_like, clone, conj
 import pickle as pk
 from os.path import exists
 import opt_einsum
@@ -303,17 +303,7 @@ class rtcc(object):
         contract = self.contract
         
         F = clone(self.ccwfn.H.F) + self.mu_tot * self.V(t)
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            eref = 2.0 * torch.trace(F[o,o])
-            # torch.trace doesn't have "axis" argument
-            #eref -= torch.trace(torch.trace(tmp, axis1=1, axis2=3))
-            tmp = self.ccwfn.H.L[o,o,o,o].to(self.ccwfn.device1)
-            eref -= torch.trace(opt_einsum.contract('i...i', tmp.swapaxes(0,1), backend='torch'))
-            del tmp
-
-        else:
-            eref = 2.0 * np.trace(F[o,o])
-            eref -= np.trace(np.trace(self.ccwfn.H.L[o,o,o,o], axis1=1, axis2=3))
+        eref = self._eref(F)
 
         eone = F.flatten().dot(opdm.flatten())
 
@@ -325,6 +315,20 @@ class rtcc(object):
         oovv_energy = 0.5 * contract('ijab,ijab->', ERI[o,o,v,v], Doovv)
         etwo = oooo_energy + vvvv_energy + ooov_energy + vvvo_energy + ovov_energy + oovv_energy
         return eref + eone + etwo
+
+    def _eref(self, F):
+        """Reference (zeroth-order) energy contribution to the CC quasienergy.
+
+        Returns ``2 Tr F_oo - sum_{ia} L_iaia`` (i.e. ``2 np.trace(F[o,o]) -
+        np.trace(np.trace(L[o,o,o,o], axis1=1, axis2=3))``). Evaluated through the
+        backend ``contract`` so the single expression runs unchanged on NumPy or
+        torch — ``contract`` handles any device transfer of ``H.L`` in GPU mode.
+        """
+        o = self.ccwfn.o
+        contract = self.contract
+        eref = 2.0 * contract('ii->', F[o, o])
+        eref -= contract('iaia->', self.ccwfn.H.L[o, o, o, o])
+        return eref
 
     def phase(self, F, t1, t2):
         """
@@ -345,15 +349,7 @@ class rtcc(object):
         v = self.ccwfn.v
         L = self.ccwfn.H.L
 
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            eref = 2.0 * torch.trace(F[o,o])
-            tmp = self.ccwfn.H.L[o,o,o,o].to(self.ccwfn.device1)
-            eref -= torch.trace(opt_einsum.contract('i...i', tmp.swapaxes(0,1), backend='torch'))
-            del tmp
-
-        else:
-            eref = 2.0 * np.trace(F[o,o])
-            eref -= np.trace(np.trace(self.ccwfn.H.L[o,o,o,o], axis1=1, axis2=3))
+        eref = self._eref(F)
 
         if self.ccwfn.model == 'CCD':
             ecc = contract('ijab,ijab->', t2, L[o,o,v,v])
@@ -396,10 +392,7 @@ class rtcc(object):
         B -= contract("ijab,ia,jb->", l2_r, t1_l, t1_r)
         B *= np.exp(-phase_r) * np.exp(phase_l)
         
-        if HAS_TORCH and isinstance(A, torch.Tensor):
-            return 0.5*A + 0.5*torch.conj(B)
-        else:
-            return 0.5*A + 0.5*np.conj(B)
+        return 0.5*A + 0.5*conj(B)
 
     def step(self,ODE,yi,t,ref=False):
         """

--- a/pycc/utils.py
+++ b/pycc/utils.py
@@ -103,6 +103,28 @@ def solve(A, b):
     return np.linalg.solve(A, b)
 
 
+def sqrt(a):
+    """Backend-aware square root: ``torch.sqrt`` for a torch tensor, else ``np.sqrt``."""
+    if HAS_TORCH and isinstance(a, torch.Tensor):
+        return torch.sqrt(a)
+    return np.sqrt(a)
+
+
+def reshape(a, shape):
+    """Backend-aware reshape: ``torch.reshape`` for a torch tensor, else ``np.reshape``."""
+    if HAS_TORCH and isinstance(a, torch.Tensor):
+        return torch.reshape(a, shape)
+    return np.reshape(a, shape)
+
+
+def concatenate(arrays):
+    """Backend-aware 1-D concatenation: ``torch.cat`` for torch tensors, else
+    ``np.concatenate``. Dispatches on the first array in ``arrays``."""
+    if HAS_TORCH and isinstance(arrays[0], torch.Tensor):
+        return torch.cat(arrays)
+    return np.concatenate(arrays)
+
+
 class helper_diis(object):
     def __init__(self, t1, t2, max_diis, precision='DP'):
         self.oldt1 = clone(t1)
@@ -122,10 +144,7 @@ class helper_diis(object):
         # Add new error vectors
         error_t1 = (self.diis_vals_t1[-1] - self.oldt1).ravel()
         error_t2 = (self.diis_vals_t2[-1] - self.oldt2).ravel()
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            self.diis_errors.append(torch.cat((error_t1, error_t2)))
-        else:
-            self.diis_errors.append(np.concatenate((error_t1, error_t2)))
+        self.diis_errors.append(concatenate((error_t1, error_t2)))
         self.oldt1 = clone(t1)
         self.oldt2 = clone(t2)
 

--- a/pycc/utils.py
+++ b/pycc/utils.py
@@ -58,11 +58,53 @@ def clone(a, device=None):
     return a.copy()
 
 
+def real_zeros(shape, like):
+    """Allocate a real-dtype zero tensor of ``shape`` on ``like``'s backend/device.
+
+    Uses the *real-component* dtype of ``like`` (``like.real.dtype``), so a complex
+    amplitude yields a real buffer of the matching precision (complex128->float64,
+    complex64->float32) while a real amplitude is unchanged. Used for the DIIS B
+    matrix / residual vector, which must stay real even when the amplitudes are
+    complex (e.g. frequency-dependent response in ``ccresponse``); precision and,
+    for torch, device placement ride along from the data.
+    """
+    if HAS_TORCH and isinstance(like, torch.Tensor):
+        return torch.zeros(shape, dtype=like.real.dtype, device=like.device)
+    return np.zeros(shape, dtype=like.real.dtype)
+
+
+def dot(a, b):
+    """Backend-aware 1-D dot product: ``torch.dot`` for torch tensors, else ``np.dot``."""
+    if HAS_TORCH and isinstance(a, torch.Tensor):
+        return torch.dot(a, b)
+    return np.dot(a, b)
+
+
+def absolute(a):
+    """Backend-aware elementwise absolute value: ``torch.abs`` for a torch tensor,
+    else ``np.abs``."""
+    if HAS_TORCH and isinstance(a, torch.Tensor):
+        return torch.abs(a)
+    return np.abs(a)
+
+
+def conj(a):
+    """Backend-aware complex conjugate: ``torch.conj`` for a torch tensor, else ``np.conj``."""
+    if HAS_TORCH and isinstance(a, torch.Tensor):
+        return torch.conj(a)
+    return np.conj(a)
+
+
+def solve(A, b):
+    """Backend-aware dense linear solve: ``torch.linalg.solve`` for a torch tensor,
+    else ``np.linalg.solve``."""
+    if HAS_TORCH and isinstance(A, torch.Tensor):
+        return torch.linalg.solve(A, b)
+    return np.linalg.solve(A, b)
+
+
 class helper_diis(object):
     def __init__(self, t1, t2, max_diis, precision='DP'):
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            self.device0 = torch.device('cpu')
-            self.device1 = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
         self.oldt1 = clone(t1)
         self.oldt2 = clone(t2)
         self.diis_vals_t1 = [clone(t1)]
@@ -100,75 +142,35 @@ class helper_diis(object):
 
         self.diis_size = len(self.diis_errors)
 
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            # Build error matrix B
-            if self.precision == 'DP':
-                B = torch.ones((self.diis_size + 1, self.diis_size + 1), dtype=torch.float64, device=self.device1) * -1
-            elif self.precision == 'SP':
-                B = torch.ones((self.diis_size + 1, self.diis_size + 1), dtype=torch.float32, device=self.device1) * -1
-            B[-1, -1] = 0
+        # Build error matrix B. B/resid are real even when the amplitudes are complex
+        # (e.g. ccresponse), so they are seeded from real_zeros (real-component dtype of
+        # oldt1), which also carries the precision and, for torch, the device.
+        B = real_zeros((self.diis_size + 1, self.diis_size + 1), self.oldt1) - 1.0
+        B[-1, -1] = 0
 
-            for n1, e1 in enumerate(self.diis_errors):
-                B[n1, n1] = torch.dot(e1, e1)
-                for n2, e2 in enumerate(self.diis_errors):
-                    if n1 >= n2:
-                        continue
-                    B[n1, n2] = torch.dot(e1, e2)
-                    B[n2, n1] = B[n1, n2]
+        for n1, e1 in enumerate(self.diis_errors):
+            B[n1, n1] = dot(e1, e1)
+            for n2, e2 in enumerate(self.diis_errors):
+                if n1 >= n2:
+                    continue
+                B[n1, n2] = dot(e1, e2)
+                B[n2, n1] = B[n1, n2]
 
-            B[:-1, :-1] /= torch.abs(B[:-1, :-1]).max()
+        B[:-1, :-1] /= absolute(B[:-1, :-1]).max()
 
-            # Build residual vector
-            if self.precision == 'DP':
-                resid = torch.zeros((self.diis_size + 1), dtype=torch.float64, device=self.device1)
-            elif self.precision == 'SP':
-                resid = torch.zeros((self.diis_size + 1), dtype=torch.float32, device=self.device1)
-            resid[-1] = -1
+        # Build residual vector
+        resid = real_zeros((self.diis_size + 1,), self.oldt1)
+        resid[-1] = -1
 
-            # Solve pulay equations
-            ci = torch.linalg.solve(B, resid)
+        # Solve pulay equations
+        ci = solve(B, resid)
 
-            # Calculate new amplitudes
-            t1 = torch.zeros_like(self.oldt1)
-            t2 = torch.zeros_like(self.oldt2)
-            for num in range(self.diis_size):
-                t1 += torch.real(ci[num] * self.diis_vals_t1[num + 1])
-                t2 += torch.real(ci[num] * self.diis_vals_t2[num + 1])
-
-        else:
-            # Build error matrix B
-            if self.precision == 'DP':
-                B = np.ones((self.diis_size + 1, self.diis_size + 1)) * -1
-            elif self.precision == 'SP':
-                B = np.ones((self.diis_size + 1, self.diis_size + 1), dtype=np.float32) * -1
-            B[-1, -1] = 0
-
-            for n1, e1 in enumerate(self.diis_errors):
-                B[n1, n1] = np.dot(e1, e1)
-                for n2, e2 in enumerate(self.diis_errors):
-                    if n1 >= n2:
-                        continue
-                    B[n1, n2] = np.dot(e1, e2)
-                    B[n2, n1] = B[n1, n2]
-
-            B[:-1, :-1] /= np.abs(B[:-1, :-1]).max()
-
-            # Build residual vector
-            if self.precision == 'DP':
-                resid = np.zeros(self.diis_size + 1)
-            elif self.precision == 'SP':
-                resid = np.zeros((self.diis_size + 1), dtype=np.float32)
-            resid[-1] = -1
-
-            # Solve pulay equations
-            ci = np.linalg.solve(B, resid)
-
-            # Calculate new amplitudes
-            t1 = np.zeros_like(self.oldt1)
-            t2 = np.zeros_like(self.oldt2)
-            for num in range(self.diis_size):
-                t1 += ci[num] * self.diis_vals_t1[num + 1]
-                t2 += ci[num] * self.diis_vals_t2[num + 1]
+        # Calculate new amplitudes
+        t1 = zeros_like(self.oldt1)
+        t2 = zeros_like(self.oldt2)
+        for num in range(self.diis_size):
+            t1 += ci[num] * self.diis_vals_t1[num + 1]
+            t2 += ci[num] * self.diis_vals_t2[num + 1]
 
         # Save extrapolated amplitudes to old_t amplitudes
         self.oldt1 = clone(t1)


### PR DESCRIPTION
Summary

  Continues the contraction-backend abstraction (smears #2/#3) by collapsing the last "irreducible" NumPy/torch dispatch
  branches behind array-namespace helpers in utils.py, moving toward the goal of relegating nearly all HAS_TORCH sections to
  helpers so GPU code is easier to extend.
  
  New backend-aware helpers in utils.py (siblings of the existing zeros/zeros_like/diag/clone): real_zeros, dot, absolute,
  conj, solve, sqrt, reshape, concatenate.

  Branches collapsed (11 total):
  - helper_diis.extrapolate — the two ~33-line DP/SP × torch/np blocks become one. B/resid are seeded from real_zeros
  (real-component dtype of the amplitude), so they stay real even when the amplitudes are complex, while precision and device
  ride along from the data. Dead device0/device1 setup dropped from __init__.
  - helper_diis.add_error_vector — torch.cat/np.concatenate → concatenate().
  - ccwfn.solve_cc / cclambda.solve_lambda — 4 convergence rms = torch.sqrt/np.sqrt → sqrt(rms).
  - rtcc.lagrangian & rtcc.phase — both HAS_TORCH trace blocks → a single _eref(F) evaluated through the backend contract
  (2·Tr F_oo − Σ_ia L_iaia), removing the torch-only .to(device1)/del dance.
  - rtcc.autocorrelation — conj().
  - rtcc.extract_amps — torch/np reshape blocks → reshape().
  
  Intentionally left as-is: one-time precision/device construction (torch.tensor/complex*/device/cuda seed-casts), the
  ccdensity complex-zeros allocations (a possible future complex_zeros helper), and collect_amps' torch.flatten (torch-only
  block — no paired else to collapse).

  Notable findings

  - Regression caught & fixed during development: seeding B/resid from the amplitude's full dtype leaked complex128 into the
  DIIS matrix for ccresponse (frequency-dependent response amplitudes are complex), making it singular. real_zeros
  (like.real.dtype) restores main's real-B semantics exactly.
  - Confirmed empirically that the magnetic-dipole/linear-momentum response amplitudes are pure imaginary (real part
  exactly 0). The ComplexWarning in DIIS is benign and pre-existing on main (the discarded imaginary part is exactly zero).

  Follow-ups logged to CODE_REVIEW.md (not in this PR)

  - Store the pure-imaginary ccresponse response amplitudes as real (caveat: the H.m/H.p integrals must stay imaginary —
  shared with rtcc for magnetic-field coupling).
  - Latent bug: ccwfn.solve_cc's torch/GPU convergence arm returns the bare CCSD energy and skips the (T) correction the
  NumPy arm computes — so model='CCSD(T)' on a torch tensor is wrong. Not in CI (no GPU/torch lane test for it).

  Testing
  
  Full non-slow suite including the einsums tests — 54 passed, 0 failed (1 skipped GPU, 1 xfailed, 10 deselected: 9 slow +
  the pre-existing einsums crasher test_040_cc2_einsums::test_cc2_h2, which fails on main too). Torch paths aren't exercised
  locally (p4env has no torch); they're covered by the CPU-torch CI lane.