### PR TITLE
Add an MPwfn (MP2) wavefunction; ccwfn composes it for its guess

### DIFF
--- a/pycc/__init__.py
+++ b/pycc/__init__.py
@@ -7,6 +7,7 @@ PyCC: A Python-based coupled cluster implementation.
 
 # Add imports here
 from .ccwfn import ccwfn
+from .mpwfn import MPwfn
 from .cchbar import cchbar
 from .cclambda import cclambda
 from .ccdensity import ccdensity
@@ -15,7 +16,7 @@ from .ccresponse import pertbar
 from pycc.rt.rtcc import rtcc
 from .cceom import cceom
 
-__all__ = ['ccwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom']
+__all__ = ['ccwfn', 'MPwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom']
 
 # Handle versioneer
 from ._version import get_versions

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -19,8 +19,9 @@ except ImportError:
 
 from typing import Any
 
-from .utils import helper_diis, zeros_like, clone, sqrt, diag
+from .utils import helper_diis, zeros_like, clone, sqrt
 from .wavefunction import Wavefunction
+from .mpwfn import MPwfn
 from .local import Local
 from .cctriples import t_tjl, t3c_ijk, t3d_ijk, t3c_abc, t3d_abc, t3_pert_ijk
 from .lccwfn import lccwfn
@@ -140,25 +141,23 @@ class ccwfn(Wavefunction):
                 self.Local.overlaps(self.Local.QL)
                 self.lccwfn = lccwfn(self.o, self.v,self.no, self.nv, self.H, self.local, self.model, self.eref, self.Local)
 
-        # Energy denominators from the MO energies (the diagonal of the seeded
-        # Fock). diag() is backend-aware, so this works whether H.F is NumPy or
-        # torch; Dia/Dijab inherit H.F's dtype/device (compute-resident).
-        eps_occ = diag(self.H.F)[o]
-        eps_vir = diag(self.H.F)[v]
-        self.Dia = eps_occ.reshape(-1, 1) - eps_vir
-        self.Dijab = (eps_occ.reshape(-1, 1, 1, 1) + eps_occ.reshape(-1, 1, 1)
-                      - eps_vir.reshape(-1, 1) - eps_vir)
+        # The MP2 wavefunction supplies the energy denominators and the CC initial
+        # guess. from_wavefunction reuses this object's already-built base (no second
+        # integral transform), so the denominator/MP2-amplitude code lives only in
+        # MPwfn. CC's singles denominator (Dia) is built here from the MP2 wfn's
+        # orbital energies -- MP2 has no singles.
+        self.mp = MPwfn.from_wavefunction(self)
+        self.Dijab = self.mp.Dijab
+        self.Dia = self.mp.eps_occ.reshape(-1, 1) - self.mp.eps_vir
 
-        # First-order (MP2) amplitudes as the CC initial guess, built from the
-        # seeded integrals/denominators so they inherit dtype/device. ERI is stored
-        # on device0 (CPU); clone(..., device1) stages the oovv block onto the
-        # compute device so the divide lands where the amplitudes live.
+        # CC initial-guess amplitudes. CC mutates t2 in place while iterating, so it
+        # takes its own copy of the MP2 doubles (the local path filters instead).
         if local is not None:
             self.t1, self.t2 = self.Local.filter_amps(np.zeros((self.no, self.nv)),
                                                        self.H.ERI[o,o,v,v])
         else:
             self.t1 = mgr.seed_compute(np.zeros((self.no, self.nv)))
-            self.t2 = clone(self.H.ERI[o,o,v,v], device=self.device1) / self.Dijab
+            self.t2 = clone(self.mp.t2)
 
         print("CCWFN object initialized in %.3f seconds." % (time.time() - time_init))
 

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -1,0 +1,70 @@
+"""
+mpwfn.py: Moller-Plesset perturbation-theory (MP2) wavefunction.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+import numpy as np
+
+from .wavefunction import Wavefunction
+from .utils import diag, clone
+
+if TYPE_CHECKING:
+    from ._typing import Tensor
+
+
+class MPwfn(Wavefunction):
+    """An MP2 wavefunction built on the shared :class:`Wavefunction` base.
+
+    Holds the energy denominators and the first-order (MP2) doubles amplitudes,
+    derived from the base's seeded MO integrals, and computes the MP2 correlation
+    energy. It is also the canonical home for that denominator/amplitude code:
+    ``ccwfn`` composes one of these (via :meth:`from_wavefunction`) to obtain its
+    energy denominators and CC initial guess without building the Hamiltonian twice.
+
+    Attributes
+    ----------
+    eps_occ, eps_vir : Tensor
+        occupied / virtual orbital energies (the diagonal of the seeded Fock)
+    Dijab : Tensor
+        two-electron energy denominator, eps_i + eps_j - eps_a - eps_b
+    t2 : Tensor
+        first-order (MP2) doubles amplitudes, <ij|ab> / Dijab
+    emp2 : float
+        the MP2 correlation energy (set by :meth:`compute_energy`)
+    """
+
+    def __init__(self, scf_wfn: Any, **kwargs) -> None:
+        super().__init__(scf_wfn, **kwargs)
+        self._build_mp2()
+
+    @classmethod
+    def from_wavefunction(cls, wfn: "Wavefunction") -> "MPwfn":
+        """Build an MPwfn that reuses ``wfn``'s already-constructed base (reference,
+        orbitals, seeded integrals, device manager) -- no second integral transform.
+        """
+        mp = cls._from_shared_base(wfn)
+        mp._build_mp2()
+        return mp
+
+    def _build_mp2(self) -> None:
+        """Build the energy denominators and MP2 doubles amplitudes from the seeded
+        MO integrals. The ERI oovv block is staged onto the compute device with
+        clone(..., device1) so the divide lands where the amplitudes live.
+        """
+        o = self.o
+        v = self.v
+        self.eps_occ = diag(self.H.F)[o]
+        self.eps_vir = diag(self.H.F)[v]
+        self.Dijab = (self.eps_occ.reshape(-1, 1, 1, 1) + self.eps_occ.reshape(-1, 1, 1)
+                      - self.eps_vir.reshape(-1, 1) - self.eps_vir)
+        self.t2 = clone(self.H.ERI[o, o, v, v], device=self.device1) / self.Dijab
+
+    def compute_energy(self) -> "Tensor":
+        """Compute and return the MP2 correlation energy, E = t2_ijab L_ijab."""
+        o = self.o
+        v = self.v
+        self.emp2 = self.contract('ijab,ijab->', self.t2, self.H.L[o, o, v, v])
+        return self.emp2

--- a/pycc/tests/test_045_mp2.py
+++ b/pycc/tests/test_045_mp2.py
@@ -1,0 +1,33 @@
+"""
+Test the MP2 correlation energy (MPwfn) against Psi4's conventional MP2.
+"""
+
+import psi4
+import pycc
+import pytest
+from ..data.molecules import *
+
+
+def test_mp2_h2o(rhf_wfn):
+    """H2O cc-pVDZ, all-electron MP2 vs Psi4's conventional MP2."""
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    emp2 = pycc.MPwfn(wfn).compute_energy()
+
+    # Independent reference: Psi4's own conventional MP2 on the same system.
+    psi4.energy('mp2')
+    ref = psi4.variable('MP2 CORRELATION ENERGY')
+
+    assert abs(emp2 - ref) < 1e-10
+
+
+def test_mp2_h2o_frzc(rhf_wfn):
+    """H2O cc-pVDZ, frozen-core MP2 vs Psi4 (exercises the active-space counts)."""
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="true",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    emp2 = pycc.MPwfn(wfn).compute_energy()
+
+    psi4.energy('mp2')
+    ref = psi4.variable('MP2 CORRELATION ENERGY')
+
+    assert abs(emp2 - ref) < 1e-10

--- a/pycc/wavefunction.py
+++ b/pycc/wavefunction.py
@@ -69,6 +69,11 @@ class Wavefunction(object):
     def __init__(self, scf_wfn: Any, *, device: str = 'CPU', precision: str = 'DP',
                  localize_occ: bool = False, local_mos: str = 'PIPEK_MEZEY',
                  **kwargs) -> None:
+        # A subclass may set its own attributes before calling super().__init__;
+        # snapshot them so _base_attrs (recorded at the end) captures only what the
+        # base itself adds -- which _from_shared_base then replicates.
+        _preexisting = set(vars(self))
+
         # The general kwargs (device/precision/localize_occ/local_mos) are owned
         # here; subclasses pop only their own kwargs and forward the rest, so this
         # is the single place they are parsed. local_mos is validated up front (a
@@ -162,3 +167,24 @@ class Wavefunction(object):
         # unrecognized keyword -- flag it instead of silently ignoring it.
         if kwargs:
             raise PyCCError("Unexpected keyword argument(s): %s" % sorted(kwargs))
+
+        # Record exactly which attributes the base set (excluding anything the
+        # subclass set first), so _from_shared_base can replicate this base onto a
+        # new instance without re-running __init__ (and re-transforming integrals).
+        self._base_attrs = tuple(k for k in vars(self) if k not in _preexisting)
+
+    @classmethod
+    def _from_shared_base(cls, source: "Wavefunction") -> "Wavefunction":
+        """Create a ``cls`` instance that REUSES ``source``'s already-built base --
+        reference, orbital spaces, seeded integrals, device manager -- by bypassing
+        ``__init__`` so the Hamiltonian is not transformed a second time. The caller
+        adds its own method-specific state afterward.
+
+        Lets one wavefunction compose another over the same base (e.g. ccwfn holds an
+        MPwfn for its MP2 guess/denominators) with a single integral build.
+        """
+        obj = cls.__new__(cls)
+        for name in source._base_attrs:
+            setattr(obj, name, getattr(source, name))
+        obj._base_attrs = source._base_attrs
+        return obj


### PR DESCRIPTION
Phase 4a of the 2026-06 refactor (docs/REFACTOR_PLAN_2026-06.md): the first new wavefunction type on the Phase 3 base, and the "second consumer" that validates the base isn't CC-shaped.

New pycc/mpwfn.py with MPwfn(Wavefunction): builds the energy denominators and the first-order (MP2) doubles amplitudes from the base's seeded MO integrals, and computes the MP2 correlation energy (E = t2_ijab L_ijab).

ccwfn now composes an MPwfn for its denominators + CC initial guess, so that code lives in exactly one place:

    self.mp = MPwfn.from_wavefunction(self)
    self.Dijab = self.mp.Dijab
    self.Dia   = self.mp.eps_occ.reshape(-1,1) - self.mp.eps_vir   # CC-only singles
    self.t2    = clone(self.mp.t2)   # CC takes its own copy (it mutates t2)

from_wavefunction reuses the caller's already-built base (reference, orbitals, seeded integrals, device manager) via a new Wavefunction._from_shared_base classmethod -- so there is NO second Hamiltonian transform (the single-H-build principle from Phase 3 holds; verified cc.mp.H is cc.H). The base auto-records which attributes it sets (_base_attrs), so the sharing copies exactly the base with no leakage of the subclass's own attributes. Bonus: ccwfn.mp.compute_energy() exposes the MP2 energy as a clean byproduct.

Export MPwfn from pycc. New test_045_mp2.py checks MPwfn against Psi4's conventional MP2 (all-electron + frozen-core) -- an independent reference, matched to <1e-10 (actually ~1e-15). Full p4env non-slow suite green (50 passed); behavior-preserving (the CC guess is the same MP2 amplitudes, bit-identical on CPU/DP).