### PR TITLE
Rename the ccwfn class to CCwfn (HFwfn/MPwfn/CIwfn convention)

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -39,7 +39,7 @@ Coupled-cluster energy
     _, wfn = psi4.energy('SCF', return_wfn=True)
 
     # model can be 'CCD', 'CC2', 'CCSD', 'CCSD(T)', or 'CC3'
-    cc = pycc.ccwfn(wfn, model='CCSD')
+    cc = pycc.CCwfn(wfn, model='CCSD')
     ecc = cc.solve_cc(e_conv=1e-8, r_conv=1e-7, maxiter=75)
 
 Lambda amplitudes and densities

--- a/pycc/__init__.py
+++ b/pycc/__init__.py
@@ -6,7 +6,7 @@ PyCC: A Python-based coupled cluster implementation.
 """
 
 # Add imports here
-from .ccwfn import ccwfn
+from .ccwfn import CCwfn, ccwfn  # ccwfn: backward-compat alias for CCwfn
 from .mpwfn import MPwfn
 from .hfwfn import HFwfn
 from .ciwfn import CIwfn
@@ -18,7 +18,7 @@ from .ccresponse import pertbar
 from pycc.rt.rtcc import rtcc
 from .cceom import cceom
 
-__all__ = ['ccwfn', 'MPwfn', 'HFwfn', 'CIwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom']
+__all__ = ['CCwfn', 'ccwfn', 'MPwfn', 'HFwfn', 'CIwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom']
 
 # Handle versioneer
 from ._version import get_versions

--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -18,7 +18,7 @@ from .cctriples import t3c_ijk, t3c_abc, l3_ijk, l3_abc, t3c_bc, l3_bc, t3_pert_
 from .utils import zeros, zeros_like, clone
 
 if TYPE_CHECKING:
-    from pycc.ccwfn import ccwfn
+    from pycc.ccwfn import CCwfn
     from pycc.cclambda import cclambda
 
 class ccdensity(object):
@@ -56,7 +56,7 @@ class ccdensity(object):
     compute_onepdm() :
         Compute the one-electron density for a given set of amplitudes (useful for RTCC)
     """
-    def __init__(self, ccwfn: "ccwfn", cclambda: "cclambda", onlyone: bool = False) -> None:
+    def __init__(self, ccwfn: "CCwfn", cclambda: "cclambda", onlyone: bool = False) -> None:
         """
         Parameters
         ----------

--- a/pycc/cceom.py
+++ b/pycc/cceom.py
@@ -11,7 +11,7 @@ import scipy.linalg
 from pycc.exceptions import InvalidKeywordError
 
 if TYPE_CHECKING:
-    from pycc.ccwfn import ccwfn
+    from pycc.ccwfn import CCwfn
     from pycc.cchbar import cchbar
 
 class cceom(object):
@@ -42,7 +42,7 @@ class cceom(object):
         Build the doubles components of the sigma = C * HBAR vector
     """
 
-    def __init__(self, ccwfn: "ccwfn", cchbar: "cchbar") -> None:
+    def __init__(self, ccwfn: "CCwfn", cchbar: "cchbar") -> None:
         """
         Parameters
         ----------

--- a/pycc/cchbar.py
+++ b/pycc/cchbar.py
@@ -18,7 +18,7 @@ if HAS_TORCH:
 from pycc.utils import clone
 
 if TYPE_CHECKING:
-    from pycc.ccwfn import ccwfn
+    from pycc.ccwfn import CCwfn
 
 
 class cchbar(object):
@@ -51,7 +51,7 @@ class cchbar(object):
         The occ,vir,occ,occ block of the two-body component HBAR.
 
     """
-    def __init__(self, ccwfn: "ccwfn") -> None:
+    def __init__(self, ccwfn: "CCwfn") -> None:
         """
         Parameters
         ----------

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -20,7 +20,7 @@ if HAS_TORCH:
 from .cctriples import t3c_ijk, l3_ijk, l3_ijk_alt, t3_pert_ijk
 
 if TYPE_CHECKING:
-    from pycc.ccwfn import ccwfn
+    from pycc.ccwfn import CCwfn
     from pycc.cchbar import cchbar
 
 
@@ -46,7 +46,7 @@ class cclambda(object):
     residuals()
         Computes the L1 and L2 residuals for a given set of amplitudes and Fock operator
     """
-    def __init__(self, ccwfn: "ccwfn", hbar: "cchbar") -> None:
+    def __init__(self, ccwfn: "CCwfn", hbar: "cchbar") -> None:
         """
         Parameters
         ----------

--- a/pycc/ccresponse.py
+++ b/pycc/ccresponse.py
@@ -16,7 +16,7 @@ from .cclambda import cclambda
 from ._typing import Tensor
 
 if TYPE_CHECKING:
-    from pycc.ccwfn import ccwfn
+    from pycc.ccwfn import CCwfn
     from pycc.ccdensity import ccdensity
 
 class ccresponse(object):
@@ -837,7 +837,7 @@ class ccresponse(object):
         return -2.0*(polar1 + polar2) 
         
 class pertbar(object):
-    def __init__(self, pert: Tensor, ccwfn: "ccwfn") -> None:
+    def __init__(self, pert: Tensor, ccwfn: "CCwfn") -> None:
         o = ccwfn.o
         v = ccwfn.v
         t1 = ccwfn.t1

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -11,7 +11,7 @@ if HAS_TORCH:
 from pycc.utils import zeros_like, diag, clone
 
 if TYPE_CHECKING:
-    from pycc.ccwfn import ccwfn
+    from pycc.ccwfn import CCwfn
 
 """Various triples drivers; useful for (T) corrections and CC3.  Each driver
 returns batches of triples amplitudes corresponding to the general expression:
@@ -187,7 +187,7 @@ def t3d_abc(o, v, a, b, c, t1, t2, Woovv, F, contract, WithDenom=True):
 
 
 # Lee and Rendell's formulation
-def t_tjl(ccwfn: "ccwfn") -> float:
+def t_tjl(ccwfn: "CCwfn") -> float:
     """Compute the (T) energy correction using the efficient formulation by Rendell
     and Lee, Chem. Phys. Lett. 178, 462-470 (1991).
 
@@ -247,7 +247,7 @@ def t_tjl(ccwfn: "ccwfn") -> float:
 
 
 # Vikings' formulation
-def t_vikings(ccwfn: "ccwfn") -> float:
+def t_vikings(ccwfn: "CCwfn") -> float:
     """Compute the (T) energy correction using the formulation by Helgaker,
     Jørgensen, and Olsen, Molecular Electronic Structure Theory, Wiley & Sons, 
     New York, 2000, Ch.14, pp. 794-795, Eqs. (14.6.62)-(14.6.64).  This algorithm
@@ -295,7 +295,7 @@ def t_vikings(ccwfn: "ccwfn") -> float:
 
 
 # Vikings' formulation – inverted algorithm
-def t_vikings_inverted(ccwfn: "ccwfn") -> float:
+def t_vikings_inverted(ccwfn: "CCwfn") -> float:
     """Compute the (T) energy correction using the formulation by Helgaker,
     Jørgensen, and Olsen, Molecular Electronic Structure Theory, Wiley & Sons, 
     New York, 2000, Ch.14, pp. 794-795, Eqs. (14.6.62)-(14.6.64).  This algorithm

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -28,7 +28,7 @@ from .lccwfn import lccwfn
 from ._typing import Tensor
 from .exceptions import InvalidKeywordError
 
-class ccwfn(Wavefunction):
+class CCwfn(Wavefunction):
     """
     An RHF-CC wave function and energy object.
 
@@ -1000,3 +1000,8 @@ class ccwfn(Wavefunction):
         ET += contract('ijab,ijab->', (4.0*t2 - 2.0*t2.swapaxes(2,3)), X2)
 
         return ET
+
+
+# Backward-compatibility alias: the class was renamed ccwfn -> CCwfn to match the
+# HFwfn/MPwfn/CIwfn method-class convention. Existing code using ``ccwfn`` still works.
+ccwfn = CCwfn

--- a/pycc/rt/rtcc.py
+++ b/pycc/rt/rtcc.py
@@ -19,7 +19,7 @@ import opt_einsum
 from pycc._typing import Tensor
 
 if TYPE_CHECKING:
-    from pycc.ccwfn import ccwfn
+    from pycc.ccwfn import CCwfn
     from pycc.cclambda import cclambda
     from pycc.ccdensity import ccdensity
 
@@ -69,7 +69,7 @@ class rtcc(object):
     lagrangian()
         Compute the CC Lagrangian energy for a given time t
     """
-    def __init__(self, ccwfn: "ccwfn", cclambda: "cclambda", ccdensity: "ccdensity", V: Tensor, magnetic: bool = False, kick: Any = None) -> None:
+    def __init__(self, ccwfn: "CCwfn", cclambda: "cclambda", ccdensity: "ccdensity", V: Tensor, magnetic: bool = False, kick: Any = None) -> None:
         self.ccwfn = ccwfn
         self.cclambda = cclambda
         self.ccdensity = ccdensity


### PR DESCRIPTION
  ## Rename the ccwfn class to CCwfn (HFwfn/MPwfn/CIwfn convention)

  The CC wavefunction class was the lone holdout from the method-class naming convention established by the `Wavefunction` base and its `HFwfn`/`MPwfn`/`CIwfn` subclasses (CapWords method abbreviation + `wfn`). The refactor plan already names it `CCwfn`, and PEP8 wants CapWords class names.
  
  - `class ccwfn` → `class CCwfn` (`pycc/ccwfn.py`), with a module-level **backward-compat alias** `ccwfn = CCwfn` so
  existing code — tests, notebooks, the in-flight quadratic-response branch — keeps working unchanged. `pycc` exports both names.
  - Internal class references (TYPE_CHECKING imports + type annotations) updated to `CCwfn` in the sub-objects: `cchbar`,  `cclambda`, `ccdensity`, `cceom`, `ccresponse`, `cctriples`, `rt/rtcc`. The `self.ccwfn` attribute handles and parameter  names stay lowercase (instance handles, correct PEP8 — same as `HFwfn`/`MPwfn`/`CIwfn`'s `self.mp`).
  - Doc example updated to `pycc.CCwfn`.
  
  **Scope:** the CC wavefunction class only; the `cc*` machinery classes (`cchbar`, …) are left as-is.

  **Validation:** behavior-preserving — full non-slow suite green; the CC (via the `ccwfn` alias) and CISD paths pass on the 
  rebased branch. Rebased onto current `main` after #131 (CIwfn) merged, so the `__init__.py` overlap (import block + 
  `__all__`) is already resolved — both the `CCwfn`/`ccwfn` import+alias and the `CIwfn` export coexist. Merges cleanly.
