### PR TITLE
Refactor/wavefunction base

### DIFF
--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -110,12 +110,6 @@ class ccwfn(Wavefunction):
         self.local = local
         self.local_cutoff = kwargs.pop('local_cutoff', 1e-5)
 
-        valid_local_MOs = ['PIPEK_MEZEY', 'BOYS']
-        local_MOs = kwargs.pop('local_mos', 'PIPEK_MEZEY').upper()
-        if local_MOs not in valid_local_MOs:
-            raise InvalidKeywordError('local_mos', local_MOs, valid_local_MOs)
-        self.local_MOs = local_MOs
-
         valid_it2_opt = [True,False]
         it2_opt = kwargs.pop('it2_opt', True)
         if it2_opt not in valid_it2_opt:
@@ -131,12 +125,10 @@ class ccwfn(Wavefunction):
         # Reference, orbital spaces, MO coefficients (occupied localized when a
         # local-CC scheme is requested, so the base's single H build uses LMOs),
         # the seeded MO-basis integrals, and the device/precision manager all come
-        # from the Wavefunction base.
-        super().__init__(scf_wfn,
-                         device=kwargs.pop('device', 'CPU'),
-                         precision=kwargs.pop('precision', 'DP'),
-                         localize_occ=(local is not None),
-                         local_mos=self.local_MOs)
+        # from the Wavefunction base. We pop only CC-specific kwargs above and
+        # forward the rest (device/precision/local_mos) to the base, which owns
+        # them -- so adding MPwfn/HFwfn/... needs no device/precision boilerplate.
+        super().__init__(scf_wfn, localize_occ=(local is not None), **kwargs)
         o = self.o
         v = self.v
         mgr = self.device_manager

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -8,7 +8,6 @@ if __name__ == "__main__":
     raise Exception("This file cannot be invoked on its own.")
 
 
-import psi4
 import time
 import numpy as np
 
@@ -20,16 +19,15 @@ except ImportError:
 
 from typing import Any
 
-from .utils import helper_diis, zeros_like, clone, sqrt
-from .device import DeviceManager
-from .hamiltonian import Hamiltonian
+from .utils import helper_diis, zeros_like, clone, sqrt, diag
+from .wavefunction import Wavefunction
 from .local import Local
 from .cctriples import t_tjl, t3c_ijk, t3d_ijk, t3c_abc, t3d_abc, t3_pert_ijk
 from .lccwfn import lccwfn
 from ._typing import Tensor
 from .exceptions import InvalidKeywordError
 
-class ccwfn(object):
+class ccwfn(Wavefunction):
     """
     An RHF-CC wave function and energy object.
 
@@ -130,65 +128,18 @@ class ccwfn(object):
             raise InvalidKeywordError('filter', filter, valid_filter)
         self.filter = filter
 
-        self.ref = scf_wfn
-        self.eref = self.ref.energy()
-
-        # Support both C1 and higher-symmetry references.
-        # frzcpi / doccpi are per-irrep Dimension objects; sum across irreps.
-        self.nfzc = int(sum(self.ref.frzcpi()))
-        self.no   = int(sum(self.ref.doccpi())) - self.nfzc
-        self.nmo  = self.ref.nmo()
-        self.nv   = self.nmo - self.no - self.nfzc
-        self.nact = self.no + self.nv
-
-        print("NMO = %d; NACT = %d; NO = %d; NV = %d" % (self.nmo, self.nact, self.no, self.nv))
-
-        self.o = slice(0, self.no)
-        self.v = slice(self.no, self.nmo)
+        # Reference, orbital spaces, MO coefficients (occupied localized when a
+        # local-CC scheme is requested, so the base's single H build uses LMOs),
+        # the seeded MO-basis integrals, and the device/precision manager all come
+        # from the Wavefunction base.
+        super().__init__(scf_wfn,
+                         device=kwargs.pop('device', 'CPU'),
+                         precision=kwargs.pop('precision', 'DP'),
+                         localize_occ=(local is not None),
+                         local_mos=self.local_MOs)
         o = self.o
         v = self.v
-
-        # Ca_subset("AO","ACTIVE") returns columns in global energy order.
-        # Ca_subset("SO","ACTIVE") returns columns in irrep-block order.
-        # We use the SO energies only to derive the irrep label for each MO.
-        self.C = self.ref.Ca_subset("AO", "ACTIVE")
-
-        eps_so_blocked  = self.ref.epsilon_a_subset("SO", "ACTIVE")
-        eps_active_so   = np.concatenate([np.array(eps_so_blocked.nph[h])
-                                          for h in range(self.ref.nirrep())])
-        sort_idx        = np.argsort(eps_active_so, kind='stable')
-
-        irrep_labels    = self.ref.molecule().irrep_labels()
-        mo_irreps       = np.array([h for h in range(self.ref.nirrep())
-                                    for _ in range(self.ref.nmopi()[h]
-                                                   - self.ref.frzcpi()[h]
-                                                   - self.ref.frzvpi()[h])])
-        mo_irreps       = mo_irreps[sort_idx]
-        mo_irrep_labels = [irrep_labels[h] for h in mo_irreps]
-        eps_active      = eps_active_so[sort_idx]
-
-        # Print MO summary
-        print("\nActive MOs by energy:")
-        print(f"  {'#':>4}  {'Irrep':>6}  {'Energy':>16}")
-        print(f"  {'-'*4}  {'-'*6}  {'-'*16}")
-        for i, (eps, label) in enumerate(zip(eps_active, mo_irrep_labels)):
-            if i == self.no:
-                print(f"  {'.'*4}  {'.'*6}  {'.'*16}")
-            idx = i if i < self.no else i - self.no
-            print(f"  {idx:>4}  {label:>6}  {eps:>16.10f}")
-
-        # Localize occupied MOs if requested
-        if (local is not None):
-            C_occ = self.ref.Ca_subset("AO", "ACTIVE_OCC")
-            LMOS = psi4.core.Localizer.build(self.local_MOs, self.ref.basisset(), C_occ)
-            LMOS.localize()
-            npL = np.asarray(LMOS.L)
-            npC = np.asarray(self.C)
-            npC[:,:self.no] = npL
-            C = psi4.core.Matrix.from_array(npC)
-            self.C = C
-
-        self.H = Hamiltonian(self.ref, self.C, self.C, self.C, self.C)
+        mgr = self.device_manager
 
         if local is not None:
             self.Local = Local(local, self.C, self.nfzc, self.no, self.nv, self.H, self.local_cutoff,self.it2_opt)
@@ -197,50 +148,25 @@ class ccwfn(object):
                 self.Local.overlaps(self.Local.QL)
                 self.lccwfn = lccwfn(self.o, self.v,self.no, self.nv, self.H, self.local, self.model, self.eref, self.Local)
 
-        # denominators
-        eps_occ = np.diag(self.H.F)[o]
-        eps_vir = np.diag(self.H.F)[v]
-        self.Dia = eps_occ.reshape(-1,1) - eps_vir
-        self.Dijab = eps_occ.reshape(-1,1,1,1) + eps_occ.reshape(-1,1,1) - eps_vir.reshape(-1,1) - eps_vir
+        # Energy denominators from the MO energies (the diagonal of the seeded
+        # Fock). diag() is backend-aware, so this works whether H.F is NumPy or
+        # torch; Dia/Dijab inherit H.F's dtype/device (compute-resident).
+        eps_occ = diag(self.H.F)[o]
+        eps_vir = diag(self.H.F)[v]
+        self.Dia = eps_occ.reshape(-1, 1) - eps_vir
+        self.Dijab = (eps_occ.reshape(-1, 1, 1, 1) + eps_occ.reshape(-1, 1, 1)
+                      - eps_vir.reshape(-1, 1) - eps_vir)
 
-        # first-order amplitudes
-        self.t1 = np.zeros((self.no, self.nv))
+        # First-order (MP2) amplitudes as the CC initial guess, built from the
+        # seeded integrals/denominators so they inherit dtype/device. ERI is stored
+        # on device0 (CPU); clone(..., device1) stages the oovv block onto the
+        # compute device so the divide lands where the amplitudes live.
         if local is not None:
-            self.t1, self.t2 = self.Local.filter_amps(self.t1, self.H.ERI[o,o,v,v])
+            self.t1, self.t2 = self.Local.filter_amps(np.zeros((self.no, self.nv)),
+                                                       self.H.ERI[o,o,v,v])
         else:
-            self.t1 = np.zeros((self.no, self.nv))
-            self.t2 = self.H.ERI[o,o,v,v]/self.Dijab
-
-        # Device / precision policy: validates the kwargs (fallback warnings for
-        # GPU-without-torch / GPU-without-CUDA), resolves device0/device1, builds
-        # the contraction backend, and owns the dtype/placement cast policy.
-        self.device_manager = DeviceManager(
-            device=kwargs.pop('device', 'CPU'),
-            precision=kwargs.pop('precision', 'DP'),
-        )
-        mgr = self.device_manager
-
-        # Back-compat handles: the builders and sub-objects still read
-        # ccwfn.<device0/device1/contract/...>. These pass-throughs dissolve in
-        # Phase 3, when consumers read the manager on the Wavefunction base.
-        self.precision = mgr.precision
-        self.device = mgr.device
-        self.device0 = mgr.device0
-        self.device1 = mgr.device1
-        self.contract = mgr.contract
-
-        # Cast/place the compute-resident arrays (amplitudes, Fock, denominators)
-        # and the storage-resident integrals (ERI/L) per the device/precision
-        # policy. On CPU+DP these are no-ops; on CPU+SP they real-cast to float32;
-        # on GPU they become complex torch tensors on device1 (compute) / device0
-        # (CPU storage).
-        self.H.F = mgr.seed_compute(self.H.F)
-        self.t1 = mgr.seed_compute(self.t1)
-        self.t2 = mgr.seed_compute(self.t2)
-        self.Dia = mgr.seed_compute(self.Dia)
-        self.Dijab = mgr.seed_compute(self.Dijab)
-        self.H.ERI = mgr.seed_store(self.H.ERI)
-        self.H.L = mgr.seed_store(self.H.L)
+            self.t1 = mgr.seed_compute(np.zeros((self.no, self.nv)))
+            self.t2 = clone(self.H.ERI[o,o,v,v], device=self.device1) / self.Dijab
 
         print("CCWFN object initialized in %.3f seconds." % (time.time() - time_init))
 

--- a/pycc/wavefunction.py
+++ b/pycc/wavefunction.py
@@ -1,0 +1,147 @@
+"""
+wavefunction.py: top-level Wavefunction base class.
+
+Owns the infrastructure shared by every correlated (and SCF-derived) method:
+the Psi4 reference, the active-orbital spaces, the MO coefficients (optionally
+with localized occupied orbitals), the MO-basis integrals (Hamiltonian), and the
+device/precision manager. Method-specific machinery (amplitudes, denominators,
+densities, response, ...) lives in the subclasses (CCwfn, and -- planned -- MPwfn,
+CIwfn, HFwfn).
+
+Part of the 2026-06 refactor (docs/REFACTOR_PLAN_2026-06.md, Phase 3): the
+reference/orbital/integral setup and the DeviceManager were lifted out of
+ccwfn.__init__ so PyCC can host more than coupled cluster.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psi4
+import numpy as np
+
+from .hamiltonian import Hamiltonian
+from .device import DeviceManager
+
+
+class Wavefunction(object):
+    """Reference + orbital + integral + device infrastructure for a wavefunction.
+
+    Attributes
+    ----------
+    ref : Psi4 SCF Wavefunction
+        the reference wave function (from Psi4's energy() method)
+    eref : float
+        reference energy (including nuclear repulsion)
+    nfzc, no, nv, nmo, nact : int
+        frozen-core / active-occupied / active-virtual / total-MO / active counts
+    o, v : slice
+        occupied and virtual active-orbital subspaces
+    C : Psi4 Matrix
+        active MO coefficients (occupied block localized if ``localize_occ``)
+    H : Hamiltonian
+        MO-basis Fock (F), ERIs, spin-adapted ERIs (L), and property integrals,
+        device/precision-seeded
+    device_manager : DeviceManager
+        owns device/precision, device0/device1, and the contraction backend
+    device, precision : str
+    device0, device1 : torch.device or None
+    contract : ContractionBackend
+
+    Parameters
+    ----------
+    scf_wfn : Psi4 Wavefunction
+        reference computed by Psi4's energy() method
+    device : str
+        'CPU' or 'GPU' (default 'CPU')
+    precision : str
+        'SP' or 'DP' (default 'DP')
+    localize_occ : bool
+        localize the active occupied MOs before building the integrals (default
+        False). The localization scheme is ``local_mos``. Subclasses request this
+        when they need localized occupied orbitals (e.g. CCwfn for local CC).
+    local_mos : str
+        'PIPEK_MEZEY' or 'BOYS' (default 'PIPEK_MEZEY'); used only when
+        ``localize_occ`` is True.
+    """
+
+    def __init__(self, scf_wfn: Any, device: str = 'CPU', precision: str = 'DP',
+                 localize_occ: bool = False, local_mos: str = 'PIPEK_MEZEY') -> None:
+        self.ref = scf_wfn
+        self.eref = self.ref.energy()
+
+        # Active-orbital counts. frzcpi/doccpi are per-irrep Dimension objects;
+        # sum across irreps to support both C1 and higher-symmetry references.
+        self.nfzc = int(sum(self.ref.frzcpi()))
+        self.no   = int(sum(self.ref.doccpi())) - self.nfzc
+        self.nmo  = self.ref.nmo()
+        self.nv   = self.nmo - self.no - self.nfzc
+        self.nact = self.no + self.nv
+
+        print("NMO = %d; NACT = %d; NO = %d; NV = %d" % (self.nmo, self.nact, self.no, self.nv))
+
+        self.o = slice(0, self.no)
+        self.v = slice(self.no, self.nmo)
+
+        # Ca_subset("AO","ACTIVE") returns columns in global energy order.
+        # Ca_subset("SO","ACTIVE") returns columns in irrep-block order.
+        # We use the SO energies only to derive the irrep label for each MO.
+        self.C = self.ref.Ca_subset("AO", "ACTIVE")
+
+        eps_so_blocked  = self.ref.epsilon_a_subset("SO", "ACTIVE")
+        eps_active_so   = np.concatenate([np.array(eps_so_blocked.nph[h])
+                                          for h in range(self.ref.nirrep())])
+        sort_idx        = np.argsort(eps_active_so, kind='stable')
+
+        irrep_labels    = self.ref.molecule().irrep_labels()
+        mo_irreps       = np.array([h for h in range(self.ref.nirrep())
+                                    for _ in range(self.ref.nmopi()[h]
+                                                   - self.ref.frzcpi()[h]
+                                                   - self.ref.frzvpi()[h])])
+        mo_irreps       = mo_irreps[sort_idx]
+        mo_irrep_labels = [irrep_labels[h] for h in mo_irreps]
+        eps_active      = eps_active_so[sort_idx]
+
+        # Print MO summary
+        print("\nActive MOs by energy:")
+        print(f"  {'#':>4}  {'Irrep':>6}  {'Energy':>16}")
+        print(f"  {'-'*4}  {'-'*6}  {'-'*16}")
+        for i, (eps, label) in enumerate(zip(eps_active, mo_irrep_labels)):
+            if i == self.no:
+                print(f"  {'.'*4}  {'.'*6}  {'.'*16}")
+            idx = i if i < self.no else i - self.no
+            print(f"  {idx:>4}  {label:>6}  {eps:>16.10f}")
+
+        # Localize the active occupied MOs if requested (used consistently for the
+        # single H build below, so all methods share the same integrals).
+        if localize_occ:
+            self.local_mos = local_mos
+            C_occ = self.ref.Ca_subset("AO", "ACTIVE_OCC")
+            LMOS = psi4.core.Localizer.build(local_mos, self.ref.basisset(), C_occ)
+            LMOS.localize()
+            npL = np.asarray(LMOS.L)
+            npC = np.asarray(self.C)
+            npC[:, :self.no] = npL
+            self.C = psi4.core.Matrix.from_array(npC)
+
+        # MO-basis integrals (built once from the final C).
+        self.H = Hamiltonian(self.ref, self.C, self.C, self.C, self.C)
+
+        # Device / precision policy: validates the kwargs (fallback warnings for
+        # GPU-without-torch / GPU-without-CUDA), resolves device0/device1, and
+        # builds the contraction backend.
+        self.device_manager = DeviceManager(device=device, precision=precision)
+        mgr = self.device_manager
+        self.precision = mgr.precision
+        self.device = mgr.device
+        self.device0 = mgr.device0
+        self.device1 = mgr.device1
+        self.contract = mgr.contract
+
+        # Seed the integrals: F is compute-resident (device1); the big ERI/L stay
+        # CPU-resident (device0). On CPU+DP these are no-ops; on CPU+SP they
+        # real-cast to float32; on GPU they become real torch tensors at the
+        # matching width.
+        self.H.F = mgr.seed_compute(self.H.F)
+        self.H.ERI = mgr.seed_store(self.H.ERI)
+        self.H.L = mgr.seed_store(self.H.L)

--- a/pycc/wavefunction.py
+++ b/pycc/wavefunction.py
@@ -22,6 +22,7 @@ import numpy as np
 
 from .hamiltonian import Hamiltonian
 from .device import DeviceManager
+from .exceptions import InvalidKeywordError, PyCCError
 
 
 class Wavefunction(object):
@@ -65,8 +66,19 @@ class Wavefunction(object):
         ``localize_occ`` is True.
     """
 
-    def __init__(self, scf_wfn: Any, device: str = 'CPU', precision: str = 'DP',
-                 localize_occ: bool = False, local_mos: str = 'PIPEK_MEZEY') -> None:
+    def __init__(self, scf_wfn: Any, *, device: str = 'CPU', precision: str = 'DP',
+                 localize_occ: bool = False, local_mos: str = 'PIPEK_MEZEY',
+                 **kwargs) -> None:
+        # The general kwargs (device/precision/localize_occ/local_mos) are owned
+        # here; subclasses pop only their own kwargs and forward the rest, so this
+        # is the single place they are parsed. local_mos is validated up front (a
+        # bad value fails fast regardless of localize_occ).
+        valid_local_mos = ['PIPEK_MEZEY', 'BOYS']
+        local_mos = local_mos.upper()
+        if local_mos not in valid_local_mos:
+            raise InvalidKeywordError('local_mos', local_mos, valid_local_mos)
+        self.local_mos = local_mos
+
         self.ref = scf_wfn
         self.eref = self.ref.energy()
 
@@ -115,9 +127,8 @@ class Wavefunction(object):
         # Localize the active occupied MOs if requested (used consistently for the
         # single H build below, so all methods share the same integrals).
         if localize_occ:
-            self.local_mos = local_mos
             C_occ = self.ref.Ca_subset("AO", "ACTIVE_OCC")
-            LMOS = psi4.core.Localizer.build(local_mos, self.ref.basisset(), C_occ)
+            LMOS = psi4.core.Localizer.build(self.local_mos, self.ref.basisset(), C_occ)
             LMOS.localize()
             npL = np.asarray(LMOS.L)
             npC = np.asarray(self.C)
@@ -145,3 +156,9 @@ class Wavefunction(object):
         self.H.F = mgr.seed_compute(self.H.F)
         self.H.ERI = mgr.seed_store(self.H.ERI)
         self.H.L = mgr.seed_store(self.H.L)
+
+        # The base is the final consumer of forwarded kwargs (each subclass pops
+        # its own and passes the remainder through), so anything left over is an
+        # unrecognized keyword -- flag it instead of silently ignoring it.
+        if kwargs:
+            raise PyCCError("Unexpected keyword argument(s): %s" % sorted(kwargs))


### PR DESCRIPTION
  ## Summary

  Phase 3 of the 2026-06 refactor (`docs/REFACTOR_PLAN_2026-06.md`): introduce a
  top-level **`Wavefunction` base class** so PyCC can host more than coupled cluster.
  `ccwfn` becomes a subclass; the reference / orbital / integral / device setup moves
  up into the base, ready to be shared by the `MPwfn` / `HFwfn` / `CIwfn` types coming
  in Phase 4.

  **Behavior-preserving** — no change to the public `pycc.ccwfn(...)` interface, full
  `p4env` non-slow suite green.

  ## What moved up to `Wavefunction` (new `pycc/wavefunction.py`)

  - the Psi4 reference + `eref`, active-orbital counts, `o`/`v` spaces
  - the MO coefficients and the MO-by-energy table
  - **occupied-MO localization** (previously CC-only; now a single shared build,
    available to MP2/CI too)
  - the MO-basis **Hamiltonian** (`F`/`ERI`/`L` + property integrals), **seeded** for
    the device/precision policy
  - the **`DeviceManager`** (and the `device`/`precision`/`contract` handles)
  - ownership of the general kwargs: `device`, `precision`, `local_mos`

  ## What `ccwfn` keeps

  - the CC kwargs (`model`, `local`, `local_cutoff`, `it2_opt`, `filter`, …)
  - the `Local` / `lccwfn` machinery
  - the energy denominators (`Dia`/`Dijab`) and the MP2 initial guess
  - a one-line `super().__init__(scf_wfn, localize_occ=(local is not None), **kwargs)`

  ## Key design decisions

  - **Base builds `H` once** (canonical, or from localized occupied MOs when requested)
    and seeds `H.F`/`H.ERI`/`H.L`. `ccwfn` derives the MO energies from `diag(H.F)` and
    builds `Dia`/`Dijab` + the MP2 guess from the seeded integrals (staging the `oovv`
    ERI block to the compute device with `clone(..., device1)`).
  - **Localization in the base**, requested via a generic `localize_occ` flag, so the
    base stays free of CC's PNO/PAO vocabulary and MP2/CI can reuse it.
  - **kwargs forwarding**: subclasses pop only their own kwargs and forward the rest, so
    Phase 4 classes need zero `device`/`precision` boilerplate. The base is the final
    consumer, so it now **flags unexpected keywords** (`PyCCError`) instead of silently
    ignoring them — e.g. `ccwfn(wfn, modle='CCSD')` is caught.

  ## Notes
  
  - **Sub-objects are untouched** (`cchbar`/`cclambda`/`ccdensity`/`cceom`/`ccresponse`/
    `rtcc`): they read base state as `self.ccwfn.<x>`, which now resolves via inheritance.
  - **Numerics:** CPU/DP is **bit-identical**; SP and torch paths differ by ~1 ULP in the
    MP2 *initial guess* only (now computed from the seeded integrals rather than
    real-then-cast) — the CC iteration erases it, so converged results are unchanged.

  ## Validation
  
  - Full `p4env` non-slow suite: **50 passed / 2 skipped / 8 deselected / 1 xfailed**
    (unchanged from baseline), including `test_030_sp` (SP) and the local-CC paths.
  - Canonical CCSD confirmed bit-identical on CPU/DP.

  ## Commits

  - `b80aa56` Extract a Wavefunction base class (Phase 3)
  - `45837ab` Forward kwargs from ccwfn to the Wavefunction base

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
