### PR TITLE
Add CIwfn (CISD/CID energies) on the Wavefunction base

### DIFF
--- a/docs/REFACTOR_PLAN_2026-06.md
+++ b/docs/REFACTOR_PLAN_2026-06.md
@@ -40,16 +40,23 @@ cached and shared across the Hessian and the APTs/AATs.
 APTs, AATs). The `Derivatives` and `CPHF` classes were written to depend only on
 base-level state, so they are **promotable to the base** for MP2/CI/CC derivative work.
 
+**`CIwfn` (CISD/CID) landed** (`pycc/ciwfn.py`): a fourth method class on the base,
+analogous to `MPwfn`. Intermediate normalization, projected equations (the linear part
+of the CCSD residual with bare integrals, energy-dependent denominators), composing an
+`MPwfn` for `Dijab` and the MP1 guess. Validated vs Psi4 DETCI (CISD, ~1e-13) and CFOUR
+(CID, ~1e-13).
+
 **To resume:** read this doc + `git log`. The structural refactor (Phases 1–4) is done;
-the canonical CC spine plus `MPwfn` and `HFwfn` all sit on the `Wavefunction` base. Open
-threads, in rough priority:
+the canonical CC spine plus `MPwfn`, `HFwfn`, and `CIwfn` all sit on the `Wavefunction`
+base. Open threads, in rough priority:
 1. **Promote the derivative engine to the base** — move `Derivatives` (and the promotable
    `CPHF`) off `HFwfn` onto `Wavefunction` so MP2/CI/CC gradient/response code can reach
    them. (Next up — see discussion below / decisions log.)
 2. **Assemble a full SCF VCD driver** from the now-complete pieces (frequencies + IR
    intensities + rotatory strengths); psi4numpy's `vcd.py` is the recipe.
-3. **Phase 5** — formally mark `local.py`/`lccwfn.py` frozen/CPU-only; or extend the base
-   to a `CIwfn`.
+3. **Phase 5** — formally mark `local.py`/`lccwfn.py` frozen/CPU-only.
+4. **Build out `CIwfn`** — densities/properties, or higher excitations, on the CISD/CID
+   foundation now in place.
 
 ## Governing principle
 

--- a/pycc/__init__.py
+++ b/pycc/__init__.py
@@ -9,6 +9,7 @@ PyCC: A Python-based coupled cluster implementation.
 from .ccwfn import ccwfn
 from .mpwfn import MPwfn
 from .hfwfn import HFwfn
+from .ciwfn import CIwfn
 from .cchbar import cchbar
 from .cclambda import cclambda
 from .ccdensity import ccdensity
@@ -17,7 +18,7 @@ from .ccresponse import pertbar
 from pycc.rt.rtcc import rtcc
 from .cceom import cceom
 
-__all__ = ['ccwfn', 'MPwfn', 'HFwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom']
+__all__ = ['ccwfn', 'MPwfn', 'HFwfn', 'CIwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom']
 
 # Handle versioneer
 from ._version import get_versions

--- a/pycc/ciwfn.py
+++ b/pycc/ciwfn.py
@@ -1,0 +1,198 @@
+"""
+ciwfn.py: Configuration-interaction (CISD) wavefunction.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, TYPE_CHECKING
+
+import numpy as np
+
+from .wavefunction import Wavefunction
+from .mpwfn import MPwfn
+from .utils import helper_diis, clone, sqrt, zeros_like
+from .exceptions import InvalidKeywordError
+
+if TYPE_CHECKING:
+    from ._typing import Tensor
+
+
+class CIwfn(Wavefunction):
+    """A configuration-interaction (CISD) wavefunction on the shared
+    :class:`Wavefunction` base.
+
+    The CI coefficients use intermediate normalization (the reference coefficient is
+    fixed at 1), and the amplitude equations are the projected form -- directly
+    analogous to the CCSD amplitude equations, but with only the *linear* terms (so no
+    similarity-transformed intermediates like F_ae or W_mbej arise) and with the
+    correlation energy appearing on the right-hand side::
+
+        <Phi_i^a  | H_N | Psi> = E_c c_i^a
+        <Phi_ij^ab| H_N | Psi> = E_c c_ij^ab
+        E_c = <Phi_0 | H_N | Psi>
+
+    Like ``ccwfn``, the energy denominators and the initial guess come from a composed
+    :class:`MPwfn` (the MP1 doubles), built over this object's already-constructed base
+    (no second integral transform). The Fock matrix is treated as a general (possibly
+    non-diagonal) matrix throughout -- only the denominators use its diagonal -- so
+    non-canonical / non-HF reference orbitals are supported, as in the CC code.
+
+    Attributes
+    ----------
+    model : str
+        'CISD' (singles + doubles) or 'CID' (doubles only)
+    mp : MPwfn
+        composed MP2 wavefunction supplying ``Dijab`` and the MP1 guess
+    Dia, Dijab : Tensor
+        one- and two-electron energy denominators (from ``diag(F)``)
+    c1, c2 : Tensor
+        current singles / doubles CI coefficients
+    eci : float
+        the CI correlation energy (set by :meth:`solve_ci`)
+    """
+
+    def __init__(self, scf_wfn: Any, **kwargs) -> None:
+        time_init = time.time()
+
+        valid_ci_models = ['CISD', 'CID']
+        model = kwargs.pop('model', 'CISD').upper()
+        if model not in valid_ci_models:
+            raise InvalidKeywordError('model', model, valid_ci_models)
+        self.model = model
+        self.need_singles = model in ['CISD']
+
+        # Reference, orbital spaces, seeded integrals, and the device manager all come
+        # from the base; CIwfn pops only its own kwargs (model) and forwards the rest.
+        super().__init__(scf_wfn, **kwargs)
+        mgr = self.device_manager
+
+        # The MP2 wavefunction supplies the energy denominators and the CISD initial
+        # guess (MP1 doubles), reusing this object's base -- the same pattern ccwfn
+        # uses. CI's singles denominator (Dia) is built from the MP2 orbital energies.
+        self.mp = MPwfn.from_wavefunction(self)
+        self.Dijab = self.mp.Dijab
+        self.Dia = self.mp.eps_occ.reshape(-1, 1) - self.mp.eps_vir
+
+        # Initial guess: c1 = 0, c2 = MP1 doubles (CI mutates c2 in place, so copy).
+        self.c1 = mgr.seed_compute(np.zeros((self.no, self.nv)))
+        self.c2 = clone(self.mp.t2)
+
+        print("CIWFN object initialized in %.3f seconds." % (time.time() - time_init))
+
+    def solve_ci(self, e_conv: float = 1e-7, r_conv: float = 1e-7, maxiter: int = 100,
+                 max_diis: int = 8, start_diis: int = 1) -> "Tensor":
+        """Iterate the projected CISD equations to convergence and return E_c.
+
+        The coefficients satisfy the eigenvalue equations ``sigma = E_c c`` (``sigma``
+        is ``<excited|H_N|Psi>``); the residual is ``r = sigma - E_c c`` and the update
+        uses the CI diagonal preconditioner -- the orbital-energy denominator shifted by
+        the correlation energy, ``c += r / (D + E_c)`` -- so the energy enters both the
+        residual and the denominator. DIIS accelerates convergence as in ``solve_cc``.
+        """
+        ci_tstart = time.time()
+
+        o, v = self.o, self.v
+        F, ERI, L = self.H.F, self.H.ERI, self.H.L
+        Dia, Dijab = self.Dia, self.Dijab
+        contract = self.contract
+
+        eci = self.ci_energy(o, v, F, L, self.c1, self.c2)
+        print("CI Iter %3d: CI Ecorr = %.15f  dE = % .5E  MP2" % (0, eci, -eci))
+
+        diis = helper_diis(self.c1, self.c2, max_diis, self.precision)
+
+        for niter in range(1, maxiter + 1):
+            eci_last = eci
+
+            s1 = self.sigma1(o, v, F, ERI, L, self.c1, self.c2)
+            s2 = self.sigma2(o, v, F, ERI, L, self.c1, self.c2)
+
+            r1 = s1 - eci * self.c1
+            r2 = s2 - eci * self.c2
+            inc1 = r1 / (Dia + eci)
+            inc2 = r2 / (Dijab + eci)
+            self.c1 = self.c1 + inc1
+            self.c2 = self.c2 + inc2
+            rms = contract('ia,ia->', inc1, inc1) + contract('ijab,ijab->', inc2, inc2)
+            rms = sqrt(rms)
+
+            eci = self.ci_energy(o, v, F, L, self.c1, self.c2)
+            ediff = eci - eci_last
+            print("CI Iter %3d: CI Ecorr = %.15f  dE = % .5E  rms = % .5E"
+                  % (niter, eci, ediff, rms))
+
+            if (abs(ediff) < e_conv) and abs(rms) < r_conv:
+                print("\nCIWFN converged in %.3f seconds.\n" % (time.time() - ci_tstart))
+                print("E(REF)   = %20.15f" % self.eref)
+                print("E(%s)  = %20.15f" % (self.model, eci))
+                print("E(TOT)   = %20.15f" % (eci + self.eref))
+                self.eci = eci
+                return eci
+
+            diis.add_error_vector(self.c1, self.c2)
+            if niter >= start_diis:
+                self.c1, self.c2 = diis.extrapolate(self.c1, self.c2)
+
+    def ci_energy(self, o, v, F, L, c1, c2) -> "Tensor":
+        """CISD correlation energy, E_c = <Phi_0|H_N|Psi> = 2 f_ia c_ia + c_ijab L_ijab.
+
+        The singles term is kept general (non-zero only for non-Brillouin references);
+        the doubles term is the linear (CI) form of the CC energy (no t1.t1).
+        """
+        contract = self.contract
+        e = 2.0 * contract('ia,ia->', F[o, v], c1)
+        e = e + contract('ijab,ijab->', c2, L[o, o, v, v])
+        return e
+
+    def sigma1(self, o, v, F, ERI, L, c1, c2) -> "Tensor":
+        """Singles sigma vector, sigma1_ia = <Phi_i^a|H_N|Psi>.
+
+        The linear part of the CCSD T1 residual (t -> c) with the dressed one-body
+        intermediates replaced by the bare Fock blocks (no diagonal-Fock assumption)::
+
+            sigma1_ia = f_ia + c1_ie f_ae - f_mi c1_ma + (2 c2_imae - c2_imea) f_me
+                      + c1_nf L_nafi + L_amef c_imef - c2_mnae L_mnie
+        """
+        if not self.need_singles:
+            return zeros_like(c1)
+
+        contract = self.contract
+        s1 = clone(F[o, v], device=self.device1)
+        s1 = s1 + contract('ie,ae->ia', c1, F[v, v])
+        s1 = s1 - contract('mi,ma->ia', F[o, o], c1)
+        s1 = s1 + contract('imae,me->ia', (2.0 * c2 - c2.swapaxes(2, 3)), F[o, v])
+        s1 = s1 + contract('nf,nafi->ia', c1, L[o, v, v, o])
+        s1 = s1 + contract('amef,imef->ia', L[v, o, v, v], c2)
+        s1 = s1 - contract('mnae,mnie->ia', c2, L[o, o, o, v])
+        return s1
+
+    def sigma2(self, o, v, F, ERI, L, c1, c2) -> "Tensor":
+        """Doubles sigma vector, sigma2_ijab = <Phi_ij^ab|H_N|Psi>.
+
+        The linear part of the CCSD T2 residual (t -> c, tau -> c2) with the dressed
+        two-body intermediates replaced by their bare integrals. Built as a "half"
+        residual and then symmetrized (i<->j, a<->b), as in ``r_T2``::
+
+            sigma2(half) = 1/2 <ij|ab> + c2_ijae f_be - c2_imab f_mj
+                         + 1/2 c2_mnab <mn|ij> + 1/2 c2_ijef <ab|ef>
+                         + c2_miea L_mbej - c2_imea <mb|ej> - c2_imeb <ma|je>
+                         + c1_ie <ab|ej> - c1_ma <mb|ij>
+            sigma2 = sigma2(half) + sigma2(half)[i<->j, a<->b]
+        """
+        contract = self.contract
+
+        s2 = 0.5 * clone(ERI[o, o, v, v], device=self.device1)
+        s2 = s2 + contract('ijae,eb->ijab', c2, F[v, v].T)
+        s2 = s2 - contract('imab,mj->ijab', c2, F[o, o])
+        s2 = s2 + 0.5 * contract('mnab,mnij->ijab', c2, ERI[o, o, o, o])
+        s2 = s2 + 0.5 * contract('ijef,abef->ijab', c2, ERI[v, v, v, v])
+        s2 = s2 + contract('miea,mbej->ijab', c2, L[o, v, v, o])
+        s2 = s2 - contract('imea,mbej->ijab', c2, ERI[o, v, v, o])
+        s2 = s2 - contract('imeb,maje->ijab', c2, ERI[o, v, o, v])
+        if self.need_singles:
+            s2 = s2 + contract('ie,abej->ijab', c1, ERI[v, v, v, o])
+            s2 = s2 - contract('ma,mbij->ijab', c1, ERI[o, v, o, o])
+
+        s2 = s2 + s2.swapaxes(0, 1).swapaxes(2, 3)
+        return s2

--- a/pycc/tests/test_051_cisd.py
+++ b/pycc/tests/test_051_cisd.py
@@ -1,0 +1,57 @@
+"""
+Test the CISD/CID correlation energy (CIwfn).
+
+CISD is validated against Psi4's DETCI (the exact CISD). The default 'cisd' driver is
+NOT used: it routes to fnocc, which applies frozen natural orbitals / truncation and so
+does not reproduce the exact CISD energy. DETCI has no doubles-only mode, so CID is
+validated against CFOUR reference values (the same H2O geometry as magpy's
+test_004_CID, reproduced exactly below so the comparison is geometry-for-geometry).
+"""
+
+import psi4
+import pycc
+
+# Exact H2O geometry behind the CFOUR CID references (bohr); identical to magpy's.
+H2O = """
+O  0.000000000000  -0.143225816552   0.000000000000
+H  1.638036840407   1.136548822547  -0.000000000000
+H -1.638036840407   1.136548822547  -0.000000000000
+units bohr
+no_com
+no_reorient
+symmetry c1
+"""
+
+
+def test_cisd_h2o(rhf_wfn):
+    """All-electron CISD vs Psi4 DETCI (exact CISD)."""
+    wfn = rhf_wfn(H2O, "cc-pVDZ", freeze_core="false", qc_module="detci",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    eci = pycc.CIwfn(wfn, frozen_core=False).solve_ci(e_conv=1e-11, r_conv=1e-11)
+    eref = psi4.energy('detci', ci_type='cisd') - wfn.energy()
+    assert abs(eci - eref) < 1e-10
+
+
+def test_cisd_h2o_frozen_core(rhf_wfn):
+    """Frozen-core CISD vs Psi4 DETCI."""
+    wfn = rhf_wfn(H2O, "cc-pVDZ", freeze_core="true", qc_module="detci",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    eci = pycc.CIwfn(wfn).solve_ci(e_conv=1e-11, r_conv=1e-11)
+    eref = psi4.energy('detci', ci_type='cisd') - wfn.energy()
+    assert abs(eci - eref) < 1e-10
+
+
+def test_cid_h2o(rhf_wfn):
+    """All-electron CID (doubles-only model seam) vs CFOUR (cc-pVDZ H2O)."""
+    wfn = rhf_wfn(H2O, "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    ecid = pycc.CIwfn(wfn, frozen_core=False, model="CID").solve_ci(e_conv=1e-12, r_conv=1e-12)
+    assert abs(ecid - (-0.21279410950205)) < 1e-11
+
+
+def test_cid_h2o_frozen_core(rhf_wfn):
+    """Frozen-core CID vs CFOUR (cc-pVDZ H2O)."""
+    wfn = rhf_wfn(H2O, "cc-pVDZ", freeze_core="true",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    ecid = pycc.CIwfn(wfn, model="CID").solve_ci(e_conv=1e-12, r_conv=1e-12)
+    assert abs(ecid - (-0.21098966441656)) < 1e-11

--- a/pycc/tests/test_051_cisd.py
+++ b/pycc/tests/test_051_cisd.py
@@ -1,17 +1,18 @@
 """
 Test the CISD/CID correlation energy (CIwfn).
 
-CISD is validated against Psi4's DETCI (the exact CISD). The default 'cisd' driver is
-NOT used: it routes to fnocc, which applies frozen natural orbitals / truncation and so
-does not reproduce the exact CISD energy. DETCI has no doubles-only mode, so CID is
-validated against CFOUR reference values (the same H2O geometry as magpy's
-test_004_CID, reproduced exactly below so the comparison is geometry-for-geometry).
+The references are exact: CISD against Psi4 DETCI, CID against CFOUR (the same H2O
+geometry as magpy's test_004_CID, reproduced exactly below). Both are hardcoded rather
+than recomputed at runtime: the default 'cisd' driver routes to fnocc (frozen natural
+orbitals / truncation, ~4e-5 off exact), and a live DETCI call is flaky on CI -- on the
+larger all-electron CISD, DETCI's Davidson intermittently hits its iteration cap. The
+DETCI values below were computed locally and match PyCC to ~2e-13; the CISD tolerance
+allows for the small psi4-version SCF drift (the CID tests confirm it is < 1e-11).
 """
 
-import psi4
 import pycc
 
-# Exact H2O geometry behind the CFOUR CID references (bohr); identical to magpy's.
+# Exact H2O geometry behind the references (bohr); identical to magpy's test_004_CID.
 H2O = """
 O  0.000000000000  -0.143225816552   0.000000000000
 H  1.638036840407   1.136548822547  -0.000000000000
@@ -22,23 +23,28 @@ no_reorient
 symmetry c1
 """
 
+# Exact CISD correlation energies (Psi4 DETCI) for the geometry above.
+CISD_REF = -0.213962927361777        # all-electron
+CISD_REF_FC = -0.212162092109267     # frozen-core
+# Exact CID correlation energies (CFOUR) for the geometry above.
+CID_REF = -0.21279410950205          # all-electron
+CID_REF_FC = -0.21098966441656       # frozen-core
+
 
 def test_cisd_h2o(rhf_wfn):
     """All-electron CISD vs Psi4 DETCI (exact CISD)."""
-    wfn = rhf_wfn(H2O, "cc-pVDZ", freeze_core="false", qc_module="detci",
+    wfn = rhf_wfn(H2O, "cc-pVDZ", freeze_core="false",
                   e_convergence=1e-12, d_convergence=1e-12)
     eci = pycc.CIwfn(wfn, frozen_core=False).solve_ci(e_conv=1e-11, r_conv=1e-11)
-    eref = psi4.energy('detci', ci_type='cisd') - wfn.energy()
-    assert abs(eci - eref) < 1e-10
+    assert abs(eci - CISD_REF) < 1e-9
 
 
 def test_cisd_h2o_frozen_core(rhf_wfn):
     """Frozen-core CISD vs Psi4 DETCI."""
-    wfn = rhf_wfn(H2O, "cc-pVDZ", freeze_core="true", qc_module="detci",
+    wfn = rhf_wfn(H2O, "cc-pVDZ", freeze_core="true",
                   e_convergence=1e-12, d_convergence=1e-12)
     eci = pycc.CIwfn(wfn).solve_ci(e_conv=1e-11, r_conv=1e-11)
-    eref = psi4.energy('detci', ci_type='cisd') - wfn.energy()
-    assert abs(eci - eref) < 1e-10
+    assert abs(eci - CISD_REF_FC) < 1e-9
 
 
 def test_cid_h2o(rhf_wfn):
@@ -46,7 +52,7 @@ def test_cid_h2o(rhf_wfn):
     wfn = rhf_wfn(H2O, "cc-pVDZ", freeze_core="false",
                   e_convergence=1e-12, d_convergence=1e-12)
     ecid = pycc.CIwfn(wfn, frozen_core=False, model="CID").solve_ci(e_conv=1e-12, r_conv=1e-12)
-    assert abs(ecid - (-0.21279410950205)) < 1e-11
+    assert abs(ecid - CID_REF) < 1e-11
 
 
 def test_cid_h2o_frozen_core(rhf_wfn):
@@ -54,4 +60,4 @@ def test_cid_h2o_frozen_core(rhf_wfn):
     wfn = rhf_wfn(H2O, "cc-pVDZ", freeze_core="true",
                   e_convergence=1e-12, d_convergence=1e-12)
     ecid = pycc.CIwfn(wfn, model="CID").solve_ci(e_conv=1e-12, r_conv=1e-12)
-    assert abs(ecid - (-0.21098966441656)) < 1e-11
+    assert abs(ecid - CID_REF_FC) < 1e-11

--- a/pycc/tests/test_051_cisd.py
+++ b/pycc/tests/test_051_cisd.py
@@ -6,8 +6,9 @@ geometry as magpy's test_004_CID, reproduced exactly below). Both are hardcoded 
 than recomputed at runtime: the default 'cisd' driver routes to fnocc (frozen natural
 orbitals / truncation, ~4e-5 off exact), and a live DETCI call is flaky on CI -- on the
 larger all-electron CISD, DETCI's Davidson intermittently hits its iteration cap. The
-DETCI values below were computed locally and match PyCC to ~2e-13; the CISD tolerance
-allows for the small psi4-version SCF drift (the CID tests confirm it is < 1e-11).
+DETCI values below were computed locally and match PyCC to ~2e-13; with the tightly
+converged RHF (1e-12) the comparison is essentially code/version-independent, so the
+1e-10 tolerance is comfortable (the CID tests, hardcoded CFOUR values, pass at 1e-11).
 """
 
 import pycc
@@ -36,7 +37,7 @@ def test_cisd_h2o(rhf_wfn):
     wfn = rhf_wfn(H2O, "cc-pVDZ", freeze_core="false",
                   e_convergence=1e-12, d_convergence=1e-12)
     eci = pycc.CIwfn(wfn, frozen_core=False).solve_ci(e_conv=1e-11, r_conv=1e-11)
-    assert abs(eci - CISD_REF) < 1e-9
+    assert abs(eci - CISD_REF) < 1e-10
 
 
 def test_cisd_h2o_frozen_core(rhf_wfn):
@@ -44,7 +45,7 @@ def test_cisd_h2o_frozen_core(rhf_wfn):
     wfn = rhf_wfn(H2O, "cc-pVDZ", freeze_core="true",
                   e_convergence=1e-12, d_convergence=1e-12)
     eci = pycc.CIwfn(wfn).solve_ci(e_conv=1e-11, r_conv=1e-11)
-    assert abs(eci - CISD_REF_FC) < 1e-9
+    assert abs(eci - CISD_REF_FC) < 1e-10
 
 
 def test_cid_h2o(rhf_wfn):


### PR DESCRIPTION
  ## Add CIwfn (CISD/CID energies) on the Wavefunction base

  A fourth method class on the `Wavefunction` base, analogous to `MPwfn`: configuration interaction with singles and doubles (CISD), plus a doubles-only CID model seam.

  ### Design
  - **Intermediate normalization, projected amplitude equations.** The singles/doubles sigma vectors are the **linear** part
  of the CCSD `r_T1`/`r_T2` (`t → c`) with the dressed intermediates replaced by bare integrals (no `Fae`/`Wmbej`), and the
  correlation energy enters the equations: residual `r = σ − E_c·c`, updated with the energy-shifted diagonal preconditioner `c += r/(D + E_c)`. DIIS-accelerated.
  - **Composes an `MPwfn`** (`from_wavefunction`) for `Dijab` and the MP1 initial guess, reusing the already-built base — the same pattern `ccwfn` uses (no second integral transform).
  - **No diagonal-Fock assumption** — uses the `F[v,v]`/`F[o,v]`/`F[o,o]` blocks throughout; only the denominators use
  `diag(F)`, so non-canonical / non-HF reference orbitals work, as in the CC code.
  - `CIwfn` exported from `pycc`; model seam (`'CISD'`/`'CID'`).

  ### Validation (`test_051`)
  | method | reference | agreement |
  |---|---|---|
  | CISD (all-electron / frozen-core) | Psi4 **DETCI** | ~1e-13 |
  | CID (all-electron / frozen-core) | **CFOUR** | ~1e-13 |

  DETCI is used rather than the default `'cisd'` driver (which routes to fnocc and truncates). CID is referenced against 
  CFOUR (DETCI has no doubles-only mode), using the CFOUR H₂O geometry in bohr verbatim — CFOUR and Psi4 use different bohr↔ångström factors, so cross-code geometry comparisons fix the coordinates in one convention.

  Full non-slow suite: **62 passed**.

  ### Files
  `pycc/ciwfn.py` (new), `pycc/__init__.py`, `pycc/tests/test_051_cisd.py` (new), `docs/REFACTOR_PLAN_2026-06.md`
