### PR TITLE
Tighten the HF gradient test tolerance to 1e-11

### DIFF
--- a/pycc/tests/test_046_hf_gradient.py
+++ b/pycc/tests/test_046_hf_gradient.py
@@ -18,7 +18,7 @@ def test_hf_gradient_h2o(rhf_wfn):
     # Independent reference: Psi4's own analytic SCF gradient on the same system.
     ref = np.asarray(psi4.gradient('scf'))
 
-    assert np.max(np.abs(grad - ref)) < 1e-9
+    assert np.max(np.abs(grad - ref)) < 1e-11
 
 
 def test_hf_gradient_frozen_core_ref(rhf_wfn):
@@ -30,4 +30,4 @@ def test_hf_gradient_frozen_core_ref(rhf_wfn):
 
     ref = np.asarray(psi4.gradient('scf'))
 
-    assert np.max(np.abs(grad - ref)) < 1e-9
+    assert np.max(np.abs(grad - ref)) < 1e-11


### PR DESCRIPTION
HFwfn.gradient() and psi4.gradient('scf') are both exact analytic gradients off the same integral derivatives, so they agree to ~1e-14 (machine precision) even at the test's 1e-11 SCF convergence (measured: 1.8e-14, and 5e-15 at d_conv=1e-13). The previous 1e-9 was an over-conservative round number; 1e-11 keeps ~3 orders of margin and is comfortably float64-safe across platforms.