### PR TITLE
Extract a DeviceManager; rename cc_contract -> ContractionBackend

### DIFF
--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -10,7 +10,6 @@ if __name__ == "__main__":
 
 import psi4
 import time
-import warnings
 import numpy as np
 
 try:
@@ -21,13 +20,14 @@ except ImportError:
 
 from typing import Any
 
-from .utils import helper_diis, cc_contract, zeros_like, clone, sqrt
+from .utils import helper_diis, zeros_like, clone, sqrt
+from .device import DeviceManager
 from .hamiltonian import Hamiltonian
 from .local import Local
 from .cctriples import t_tjl, t3c_ijk, t3d_ijk, t3c_abc, t3d_abc, t3_pert_ijk
 from .lccwfn import lccwfn
 from ._typing import Tensor
-from .exceptions import InvalidKeywordError, PyCCWarning
+from .exceptions import InvalidKeywordError
 
 class ccwfn(object):
     """
@@ -211,74 +211,37 @@ class ccwfn(object):
             self.t1 = np.zeros((self.no, self.nv))
             self.t2 = self.H.ERI[o,o,v,v]/self.Dijab
 
-        valid_precision = ['SP', 'DP']
-        precision = kwargs.pop('precision', 'DP')
-        if precision.upper() not in valid_precision:
-            raise InvalidKeywordError('precision', precision, valid_precision)
-        self.precision = precision.upper()
+        # Device / precision policy: validates the kwargs (fallback warnings for
+        # GPU-without-torch / GPU-without-CUDA), resolves device0/device1, builds
+        # the contraction backend, and owns the dtype/placement cast policy.
+        self.device_manager = DeviceManager(
+            device=kwargs.pop('device', 'CPU'),
+            precision=kwargs.pop('precision', 'DP'),
+        )
+        mgr = self.device_manager
 
-        valid_device = ['CPU', 'GPU']
-        device = kwargs.pop('device', 'CPU')
-        if device.upper() not in valid_device:
-            raise InvalidKeywordError('device', device, valid_device)
-        self.device = device.upper()
-        if self.device == 'GPU' and not HAS_TORCH:
-            warnings.warn("GPU requested, but PyTorch is not available; "
-                          "falling back to CPU.", PyCCWarning, stacklevel=2)
-            self.device = 'CPU'
-        elif self.device == 'GPU' and not torch.cuda.is_available():
-            warnings.warn("GPU requested, but no CUDA device is available; "
-                          "PyTorch tensors will run on CPU.", PyCCWarning,
-                          stacklevel=2)
+        # Back-compat handles: the builders and sub-objects still read
+        # ccwfn.<device0/device1/contract/...>. These pass-throughs dissolve in
+        # Phase 3, when consumers read the manager on the Wavefunction base.
+        self.precision = mgr.precision
+        self.device = mgr.device
+        self.device0 = mgr.device0
+        self.device1 = mgr.device1
+        self.contract = mgr.contract
 
-        if self.precision == 'SP':
-            self.H.F = np.float32(self.H.F)
-            self.t1 = np.float32(self.t1)
-            self.t2 = np.float32(self.t2)
-            self.Dia = np.float32(self.Dia)
-            self.Dijab = np.float32(self.Dijab)
-            self.H.ERI = np.float32(self.H.ERI)
-            self.H.L = np.float32(self.H.L)
+        # Cast/place the compute-resident arrays (amplitudes, Fock, denominators)
+        # and the storage-resident integrals (ERI/L) per the device/precision
+        # policy. On CPU+DP these are no-ops; on CPU+SP they real-cast to float32;
+        # on GPU they become complex torch tensors on device1 (compute) / device0
+        # (CPU storage).
+        self.H.F = mgr.seed_compute(self.H.F)
+        self.t1 = mgr.seed_compute(self.t1)
+        self.t2 = mgr.seed_compute(self.t2)
+        self.Dia = mgr.seed_compute(self.Dia)
+        self.Dijab = mgr.seed_compute(self.Dijab)
+        self.H.ERI = mgr.seed_store(self.H.ERI)
+        self.H.L = mgr.seed_store(self.H.L)
 
-        # Initiate the object for a generalized contraction function 
-        # for GPU or CPU.  
-        self.contract = cc_contract(device=self.device)
-
-        # CPU/compute device handles for the GPU path. Default to None on CPU so
-        # that clone(x, device=self.device1) is a plain copy with no transfer
-        # (the device arg is ignored for NumPy arrays).
-        self.device0 = None
-        self.device1 = None
-
-        # Convert the arrays to torch.Tensors if the calculation is on GPU.
-        # Send the copy of F, t1, t2 to GPU.
-        # ERI will be kept on GPU
-        if self.device == 'GPU':
-            if self.precision == 'DP':
-                self.device0 = torch.device('cpu')
-                self.device1 = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-                # Storing on GPU
-                self.H.F = torch.tensor(self.H.F, dtype=torch.complex128, device=self.device1)
-                self.t1 = torch.tensor(self.t1, dtype=torch.complex128, device=self.device1)
-                self.t2 = torch.tensor(self.t2, dtype=torch.complex128, device=self.device1)
-                self.Dia = torch.tensor(self.Dia, dtype=torch.complex128, device=self.device1)
-                self.Dijab = torch.tensor(self.Dijab, dtype=torch.complex128, device=self.device1)
-                # Storing on CPU
-                self.H.ERI = torch.tensor(self.H.ERI, dtype=torch.complex128, device=self.device0)
-                self.H.L = torch.tensor(self.H.L, dtype=torch.complex128, device=self.device0)
-            elif self.precision == 'SP':
-                self.device0 = torch.device('cpu')
-                self.device1 = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-                # Storing on GPU
-                self.H.F = torch.tensor(self.H.F, dtype=torch.complex64, device=self.device1)
-                self.t1 = torch.tensor(self.t1, dtype=torch.complex64, device=self.device1)
-                self.t2 = torch.tensor(self.t2, dtype=torch.complex64, device=self.device1)
-                self.Dia = torch.tensor(self.Dia, dtype=torch.complex64, device=self.device1)
-                self.Dijab = torch.tensor(self.Dijab, dtype=torch.complex64, device=self.device1)
-                # Storing on CPU
-                self.H.ERI = torch.tensor(self.H.ERI, dtype=torch.complex64, device=self.device0)
-                self.H.L = torch.tensor(self.H.L, dtype=torch.complex64, device=self.device0)
-                
         print("CCWFN object initialized in %.3f seconds." % (time.time() - time_init))
 
 
@@ -985,7 +948,7 @@ class ccwfn(object):
             Indexed [a, b, e, i]. See the inline construction for the exact
             term-by-term T1 dressing.
         """
-        contract =self.contract
+        contract = self.contract
         # eiab
         Z = clone(ERI[v,o,v,v], device=self.device1)
         tmp_ints = ERI[v,v,v,v] + ERI[v,v,v,v].swapaxes(2,3)

--- a/pycc/device.py
+++ b/pycc/device.py
@@ -1,0 +1,174 @@
+"""Device / precision manager for PyCC wavefunctions.
+
+A single object that owns the ``device`` ('CPU'/'GPU') and ``precision``
+('SP'/'DP') policy: it validates the kwargs, resolves the storage (``device0``)
+and compute (``device1``) handles, builds the contraction backend, and applies
+the dtype/placement cast policy through :meth:`seed_compute` / :meth:`seed_store`.
+
+This centralizes logic that was previously duplicated across ``ccwfn.__init__``
+(the SP real-casts and the GPU torch casts) and the contraction backend's
+``__init__`` (a third copy of the device resolution). In the 2026-06 refactor the
+manager is created in ``ccwfn.__init__``; it moves to the ``Wavefunction`` base in
+Phase 3.
+
+Notes
+-----
+GPU tensors are currently always *complex* (the historical behavior, shared with
+RT-CC). The ``needs_complex`` seam exists so a future phase can give ground-state
+methods a real GPU dtype; it defaults to True, so present behavior is unchanged.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import opt_einsum
+
+try:
+    import torch
+    HAS_TORCH = True
+except ImportError:
+    HAS_TORCH = False
+
+from .exceptions import InvalidKeywordError, PyCCWarning
+
+
+class ContractionBackend(object):
+    """A device-aware wrapper around ``opt_einsum.contract``.
+
+    On CPU it calls ``opt_einsum.contract`` directly; on GPU it first moves any
+    operand not already resident on the compute device (``device1``) there, so
+    CPU-stored integrals (``H.ERI``/``H.L``) can participate in GPU contractions.
+    Created and owned by :class:`DeviceManager`, which injects the resolved
+    ``device1``; also passed by value into the module-level (T)/triples kernels.
+    """
+
+    def __init__(self, device='CPU', device1=None):
+        """
+        Parameters
+        ----------
+        device : str
+            'CPU' or 'GPU' (default 'CPU').
+        device1 : torch.device, optional
+            the compute device, normally injected by DeviceManager (the single
+            resolver). Falls back to local resolution for standalone use.
+        """
+        self.device = device
+        if self.device == 'GPU':
+            # torch.device is the device on which a torch.Tensor is/will be allocated.
+            self.device1 = device1 if device1 is not None else torch.device(
+                'cuda:0' if torch.cuda.is_available() else 'cpu')
+
+    def __call__(self, subscripts, *operands):
+        """Contract ``operands`` per ``subscripts`` (numpy.einsum format),
+        returning an ndarray (CPU) or torch.Tensor (GPU)."""
+        if self.device == 'CPU':
+            return opt_einsum.contract(subscripts, *operands)
+        elif self.device == 'GPU':
+            # Move any CPU-resident operand (e.g. ERI) onto the compute device.
+            input_list = list(operands)
+            for i in range(len(input_list)):
+                if not input_list[i].is_cuda:
+                    input_list[i] = input_list[i].to(self.device1)
+            output = opt_einsum.contract(subscripts, *input_list)
+            del input_list
+            return output
+
+
+class DeviceManager(object):
+    """Owns the device/precision policy and the contraction backend.
+
+    Parameters
+    ----------
+    device : str
+        'CPU' or 'GPU'. 'GPU' falls back to 'CPU' (with a ``PyCCWarning``) when
+        PyTorch is unavailable; with PyTorch but no CUDA device it stays 'GPU'
+        but tensors run on CPU.
+    precision : str
+        'SP' (single) or 'DP' (double).
+    needs_complex : bool
+        Whether GPU tensors must be complex (RT-CC). Defaults True, reproducing
+        the historical always-complex-on-GPU behavior; Phase 2b will set it False
+        for real ground-state methods.
+
+    Attributes
+    ----------
+    device, precision : str
+        The resolved (post-fallback) device and precision.
+    device0, device1 : torch.device or None
+        Storage (CPU-resident integrals) and compute handles; None on CPU.
+    contract : ContractionBackend
+        The contraction callable, owning the single resolved ``device1``.
+    real_dtype : numpy dtype
+        float32 for SP, float64 for DP.
+    """
+
+    VALID_DEVICE = ['CPU', 'GPU']
+    VALID_PRECISION = ['SP', 'DP']
+
+    def __init__(self, device: str = 'CPU', precision: str = 'DP',
+                 needs_complex: bool = True) -> None:
+        # --- precision ---
+        if precision.upper() not in self.VALID_PRECISION:
+            raise InvalidKeywordError('precision', precision, self.VALID_PRECISION)
+        self.precision = precision.upper()
+
+        # --- device (with graceful fallback) ---
+        if device.upper() not in self.VALID_DEVICE:
+            raise InvalidKeywordError('device', device, self.VALID_DEVICE)
+        self.device = device.upper()
+        if self.device == 'GPU' and not HAS_TORCH:
+            warnings.warn("GPU requested, but PyTorch is not available; "
+                          "falling back to CPU.", PyCCWarning, stacklevel=3)
+            self.device = 'CPU'
+        elif self.device == 'GPU' and not torch.cuda.is_available():
+            warnings.warn("GPU requested, but no CUDA device is available; "
+                          "PyTorch tensors will run on CPU.", PyCCWarning,
+                          stacklevel=3)
+
+        self.needs_complex = needs_complex
+
+        # --- device handles ---
+        # device0: storage/CPU-resident (the big integrals); device1: compute.
+        # Both None on CPU so clone(x, device=device1) is a plain copy.
+        self.device0 = None
+        self.device1 = None
+        if self.device == 'GPU':
+            self.device0 = torch.device('cpu')
+            self.device1 = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+
+        # --- dtypes ---
+        # The numpy real dtype rides precision; the torch dtype for GPU-resident
+        # tensors is complex (under needs_complex) at the matching width.
+        self.real_dtype = np.float32 if self.precision == 'SP' else np.float64
+        self._torch_dtype = None
+        if HAS_TORCH:
+            if self.needs_complex:
+                self._torch_dtype = (torch.complex64 if self.precision == 'SP'
+                                     else torch.complex128)
+            else:
+                self._torch_dtype = (torch.float32 if self.precision == 'SP'
+                                     else torch.float64)
+
+        # --- contraction backend (single owner of the resolved device1) ---
+        self.contract = ContractionBackend(device=self.device, device1=self.device1)
+
+    def _real_cast(self, a):
+        # SP -> float32; DP -> unchanged (matches the historical behavior, which
+        # only re-cast arrays on the SP path).
+        return np.float32(a) if self.precision == 'SP' else a
+
+    def seed_compute(self, a):
+        """Cast + place a compute-resident array (amplitudes/Fock; rtcc mu/m)."""
+        a = self._real_cast(a)
+        if self.device == 'GPU':
+            return torch.tensor(a, dtype=self._torch_dtype, device=self.device1)
+        return a
+
+    def seed_store(self, a):
+        """Cast + place a storage-resident array (the big integrals, ERI/L)."""
+        a = self._real_cast(a)
+        if self.device == 'GPU':
+            return torch.tensor(a, dtype=self._torch_dtype, device=self.device0)
+        return a

--- a/pycc/utils.py
+++ b/pycc/utils.py
@@ -2,7 +2,6 @@ import numpy as np
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
-import opt_einsum
 
 
 def zeros_like(a):
@@ -196,52 +195,3 @@ class helper_diis(object):
         self.oldt2 = clone(t2)
 
         return t1, t2
-
-class cc_contract(object):
-    """
-    A wrapper for opt_einsum.contract with tensors stored on CPU and/or GPU.
-    """
-    def __init__(self, device='CPU'):
-        """
-        Parameters
-        ----------
-        device: string
-            initiated in ccwfn object, default: 'CPU'
-        
-        Returns
-        -------
-        None
-        """
-        self.device = device
-        if self.device == 'GPU':
-            # torch.device is an object representing the device on which torch.Tensor is or will be allocated.
-            self.device0 = torch.device('cpu')
-            self.device1 = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-        
-    def __call__(self, subscripts, *operands): 
-        """
-        Parameters
-        ----------
-        subscripts: string
-            specify the subscripts for summation (same format as numpy.einsum)
-        *operands: list of array_like
-            the arrays/tensors for the operation
-   
-        Returns
-        -------
-        An ndarray/torch.Tensor that is calculated based on Einstein summation convention.   
-        """       
-        if self.device == 'CPU':
-            return opt_einsum.contract(subscripts, *operands)
-        elif self.device == 'GPU':
-            # Check the type and allocation of the tensors 
-            # Transfer the copy from CPU to GPU if needed (for ERI)
-            input_list = list(operands)
-            for i in range(len(input_list)):
-                if (not input_list[i].is_cuda):
-                    input_list[i] = input_list[i].to(self.device1)               
-            #print(len(input_list), type(input_list[0]), type(input_list[1]))    
-            output = opt_einsum.contract(subscripts, *input_list)
-            del input_list
-            return output
-


### PR DESCRIPTION
Phase 2 of the 2026-06 refactor (docs/REFACTOR_PLAN_2026-06.md). Behavior- preserving: CPU and GPU paths are unchanged (full p4env non-slow suite green -- 50 passed / 2 skipped / 8 deselected / 1 xfailed, incl. test_030_sp for the SP real-cast path).

The device/precision policy was triplicated and spread across ccwfn.__init__ (the SP real-casts + two near-identical GPU complex-cast blocks) and cc_contract.__init__ (a third copy of the device0/device1 resolution). Centralize it in one object:

- New pycc/device.py with DeviceManager: validates the device/precision kwargs (incl. the GPU-without-torch / GPU-without-CUDA fallback warnings), resolves device0/device1 once, builds the contraction backend (injecting the resolved device1, killing the third copy), and owns the dtype/placement cast policy via seed_compute() (amplitudes/Fock -> compute device) and seed_store() (the big ERI/L integrals -> CPU storage).
- ccwfn.__init__ creates self.device_manager and keeps thin pass-through handles (self.device/device0/device1/precision/contract) so the builders and sub-objects that read ccwfn.<x> are untouched (2a-minimal scope). These dissolve in Phase 3 when the manager moves to the Wavefunction base.
- A needs_complex seam is added (defaults True = current always-complex-on-GPU behavior); Phase 2b will flip it to give ground-state methods a real GPU dtype.

Move cc_contract out of utils.py into device.py and rename it ContractionBackend: it is a generic device-aware opt_einsum wrapper, not CC-specific, and will serve the HF/MP/CI wavefunctions too. Kept as a separate composed callable rather than merged into DeviceManager -- it is a hot-path object passed by value into the (T)/triples kernels. utils.py drops its now-unused opt_einsum import; ccwfn drops its now-unused warnings/PyCCWarning imports.