### PR TITLE
Fold the per-method einsums library dispatch into ccwfn._contract

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -15,7 +15,7 @@ in the **Critique** section.
 - [x] `.gitignore` — Psi4 scratch (`psi.*.clean`), `ijk.dat`, `profile.txt`, `.DS_Store`
 - [ ] **Shared CC solver base** — extract a `_CCSolver` (or composition) shared by
       `ccwfn` and `lccwfn` to kill the ~800–960-line duplication. _Highest leverage._
-- [~] **Contraction-backend abstraction** — replace the ~50×/module
+- [x] **Contraction-backend abstraction** — replace the ~50×/module
       `contract = self.ec.contract if self.einsums ...` + `.clone()/.copy()` device
       branching with one callable that owns library/device/precision. (Root cause of
       the `zero_like` bug.) _Design drafted below — see "Design note:
@@ -43,9 +43,22 @@ in the **Critique** section.
       `np.zeros((no,no,no.nv), …)` typo and a torch-vs-numpy DP dtype mismatch in the CCD
       branches (only the numpy/DP sub-path was ever exercised). The only explicit
       `torch.*` left is genuine one-time construction (`torch.tensor`/`complex*`/`device`/
-      `cuda` precision seed-casts in `__init__`). _Still open:_ **smear #1** — the
-      per-method `contract = self.ec.contract if self.einsums` library re-dispatch (paused;
-      the einsums path is not in CI, so it needs a manual run before collapsing).
+      `cuda` precision seed-casts in `__init__`). **Smear #1 (library dispatch) DONE.**
+      The ~27 per-method `contract = self.contract; if self.einsums: contract =
+      self.ec.contract` blocks fold into one `ccwfn.__init__` attribute
+      `self._contract = self.ec.contract if self.einsums else self.contract`, used by
+      ccwfn's builders and the `cctriples` (T) kernels (−35 lines). **The audit changed
+      the plan:** einsums is a *partial* feature (only `ccwfn`/`cctriples` dispatch to
+      `self.ec`), so the fold is scoped to a ccwfn-private `_contract` rather than
+      `self.contract` — folding into `self.contract` would have silently switched the
+      H-bar/Λ/density/EOM/response sub-objects (which inherit it) to einsums. Genuine
+      einsums-specific code was preserved: `build_tau`'s transpose formula, the MP2
+      sanity check, and `_cc3_t_residual`'s deliberate opt_einsum reset before its final
+      `'abc,c->ab'` contraction. Verified locally — einsums *is* installed in `p4env`
+      (unlike torch), so `test_038–042` exercise the dispatch (the old "not in CI →
+      unverifiable" worry was moot). **This item is now fully done; the only remaining
+      backend work is the deeper device-placed object the design note describes (a future
+      direction, not a worklist gap).**
 - [ ] **Real-valued response amplitudes for imaginary perturbations.** The magnetic-dipole
       (`H.m`) and linear-momentum (`H.p`) integrals are stored pure-imaginary (`* 1.0j`),
       so for those perturbations `ccresponse`'s `X1`/`X2` come out **pure imaginary** —

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -193,9 +193,7 @@ def t_tjl(ccwfn: "ccwfn") -> float:
     float
 
     """
-    contract = ccwfn.contract
-    if ccwfn.einsums:
-        contract = ccwfn.ec.contract
+    contract = ccwfn._contract
 
     o = ccwfn.o
     v = ccwfn.v
@@ -256,9 +254,7 @@ def t_vikings(ccwfn: "ccwfn") -> float:
     float
 
     """
-    contract = ccwfn.contract
-    if ccwfn.einsums:
-        contract = ccwfn.ec.contract
+    contract = ccwfn._contract
 
     o = ccwfn.o
     v = ccwfn.v
@@ -274,8 +270,6 @@ def t_vikings(ccwfn: "ccwfn") -> float:
     for i in range(no):
         for j in range(no):
             for k in range(no):
-                if ccwfn.einsums:
-                    contract = ccwfn.ec.contract
 
                 t3 = t3c_ijk(o, v, i, j, k, t2, ERI[v,v,v,o], ERI[o,v,o,o], F, contract)
 
@@ -285,8 +279,6 @@ def t_vikings(ccwfn: "ccwfn") -> float:
 
                 X2[i,j] += contract('abc,c->ab',(t3 - t3.swapaxes(0,2)), F[k,v])
 
-    if ccwfn.einsums:
-        contract = ccwfn.ec.contract
 
     ET = 2.0 * contract('ia,ia->', t1, X1)
     ET += contract('ijab,ijab->', (4.0*t2 - 2.0*t2.swapaxes(2,3)), X2)
@@ -306,9 +298,7 @@ def t_vikings_inverted(ccwfn: "ccwfn") -> float:
     float
 
     """
-    contract = ccwfn.contract
-    if ccwfn.einsums:
-        contract = ccwfn.ec.contract
+    contract = ccwfn._contract
 
     o = ccwfn.o
     v = ccwfn.v
@@ -325,8 +315,6 @@ def t_vikings_inverted(ccwfn: "ccwfn") -> float:
     for a in range(nv):
         for b in range(nv):
             for c in range(nv):
-                if ccwfn.einsums:
-                    contract = ccwfn.ec.contract
                 t3 = t3c_abc(o, v, a, b, c, t2, ERI[v,v,v,o], ERI[o,v,o,o], F, contract, True)
 
                 X1[a] += contract('ijk,jk->i',(t3 - t3.swapaxes(0,2)), L[o,o,b+no,c+no])
@@ -335,8 +323,6 @@ def t_vikings_inverted(ccwfn: "ccwfn") -> float:
 
                 X2[a,b] += contract('ijk,k->ij',(t3 - t3.swapaxes(0,2)), F[o,c+no])
 
-    if ccwfn.einsums:
-        contract = ccwfn.ec.contract
 
     ET = 2.0 * contract('ia,ia->', t1, X1.T)
     ET += contract('ijab,ijab->', (4.0*t2 - 2.0*t2.swapaxes(2,3)), X2.T)

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -293,6 +293,13 @@ class ccwfn(object):
             self.einsums = False
             print('C++ Einsums library requested but not available.')
 
+        # Contraction callable for ccwfn's own intermediate/residual builders (and the
+        # module-level cctriples kernels): the C++ einsums backend where enabled, else the
+        # shared opt_einsum cc_contract. Scoped to ccwfn + cctriples on purpose -- the
+        # cchbar/cclambda/ccdensity/cceom/ccresponse sub-objects deliberately stay on
+        # self.contract (opt_einsum), as einsums implements only the T/triples paths.
+        self._contract = self.ec.contract if self.einsums else self.contract
+
         # Compute MP2 energy as einsums test
         if self.einsums:
             t2 = 2*self.t2 - self.t2.swapaxes(2,3)
@@ -333,9 +340,7 @@ class ccwfn(object):
         Dia = self.Dia
         Dijab = self.Dijab
 
-        contract = self.contract
-        if self.einsums:
-            contract = self.ec.contract
+        contract = self._contract
 
         ecc = self.cc_energy(o, v, F, L, self.t1, self.t2)
         print("CC Iter %3d: CC Ecorr = %.15f  dE = % .5E  MP2" % (0, ecc, -ecc))
@@ -412,9 +417,7 @@ class ccwfn(object):
             New T1 and T2 residuals: r_mu = <mu|HBAR|0>
         """
 
-        contract = self.contract
-        if self.einsums:
-            contract = self.ec.contract
+        contract = self._contract
 
         o = self.o
         v = self.v
@@ -484,12 +487,12 @@ class ccwfn(object):
         X1 = zeros_like(t1)
         X2 = zeros_like(t2)
 
-        contract = self.contract
         for i in range(no):
             for j in range(no):
                 for k in range(no):
-                    if self.einsums:
-                        contract = self.ec.contract
+                    # re-established each iteration: the final contraction below resets
+                    # contract back to self.contract (opt_einsum), which einsums cannot do
+                    contract = self._contract
                     t3 = t3c_ijk(o, v, i, j, k, t2, Wabei_cc3, Wmbij_cc3, F, contract, WithDenom=True)
 
                     if real_time is True:
@@ -555,9 +558,7 @@ class ccwfn(object):
             F_ae = f_ae - 1/2 f_me t_ma + t_mf L_mafe
                         - (t2_mnaf + 1/2 t_ma t_nf) L_mnef
         """
-        contract = self.contract
-        if self.einsums:
-            contract = self.ec.contract
+        contract = self._contract
 
         if self.model == 'CCD':
             Fae = clone(F[v,v])
@@ -586,9 +587,7 @@ class ccwfn(object):
             F_mi = f_mi + 1/2 t_ie f_me + t_ne L_mnie
                         + (t2_inef + 1/2 t_ie t_nf) L_mnef
         """
-        contract = self.contract
-        if self.einsums:
-            contract = self.ec.contract
+        contract = self._contract
 
         if self.model == 'CCD':
             Fmi = clone(F[o,o])
@@ -616,9 +615,7 @@ class ccwfn(object):
 
             F_me = f_me + t_nf L_mnef
         """
-        contract = self.contract
-        if self.einsums:
-            contract = self.ec.contract
+        contract = self._contract
 
         if self.model == 'CCD':
             return
@@ -643,9 +640,7 @@ class ccwfn(object):
             W_mnij = <mn|ij> + t_je <mn|ie> + t_ie <mn|ej>
                             + (t2_ijef + t_ie t_jf) <mn|ef>
         """
-        contract = self.contract
-        if self.einsums:
-            contract = self.ec.contract
+        contract = self._contract
 
         if self.model == 'CCD':
             Wmnij = clone(ERI[o,o,o,o], device=self.device1)
@@ -679,9 +674,7 @@ class ccwfn(object):
                             - (1/2 t2_jnfb + t_jf t_nb) <mn|ef>
                             + 1/2 t2_njfb L_mnef
         """
-        contract = self.contract
-        if self.einsums:
-            contract = self.ec.contract
+        contract = self._contract
 
         if self.model == 'CCD':
             Wmbej = clone(ERI[o,v,v,o], device=self.device1)
@@ -714,9 +707,7 @@ class ccwfn(object):
             W_mbje = -<mb|je> - t_jf <mb|fe> + t_nb <mn|je>
                              + (1/2 t2_jnfb + t_jf t_nb) <mn|fe>
         """
-        contract = self.contract
-        if self.einsums:
-            contract = self.ec.contract
+        contract = self._contract
 
         if self.model == 'CCD':
             Wmbje = -1.0 * clone(ERI[o,v,o,v], device=self.device1)
@@ -745,9 +736,7 @@ class ccwfn(object):
 
             Z_mbij = <mb|ef> (t2_ijef + t_ie t_jf)
         """
-        contract = self.contract
-        if self.einsums:
-            contract = self.ec.contract
+        contract = self._contract
 
         if self.model == 'CCD':
             return
@@ -779,9 +768,7 @@ class ccwfn(object):
                     + (2 t2_mief - t2_mife) <ma|ef>
                     - t2_mnae L_nmei
         """
-        contract = self.contract
-        if self.einsums:
-            contract = self.ec.contract
+        contract = self._contract
 
         if self.model == 'CCD':
             r_T1 = zeros_like(t1)
@@ -837,9 +824,7 @@ class ccwfn(object):
                       + t2_imae (W_mbej + W_mbje[e<->j])
                       + t2_mjae W_mbie
         """
-        contract = self.contract
-        if self.einsums:
-            contract = self.ec.contract
+        contract = self._contract
 
         r_T2 = 0.5 * clone(ERI[o,o,v,v], device=self.device1)
         r_T2 = r_T2 + contract('ijae,eb->ijab', t2, Fae.T)
@@ -869,9 +854,7 @@ class ccwfn(object):
                       - t_ie t_ma <mb|ej> - t_ie t_mb <ma|je>
                       + t_ie <ab|ej> - t_ma <mb|ij>
         """
-        contract = self.contract
-        if self.einsums:
-            contract = self.ec.contract
+        contract = self._contract
 
         r_T2 = 0.5 * clone(ERI[o,o,v,v], device=self.device1)
 
@@ -914,9 +897,7 @@ class ccwfn(object):
                       - t_ie t_ma <mb|ej> - t_ie t_mb <ma|je>
                       + t_ie <ab|ej> - t_ma <mb|ij>
         """
-        contract = self.contract
-        if self.einsums:
-            contract = self.ec.contract
+        contract = self._contract
 
         r_T2 = 0.5 * clone(ERI[o,o,v,v], device=self.device1)
         r_T2 = r_T2 + contract('ijae,eb->ijab', t2, Fae.T)
@@ -1085,9 +1066,7 @@ class ccwfn(object):
                 CCD:   E = t2_ijab L_ijab
                 else:  E = 2 f_ia t_ia + tau_ijab L_ijab   (tau = t2 + t1 t1)
         """
-        contract = self.contract
-        if self.einsums:
-            contract = self.ec.contract
+        contract = self._contract
         if self.model == 'CCD':
             ecc = contract('ijab,ijab->', t2, L[o,o,v,v])
         else:


### PR DESCRIPTION
Smear #1 of the contraction-backend abstraction. Collapses the ~27 repeated contract = self.contract; if self.einsums: 
  contract = self.ec.contract re-dispatch blocks into one ccwfn.__init__ attribute:
  self._contract = self.ec.contract if self.einsums else self.contract
  used by ccwfn's intermediate/residual builders and the cctriples (T) kernels. Net −35 lines.
  
  The audit changed the plan from the design note. einsums is a partial feature — only ccwfn and cctriples ever dispatch to
  self.ec; cchbar/cclambda/ccdensity/cceom/ccresponse always use self.contract (opt_einsum). So the fold is scoped to a
  ccwfn-private _contract, not self.contract — folding into self.contract (which all those sub-objects inherit) would have
  silently switched H̄/Λ/density/EOM/response to einsums (untested, likely-unimplemented contractions).
  
  Preserved as genuine einsums-specific code (not redundancy): build_tau's transpose-based formula, the MP2 sanity check, and
  _cc3_t_residual's deliberate contract = self.contract reset before its final 'abc,c->ab' contraction (re-established each
  loop iteration). The cctriples (T) kernels had no such reset, so their in-loop/post-loop overrides were pure redundancy and
  were removed.

  Verification: einsums is installed in p4env (unlike torch), so test_038–042 exercise the CCSD/CCD/CC2/CCSD(T)/CC3 einsums
  dispatch — the old "not in CI → can't verify" concern was moot. Full non-slow suite: 54 passed, 0 failed
  (test_040_cc2_einsums::test_cc2_h2 deselected — pre-existing crasher on main).
 