### PR TITLE
Hoist the duplicated datadir fixture into conftest.py

### DIFF
--- a/pycc/tests/conftest.py
+++ b/pycc/tests/conftest.py
@@ -14,6 +14,9 @@ The ``pycc.ccwfn(...)`` call (model, local, ... kwargs) legitimately
 varies per test and intentionally stays in the test body.
 """
 
+import os
+from distutils import dir_util
+
 import psi4
 import pytest
 
@@ -88,3 +91,22 @@ def rhf_wfn(psi4_environment):
         _, wfn = psi4.energy('SCF', return_wfn=True)
         return wfn
     return _build
+
+
+@pytest.fixture
+def datadir(tmpdir, request):
+    '''
+    from: https://stackoverflow.com/a/29631801
+    Fixture responsible for searching a folder with the same name of test
+    module and, if available, moving all contents to a temporary directory so
+    tests can use them freely.
+    '''
+    filename = request.module.__file__
+    test_dir, _ = os.path.splitext(filename)
+
+    if os.path.isdir(test_dir):
+        dir_util.copy_tree(test_dir, str(tmpdir))
+    else:
+        raise FileNotFoundError("Test folder not found.")
+
+    return tmpdir

--- a/pycc/tests/test_010_denoise.py
+++ b/pycc/tests/test_010_denoise.py
@@ -1,28 +1,7 @@
 # Import required packages
 import numpy as np
 import pytest
-import os
 from pycc.rt.utils import denoise
-from pytest import fixture
-from distutils import dir_util
-
-@fixture
-def datadir(tmpdir, request):
-    '''
-    from: https://stackoverflow.com/a/29631801
-    Fixture responsible for searching a folder with the same name of test
-    module and, if available, moving all contents to a temporary directory so
-    tests can use them freely.
-    '''
-    filename = request.module.__file__
-    test_dir, _ = os.path.splitext(filename)
-
-    if os.path.isdir(test_dir):
-        dir_util.copy_tree(test_dir, str(tmpdir))
-    else:
-        raise FileNotFoundError("Test folder not found.")
-
-    return tmpdir
 
 def test_denoise(datadir):
     # Define function

--- a/pycc/tests/test_011_damp.py
+++ b/pycc/tests/test_011_damp.py
@@ -1,28 +1,7 @@
 #Import required packages
 import numpy as np
 import pytest
-import os
 from pycc.rt.utils import damp
-from pytest import fixture
-from distutils import dir_util
-
-@fixture
-def datadir(tmpdir, request):
-    '''
-    from: https://stackoverflow.com/a/29631801
-    Fixture responsible for searching a folder with the same name of test
-    module and, if available, moving all contents to a temporary directory so
-    tests can use them freely.
-    '''
-    filename = request.module.__file__
-    test_dir, _ = os.path.splitext(filename)
-
-    if os.path.isdir(test_dir):
-        dir_util.copy_tree(test_dir, str(tmpdir))
-    else:
-        raise FileNotFoundError("Test folder not found.")
-
-    return tmpdir
 
 def test_damp(datadir):
     #Define function

--- a/pycc/tests/test_016_chk.py
+++ b/pycc/tests/test_016_chk.py
@@ -6,32 +6,11 @@ Pull checkpoint file for 0-5.1au, then finish propagation to 10au
 # Import package, test suite, and other packages as needed
 import psi4
 import pycc
-import os
 import pickle as pk
 import numpy as np
 from pycc.rt.integrators import rk2
 from pycc.rt.lasers import gaussian_laser
 from pycc.data.molecules import *
-from pytest import fixture
-from distutils import dir_util
-
-@fixture
-def datadir(tmpdir, request):
-    '''
-    from: https://stackoverflow.com/a/29631801
-    Fixture responsible for searching a folder with the same name of test
-    module and, if available, moving all contents to a temporary directory so
-    tests can use them freely.
-    '''
-    filename = request.module.__file__
-    test_dir, _ = os.path.splitext(filename)
-
-    if os.path.isdir(test_dir):
-        dir_util.copy_tree(test_dir, str(tmpdir))
-    else:
-        raise FileNotFoundError("Test folder not found.")
-
-    return tmpdir
 
 def test_chk(datadir):
     # run cc

--- a/pycc/tests/test_019_localrt.py
+++ b/pycc/tests/test_019_localrt.py
@@ -6,30 +6,9 @@ Test RT-CCSD with local correlation simulation.
 import psi4
 import pycc
 import pytest
-import os
 from pycc.rt.lasers import gaussian_laser
 from pycc.rt.integrators import rk4
 from ..data.molecules import *
-from pytest import fixture
-from distutils import dir_util
-
-@fixture
-def datadir(tmpdir, request):
-    '''
-    from: https://stackoverflow.com/a/29631801
-    Fixture responsible for searching a folder with the same name of test
-    module and, if available, moving all contents to a temporary directory so
-    tests can use them freely.
-    '''
-    filename = request.module.__file__
-    test_dir, _ = os.path.splitext(filename)
-
-    if os.path.isdir(test_dir):
-        dir_util.copy_tree(test_dir, str(tmpdir))
-    else:
-        raise FileNotFoundError("Test folder not found.")
-
-    return tmpdir
 
 def test_rtpno(datadir):
     """H2O RT-PNO"""

--- a/pycc/tests/test_031_cc3.py
+++ b/pycc/tests/test_031_cc3.py
@@ -42,36 +42,3 @@ def test_cc3_h2o(rhf_wfn):
     assert (abs(ref[1] - np.real(mu_y)) < 1E-10)
     assert (abs(ref[2] - np.real(mu_z)) < 1E-10)
 
-# H2/cc-pVDZ
-"""
-def test_cc3_h2():
-    # Psi4 Setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    psi4.set_options({'basis': 'cc-pVDZ',
-                      'scf_type': 'pk',
-                      'mp2_type': 'conv',
-                      'freeze_core': 'false',
-                      'e_convergence': 1e-12,
-                      'd_convergence': 1e-12,
-                      'r_convergence': 1e-12,
-                      'diis': 1})
-    mol = psi4.geometry(moldict["H2"])
-    rhf_e, rhf_wfn = psi4.energy('SCF', return_wfn=True)
-
-    maxiter = 75
-    e_conv = 1e-12
-    r_conv = 1e-12
-    cc = pycc.ccwfn(rhf_wfn, model='CC3')
-    ecc = cc.solve_cc(e_conv,r_conv,maxiter)
-    epsi4 = -0.034689283017250
-    ecfour = -0.0346892830172550
-    assert (abs(epsi4 - ecc) < 1e-11)
-
-    hbar = pycc.cchbar(cc)
-    cclambda = pycc.cclambda(cc, hbar)
-    lcc = cclambda.solve_lambda(e_conv, r_conv)
-    lcc_cfour = -0.0341034656430758
-    assert(abs(lcc - lcc_cfour) < 1e-11)
-"""
-


### PR DESCRIPTION
  ### What & why
  The `datadir` fixture — copies a test module's data folder into a tmpdir — was copy-pasted **verbatim across four test 
  modules** (`test_010`, `test_011`, `test_016`, `test_019`). This moves it to `conftest.py` so the suite shares one
  definition.

  ### Changes
  - **`conftest.py`** — add the `datadir` fixture (+ `import os`, `from distutils import dir_util`).
  - **`test_010`, `test_011`, `test_016`, `test_019`** — remove the duplicated fixture and its now-unused per-module imports
  (`os`, `distutils.dir_util`, `pytest.fixture`).
  - **`test_031_cc3.py`** — delete the commented-out `test_cc3_h2` (dead code in a triple-quoted string; the live
  `test_cc3_h2o` already uses the `rhf_wfn` fixture).

  ### Not changed (deliberately)
  `test_016`/`test_019` keep loading their **pinned reference wavefunctions** via `Wavefunction.from_file` — they're
  reproducibility-pinned checkpoint-restart and local-CC/RT tests, so they should *not* be switched to a fresh fixture SCF
  build. They just get `datadir` from conftest now.

  ### Testing
  The 6 affected tests pass. Net **−95 lines** (22 insertions, 117 deletions).