### PR TITLE
Fix CCSD(T) on the torch/GPU device path (and a latent bug it surfaced)

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -220,16 +220,17 @@ recorded with their PRs in the worklist above._
   PNO/PNO++ opt paths converge fine, so this is PAO-specific (possibly the `local_cutoff=2e-2`
   domain construction or a sign/projection error on the PAO path) — a genuine numerical bug,
   not the (now-fixed) `np.zeros(dim,dim)` shape trap. Needs investigation.
-- **`ccwfn.py:solve_cc` — the torch/GPU convergence branch silently skips the `(T)`
-  correction (open).** In the convergence block the `if HAS_TORCH and isinstance(self.t1,
-  torch.Tensor):` arm prints/returns the bare `ecc` (CCSD energy), while only the NumPy
-  `else` arm has the `if self.model == 'CCSD(T)': et = t3_density()/t_tjl(self); ecc += et`
-  step. So **`model='CCSD(T)'` run on a torch tensor returns the CCSD energy with no `(T)`
-  correction** — a wrong result, not a crash. Latent because torch/GPU isn't in CI (the
-  CPU-torch lane added in PR #99 *would* catch it if a `CCSD(T)` torch test existed). Fix:
-  hoist the `(T)` step out of the backend branch so both paths compute it. Surfaced while
-  auditing remaining `HAS_TORCH` branches for the backend-helper sweep; left as a separate
-  behavior fix (untestable locally — no torch in `p4env`).
+- **`ccwfn.py:solve_cc` — the torch/GPU convergence branch silently skipped the `(T)`
+  correction — FIXED (PR #112).** The convergence block was a `HAS_TORCH`/`else` pair where
+  only the NumPy arm computed `(T)`, so `model='CCSD(T)'` on a torch tensor returned the bare
+  CCSD energy. Unified the two arms (`abs()` dispatches to `__abs__` on both NumPy scalars and
+  0-d torch tensors), so `(T)` runs on either backend; also made the default `(T)` kernels
+  backend-aware (`t_tjl`/`t3d_ijk` `np.diag`/`np.zeros_like` → `diag`/`zeros_like`). Added
+  `test_044_ccsd_t_gpu.py` (`device='GPU'` CCSD(T)) for the CPU-torch CI lane. **Verifying on a
+  local CPU-torch clone surfaced a second pre-existing latent torch bug** the test then caught:
+  `_r_T2_ccsd` used `np.transpose(tmp, (3,2,1,0))` on a tensor (breaks on torch at CCSD
+  iteration 1) → `tmp.swapaxes(0,3).swapaxes(1,2)`. CCSD(T) now verified on real torch tensors;
+  numpy suite unchanged.
 
 ### Structural issues (the expensive ones)
 
@@ -283,6 +284,6 @@ Scientifically impressive and broad. Of the three original debt clusters —
 (1) the `ccwfn`/`lccwfn` fork, (2) hand-rolled backend dispatch, (3) test-setup duplication —
 **(2) and (3) are done**, and **(1) was re-scoped**: the audit showed it's two implementations
 of the same equations (not copy-paste), so the decision is to keep both solvers explicit. The
-remaining open work is concrete and bounded: the **PAO NaN bug** and the **CCSD(T)-on-GPU
-`(T)` skip** — both in the worklist above. (The real-valued response amplitudes landed in
-PR #111.)
+remaining open work is concrete and bounded: the **PAO NaN bug** is the main one in the
+worklist above. (The real-valued response amplitudes landed in PR #111; the CCSD(T)-on-GPU
+`(T)` skip — and a latent `np.transpose`-on-torch bug it surfaced — in PR #112.)

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -136,8 +136,8 @@ def t3d_ijk(o, v, i, j, k, t1, t2, Woovv, F, contract, WithDenom=True):
     t3 += contract('bc,a->abc', t2[j,k], F[i,v])
 
     if WithDenom is True:
-        Fv = np.diag(F)[v]
-        denom = np.zeros_like(t3)
+        Fv = diag(F)[v]
+        denom = zeros_like(t3)
         denom -= Fv.reshape(-1,1,1) + Fv.reshape(-1,1) + Fv
         denom += F[i,i] + F[j,j] + F[k,k]
         return t3/denom
@@ -226,8 +226,8 @@ def t_tjl(ccwfn: "ccwfn") -> float:
                 Y3 = V3 + V3.swapaxes(0,1).swapaxes(1,2) + V3.swapaxes(0,1).swapaxes(0,2)
                 Z3 = V3.swapaxes(1,2) + V3.swapaxes(0,1) + V3.swapaxes(0,2)
 
-                Fv = np.diag(F)[v]
-                denom = np.zeros_like(W3)
+                Fv = diag(F)[v]
+                denom = zeros_like(W3)
                 denom -= Fv.reshape(-1,1,1) + Fv.reshape(-1,1) + Fv
                 denom += F[i,i] + F[j,j] + F[k,k]
 

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -369,32 +369,27 @@ class ccwfn(object):
             ediff = ecc - ecc_last
             print("CC Iter %3d: CC Ecorr = %.15f  dE = % .5E  rms = % .5E" % (niter, ecc, ediff, rms))
 
-            # check for convergence
-            if HAS_TORCH and isinstance(self.t1, torch.Tensor):
-                if ((torch.abs(ediff) < e_conv) and torch.abs(rms) < r_conv):
-                    print("\nCCWFN converged in %.3f seconds.\n" % (time.time() - ccsd_tstart))
-                    print("E(REF)  = %20.15f" % self.eref)
-                    print("E(%s) = %20.15f" % (self.model, ecc))
-                    print("E(TOT)  = %20.15f" % (ecc + self.eref))
-                    self.ecc = ecc
-                    return ecc
-            else:
-                if ((abs(ediff) < e_conv) and abs(rms) < r_conv):
-                    print("\nCCWFN converged in %.3f seconds.\n" % (time.time() - ccsd_tstart))
-                    print("E(REF)  = %20.15f" % self.eref)
-                    if (self.model == 'CCSD(T)'):
-                        print("E(CCSD) = %20.15f" % ecc)
-                        if self.make_t3_density is True:
-                            et = self.t3_density()
-                        else:
-                            et = t_tjl(self)
-                        print("E(T)    = %20.15f" % et)
-                        ecc = ecc + et
+            # check for convergence. abs() dispatches to __abs__ on both NumPy scalars
+            # and 0-d torch tensors, so this single block (and the (T) correction below)
+            # runs on either backend -- previously the torch arm was a separate copy that
+            # silently skipped the (T) step, so CCSD(T) on a torch tensor returned the
+            # bare CCSD energy.
+            if ((abs(ediff) < e_conv) and abs(rms) < r_conv):
+                print("\nCCWFN converged in %.3f seconds.\n" % (time.time() - ccsd_tstart))
+                print("E(REF)  = %20.15f" % self.eref)
+                if (self.model == 'CCSD(T)'):
+                    print("E(CCSD) = %20.15f" % ecc)
+                    if self.make_t3_density is True:
+                        et = self.t3_density()
                     else:
-                        print("E(%s) = %20.15f" % (self.model, ecc))
-                    self.ecc = ecc
-                    print("E(TOT)  = %20.15f" % (ecc + self.eref))
-                    return ecc
+                        et = t_tjl(self)
+                    print("E(T)    = %20.15f" % et)
+                    ecc = ecc + et
+                else:
+                    print("E(%s) = %20.15f" % (self.model, ecc))
+                self.ecc = ecc
+                print("E(TOT)  = %20.15f" % (ecc + self.eref))
+                return ecc
 
             diis.add_error_vector(self.t1, self.t2)
             if niter >= start_diis:
@@ -914,8 +909,8 @@ class ccwfn(object):
         r_T2 = r_T2 + contract('imae,mbej->ijab', t2, (Wmbej + Wmbje.swapaxes(2,3)))
         r_T2 = r_T2 + contract('mjae,mbie->ijab', t2, Wmbje)
         tmp = contract('ei,am->aemi', t1.T, t1.T)
-        r_T2 = r_T2 - contract('imea,mbej->ijab', np.transpose(tmp, (3,2,1,0)), ERI[o,v,v,o])
-        r_T2 = r_T2 - contract('imeb,maje->ijab', np.transpose(tmp, (3,2,1,0)), ERI[o,v,o,v])
+        r_T2 = r_T2 - contract('imea,mbej->ijab', tmp.swapaxes(0,3).swapaxes(1,2), ERI[o,v,v,o])
+        r_T2 = r_T2 - contract('imeb,maje->ijab', tmp.swapaxes(0,3).swapaxes(1,2), ERI[o,v,o,v])
         r_T2 = r_T2 + contract('ie,abej->ijab', t1, ERI[v,v,v,o])
         r_T2 = r_T2 - contract('ma,mbij->ijab', t1, ERI[o,v,o,o])
 

--- a/pycc/tests/test_044_ccsd_t_gpu.py
+++ b/pycc/tests/test_044_ccsd_t_gpu.py
@@ -1,0 +1,38 @@
+"""
+Test CCSD(T) energy on the torch ("GPU") device path.
+
+This exercises the bug where ccwfn.solve_cc's torch convergence branch used to
+return the bare CCSD energy and silently skip the (T) correction (the numpy
+branch computed it). It also covers the (T) kernels t_tjl/t3d_ijk now that their
+denominator construction is backend-aware. With a CPU-only torch wheel the
+"GPU" path runs on CPU tensors, which is enough to exercise the torch code in CI.
+"""
+
+import psi4
+import pycc
+import pytest
+from ..data.molecules import *
+
+# Skip the whole module if PyTorch is absent, and bind `torch` for use below.
+torch = pytest.importorskip("torch")
+
+
+@pytest.mark.gpu
+def test_ccsd_t_h2o_gpu(rhf_wfn):
+    """H2O STO-3G CCSD(T) on the torch device path.
+
+    solve_cc with model='ccsd(t)' must return the CCSD(T) correlation energy
+    (CCSD + (T)), not the bare CCSD energy. Reference is the numpy result for
+    the same fixture geometry; E(T) = -0.000099957499645 matches test_005.
+    """
+    maxiter = 75
+    e_conv = 1e-12
+    r_conv = 1e-12
+
+    wfn = rhf_wfn("H2O", "STO-3G")
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', device='GPU')
+    ecc = cc.solve_cc(e_conv, r_conv, maxiter)
+
+    # CCSD(T) correlation energy (CCSD = -0.070616830152764, (T) = -0.000099957499645)
+    eccsd_t = -0.0707167876524093
+    assert (abs(eccsd_t - float(ecc)) < 1e-11)


### PR DESCRIPTION
  ### Summary

  `ccwfn.solve_cc`'s convergence check was a `HAS_TORCH`/`else` pair in which **only the NumPy arm computed the `(T)` 
  correction** — the torch arm printed/returned the bare CCSD energy. So `model='CCSD(T)'` run on a torch tensor
  (`device='GPU'`) silently returned the **CCSD energy with no `(T)`** — a wrong result, not a crash. It went unnoticed
  because no `CCSD(T)` test ran on the torch device.

  This unifies the two arms into one block (`abs()` dispatches to `__abs__` on both NumPy scalars and 0-d torch tensors), so
  the `(T)` step runs on either backend, and the duplicated convergence/print/return logic is removed.

  ### Changes

  - **`ccwfn.solve_cc`** — single backend-agnostic convergence block; `(T)` now computed on torch as well as NumPy.
  - **`cctriples.t_tjl` + `t3d_ijk`** — denominator construction made backend-aware (`np.diag`/`np.zeros_like` → 
  `diag`/`zeros_like`) so the now-enabled torch `(T)` path actually runs. Identical on NumPy.
  - **`tests/test_044_ccsd_t_gpu.py`** — new `device='GPU'` CCSD(T) test (mirrors `test_025`'s `pytest.importorskip("torch")`
  / `@pytest.mark.gpu`). Asserts `solve_cc` returns the CCSD(T) **total** `-0.0707167876524093` (its `(T)` part 
  `-0.000099957499645` matches `test_005`). Skips without torch; runs on CPU tensors in the CPU-torch CI lane.

  ### Latent bug found while verifying on torch

  Running the new test on a local CPU-torch environment surfaced a **second, pre-existing** torch bug the fix then exposed: 
  `_r_T2_ccsd` used `np.transpose(tmp, (3,2,1,0))` — a NumPy function on a tensor — which breaks on torch at **CCSD iteration
  1**, before any `(T)` code. Replaced with `tmp.swapaxes(0,3).swapaxes(1,2)`, which both backends support and is identical 
  on NumPy. (The `build_tau` `np.transpose` at `ccwfn.py:527–528` is inside the `if self.einsums:` branch — not the torch 
  path — so it is left alone.)

  ### Testing

  - **NumPy full non-slow suite: 54 passed, 0 failed** — `_r_T2_ccsd`, `t_tjl`/`t3d_ijk`, and the unified convergence block 
  all exercised; behavior on the NumPy path is unchanged.
  - **`test_044` passes on real (CPU) torch tensors**, matching the NumPy reference to 1e-11 — so the `(T)`-on-torch path is
  verified end-to-end, not just correct-by-construction.
  - The CPU-torch CI lane will now run `test_044` (and continue running `test_025`), giving the torch `(T)` path ongoing
  coverage.
