### PR TITLE
Seed GPU tensors real; promote real<->complex in the backend (Phase 2b)

### DIFF
--- a/pycc/device.py
+++ b/pycc/device.py
@@ -13,9 +13,10 @@ Phase 3.
 
 Notes
 -----
-GPU tensors are currently always *complex* (the historical behavior, shared with
-RT-CC). The ``needs_complex`` seam exists so a future phase can give ground-state
-methods a real GPU dtype; it defaults to True, so present behavior is unchanged.
+GPU tensors are seeded *real* (float32/64). Complex arithmetic appears only
+transiently during RT-CC propagation; :class:`ContractionBackend` and
+``utils.dot`` upcast the real operands to complex per-contraction, since torch
+(unlike NumPy) does not promote real<->complex in einsum/matmul/dot.
 """
 
 from __future__ import annotations
@@ -71,6 +72,15 @@ class ContractionBackend(object):
             for i in range(len(input_list)):
                 if not input_list[i].is_cuda:
                     input_list[i] = input_list[i].to(self.device1)
+            # torch (unlike NumPy) will not promote real<->complex in a contraction,
+            # so when the operands mix, upcast the real ones to the complex dtype.
+            # This lets real ground-state integrals contract with complex RT
+            # amplitudes; for all-real (ground state) it is a no-op fast path.
+            if any(t.is_complex() for t in input_list):
+                ctype = next(t.dtype for t in input_list if t.is_complex())
+                for i in range(len(input_list)):
+                    if not input_list[i].is_complex():
+                        input_list[i] = input_list[i].to(ctype)
             output = opt_einsum.contract(subscripts, *input_list)
             del input_list
             return output
@@ -87,10 +97,6 @@ class DeviceManager(object):
         but tensors run on CPU.
     precision : str
         'SP' (single) or 'DP' (double).
-    needs_complex : bool
-        Whether GPU tensors must be complex (RT-CC). Defaults True, reproducing
-        the historical always-complex-on-GPU behavior; Phase 2b will set it False
-        for real ground-state methods.
 
     Attributes
     ----------
@@ -107,8 +113,7 @@ class DeviceManager(object):
     VALID_DEVICE = ['CPU', 'GPU']
     VALID_PRECISION = ['SP', 'DP']
 
-    def __init__(self, device: str = 'CPU', precision: str = 'DP',
-                 needs_complex: bool = True) -> None:
+    def __init__(self, device: str = 'CPU', precision: str = 'DP') -> None:
         # --- precision ---
         if precision.upper() not in self.VALID_PRECISION:
             raise InvalidKeywordError('precision', precision, self.VALID_PRECISION)
@@ -127,8 +132,6 @@ class DeviceManager(object):
                           "PyTorch tensors will run on CPU.", PyCCWarning,
                           stacklevel=3)
 
-        self.needs_complex = needs_complex
-
         # --- device handles ---
         # device0: storage/CPU-resident (the big integrals); device1: compute.
         # Both None on CPU so clone(x, device=device1) is a plain copy.
@@ -139,17 +142,13 @@ class DeviceManager(object):
             self.device1 = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
         # --- dtypes ---
-        # The numpy real dtype rides precision; the torch dtype for GPU-resident
-        # tensors is complex (under needs_complex) at the matching width.
+        # GPU tensors are seeded REAL at the matching width; complex appears only
+        # transiently during RT, where ContractionBackend/dot upcast per-contraction.
         self.real_dtype = np.float32 if self.precision == 'SP' else np.float64
         self._torch_dtype = None
         if HAS_TORCH:
-            if self.needs_complex:
-                self._torch_dtype = (torch.complex64 if self.precision == 'SP'
-                                     else torch.complex128)
-            else:
-                self._torch_dtype = (torch.float32 if self.precision == 'SP'
-                                     else torch.float64)
+            self._torch_dtype = (torch.float32 if self.precision == 'SP'
+                                 else torch.float64)
 
         # --- contraction backend (single owner of the resolved device1) ---
         self.contract = ContractionBackend(device=self.device, device1=self.device1)

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -11,7 +11,7 @@ import numpy as np
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
-from pycc.utils import zeros_like, clone, conj, reshape
+from pycc.utils import zeros_like, clone, conj, reshape, dot
 import pickle as pk
 from os.path import exists
 import opt_einsum
@@ -251,20 +251,20 @@ class rtcc(object):
                 ints_cc3[i][:no,:no] = self.ccdensity.build_Moo(no, nv, ints[i], t1)     
                 ints_cc3[i][-nv:,-nv:] = self.ccdensity.build_Mvv(no, nv, ints[i], t1)      
      
-            x = ints[0].flatten().dot(opdm.flatten())
-            y = ints[1].flatten().dot(opdm.flatten())
-            z = ints[2].flatten().dot(opdm.flatten())
+            x = dot(ints[0].flatten(), opdm.flatten())
+            y = dot(ints[1].flatten(), opdm.flatten())
+            z = dot(ints[2].flatten(), opdm.flatten())
             # Contractions between Doo_cc3, Dvv_cc3 and T1-transformed dipole integrals
-            x += ints_cc3[0].flatten().dot(opdm_cc3.flatten())
-            y += ints_cc3[1].flatten().dot(opdm_cc3.flatten())
-            z += ints_cc3[2].flatten().dot(opdm_cc3.flatten())
+            x += dot(ints_cc3[0].flatten(), opdm_cc3.flatten())
+            y += dot(ints_cc3[1].flatten(), opdm_cc3.flatten())
+            z += dot(ints_cc3[2].flatten(), opdm_cc3.flatten())
             
             return x, y, z
 
         else:
-            x = ints[0].flatten().dot(opdm.flatten())
-            y = ints[1].flatten().dot(opdm.flatten())
-            z = ints[2].flatten().dot(opdm.flatten())
+            x = dot(ints[0].flatten(), opdm.flatten())
+            y = dot(ints[1].flatten(), opdm.flatten())
+            z = dot(ints[2].flatten(), opdm.flatten())
 
             return x, y, z    
     
@@ -301,7 +301,7 @@ class rtcc(object):
         F = clone(self.ccwfn.H.F) + self.mu_tot * self.V(t)
         eref = self._eref(F)
 
-        eone = F.flatten().dot(opdm.flatten())
+        eone = dot(F.flatten(), opdm.flatten())
 
         oooo_energy = 0.5 * contract('ijkl,ijkl->', ERI[o,o,o,o], Doooo)
         vvvv_energy = 0.5 * contract('abcd,abcd->', ERI[v,v,v,v], Dvvvv)

--- a/pycc/utils.py
+++ b/pycc/utils.py
@@ -73,8 +73,16 @@ def real_zeros(shape, like):
 
 
 def dot(a, b):
-    """Backend-aware 1-D dot product: ``torch.dot`` for torch tensors, else ``np.dot``."""
+    """Backend-aware 1-D dot product: ``torch.dot`` for torch tensors, else ``np.dot``.
+
+    torch (unlike NumPy) refuses a real<->complex dot, so when the operands mix the
+    real one is upcast to the other's complex dtype. This lets real ground-state
+    integrals dot with complex RT densities (e.g. in rtcc's dipole/energy)."""
     if HAS_TORCH and isinstance(a, torch.Tensor):
+        if a.is_complex() and not b.is_complex():
+            b = b.to(a.dtype)
+        elif b.is_complex() and not a.is_complex():
+            a = a.to(b.dtype)
         return torch.dot(a, b)
     return np.dot(a, b)
 


### PR DESCRIPTION
Phase 2b of the 2026-06 refactor (docs/REFACTOR_PLAN_2026-06.md). Ground-state CC on the GPU now runs in real arithmetic instead of complex -- halving its memory and flops -- while RT-CC still propagates in complex. The dtype is no longer a per-wavefunction decision: nothing has to be told "this is RT".

Previously GPU seeded everything complex up front so RT-CC could reuse the tensors, taxing every ground-state GPU calc 2x. The fix mirrors NumPy's promotion semantics, which torch lacks: torch will not promote real<->complex in einsum/matmul/dot (verified -- only elementwise ops promote). So:

- DeviceManager seeds GPU tensors REAL (float32/64); the needs_complex seam from Phase 2 is removed.
- ContractionBackend.__call__ (GPU): when operands mix real and complex, upcast the real ones to the complex dtype before opt_einsum (all-real ground state is a no-op fast path). RT's complex amplitudes thus contract against the real ground-state integrals/Hbar transparently.
- utils.dot promotes likewise; rtcc's raw .flatten().dot(.flatten()) sites (dipole/energy) route through it. No raw matmul exists on the GPU path -- the canonical modules are contract-based; raw @ lives only in the numpy-only lccwfn/local, which never run on GPU.

CPU is unaffected (already real + NumPy promotion). Validation: full p4env CPU suite green (50 passed); the promotion mechanism unit-tested on real torch (mixed -> promotes and matches the all-complex reference, all-real stays real); test_044 (ground-state CCSD(T) on GPU) passes with float64 tensors. test_025 (RT-CCSD on GPU) is not locally runnable on this Intel-Mac clone -- it segfaults on clean main too (a pre-existing torch 2.2.2 + psi4 + BLAS env artifact, not this change) -- so it rides CI's CPU-torch lane.