### PR TITLE
Promote the derivative-integral provider to the Wavefunction base (stage 1)

### DIFF
--- a/docs/REFACTOR_PLAN_2026-06.md
+++ b/docs/REFACTOR_PLAN_2026-06.md
@@ -5,7 +5,7 @@ _Authored from the June 2026 design discussion. Supersedes the GPU/abstraction
 
 ## Status / progress
 
-_Last updated 2026-06-14. This section is the cross-machine source of truth for
+_Last updated 2026-06-16. This section is the cross-machine source of truth for
 where the refactor stands — the per-session memory used while authoring it is
 machine-local, but this doc and `git log` travel with the repo._
 
@@ -16,14 +16,40 @@ machine-local, but this doc and `git log` travel with the repo._
 | 2 — device/precision manager | ✅ done | PR #115 (`DeviceManager` + `ContractionBackend` in `pycc/device.py`) |
 | 2b — GPU ground-state real; RT complex via backend promotion | ✅ done | PR #116 |
 | _(bonus)_ tighten RT-CCSD tests (`test_024`/`test_025`) | ✅ done | PR #117 (1e-10, real dynamics, reference verified bit-for-bit against pre-refactor code) |
-| **3 — extract `Wavefunction` base** | ⏭️ **next** | design-first |
-| 4 — `MPwfn`, then `HFwfn` (+ derivative/CPHF engine) | ⬜ pending | |
-| 5 — local frozen under `CCwfn`, CPU-only | ⬜ pending | |
+| 3 — extract `Wavefunction` base | ✅ done | PR #119 (`pycc/wavefunction.py`; `ccwfn(Wavefunction)`; kwargs forwarding) |
+| 4a — `MPwfn` | ✅ done | PR #120 (`pycc/mpwfn.py`; CC composes `mp = MPwfn.from_wavefunction(self)`, shared base) |
+| 4b — `HFwfn` + derivative/CPHF engine | ✅ done | PRs #121–#128 — see HF-derivative arc below |
+| _(refactor)_ full-space-`H` unification (frozen core as slice offset) | ✅ done | PR #123 (fixed `cctriples` absolute indices; `Local` fails fast for `nfzc>0`) |
+| _(cleanup)_ conftest hygiene (`datadir` fixture hoist) | ✅ done | PR #124 |
+| 5 — local frozen under `CCwfn`, CPU-only | 🟡 partial | `Local` raises for `nfzc>0` (#123); full freeze/marking deferred to the local rewrite |
 
-**To resume:** read this doc + `git log`. The next step is the **Phase 3 design
-pass** — the `Wavefunction` base: what moves up from `ccwfn.__init__`, the base's
-public surface (replacing the `self.ccwfn.<x>` reach-ins), and the two-lifetime
-integral layer with the lazy MO-basis derivative-integral seam.
+### HF-derivative arc (Phase 4b) — complete
+
+All MO-basis, validated against an external reference, with the nuclear CPHF response
+cached and shared across the Hessian and the APTs/AATs.
+
+| Increment | Landed | Validation |
+|---|---|---|
+| gradient + `Derivatives` provider | PR #121 (tol tightened #122) | vs `psi4.gradient('scf')`, ~1e-14 |
+| CPHF solver + static polarizability | PR #125 | vs `psi4` analytic polarizability, ~4e-13 |
+| nuclear CPHF → dipole derivatives / APTs | PR #126 | vs finite-difference SCF dipole, ~1e-8 |
+| nuclear Hessian + persistent response cache | PR #127 | vs `psi4.hessian('scf')`, ~1e-12 |
+| atomic axial tensors (AATs) via magnetic CPHF | PR #128 | vs DALTON SCF AATs (psi4numpy VCD ref), ~5e-9 |
+
+`HFwfn`/`CPHF`/`Derivatives` now hold every SCF VCD ingredient (Hessian → normal modes,
+APTs, AATs). The `Derivatives` and `CPHF` classes were written to depend only on
+base-level state, so they are **promotable to the base** for MP2/CI/CC derivative work.
+
+**To resume:** read this doc + `git log`. The structural refactor (Phases 1–4) is done;
+the canonical CC spine plus `MPwfn` and `HFwfn` all sit on the `Wavefunction` base. Open
+threads, in rough priority:
+1. **Promote the derivative engine to the base** — move `Derivatives` (and the promotable
+   `CPHF`) off `HFwfn` onto `Wavefunction` so MP2/CI/CC gradient/response code can reach
+   them. (Next up — see discussion below / decisions log.)
+2. **Assemble a full SCF VCD driver** from the now-complete pieces (frequencies + IR
+   intensities + rotatory strengths); psi4numpy's `vcd.py` is the recipe.
+3. **Phase 5** — formally mark `local.py`/`lccwfn.py` frozen/CPU-only; or extend the base
+   to a `CIwfn`.
 
 ## Governing principle
 
@@ -199,8 +225,16 @@ boundary; because the local and einsums tests are not in CI, also run them local
 
 ## Open questions
 
-- Exact public surface the sub-objects depend on (the base's documented contract,
-  replacing `self.ccwfn.<x>` reach-ins).
-- Internal structure of the `HFwfn` derivative engine (which pieces become sub-objects;
-  where the Z-vector/CPHF solver sits when it is promoted to shared use).
-- Tag/release naming for Phase 0.
+- **Promoting the derivative engine to the base** (the live question): `Derivatives` and
+  `CPHF` already depend only on base-level state (basis/molecule/`C`/`H`/`o`/`v`/Fock
+  diagonal), so they can move from `HFwfn` onto `Wavefunction`. To settle: do they become
+  always-constructed base attributes or lazily built on first use; how does the 2-e
+  derivative provider stay lazy/transient under the device manager; and what does an
+  MP2/CI/CC gradient need beyond the HF pieces (a Z-vector / relaxed density on top of the
+  same CPHF solver).
+- _(resolved)_ ~~Internal structure of the `HFwfn` derivative engine~~ — landed as the
+  `Derivatives` provider + `CPHF` solver (orbital Hessian, field/nuclear/magnetic RHS,
+  shared nuclear-response cache); `HFwfn` delegates. See Phase 4b arc above.
+- _(resolved)_ ~~Tag/release naming for Phase 0~~ — `v0.1.0`.
+- Base public surface vs the remaining `self.ccwfn.<x>` reach-ins from CC sub-objects
+  (works via inheritance today; a documented base contract is still desirable).

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -10,7 +10,6 @@ import psi4
 import numpy as np
 
 from .wavefunction import Wavefunction
-from .derivatives import Derivatives
 from .cphf import CPHF
 from .utils import diag
 
@@ -26,9 +25,11 @@ class HFwfn(Wavefunction):
     Attributes
     ----------
     derivatives : Derivatives
-        MO-basis derivative-integral provider (promotable to the base later)
+        MO-basis derivative-integral provider, inherited from the :class:`Wavefunction`
+        base (lazy ``self.derivatives``)
     cphf : CPHF
-        coupled-perturbed HF orbital-response solver (promotable to the base later)
+        coupled-perturbed HF orbital-response solver (promotable to the base later,
+        once a correlated-gradient consumer fixes the solver/assembly seam)
     grad : numpy.ndarray
         the most recently computed nuclear gradient, shape (natom, 3)
     """
@@ -38,7 +39,7 @@ class HFwfn(Wavefunction):
         # of any frozen core the reference was run with.
         kwargs.pop('frozen_core', None)
         super().__init__(scf_wfn, frozen_core=False, **kwargs)
-        self.derivatives = Derivatives(self)
+        # The derivative-integral provider now lives on the base (lazy ``self.derivatives``).
         self.cphf = CPHF(self)
 
     def gradient(self) -> np.ndarray:

--- a/pycc/wavefunction.py
+++ b/pycc/wavefunction.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from .hamiltonian import Hamiltonian
 from .device import DeviceManager
+from .derivatives import Derivatives
 from .exceptions import InvalidKeywordError, PyCCError
 
 
@@ -48,6 +49,11 @@ class Wavefunction(object):
     H : Hamiltonian
         full-MO-basis Fock (F), ERIs, spin-adapted ERIs (L), and property integrals,
         device/precision-seeded
+    derivatives : Derivatives
+        lazy MO-basis derivative-integral provider (built on first access). Depends
+        only on base state (basis set, molecule, ``C``), so derivative property code in
+        any subclass -- HF gradients/Hessians/APTs/AATs today, MP2/CI/CC later -- reads
+        it from the base rather than constructing its own.
     device_manager : DeviceManager
         owns device/precision, device0/device1, and the contraction backend
     device, precision : str
@@ -178,6 +184,11 @@ class Wavefunction(object):
         self.H.ERI = mgr.seed_store(self.H.ERI)
         self.H.L = mgr.seed_store(self.H.L)
 
+        # Derivative-integral provider: built lazily on first access (see the
+        # ``derivatives`` property), so methods that never take derivatives pay
+        # nothing. Recorded here as part of the base so _from_shared_base carries it.
+        self._derivatives = None
+
         # The base is the final consumer of forwarded kwargs (each subclass pops
         # its own and passes the remainder through), so anything left over is an
         # unrecognized keyword -- flag it instead of silently ignoring it.
@@ -188,6 +199,15 @@ class Wavefunction(object):
         # subclass set first), so _from_shared_base can replicate this base onto a
         # new instance without re-running __init__ (and re-transforming integrals).
         self._base_attrs = tuple(k for k in vars(self) if k not in _preexisting)
+
+    @property
+    def derivatives(self) -> Derivatives:
+        """Lazy MO-basis derivative-integral provider, built on first access and
+        cached. Lives on the base (it depends only on base state) so any subclass's
+        derivative property code reaches it through ``self.derivatives``."""
+        if self._derivatives is None:
+            self._derivatives = Derivatives(self)
+        return self._derivatives
 
     @classmethod
     def _from_shared_base(cls, source: "Wavefunction") -> "Wavefunction":


### PR DESCRIPTION
  ## Promote the derivative-integral provider to the Wavefunction base (stage 1)

  Moves the MO-basis `Derivatives` provider from `HFwfn` onto the `Wavefunction` base, plus a refresh of the refactor-plan
  doc. Stage 1 of the two-stage derivative-engine promotion.

  ### Derivatives → base (lazy property)
  - `Wavefunction` gains a lazy `derivatives` property: `Derivatives(self)` is built on first access and cached in
  `self._derivatives` (initialized in `__init__`, so it's part of `_base_attrs` and carries through `_from_shared_base`).
  Methods that never take derivatives pay nothing.
  - `HFwfn` drops `self.derivatives = Derivatives(self)` and the import — it now inherits the provider. `CPHF` still reads
  `self.wfn.derivatives`, which resolves through the base property unchanged.
  - Pure move: `Derivatives` only ever depended on base state (basis set, molecule, `C`).

  ### Deferred to stage 2
  `CPHF` stays on `HFwfn` until a correlated-gradient consumer (MP2 gradient) fixes the clean split between the generic
  orbital-response **solver** (→ base) and the method-specific property **assemblies** (polarizability / APTs / Hessian /
  AATs).

  ### Doc
  `docs/REFACTOR_PLAN_2026-06.md` brought current: status through #128, a dedicated HF-derivative-arc table, refreshed "to resume" pointer and Open Questions.

  ### Validation
  Full non-slow suite: **58 passed, 3 skipped, 8 deselected, 1 xfailed** — identical to before; CC/MP2/RT/local all
  unaffected.

  ### Files
  `pycc/wavefunction.py`, `pycc/hfwfn.py`, `docs/REFACTOR_PLAN_2026-06.md`
