### PR TITLE
Add RHF nuclear dipole derivatives / APTs via nuclear CPHF (Phase 4b, increment 2b-i)

### DIFF
--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -37,8 +37,9 @@ engine (the explicit orbital Hessian is solved directly with ``numpy.linalg``).
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, List
 
+import psi4
 import numpy as np
 
 from .utils import diag
@@ -126,6 +127,99 @@ class CPHF(object):
         the response ``U`` is reused by other properties where they do not.)
         """
         return -self._mu_ov(axis)
+
+    def rhs_nuclear(self, atom: int) -> List[np.ndarray]:
+        """Nuclear-perturbation CPHF RHS for ``atom``: list of 3 (x,y,z) ``(no, nv)``
+        arrays ``B^X_ia``.
+
+        Unlike the electric-field RHS, a nuclear displacement moves the basis
+        functions, so the right-hand side folds in (a) the skeleton derivative Fock
+        ``F^X`` (built from the first-derivative one- and two-electron integrals at
+        fixed MO coefficients), (b) the overlap-derivative term ``-eps_i S^X_ia``, and
+        (c) the coupling of the overlap-determined occupied-occupied response
+        ``U^X_kl = -1/2 S^X_kl`` back into the Fock matrix (the Pulay term). The CPHF
+        RHS is minus that first-order off-diagonal ("perturbation") Fock, ``B = -Q``
+        (the nuclear analog of the field's ``B = -mu``)::
+
+            B^X_ia = -[ F^X_ia - eps_i S^X_ia
+                        - 1/2 sum_kl S^X_kl ( L[a,k,i,l] + L[a,l,i,k] ) ]
+
+        with the skeleton derivative Fock  F^X_pq = h^X_pq + sum_k(occ) L[p,k,q,k]^X.
+
+        Everything is cast with the spin-adapted L = 2<pq|rs> - <pq|sr> (physicist's
+        notation), as in the orbital Hessian. The Pulay coupling is the closed-shell
+        G-operator for the symmetric occupied-occupied perturbation S^X_kl,
+        ``sum_kl (-1/2 S^X_kl)(L[a,k,i,l] + L[a,l,i,k])`` (the L[a,k,i,l]/L[a,l,i,k]
+        pair, not L[i,k,a,l] -- their Coulomb parts coincide but the exchange parts
+        differ). The first-derivative integrals come from the (full-MO) Derivatives
+        provider; the unperturbed L is H.L. Validated to ~1e-8 via the dipole-
+        derivative / APT-transpose check against finite difference of the SCF dipole.
+        """
+        o, v, no, nv = self.o, self.v, self.no, self.nv
+        eps_o = self.eps[o]
+        L = np.asarray(self.wfn.H.L)  # spin-adapted, physicist, unperturbed
+
+        C = np.asarray(self.wfn.C)
+        Call = psi4.core.Matrix.from_array(C)
+        d = self.wfn.derivatives
+        Sx = d.overlap(atom, Call, Call)                       # 3 x (nmo,nmo)
+        hx = d.core(atom, Call, Call)                          # 3 x (nmo,nmo)
+        gx = [g.swapaxes(1, 2) for g in                        # chemist -> physicist
+              d.eri(atom, Call, Call, Call, Call)]             # 3 x (nmo^4) <pq|rs>^X
+
+        B = []
+        for c in range(3):
+            Lx = 2.0 * gx[c] - gx[c].swapaxes(2, 3)            # derivative spin-adapted L
+            # skeleton derivative Fock: F^X_pq = h^X + sum_k L[p,k,q,k]^X
+            Fx = hx[c] + np.einsum('pkqk->pq', Lx[:, o, :, o])
+            # Pulay coupling of the overlap-determined U^X_kl = -1/2 S^X_kl into the
+            # ov block:  -1/2 S^X_kl ( L[a,k,i,l] + L[a,l,i,k] ).
+            Lvooo = L[v, o, o, o]
+            coupling = (np.einsum('akil,kl->ia', Lvooo, Sx[c][o, o])
+                        + np.einsum('alik,kl->ia', Lvooo, Sx[c][o, o]))
+            # The CPHF RHS is minus the first-order off-diagonal ("perturbation")
+            # Fock that the response drives to zero -- B = -Q (nuclear analog of the
+            # field's B = -mu).
+            Q = Fx[o, v] - eps_o[:, None] * Sx[c][o, v] - 0.5 * coupling
+            B.append(-Q)
+        return B
+
+    def dipole_derivatives(self) -> np.ndarray:
+        """Analytic nuclear dipole derivatives ``d(mu_alpha)/d(X_A,beta)`` (a.u.),
+        shape ``(natom, 3, 3)`` indexed ``[A, beta, alpha]`` -- the atomic polar
+        tensors (APTs), transposed.
+
+        Built from the nuclear CPHF response, so the ov term probes ``U^X`` directly
+        (unlike the energy gradient, which is variationally insensitive to it). The
+        assembly is nuclear + explicit electronic + overlap (Pulay) + CPHF response::
+
+            d mu_a / d X_Ab = Z_A delta_ab                         (nuclear)
+                            + 2 sum_i (d mu_a / d X_Ab)_ii         (explicit electronic)
+                            - 2 sum_ik S^X_ki (mu_a)_ik            (oo / Pulay response)
+                            + 4 sum_ia U^X_ia (mu_a)_ia            (ov / CPHF response)
+        """
+        o, v = self.o, self.v
+        mu = [np.asarray(self.wfn.H.mu[a]) for a in range(3)]
+        d = self.wfn.derivatives
+        C = np.asarray(self.wfn.C)
+        Cocc = psi4.core.Matrix.from_array(C[:, o])
+        mol = self.wfn.ref.molecule()
+        natom = mol.natom()
+
+        dmu = np.zeros((natom, 3, 3))
+        for A in range(natom):
+            Bx = self.rhs_nuclear(A)
+            Ux = [self.solve(Bx[c], kind="electric") for c in range(3)]
+            Sx = d.overlap(A, Cocc, Cocc)        # 3 x (no,no)
+            dip = d.dipole(A, Cocc, Cocc)        # 9 x (no,no): index alpha*3 + beta
+            for beta in range(3):
+                for alpha in range(3):
+                    val = mol.Z(A) if alpha == beta else 0.0
+                    val += 2.0 * np.trace(dip[alpha * 3 + beta])
+                    val -= 2.0 * np.einsum('ki,ki->', Sx[beta], mu[alpha][o, o])
+                    val += 4.0 * np.einsum('ia,ia->', Ux[beta], mu[alpha][o, v])
+                    dmu[A, beta, alpha] = val
+        return dmu
 
     # ---- property drivers ----
     def polarizability(self) -> np.ndarray:

--- a/pycc/derivatives.py
+++ b/pycc/derivatives.py
@@ -72,8 +72,16 @@ class Derivatives(object):
     def dipole(self, atom: int, C1, C2) -> List[np.ndarray]:
         """Electric-dipole derivatives for ``atom``: list of 9 arrays, the
         d(mu_alpha)/d(X_beta) blocks (3 dipole components x 3 Cartesians). Used by
-        the APT machinery."""
-        return [np.asarray(m) for m in self.mints.mo_elec_dip_deriv1(atom, C1, C2)]
+        the APT machinery.
+
+        The AO-basis derivatives (``ao_elec_dip_deriv1``) are transformed into the
+        (C1, C2) MO block here rather than via ``mo_elec_dip_deriv1`` -- the latter
+        segfaults on the linux build of Psi4 1.10.1 (the mo_oei/mo_tei deriv routines
+        are unaffected). The two routes are numerically identical."""
+        npC1 = np.asarray(C1)
+        npC2 = np.asarray(C2)
+        return [npC1.T @ np.asarray(m) @ npC2
+                for m in self.mints.ao_elec_dip_deriv1(atom)]
 
     # ---- two-electron (heavy: lazy, per atom) ----
     def eri(self, atom: int, C1, C2, C3, C4) -> List[np.ndarray]:

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -91,3 +91,17 @@ class HFwfn(Wavefunction):
         """
         self.alpha = self.cphf.polarizability()
         return self.alpha
+
+    def dipole_derivatives(self) -> np.ndarray:
+        """Nuclear dipole derivatives ``d(mu_alpha)/d(X_A,beta)`` (a.u.), shape
+        ``(natom, 3, 3)`` indexed ``[A, beta, alpha]`` -- the atomic polar tensors
+        (APTs), transposed.
+
+        Solves the nuclear CPHF orbital response (:class:`CPHF`) for each atom and
+        contracts it (plus the skeleton and overlap/Pulay terms) with the MO dipole
+        integrals. Unlike the energy gradient, the dipole derivative is sensitive to
+        the occupied-virtual orbital response, so this is what validates the nuclear
+        CPHF solution (against finite difference of the SCF dipole).
+        """
+        self.dipder = self.cphf.dipole_derivatives()
+        return self.dipder

--- a/pycc/tests/test_048_dipole_derivatives.py
+++ b/pycc/tests/test_048_dipole_derivatives.py
@@ -1,0 +1,52 @@
+"""
+Test the RHF nuclear dipole derivatives / atomic polar tensors (HFwfn CPHF nuclear
+response) against finite difference of the SCF dipole.
+
+The dipole derivative d(mu_alpha)/d(X_A,beta) is sensitive to the occupied-virtual
+orbital response (unlike the energy gradient, which is variationally insensitive to
+it), so it validates the nuclear CPHF solution.
+"""
+
+import psi4
+import pycc
+import numpy as np
+from ..data.molecules import *
+
+
+def test_dipole_derivatives_h2o(rhf_wfn):
+    """H2O STO-3G APTs vs finite difference of the SCF dipole (frame locked)."""
+    wfn = rhf_wfn("H2O", "STO-3G", geom_extra="\nsymmetry c1\nnoreorient\nnocom",
+                  e_convergence=1e-11, d_convergence=1e-11)
+    analytic = pycc.HFwfn(wfn).dipole_derivatives()   # (natom, beta, alpha)
+
+    # Reference: central finite difference of Psi4's SCF dipole under nuclear
+    # displacement. Lock the molecular frame (fix com/orientation and stop Psi4 from
+    # reinterpreting the cartesians from the internal coordinate entry) so a
+    # displacement survives instead of being reoriented away.
+    mol = wfn.molecule()
+    mol.fix_com(True)
+    mol.fix_orientation(True)
+    mol.update_geometry()
+    mol.reinterpret_coordentry(False)
+    geom0 = np.asarray(mol.geometry())
+    natom = mol.natom()
+    h = 1e-4
+
+    def scf_dipole(geom):
+        mol.set_geometry(psi4.core.Matrix.from_array(geom))
+        mol.update_geometry()
+        psi4.energy('scf')
+        return np.asarray(psi4.variable('SCF DIPOLE'))
+
+    fd = np.zeros((natom, 3, 3))
+    for A in range(natom):
+        for beta in range(3):
+            gp = geom0.copy(); gp[A, beta] += h
+            gm = geom0.copy(); gm[A, beta] -= h
+            fd[A, beta] = (scf_dipole(gp) - scf_dipole(gm)) / (2.0 * h)
+
+    # restore the reference geometry
+    mol.set_geometry(psi4.core.Matrix.from_array(geom0))
+    mol.update_geometry()
+
+    assert np.max(np.abs(analytic - fd)) < 1e-6


### PR DESCRIPTION
  ## Add RHF nuclear dipole derivatives / APTs via nuclear CPHF (Phase 4b, increment 2b-i)

  ### What & why
  Extends the CPHF solver with the **nuclear-perturbation orbital response** and assembles the **atomic polar tensors 
  (APTs)**, `∂μ_α/∂X_Aβ`. This is the APT functionality we ultimately wanted, and a validated first step toward the RHF
  Hessian: it carries the Hessian's hardest new physics — the overlap/Pulay-augmented nuclear CPHF RHS — so pinning it now
  de-risks the rest.
  
  ### Changes
  - **`CPHF.rhs_nuclear`** — the nuclear CPHF RHS, `B = −Q` with
    Q_ia = F^X_ia − ε_i S^X_ia − ½ S^X_kl ( L[a,k,i,l] + L[a,l,i,k] )
  i.e. the skeleton derivative Fock `F^X_pq = h^X_pq + Σ_k L[p,k,q,k]^X`, the overlap-derivative term, and the Pulay coupling
  of the overlap-determined occupied response `U^X_kl = −½ S^X_kl` into the ov block. Physicist's notation with the
  spin-adapted `L = H.L`, reusing the electric orbital Hessian from 2a. First-derivative integrals from the existing
  `Derivatives` provider. 
  - **`HFwfn.dipole_derivatives()`** — solves the nuclear response per atom and contracts it (plus skeleton + overlap terms)
  with `H.mu` → APTs, shape `(natom, 3, 3)`.
  
  ### Validation
  The dipole derivative is sensitive to the occupied–virtual response (the energy gradient is not, by Brillouin), so it's the
  right probe of the nuclear `U^X`. `test_048` compares the APTs to **finite difference of the SCF dipole** (frame locked 
  via `fix_com`/`fix_orientation`/`reinterpret_coordentry`) — agreement **~1e-8** (tol 1e-6).
  
  ### Next
  2b-ii: second-derivative integrals (`Derivatives.overlap2/core2/eri2`) + the Hessian skeleton/assembly, validated vs
  `psi4.hessian('scf')`.