### PR TITLE
Adopt zeros(shape, like) for ccdensity complex allocations; fix laten…

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -30,12 +30,22 @@ in the **Critique** section.
       #105):** `clone(a, device=None)` collapsed ~166 branched copy sites across
       `cchbar`/`ccwfn`/`cclambda`/`ccdensity`/`cctriples`/`rtcc` + `utils`'s `helper_diis`
       (−215 lines); bare `.copy()` in the numpy-only modules (`ccresponse`/`local`/
-      `lccwfn`/`cceom`/`integrators`) was left as-is. _Still open:_ **smear #1** — the
+      `lccwfn`/`cceom`/`integrators`) was left as-is. **The remaining "irreducible" branches
+      are now DONE (PR #107):** `helper_diis.extrapolate` collapses to one block via new
+      `real_zeros(shape, like)`/`dot`/`absolute`/`solve` helpers (B/resid use
+      `real_zeros` = `like.real.dtype`, staying real even for the complex `ccresponse`
+      response amplitudes), and `rtcc`'s `torch.trace`/`np.trace` arms become one
+      backend-`contract` `_eref(F)`; same PR added `sqrt`/`reshape`/`concatenate`/`conj`
+      and collapsed the convergence-`rms`, `add_error_vector`, `extract_amps`, and
+      `autocorrelation` branches (11 branches total). **The `ccdensity` complex
+      allocations** (`opdm`/`Dooov`/`Dvvvo`) now use `zeros(shape, like=t1)` so dtype
+      tracks the amplitude (real ground-state, complex RT) — which also fixed a dormant
+      `np.zeros((no,no,no.nv), …)` typo and a torch-vs-numpy DP dtype mismatch in the CCD
+      branches (only the numpy/DP sub-path was ever exercised). The only explicit
+      `torch.*` left is genuine one-time construction (`torch.tensor`/`complex*`/`device`/
+      `cuda` precision seed-casts in `__init__`). _Still open:_ **smear #1** — the
       per-method `contract = self.ec.contract if self.einsums` library re-dispatch (paused;
-      the einsums path is not in CI, so it needs a manual run before collapsing). The
-      genuinely backend-divergent bodies that no copy/alloc helper can unify
-      (`helper_diis.extrapolate`'s `torch.linalg.solve` vs `np.linalg.solve`; `rtcc`'s
-      `torch.trace`/`np.trace` arms) await the fuller backend object.
+      the einsums path is not in CI, so it needs a manual run before collapsing).
 - [ ] **Real-valued response amplitudes for imaginary perturbations.** The magnetic-dipole
       (`H.m`) and linear-momentum (`H.p`) integrals are stored pure-imaginary (`* 1.0j`),
       so for those perturbations `ccresponse`'s `X1`/`X2` come out **pure imaginary** —

--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -184,16 +184,7 @@ class ccdensity(object):
         ERI = self.ccwfn.H.ERI
         L = self.ccwfn.H.L
  
-        if HAS_TORCH and isinstance(t1, torch.Tensor):
-            if self.ccwfn.precision == 'DP':
-                opdm = torch.zeros((nt, nt), dtype=torch.complex128, device=self.ccwfn.device1)
-            elif self.ccwfn.precision == 'SP':
-                opdm = torch.zeros((nt, nt), dtype=torch.complex64, device=self.ccwfn.device1)
-        else:
-            if self.ccwfn.precision == 'DP':
-                opdm = np.zeros((nt, nt), dtype='complex128')
-            elif self.ccwfn.precision == 'SP':
-                opdm = np.zeros((nt, nt), dtype='complex64')
+        opdm = zeros((nt, nt), like=t1)
         opdm[o,o] = self.build_Doo(t1, t2, l1, l2)
         opdm[v,v] = self.build_Dvv(t1, t2, l1, l2)
         opdm[o,v] = self.build_Dov(t1, t2, l1, l2)
@@ -348,16 +339,7 @@ class ccdensity(object):
         if self.ccwfn.model == 'CCD':
             no = self.ccwfn.no
             nv = self.ccwfn.nv
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                if self.ccwfn.precision == 'DP':
-                    Dooov = torch.zeros((no,no,no,nv), dtype=torch.complex128, device=self.ccwfn.device1)
-                elif self.ccwfn.precision == 'SP':                    
-                    Dooov = torch.zeros((no,no,no,nv), dtype=torch.complex64, device=self.ccwfn.device1)
-            else:
-                if self.ccwfn.precision == 'DP':
-                    Dooov = np.zeros((no,no,no,nv))
-                elif self.ccwfn.precision == 'SP':
-                    Dooov = np.zeros((no,no,no.nv), dtype=np.complex64)
+            Dooov = zeros((no,no,no,nv), like=t1)
         else:
             tmp = 2.0 * self.ccwfn.build_tau(t1, t2) - self.ccwfn.build_tau(t1, t2).swapaxes(2, 3)
             Dooov = -1.0 * contract('ke,ijea->ijka', l1, tmp)
@@ -401,16 +383,7 @@ class ccdensity(object):
         if self.ccwfn.model == 'CCD':
             no = self.ccwfn.no
             nv = self.ccwfn.nv
-            if HAS_TORCH and isinstance(t1, torch.Tensor):
-                if self.ccwfn.precision == 'DP':
-                    Dvvvo = torch.zeros((nv,nv,nv,no), dtype=torch.complex128, device=self.ccwfn.device1)
-                if self.ccwfn.precision == 'SP':
-                    Dvvvo = torch.zeros((nv,nv,nv,no), dtype=torch.complex64, device=self.ccwfn.device1)
-            else:
-                if self.ccwfn.precision == 'DP':
-                    Dvvvo = np.zeros((nv,nv,nv,no))
-                if self.ccwfn.precision == 'SP':
-                    Dvvvo = np.zeros((nv,nv,nv,no), dtype=np.complex64)
+            Dvvvo = zeros((nv,nv,nv,no), like=t1)
         else: 
             tmp = 2.0 * self.ccwfn.build_tau(t1, t2) - self.ccwfn.build_tau(t1, t2).swapaxes(2, 3)
             Dvvvo = contract('mc,miab->abci', l1, tmp)


### PR DESCRIPTION
  Summary
  
  The opdm, Dooov, and Dvvvo density containers in ccdensity.py were each allocated with a 6-line DP/SP × torch/np block that
  hardcoded torch.complex128/64 (+ device) or np.zeros. This replaces each with the existing zeros(shape, like=t1) helper,
  so the allocation inherits the amplitude's dtype/device — real for ground-state CC, complex for RT-CC (where rtcc casts the
  amplitudes to complex). No new helper is needed; ccdensity already uses this idiom (build_Dvv, line 315).
  
  Net: −30/+3 lines, and the last explicit np./complex/device literals are gone from ccdensity.

  Why zeros(like=…) rather than forcing complex
  
  These containers are just pre-sized holders that get filled with amplitude contractions, so their dtype should track the
  amplitude — which is exactly what like= does. Forcing complex (a new complex_zeros helper or a complex=True flag) would
  only be needed to keep ground-state densities complex, which isn't required: the numpy DP paths of Dooov/Dvvvo were already
  real, and the density/property tests pass with a real ground-state opdm.

  Latent bug fixed (dormant)

  The CCD branches of build_Dooov/build_Dvvvo (zero placeholders) were self-inconsistent:
  - torch DP allocated complex128 while numpy DP allocated real float64 — now uniformly t1's dtype.
  - build_Dooov's numpy-SP line had a typo: np.zeros((no,no,no.nv), dtype=np.complex64) — no.nv raises AttributeError, and
  it's only 3 dimensions.
  
  These survived because coverage there is thin: test_017_ccd does execute the CCD branch (it builds a full density —
  onlyone=False default — and calls compute_energy), but only the numpy/double-precision sub-path. The torch sub-path (no
  torch in the local p4env; the CI CPU-torch lane covers it) and the SP sub-path — where the bugs lived — are never run.

  Behavior

  Behavior-identical on the covered path: ground-state CCD t1 is real, so zeros(…, like=t1) is real float64, matching the old
  np.zeros(…). The one intentional change is that ground-state opdm goes complex128 → real float64 (its imaginary part was
  always zero); RT is unaffected (complex t1 → complex opdm). Confirmed the density/property tests are unaffected.
  
  Testing

  Full non-slow suite including the einsums tests — 54 passed, 0 failed (1 skipped GPU, 1 xfailed, 10 deselected: 9 slow +
  the pre-existing einsums crasher test_040_cc2_einsums::test_cc2_h2, which fails on main too). Torch paths aren't exercised
  locally (p4env has no torch); they're covered by the CPU-torch CI lane.
  
  Small follow-on to the backend-helper work in PRs #102 / #107.
