### PR TITLE
Add HFwfn + a Derivatives provider; RHF analytic gradient

### DIFF
--- a/pycc/__init__.py
+++ b/pycc/__init__.py
@@ -8,6 +8,7 @@ PyCC: A Python-based coupled cluster implementation.
 # Add imports here
 from .ccwfn import ccwfn
 from .mpwfn import MPwfn
+from .hfwfn import HFwfn
 from .cchbar import cchbar
 from .cclambda import cclambda
 from .ccdensity import ccdensity
@@ -16,7 +17,7 @@ from .ccresponse import pertbar
 from pycc.rt.rtcc import rtcc
 from .cceom import cceom
 
-__all__ = ['ccwfn', 'MPwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom']
+__all__ = ['ccwfn', 'MPwfn', 'HFwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom']
 
 # Handle versioneer
 from ._version import get_versions

--- a/pycc/derivatives.py
+++ b/pycc/derivatives.py
@@ -1,0 +1,94 @@
+"""
+derivatives.py: lazy MO-basis derivative-integral provider.
+
+A thin, memory-conscious wrapper around Psi4's MintsHelper MO derivative-integral
+routines (mo_*_deriv1). It serves the *skeleton* (fixed-MO-coefficient) first
+derivatives of the one- and two-electron integrals, the overlap half-derivatives
+(for AATs), and the dipole derivatives (for APTs), in the MO basis -- consistent
+with PyCC's reference-implementation, MO-basis derivative-property formulations.
+
+The caller supplies the MO-coefficient blocks to transform into. Those should be
+the base's symmetry-handled ``self.C`` (or a slice of it): it is a single irrep
+block in global energy order, so derivative integrals work with molecular symmetry
+left on -- no need to drop to C1.
+
+Memory discipline
+-----------------
+One-electron derivatives are small (3*N_atom * nmo**2), so they are served per
+atom directly. Two-electron derivatives (3*N_atom * nmo**4) are the heavy class:
+they are computed one atom at a time (via :meth:`eri` / :meth:`iter_eri`), so the
+caller contracts and discards each atom's block rather than ever materializing all
+3*N_atom of them.
+
+Created and owned by HFwfn for now; it depends only on base state (the basis set,
+molecule, and MO coefficients), so it can be promoted to the Wavefunction base when
+MP2/CI/CC derivative code needs it too.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Iterator, Tuple
+
+import psi4
+import numpy as np
+
+
+class Derivatives(object):
+    """MO-basis derivative-integral provider built on Psi4's MintsHelper.
+
+    Parameters
+    ----------
+    wfn : Wavefunction
+        provides the basis set (``wfn.H.basisset``) and the molecule.
+
+    Notes
+    -----
+    Each ``deriv1`` call returns the three Cartesian (x, y, z) derivatives with
+    respect to the coordinates of a single ``atom``; the returned arrays are NumPy
+    arrays in the MO block defined by the supplied coefficient matrices.
+    """
+
+    def __init__(self, wfn: Any) -> None:
+        self.mints = psi4.core.MintsHelper(wfn.H.basisset)
+        self.mol = wfn.ref.molecule()
+        self.natom = self.mol.natom()
+
+    # ---- one-electron (small) ----
+    def overlap(self, atom: int, C1, C2) -> List[np.ndarray]:
+        """Overlap (Sx) derivatives for ``atom``: list of 3 (x, y, z) arrays."""
+        return [np.asarray(m) for m in self.mints.mo_oei_deriv1("OVERLAP", atom, C1, C2)]
+
+    def core(self, atom: int, C1, C2) -> List[np.ndarray]:
+        """Core one-electron (kinetic + potential) hx derivatives for ``atom``."""
+        T = self.mints.mo_oei_deriv1("KINETIC", atom, C1, C2)
+        V = self.mints.mo_oei_deriv1("POTENTIAL", atom, C1, C2)
+        return [np.asarray(t) + np.asarray(v) for t, v in zip(T, V)]
+
+    def overlap_half(self, atom: int, C1, C2, side: str = "LEFT") -> List[np.ndarray]:
+        """Overlap half-derivatives for ``atom`` (``side`` = 'LEFT' or 'RIGHT');
+        list of 3 arrays. Used by the AAT machinery."""
+        return [np.asarray(m) for m in self.mints.mo_overlap_half_deriv1(side, atom, C1, C2)]
+
+    def dipole(self, atom: int, C1, C2) -> List[np.ndarray]:
+        """Electric-dipole derivatives for ``atom``: list of 9 arrays, the
+        d(mu_alpha)/d(X_beta) blocks (3 dipole components x 3 Cartesians). Used by
+        the APT machinery."""
+        return [np.asarray(m) for m in self.mints.mo_elec_dip_deriv1(atom, C1, C2)]
+
+    # ---- two-electron (heavy: lazy, per atom) ----
+    def eri(self, atom: int, C1, C2, C3, C4) -> List[np.ndarray]:
+        """Two-electron (ERI) derivatives for ``atom``: list of 3 (x, y, z) arrays.
+        Computed on demand so a caller iterating over atoms never holds more than
+        one atom's block at a time."""
+        return [np.asarray(m) for m in self.mints.mo_tei_deriv1(atom, C1, C2, C3, C4)]
+
+    def iter_eri(self, C1, C2, C3, C4) -> Iterator[Tuple[int, List[np.ndarray]]]:
+        """Yield ``(atom, [Ex, Ey, Ez])`` one atom at a time -- the lazy, non-
+        materializing way to sweep the 2-e derivatives."""
+        for atom in range(self.natom):
+            yield atom, self.eri(atom, C1, C2, C3, C4)
+
+    # ---- nuclear repulsion ----
+    def nuclear_repulsion(self) -> np.ndarray:
+        """Nuclear-repulsion-energy gradient, shape (natom, 3)."""
+        return np.asarray(self.mol.nuclear_repulsion_energy_deriv1())

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -12,7 +12,6 @@ import numpy as np
 from .wavefunction import Wavefunction
 from .derivatives import Derivatives
 from .utils import diag
-from .exceptions import PyCCError
 
 
 class HFwfn(Wavefunction):
@@ -32,7 +31,10 @@ class HFwfn(Wavefunction):
     """
 
     def __init__(self, scf_wfn: Any, **kwargs) -> None:
-        super().__init__(scf_wfn, **kwargs)
+        # HF properties are all-electron: always use the full MO space, regardless
+        # of any frozen core the reference was run with.
+        kwargs.pop('frozen_core', None)
+        super().__init__(scf_wfn, frozen_core=False, **kwargs)
         self.derivatives = Derivatives(self)
 
     def gradient(self) -> np.ndarray:
@@ -49,13 +51,9 @@ class HFwfn(Wavefunction):
 
         The derivative integrals are transformed with the base's symmetry-handled
         ``self.C`` (single irrep block, global energy order), so this works with
-        molecular symmetry left on. Currently all-electron -- build the reference
-        without a frozen core.
+        molecular symmetry left on. HFwfn always uses the full (all-electron) MO
+        space, so a frozen core on the reference does not affect the gradient.
         """
-        if self.nfzc != 0:
-            raise PyCCError("HF gradient is all-electron; build the reference "
-                            "without a frozen core (nfzc = %d)." % self.nfzc)
-
         o = self.o
         no = self.no
         # Occupied block of the symmetry-handled MO coefficients, and the matching

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -1,0 +1,80 @@
+"""
+hfwfn.py: Hartree-Fock wavefunction and MO-basis analytic derivative properties.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psi4
+import numpy as np
+
+from .wavefunction import Wavefunction
+from .derivatives import Derivatives
+from .utils import diag
+from .exceptions import PyCCError
+
+
+class HFwfn(Wavefunction):
+    """An RHF wavefunction on the shared :class:`Wavefunction` base, and the home
+    for MO-basis HF analytic derivative properties (gradient now; Hessian, APTs,
+    AATs, and a CPHF solver to follow).
+
+    The SCF energy is the base's reference energy (``self.eref``); this class adds
+    the response/derivative engine, including a :class:`Derivatives` provider.
+
+    Attributes
+    ----------
+    derivatives : Derivatives
+        MO-basis derivative-integral provider (promotable to the base later)
+    grad : numpy.ndarray
+        the most recently computed nuclear gradient, shape (natom, 3)
+    """
+
+    def __init__(self, scf_wfn: Any, **kwargs) -> None:
+        super().__init__(scf_wfn, **kwargs)
+        self.derivatives = Derivatives(self)
+
+    def gradient(self) -> np.ndarray:
+        """RHF analytic energy gradient (a.u.), shape (natom, 3).
+
+        Closed-shell, MO-basis, CPHF-free RHF gradient (i, j over occupied; the
+        ``^x`` skeleton derivatives come from :class:`Derivatives`, ``eps_i`` are the
+        occupied orbital energies, and the ``-2 eps_i S^x_ii`` term is the
+        energy-weighted-density / orbital-response contribution that makes the HF
+        gradient CPHF-free)::
+
+            dE/dX = sum_i 2 h^x_ii + sum_ij (2 (ii|jj)^x - (ij|ij)^x)
+                    - sum_i 2 eps_i S^x_ii + dV_NN/dX
+
+        The derivative integrals are transformed with the base's symmetry-handled
+        ``self.C`` (single irrep block, global energy order), so this works with
+        molecular symmetry left on. Currently all-electron -- build the reference
+        without a frozen core.
+        """
+        if self.nfzc != 0:
+            raise PyCCError("HF gradient is all-electron; build the reference "
+                            "without a frozen core (nfzc = %d)." % self.nfzc)
+
+        o = self.o
+        no = self.no
+        # Occupied block of the symmetry-handled MO coefficients, and the matching
+        # (energy-ordered) occupied orbital energies from the Fock diagonal.
+        Cocc = psi4.core.Matrix.from_array(np.asarray(self.C)[:, :no])
+        eps = np.asarray(diag(self.H.F))[o]
+
+        d = self.derivatives
+        grad = np.zeros((d.natom, 3))
+        Vnn = d.nuclear_repulsion()
+        for atom in range(d.natom):
+            Sx = d.overlap(atom, Cocc, Cocc)
+            hx = d.core(atom, Cocc, Cocc)
+            erix = d.eri(atom, Cocc, Cocc, Cocc, Cocc)
+            for c in range(3):
+                grad[atom, c] = (2.0 * np.trace(hx[c])
+                                 + 2.0 * np.einsum('iijj->', erix[c])
+                                 - np.einsum('ijij->', erix[c])
+                                 - 2.0 * np.einsum('i,ii->', eps, Sx[c])
+                                 + Vnn[atom, c])
+        self.grad = grad
+        return grad

--- a/pycc/tests/test_046_hf_gradient.py
+++ b/pycc/tests/test_046_hf_gradient.py
@@ -7,7 +7,6 @@ import pycc
 import numpy as np
 import pytest
 from ..data.molecules import *
-from pycc.exceptions import PyCCError
 
 
 def test_hf_gradient_h2o(rhf_wfn):
@@ -22,9 +21,13 @@ def test_hf_gradient_h2o(rhf_wfn):
     assert np.max(np.abs(grad - ref)) < 1e-9
 
 
-def test_hf_gradient_frozen_core_raises(rhf_wfn):
-    """The HF gradient is all-electron; a frozen-core reference must fail loudly."""
+def test_hf_gradient_frozen_core_ref(rhf_wfn):
+    """A frozen-core reference still yields the correct all-electron HF gradient:
+    HFwfn uses the full MO space regardless of the reference's freeze_core."""
     wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="true",
                   e_convergence=1e-11, d_convergence=1e-11)
-    with pytest.raises(PyCCError):
-        pycc.HFwfn(wfn).gradient()
+    grad = pycc.HFwfn(wfn).gradient()
+
+    ref = np.asarray(psi4.gradient('scf'))
+
+    assert np.max(np.abs(grad - ref)) < 1e-9

--- a/pycc/tests/test_046_hf_gradient.py
+++ b/pycc/tests/test_046_hf_gradient.py
@@ -1,0 +1,30 @@
+"""
+Test the RHF analytic nuclear gradient (HFwfn) against Psi4's analytic SCF gradient.
+"""
+
+import psi4
+import pycc
+import numpy as np
+import pytest
+from ..data.molecules import *
+from pycc.exceptions import PyCCError
+
+
+def test_hf_gradient_h2o(rhf_wfn):
+    """H2O cc-pVDZ RHF gradient vs Psi4 (molecular symmetry left on)."""
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-11, d_convergence=1e-11)
+    grad = pycc.HFwfn(wfn).gradient()
+
+    # Independent reference: Psi4's own analytic SCF gradient on the same system.
+    ref = np.asarray(psi4.gradient('scf'))
+
+    assert np.max(np.abs(grad - ref)) < 1e-9
+
+
+def test_hf_gradient_frozen_core_raises(rhf_wfn):
+    """The HF gradient is all-electron; a frozen-core reference must fail loudly."""
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="true",
+                  e_convergence=1e-11, d_convergence=1e-11)
+    with pytest.raises(PyCCError):
+        pycc.HFwfn(wfn).gradient()

--- a/pycc/wavefunction.py
+++ b/pycc/wavefunction.py
@@ -64,11 +64,15 @@ class Wavefunction(object):
     local_mos : str
         'PIPEK_MEZEY' or 'BOYS' (default 'PIPEK_MEZEY'); used only when
         ``localize_occ`` is True.
+    frozen_core : bool
+        honor the reference's frozen core, i.e. use the active MO space (default
+        True, for correlated methods). False uses the full, all-electron MO space
+        (nfzc = 0) -- HFwfn passes this, since HF properties are all-electron.
     """
 
     def __init__(self, scf_wfn: Any, *, device: str = 'CPU', precision: str = 'DP',
                  localize_occ: bool = False, local_mos: str = 'PIPEK_MEZEY',
-                 **kwargs) -> None:
+                 frozen_core: bool = True, **kwargs) -> None:
         # A subclass may set its own attributes before calling super().__init__;
         # snapshot them so _base_attrs (recorded at the end) captures only what the
         # base itself adds -- which _from_shared_base then replicates.
@@ -87,9 +91,13 @@ class Wavefunction(object):
         self.ref = scf_wfn
         self.eref = self.ref.energy()
 
-        # Active-orbital counts. frzcpi/doccpi are per-irrep Dimension objects;
-        # sum across irreps to support both C1 and higher-symmetry references.
-        self.nfzc = int(sum(self.ref.frzcpi()))
+        # Orbital counts and the MO subset. Correlated methods honor the reference's
+        # frozen core (frozen_core=True -> the active space). HF properties are
+        # all-electron, so HFwfn passes frozen_core=False to use the full MO space
+        # (nfzc=0). frzcpi/doccpi are per-irrep Dimension objects; sum over irreps to
+        # support both C1 and higher-symmetry references.
+        subset = "ACTIVE" if frozen_core else "ALL"
+        self.nfzc = int(sum(self.ref.frzcpi())) if frozen_core else 0
         self.no   = int(sum(self.ref.doccpi())) - self.nfzc
         self.nmo  = self.ref.nmo()
         self.nv   = self.nmo - self.no - self.nfzc
@@ -100,21 +108,24 @@ class Wavefunction(object):
         self.o = slice(0, self.no)
         self.v = slice(self.no, self.nmo)
 
-        # Ca_subset("AO","ACTIVE") returns columns in global energy order.
-        # Ca_subset("SO","ACTIVE") returns columns in irrep-block order.
-        # We use the SO energies only to derive the irrep label for each MO.
-        self.C = self.ref.Ca_subset("AO", "ACTIVE")
+        # Ca_subset("AO", subset) returns columns in global energy order;
+        # Ca_subset("SO", subset) in irrep-block order (used only for irrep labels).
+        self.C = self.ref.Ca_subset("AO", subset)
 
-        eps_so_blocked  = self.ref.epsilon_a_subset("SO", "ACTIVE")
+        eps_so_blocked  = self.ref.epsilon_a_subset("SO", subset)
         eps_active_so   = np.concatenate([np.array(eps_so_blocked.nph[h])
                                           for h in range(self.ref.nirrep())])
         sort_idx        = np.argsort(eps_active_so, kind='stable')
 
         irrep_labels    = self.ref.molecule().irrep_labels()
-        mo_irreps       = np.array([h for h in range(self.ref.nirrep())
-                                    for _ in range(self.ref.nmopi()[h]
-                                                   - self.ref.frzcpi()[h]
-                                                   - self.ref.frzvpi()[h])])
+        nirrep          = self.ref.nirrep()
+        nmopi           = self.ref.nmopi()
+        if frozen_core:
+            frzcpi, frzvpi = self.ref.frzcpi(), self.ref.frzvpi()
+            mopi = [nmopi[h] - frzcpi[h] - frzvpi[h] for h in range(nirrep)]
+        else:
+            mopi = [nmopi[h] for h in range(nirrep)]
+        mo_irreps       = np.array([h for h in range(nirrep) for _ in range(mopi[h])])
         mo_irreps       = mo_irreps[sort_idx]
         mo_irrep_labels = [irrep_labels[h] for h in mo_irreps]
         eps_active      = eps_active_so[sort_idx]
@@ -129,10 +140,12 @@ class Wavefunction(object):
             idx = i if i < self.no else i - self.no
             print(f"  {idx:>4}  {label:>6}  {eps:>16.10f}")
 
-        # Localize the active occupied MOs if requested (used consistently for the
-        # single H build below, so all methods share the same integrals).
+        # Localize the occupied MOs if requested (used consistently for the single H
+        # build below, so all methods share the same integrals). The occupied subset
+        # tracks frozen_core: active occupied for correlated methods, all occupied
+        # for the full (HF) space.
         if localize_occ:
-            C_occ = self.ref.Ca_subset("AO", "ACTIVE_OCC")
+            C_occ = self.ref.Ca_subset("AO", "ACTIVE_OCC" if frozen_core else "OCC")
             LMOS = psi4.core.Localizer.build(self.local_mos, self.ref.basisset(), C_occ)
             LMOS.localize()
             npL = np.asarray(LMOS.L)


### PR DESCRIPTION
⏺ ## Summary
  
  Phase 4b of the 2026-06 refactor (`docs/REFACTOR_PLAN_2026-06.md`), first increment:
  stand up the **HF wavefunction** and the **MO-basis derivative-integral scaffold**,
  and implement the **RHF analytic gradient** as the first consumer. This is the base
  on which the HF-level Hessian, APTs, AATs, and a CPHF solver will be built.

  `HFwfn`/`Derivatives` are new modules; nothing existing changes except the package
  export and a new (default-preserving) base kwarg.

  ## New: `pycc/derivatives.py` → `Derivatives`

  A lazy MO-basis derivative-integral provider over Psi4's `MintsHelper.mo_*_deriv1`
  routines:

  - **1-e (small, per atom):** `overlap` (Sˣ), `core` (hˣ = kinetic + potential),
    `overlap_half` (for AATs), `dipole` (the nine ∂μ_α/∂X_β blocks, for APTs).
  - **2-e (heavy):** `eri` / `iter_eri` — computed **one atom at a time**, so a caller
    never materializes all `3·N_atom` derivative tensors at once.
  - `nuclear_repulsion` gradient.

  Transforms use the base's **symmetry-handled `self.C`** (a single irrep block in                         
  global energy order), so the derivative integrals work with **molecular symmetry
  left on** — no drop to C1. `Derivatives` depends only on base state (basis set,
  molecule, MO coefficients), so it can be promoted to the `Wavefunction` base when
  MP2/CI/CC derivative code needs it; for now `HFwfn` owns it.

  ## New: `pycc/hfwfn.py` → `HFwfn(Wavefunction)`

  The SCF energy is the base reference energy (`self.eref`); the class adds the
  response/derivative engine — a `Derivatives` instance and a `gradient()` method.
  The closed-shell RHF gradient is MO-basis and CPHF-free:

      dE/dX = sum_i 2 h^x_ii + sum_ij (2 (ii|jj)^x - (ij|ij)^x)
              - sum_i 2 eps_i S^x_ii + dV_NN/dX

  (i, j over occupied; the `-2 eps_i S^x_ii` energy-weighted-density term is what
  makes the HF gradient CPHF-free).

  ## Frozen-core handling
  
  HF properties are all-electron, so `HFwfn` must not be restricted to the active
  space even when the reference was run with `freeze_core`. The base now takes
  `frozen_core=True` (default — active space, correlated methods unchanged) vs
  `False` (full all-electron MO space: `nfzc=0`, `Ca_subset("AO","ALL")`, all MOs
  through the orbital counts, `C`/`H`, the MO-by-energy table, and the localization
  subset). `HFwfn` forces `frozen_core=False`, so its gradient is all-electron
  regardless of the reference's `freeze_core`.

  ## Validation
  
  - `test_046_hf_gradient.py` checks the gradient against **Psi4's own analytic SCF
    gradient** (cc-pVDZ H2O, molecular symmetry on) to **< 1e-9**, for both a
    `freeze_core=false` and a `freeze_core=true` reference (the latter confirming the
    all-electron result).
  - Full `p4env` non-slow suite green (**54 passed** / 2 skipped / 8 deselected /
    1 xfailed); the `frozen_core=True` default path is unchanged.

  ## Commits
  
  - `9b187c9` Add HFwfn + a Derivatives provider; RHF analytic gradient
  - `b85c579` Make HFwfn all-electron via a base frozen_core flag

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
