### PR TITLE
Tighten the RT-CCSD propagation tests (test_024/025)

### DIFF
--- a/pycc/tests/test_024_contract_cpu.py
+++ b/pycc/tests/test_024_contract_cpu.py
@@ -1,5 +1,5 @@
 """
-Test RT-CCSD propagation with RK4 integrator on water molecule.
+Test RT-CCSD propagation with the RK4 integrator on water (CPU/NumPy path).
 """
 
 # Import package, test suite, and other packages as needed
@@ -7,25 +7,22 @@ import psi4
 import numpy as np
 import pycc
 import pytest
-from pycc.rt.integrators import rk4 
+from pycc.rt.integrators import rk4
 from pycc.rt.lasers import gaussian_laser
 from ..data.molecules import *
 
 
 def test_rtcc_water_cc_pvdz(rhf_wfn):
-    """H2O cc-pVDZ"""
+    """H2O cc-pVDZ, RT-CCSD propagated with RK4 to t=0.1 a.u."""
     e_conv = 1e-13
     r_conv = 1e-13
 
     wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
                   e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
 
-    # The device for the calculation (CPU/GPU) can be specified.
-    # Option: 'CPU', 'GPU'
-    # Default: 'CPU'
     cc = pycc.ccwfn(wfn)
     ecc = cc.solve_cc(e_conv, r_conv)
-    
+
     hbar = pycc.cchbar(cc)
 
     cclambda = pycc.cclambda(cc, hbar)
@@ -34,59 +31,38 @@ def test_rtcc_water_cc_pvdz(rhf_wfn):
     ccdensity = pycc.ccdensity(cc, cclambda)
 
     # Gaussian pulse (a.u.)
-    F_str = 0.01
+    F_str = 0.1
     omega = 0
     sigma = 0.01
     center = 0.05
     V = gaussian_laser(F_str, omega, sigma, center)
 
-    # RT-CC Setup
+    # RT-CC setup
     phase = 0
-    t0 = 0
+    t0 = 0.0
     tf = 0.1
     h = 0.01
-    t = t0
     rtcc = pycc.rtcc(cc, cclambda, ccdensity, V)
     y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2, phase).astype('complex128')
     y = y0
     ODE = rk4(h)
-    t1, t2, l1, l2, phase = rtcc.extract_amps(y0)
-    mu0_x, mu0_y, mu0_z = rtcc.dipole(t1, t2, l1, l2)
-    ecc0 = rtcc.lagrangian(t0, t1, t2, l1, l2)
 
-    # For saving data at each time step.
-    """
-    dip_x = []
-    dip_y = []
-    dip_z = []
-    time_points = []
-    dip_x.append(mu0_x)
-    dip_y.append(mu0_y)
-    dip_z.append(mu0_z)
-    time_points.append(t)
-    """
-    
-    while t < tf:
+    # Propagate t0 -> tf with a fixed number of RK4 steps. Driving the loop with a
+    # `while t < tf` bound would overshoot by one step here: ten 0.01 increments
+    # sum to 0.09999999999999999 < 0.1 in floating point, triggering an extra step.
+    nsteps = int(round((tf - t0) / h))
+    t = t0
+    for step in range(nsteps):
         y = ODE(rtcc.f, t, y)
-        t += h 
+        t = t0 + (step + 1) * h
         t1, t2, l1, l2, phase = rtcc.extract_amps(y)
         mu_x, mu_y, mu_z = rtcc.dipole(t1, t2, l1, l2)
-        ecc = rtcc.lagrangian(t, t1, t2, l1, l2)
-        """
-        dip_x.append(mu_x)
-        dip_y.append(mu_y)
-        dip_z.append(mu_z)
-        time_points.append(t)
-        """
-        
-    print(mu_z)
-    mu_z_ref = -0.0780067603267549 # computed by removing SCF from original ref
-    assert (abs(mu_z_ref - mu_z.real) < 1e-4)
-    
-    #return (dip_x, dip_y, dip_z, time_points)
 
-#dip = test_rtcc_water_cc_pvdz()
-#np.savez('h2o_F_0.01_h_0.01_t_1_rk4', dip_x=dip[0], dip_y=dip[1], dip_z=dip[2], time_points=dip[3])
-
-
-
+    # Reference is mu_z(t=tf) computed with this code (RK4, h=0.01). The RT-CCSD
+    # propagation is deterministic and reproduces to ~1e-10 across platforms
+    # (cf. test_006). The F_str=0.1 pulse drives ~7e-4 of dipole motion over the
+    # run, so matching to 1e-10 genuinely tests the time evolution.
+    mu_z_ref = -0.078669702343987763
+    assert abs(mu_z_ref - mu_z.real) < 1e-10
+    # <mu_z> is a real observable; the propagated imaginary part is numerical noise.
+    assert abs(mu_z.imag) < 1e-7

--- a/pycc/tests/test_025_contract_gpu.py
+++ b/pycc/tests/test_025_contract_gpu.py
@@ -1,5 +1,5 @@
 """
-Test RT-CCSD propagation with RK4 integrator on water molecule on GPU.
+Test RT-CCSD propagation with the RK4 integrator on water (torch "GPU" path).
 """
 
 # Import package, test suite, and other packages as needed
@@ -16,21 +16,23 @@ from ..data.molecules import *
 # on CPU, which is enough to exercise the torch code path in CI.)
 torch = pytest.importorskip("torch")
 
+
 @pytest.mark.gpu
 def test_rtcc_water_cc_pvdz(rhf_wfn):
-    """H2O cc-pVDZ"""
+    """H2O cc-pVDZ, RT-CCSD propagated with RK4 to t=0.1 a.u. on the torch device.
+
+    Mirrors test_024 (CPU/NumPy) and compares against the same reference, so it
+    checks that the torch path reproduces the NumPy propagation.
+    """
     e_conv = 1e-13
     r_conv = 1e-13
 
     wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
                   e_convergence=1e-13, d_convergence=1e-13, r_convergence=1e-13)
 
-    # The device for the calculation (CPU/GPU) can be specified.
-    # Option: 'CPU', 'GPU'
-    # Default: 'CPU'
     cc = pycc.ccwfn(wfn, device='GPU')
     ecc = cc.solve_cc(e_conv, r_conv)
-    
+
     hbar = pycc.cchbar(cc)
 
     cclambda = pycc.cclambda(cc, hbar)
@@ -39,59 +41,35 @@ def test_rtcc_water_cc_pvdz(rhf_wfn):
     ccdensity = pycc.ccdensity(cc, cclambda)
 
     # Gaussian pulse (a.u.)
-    F_str = 0.01
+    F_str = 0.1
     omega = 0
     sigma = 0.01
     center = 0.05
     V = gaussian_laser(F_str, omega, sigma, center)
 
-    # RT-CC Setup
+    # RT-CC setup
     phase = 0
-    t0 = 0
+    t0 = 0.0
     tf = 0.1
     h = 0.01
-    t = t0
     rtcc = pycc.rtcc(cc, cclambda, ccdensity, V)
     y0 = rtcc.collect_amps(cc.t1, cc.t2, cclambda.l1, cclambda.l2, phase).type(torch.complex128)
     y = y0
     ODE = rk4(h)
-    t1, t2, l1, l2, phase = rtcc.extract_amps(y0)
-    mu0_x, mu0_y, mu0_z = rtcc.dipole(t1, t2, l1, l2)
-    ecc0 = rtcc.lagrangian(t0, t1, t2, l1, l2)
 
-    # For saving data at each time step.
-    """
-    dip_x = []
-    dip_y = []
-    dip_z = []
-    time_points = []
-    dip_x.append(mu0_x)
-    dip_y.append(mu0_y)
-    dip_z.append(mu0_z)
-    time_points.append(t)
-    """
-    
-    while t < tf:
+    # Propagate t0 -> tf with a fixed number of RK4 steps (a `while t < tf` bound
+    # overshoots by one step here -- see test_024).
+    nsteps = int(round((tf - t0) / h))
+    t = t0
+    for step in range(nsteps):
         y = ODE(rtcc.f, t, y)
-        t += h 
+        t = t0 + (step + 1) * h
         t1, t2, l1, l2, phase = rtcc.extract_amps(y)
         mu_x, mu_y, mu_z = rtcc.dipole(t1, t2, l1, l2)
-        ecc = rtcc.lagrangian(t, t1, t2, l1, l2)
-        """
-        dip_x.append(mu_x)
-        dip_y.append(mu_y)
-        dip_z.append(mu_z)
-        time_points.append(t)
-        """
-        
-    print(mu_z)
-    mu_z_ref = -0.0780067603267549 # matches test_024 (identical propagation); old value predated removing SCF from the ref
-    assert (abs(mu_z_ref - mu_z.real) < 1e-4)
-    
-    #return (dip_x, dip_y, dip_z, time_points)
 
-#dip = test_rtcc_water_cc_pvdz()
-#np.savez('h2o_F_0.01_h_0.01_t_1_rk4', dip_x=dip[0], dip_y=dip[1], dip_z=dip[2], time_points=dip[3])
-
-
-
+    # Same reference as test_024 (mu_z(t=tf) from this code, RK4, h=0.01): the torch
+    # path must reproduce the NumPy propagation to ~1e-10.
+    mu_z_ref = -0.078669702343987763
+    assert abs(mu_z_ref - mu_z.real) < 1e-10
+    # <mu_z> is a real observable; the propagated imaginary part is numerical noise.
+    assert abs(mu_z.imag) < 1e-7


### PR DESCRIPTION
The RT-CCSD water tests compared only the real part of mu_z(t) to a reference, to 1e-4 -- looser than the dipole's total motion over the run, so they did not actually test the time evolution. Investigation also found the stored reference was the *static* t=0 dipole (it matched mu_z(0) to ~7 places, the endpoint to only ~4), and that the `while t < tf` loop overshot by one step (ten 0.01 increments sum to 0.0999... < 0.1, so it ran to t=0.11, not 0.1).

Rework both tests (modeled on test_006):
- Stronger field (F_str 0.01 -> 0.1) so mu_z moves ~7e-4 over the run -- real dynamics, not a near-static signal.
- Fixed-step loop (nsteps = round((tf-t0)/h)) -> exactly t=0.1, no FP overshoot.
- Fresh reference mu_z(t=0.1) = -0.078669702343987763 from this code, compared at 1e-10 (was 1e-4).
- Added a physical check that the observable stays real: abs(mu_z.imag) < 1e-7.
- Removed the dead commented save/plot blocks.

The reference is independently verified: the pre-refactor code (PR #113, before the einsums removal / DeviceManager / real-dtype changes) reproduces it bit-for-bit (0.0 difference), confirming both the value and that none of those changes altered the RT-CCSD numerics.

test_024 (CPU) verified locally at 1e-10. test_025 (torch path) shares the reference, so it checks that torch reproduces the NumPy propagation; it runs only on CI's torch lane (RT-on-torch segfaults on the local Intel-Mac clone, independent of any code change).