### PR TITLE
Add RHF atomic axial tensors (AATs) via magnetic CPHF (Phase 4b, increment 2c)

### DIFF
--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -81,6 +81,7 @@ class CPHF(object):
         self._B_nuc: dict = {}  # atom -> list of 3 (no, nv) nuclear RHS B^X
         self._F_nuc: dict = {}  # atom -> list of 3 (no, no) skeleton deriv Fock F^X_ij
         self._S_nuc: dict = {}  # atom -> list of 3 (no, no) overlap deriv S^X_ij
+        self._U_mag: dict = {}  # axis -> (no, nv) magnetic-field response U^B (real)
 
     # ---- orbital Hessian ----
     def hessian(self, kind: str = "electric") -> np.ndarray:
@@ -137,6 +138,34 @@ class CPHF(object):
         the response ``U`` is reused by other properties where they do not.)
         """
         return -self._mu_ov(axis)
+
+    # ---- magnetic-field perturbation (imaginary; for AATs) ----
+    def _m_ov(self, axis: int) -> np.ndarray:
+        """ov block of the (real) MO magnetic-dipole integral for ``axis`` (0/1/2).
+
+        ``H.m`` carries the ``-1/2`` and an imaginary unit (it is the pure-imaginary
+        operator ``-i/2 L``, with the ``i`` convention shared by the CC response code);
+        the magnetic CPHF can be solved as a real problem, so this strips the ``i`` by
+        multiplying by ``-i`` -- the final VCD rotatory strength takes the imaginary
+        component of the APT*AAT product, not of the AAT itself."""
+        return np.asarray(-1.0j * self.wfn.H.m[axis])[self.o, self.v].real
+
+    def rhs_magnetic(self, axis: int) -> np.ndarray:
+        """Magnetic-field CPHF RHS for ``axis`` (0/1/2), i.e. ``B = -m`` (real).
+
+        The magnetic field enters as ``H' = -m . B`` (analogous to ``-mu . E`` for the
+        electric field), and -- like the electric field -- it does not move the basis
+        functions, so there is no overlap/Pulay term: the RHS is just the (negated)
+        real magnetic-dipole ov integral. The magnetic perturbation is imaginary, so
+        this response uses the antisymmetric (``kind='magnetic'``) orbital Hessian."""
+        return -self._m_ov(axis)
+
+    def solve_magnetic(self, axis: int) -> np.ndarray:
+        """Magnetic-field CPHF response ``U^B`` for ``axis`` (0/1/2), ``(no, nv)``,
+        solved once and cached. Real (the magnetic-dipole RHS is stripped of its i)."""
+        if axis not in self._U_mag:
+            self._U_mag[axis] = self.solve(self.rhs_magnetic(axis), kind="magnetic")
+        return self._U_mag[axis]
 
     def _build_nuclear(self, atom: int):
         """One heavy pass over the derivative integrals for ``atom``; returns three
@@ -357,6 +386,51 @@ class CPHF(object):
                                 + 2.0 * np.einsum('ij,nm,imjn->', Sx, Sy, Loooo))
                         H[A * 3 + a, Bat * 3 + b] = skel + resp
         return H
+
+    def atomic_axial_tensors(self) -> np.ndarray:
+        """RHF atomic axial tensors (AATs) ``I^lambda_{alpha,beta}`` (a.u.), shape
+        ``(natom, 3, 3)`` indexed ``[lambda, alpha, beta]`` -- the overlap of the
+        nuclear (``R_{lambda,alpha}``) and magnetic-field (``B_beta``) wavefunction
+        derivatives, the electronic part of the magnetic-dipole vibrational transition
+        moment (common gauge origin).
+
+        Implements Eq. (16) of the AAT note (CPHF coefficients over dependent pairs
+        already cancelled analytically)::
+
+            I^lambda_{alpha,beta} = 2 sum_{ia} [ U^{R}_{ai} U^{B}_{ai}
+                                                 + U^{B}_{ai} <phi^{R}_i | phi_a> ]
+
+        with ``U^{R}`` the nuclear CPHF response (shared cache, :meth:`solve_nuclear`),
+        ``U^{B}`` the magnetic-field response (:meth:`solve_magnetic`, antisymmetric
+        Hessian), and ``<phi^R_i|phi_a>`` the nuclear half-derivative overlap (occupied
+        derivative against the unperturbed virtual; ``Derivatives.overlap_half`` 'LEFT').
+
+        This is the electronic part only (the magnetic-dipole vibrational transition
+        moment); the full VCD AAT adds the nuclear term
+        ``(Z_lambda / 4) eps_{alpha,beta,gamma} R_{lambda,gamma}``. The magnetic-dipole
+        integrals are stripped of their ``i`` (:meth:`_m_ov`) so the magnetic response
+        and the AAT are real -- the VCD rotatory strength takes the imaginary component
+        of the APT*AAT product, not of the AAT. Validated against DALTON's STO-3G H2O2
+        electronic AATs (via the psi4numpy SCF-VCD reference) to ~5e-9.
+        """
+        o, v = self.o, self.v
+        d = self.wfn.derivatives
+        C = np.asarray(self.wfn.C)
+        Cocc = psi4.core.Matrix.from_array(C[:, o])
+        Cvir = psi4.core.Matrix.from_array(C[:, v])
+        natom = self.wfn.ref.molecule().natom()
+
+        Ub = [self.solve_magnetic(beta) for beta in range(3)]      # 3 x (no,nv), real
+        aat = np.zeros((natom, 3, 3))
+        for lam in range(natom):
+            Ur = self.solve_nuclear(lam)                           # 3 x (no,nv), cached
+            Shalf = d.overlap_half(lam, Cocc, Cvir, side="LEFT")   # 3 x (no,nv)
+            for alpha in range(3):
+                for beta in range(3):
+                    aat[lam, alpha, beta] = 2.0 * (
+                        np.einsum('ia,ia->', Ur[alpha], Ub[beta])
+                        + np.einsum('ia,ia->', Ub[beta], Shalf[alpha]))
+        return aat
 
     # ---- property drivers ----
     def polarizability(self) -> np.ndarray:

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -93,6 +93,18 @@ class HFwfn(Wavefunction):
         self.hess = self.cphf.molecular_hessian()
         return self.hess
 
+    def atomic_axial_tensors(self) -> np.ndarray:
+        """RHF atomic axial tensors (AATs) ``I^lambda_{alpha,beta}`` (a.u.), shape
+        ``(natom, 3, 3)`` -- the electronic magnetic-dipole vibrational transition
+        moment (common gauge origin), for VCD.
+
+        Solves the magnetic-field CPHF response (antisymmetric Hessian) and reuses the
+        cached nuclear response plus the nuclear half-derivative overlaps. Delegates to
+        :class:`CPHF`.
+        """
+        self.aat = self.cphf.atomic_axial_tensors()
+        return self.aat
+
     def polarizability(self) -> np.ndarray:
         """Static electric-dipole polarizability tensor (a.u.), shape (3, 3).
 

--- a/pycc/tests/test_050_aat.py
+++ b/pycc/tests/test_050_aat.py
@@ -1,0 +1,95 @@
+"""
+Test the RHF atomic axial tensors (AATs) -- the electronic magnetic-dipole
+vibrational transition moment, the magnetic analogue of the APTs and the last piece
+of the SCF VCD machinery.
+
+The AAT (Eq. 16 of the AAT note) is the overlap of the nuclear- and magnetic-field
+wavefunction derivatives. It reuses the cached nuclear CPHF response, adds a magnetic-
+field response (the antisymmetric ``kind='magnetic'`` orbital Hessian), and the nuclear
+half-derivative overlaps. The reference is DALTON's analytic SCF AATs for hydrogen
+peroxide in DALTON's STO-3G, as tabulated in the psi4numpy SCF-VCD example.
+"""
+
+import psi4
+import pycc
+import numpy as np
+
+
+# DALTON's STO-3G (spherical) -- the exact contraction the reference AATs were computed
+# with; the built-in STO-3G differs, so the hard reference numbers require this basis.
+def _dalton_sto3g(mol, role):
+    mol.set_basis_all_atoms("sto-3g", role=role)
+    basis = """
+spherical
+****
+H 0
+S 3 1.00
+      3.4252509 0.15432897
+      0.6239137 0.53532814
+      0.1688554 0.44463454
+****
+O 0
+S 3 1.00
+    130.7093200 0.15432897
+     23.8088610 0.53532814
+      6.4436083 0.44463454
+SP 3 1.00
+      5.0331513 -0.09996723 0.15591627
+      1.1695961 0.39951283 0.60768372
+      0.3803890 0.70011547 0.39195739
+****
+"""
+    return {'sto-3g': basis}
+
+
+# DALTON total AATs (electronic + nuclear), [3*natom, 3] = [nuclear coord, B component].
+AAT_DALTON = np.array([
+    [-0.16438927, -0.10446393, -2.00901728],
+    [ 0.09439940,  0.00574249,  0.11809387],
+    [ 2.19819309, -0.11635324,  0.15601962],
+    [-0.16438927, -0.10446393,  2.00901728],
+    [ 0.09439940,  0.00574249, -0.11809387],
+    [-2.19819309,  0.11635324,  0.15601962],
+    [-0.11803349,  0.11314253, -0.10726430],
+    [-0.19342146,  0.00350944,  0.36522207],
+    [ 0.25524026, -0.20123957,  0.12058354],
+    [-0.11803349,  0.11314253,  0.10726430],
+    [-0.19342146,  0.00350944, -0.36522207],
+    [-0.25524026,  0.20123957,  0.12058354]])
+
+
+def test_aat_h2o2_vs_dalton():
+    """H2O2 electronic AATs (+ nuclear term) vs DALTON's analytic SCF AATs."""
+    mol = psi4.geometry("""
+        O   0.0000000000   1.3192641900  -0.0952542913
+        O  -0.0000000000  -1.3192641900  -0.0952542913
+        H   1.6464858700   1.6841036400   0.7620343300
+        H  -1.6464858700  -1.6841036400   0.7620343300
+        symmetry c1
+        units bohr
+        noreorient
+        no_com
+    """)
+    psi4.qcdb.libmintsbasisset.basishorde['STO-3G_DALTON'] = _dalton_sto3g
+    psi4.core.set_global_option("BASIS", "STO-3G_dalton")
+    psi4.set_options({'scf_type': 'pk', 'e_convergence': 1e-12, 'd_convergence': 1e-12})
+
+    _, wfn = psi4.energy('SCF', return_wfn=True)
+    natom = mol.natom()
+
+    # Electronic AAT (Eq. 16), reshaped [lambda, alpha, beta] -> [3*natom, 3].
+    aat_elec = pycc.HFwfn(wfn).atomic_axial_tensors().reshape(3 * natom, 3)
+
+    # Nuclear contribution: (Z_lambda / 4) eps_{alpha,beta,gamma} R_{lambda,gamma}.
+    geom = np.asarray(mol.geometry())
+    eps_lc = np.zeros((3, 3, 3))
+    eps_lc[0, 1, 2] = eps_lc[1, 2, 0] = eps_lc[2, 0, 1] = 1.0
+    eps_lc[0, 2, 1] = eps_lc[1, 0, 2] = eps_lc[2, 1, 0] = -1.0
+    aat_nuc = np.zeros((3 * natom, 3))
+    for A in range(natom):
+        for a in range(3):
+            for b in range(3):
+                aat_nuc[3 * A + a, b] = (mol.Z(A) / 4.0) * np.einsum(
+                    'g,g->', eps_lc[a, b], geom[A])
+
+    assert np.allclose(aat_elec + aat_nuc, AAT_DALTON, atol=1e-6)


### PR DESCRIPTION
  ## Add RHF atomic axial tensors (AATs) via magnetic CPHF (Phase 4b, increment 2c)

  Adds the electronic atomic axial tensors `I^lambda_{alpha,beta}` — the magnetic-dipole vibrational transition moment, the magnetic analogue of the APTs and the last SCF VCD ingredient. Implements Eq. (16) of the AAT note (`i,j` occupied; `a`  virtual; `λα` = nuclear coordinate, `β` = magnetic-field component):
  
  $$I^{\lambda}_{\alpha\beta} = 2\sum_{ia}\left[ U^{R_{\lambda\alpha}}_{ai}\ U^{B_\beta}_{ai} + U^{B_\beta}_{ai}\
  \langle\phi^{R_{\lambda\alpha}}_i | \phi_a\rangle\right]$$

  ### What's new
  - **`U^R`** — the nuclear CPHF response, taken from the existing shared cache (`solve_nuclear`); the AATs reuse it for  free, exactly as the APTs do.
  - **`U^B`** — a new magnetic-field response (`solve_magnetic`) using the antisymmetric `kind='magnetic'` orbital Hessian.   Verified algebraically and numerically that our `L[a,j,i,b] − L[a,b,i,j]` equals psi4numpy's `G_m = (ε_a−ε_i)δδ + ⟨ij|ba⟩ −  ⟨ia|jb⟩`.
  - **`⟨φ^R_i|φ_a⟩`** — the nuclear half-derivative overlap (`Derivatives.overlap_half`, `LEFT`); the `S^R = LEFT + RIGHT`  identity confirms the side convention.

  ### Real magnetic solve
  The magnetic-dipole integrals carry an imaginary unit in `H.m` (shared with the CC optical-rotation code). The magnetic  CPHF can be solved as a real problem, so `_m_ov` strips the `i` **locally** (multiplying `H.m` by `−i`) — `H.m` itself is untouched, so `ccresponse` is unaffected. The magnetic response and the AAT are therefore real; VCD takes the imaginary part of the APT·AAT product, not of the AAT.
  
  ### Validation
  Psi4 has no AATs, so `test_050` validates against **DALTON's analytic SCF AATs** (the reference in the psi4numpy SCF-VCD  example): H₂O₂ in DALTON's STO-3G, electronic AAT plus the nuclear term `(Z/4) ε R`, vs the DALTON values → **max abs diff  ~5e-9** (limited by the 8-decimal printed reference). Full non-slow suite: **58 passed, 3 skipped, 8 deselected, 1 xfailed**.
  
  ### Files
  `cphf.py`, `hfwfn.py`, `pycc/tests/test_050_aat.py`
