### PR TITLE
Add spin-orbital Hamiltonian + orbital_basis dispatch (UHF/ROHF, step 1)

### DIFF
--- a/docs/ENHANCEMENT_PLAN_2026-06.md
+++ b/docs/ENHANCEMENT_PLAN_2026-06.md
@@ -1,0 +1,157 @@
+# PyCC Enhancement Plan — Spin-Orbital Path for UHF/ROHF — 2026-06
+
+_Authored from the June 2026 design discussion. This document is **new
+territory**, not a continuation of [`REFACTOR_PLAN_2026-06.md`](REFACTOR_PLAN_2026-06.md):
+the refactor reorganized the existing closed-shell RHF code onto a `Wavefunction`
+base; this plan adds a second, parallel correlation formulation so PyCC can treat
+**open-shell UHF (and, later, ROHF) references** via spin orbitals._
+
+## Goal
+
+Let PyCC compute correlated energies on top of a UHF reference (ROHF to follow)
+by adding a spin-orbital path alongside the existing spin-adapted spatial path.
+The two coexist under one `Wavefunction` base and are chosen by reference type.
+
+The seed for the spin-orbital equations is `~/src/socc` — a separate, fully
+spin-orbital code originally forked from PyCC. It already implements spin-orbital
+CCSD, CCSD(T), CC3, Lambda, one-particle density, and response (polarizability,
+optical rotation) and handles RHF/UHF/ROHF through one Hamiltonian. We graft its
+equation kernels in; we do **not** rewrite PyCC around them.
+
+## Decisions (locked, June 2026)
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Architecture | **Dispatch on reference** | Keep the spatial spin-adapted RHF path as the default for closed shells; add a parallel spin-orbital path under the shared base. Two equation kernels, one base. |
+| v1 scope | **Energies first** | MP2 + CCSD + CCSD(T)/CC3 energies. Lambda/density/response deferred to a later phase. |
+| Priority reference | **UHF** | UHF is the validation driver. ROHF rides along where correct but is not on the v1 test hook. |
+
+### Why not a flag, and why not a full unification
+
+PyCC's entire correlation layer is written against the closed-shell spin-adapted
+tensor
+
+```
+L = 2·<pq|rs> − <pq|sr>          # pycc/hamiltonian.py:44
+```
+
+`L` exists only for a closed-shell RHF reference (doubly-occupied spatial
+orbitals). There is no `L` for UHF/ROHF; the natural object is the antisymmetrized
+`<pq||rs>` over spin orbitals, and every residual, intermediate, and energy
+expression collapses to the simpler, un-spin-adapted form. So the spin-orbital
+capability is a **second formulation**, not a flag — it shares scaffolding with the
+spatial path but not equation code.
+
+We rejected unifying everything on spin orbitals (RHF as the α=β special case): it
+would discard the 4–8× spin-adaptation speedup *and* the local-correlation and
+GPU paths, which all assume spatial `L`, for no correctness gain. Two kernels on one
+base is the right cost/clarity trade-off and matches PyCC's reference-implementation
+philosophy. We also rejected wholly separate `SOCCwfn`/`SOMPwfn` classes: they would
+fragment the public API and duplicate the iteration/DIIS scaffolding.
+
+## Design
+
+### Dispatch mechanism
+
+`Wavefunction.__init__` resolves an `orbital_basis` attribute:
+
+- RHF with `nalpha() == nbeta()` → `'spatial'` (today's behavior, unchanged default).
+- UHF, or RHF with an explicit `orbital_basis='spinorbital'` override → `'spinorbital'`.
+
+The base then builds one of two Hamiltonians and exposes a **uniform attribute
+surface** (`o, v, no, nv, F, ERI, eps`, plus property integrals `mu/m/p/Q`):
+
+- `Hamiltonian` (current) — spatial; additionally exposes `L`.
+- `SpinOrbitalHamiltonian` (new) — block-diagonal Fock from `Fa()`/`Fb()` transformed
+  by `Ca`/`Cb`, and antisymmetrized `ERI = <pq||rs>`; **no `L`**.
+
+`_from_shared_base` is untouched — `MPwfn`/`CCwfn` reuse whichever `H` the base built.
+
+### Equation kernels
+
+Method classes keep their public names (`CCwfn`, `MPwfn`, `CIwfn`) and select a
+kernel by `self.orbital_basis`:
+
+- `MPwfn._build_mp2` gains a one-line branch: `t2 = ERI[o,o,v,v]/Dijab`, energy
+  `¼·<ij||ab>·t2` instead of the `L` contraction.
+- `CCwfn` gains a `_residuals_spinorbital` sibling to today's `residuals()`, porting
+  `socc`'s `r_T1`/`r_T2` and the `Fae/Fmi/Fme/Wmnij/Wabef/Wmbej` intermediates.
+
+### Reconciliation points
+
+- **Frozen core.** `socc` subtracts `nfrzc()` from *both* spins; PyCC's base already
+  slices a frozen core. Reconcile into the base so both kernels agree on the active
+  space.
+- **Non-diagonal Fock.** `socc` builds denominators from `np.diag(F)` but keeps the
+  full `F[v,v]`/`F[o,o]` in `Fae`/`Fmi` — i.e. it does **not** assume a diagonal Fock,
+  exactly PyCC's existing discipline. This is what makes ROHF / non-canonical /
+  semicanonical orbitals correct without special-casing.
+- **Integral build performance.** `socc/hamiltonian.py` assembles `<pq||rs>` with
+  `O(nact⁴)` Python loops over spin-orbital quadruples (2× dimension, no
+  permutational symmetry). Acceptable as a reference at small basis, but the port
+  should be **vectorized** with spin masks before landing.
+
+### Explicitly out of scope for v1
+
+Lambda, density, response, EOM, real-time, local correlation (PNO/PAO), GPU/precision,
+and the CPHF/derivative/HF-property stack stay **spatial-RHF-only**. The spin-orbital
+path must raise a clear error if asked for any of them — never silently return a wrong
+number. ROHF gets a seam and a guard, not half-tested support.
+
+## Validation ladder
+
+The keystone is step 1: it isolates and proves the Hamiltonian fork before any
+open-shell physics is introduced.
+
+1. **SO-RHF == spatial-RHF.** Force `orbital_basis='spinorbital'` on a closed shell;
+   MP2 and CCSD energies must match the spatial path to ~1e-12.
+2. **UHF MP2** vs Psi4 UHF-MP2.
+3. **UHF CCSD** vs Psi4 UHF-CCSD — a doublet (e.g. `OH·`, `CH₃·`) or triplet
+   (`O₂`/`NO`), STO-3G then cc-pVDZ.
+4. **UHF CCSD(T)/CC3** vs Psi4.
+
+## Phasing (one branch per item, PRs merged in the browser)
+
+| # | Branch | Content | Risk |
+|---|---|---|---|
+| 1 | `feature/spinorbital-hamiltonian` | base dispatch + `SpinOrbitalHamiltonian` (vectorized) + keystone SO-RHF==RHF test | **carries essentially all the architectural risk** |
+| 2 | `feature/spinorbital-mp2` | `MPwfn` SO branch + UHF-MP2 test | low |
+| 3 | `feature/spinorbital-ccsd` | `CCwfn` SO CCSD kernel + UHF-CCSD test | medium |
+| 4 | `feature/spinorbital-pt` | CCSD(T)/CC3 SO kernels + tests | low (transcription) |
+
+Step 1 is the real work and the real risk. Steps 2–4 are largely transcription from
+`socc` plus PyCC-style validation.
+
+## Status / progress
+
+_Last updated 2026-06-17._
+
+| Phase | Status | Landed |
+|---|---|---|
+| Design / this document | ✅ done | — |
+| 1 — SO Hamiltonian + dispatch | 🟡 in review | branch `feature/spinorbital-hamiltonian` |
+| 2 — SO MP2 | ⬜ not started | — |
+| 3 — SO CCSD | ⬜ not started | — |
+| 4 — SO CCSD(T)/CC3 | ⬜ not started | — |
+
+### Phase 1 — what landed
+
+- `SpinOrbitalHamiltonian` (`pycc/hamiltonian.py`): block-diagonal Fock from
+  `Fa_subset("AO")`/`Fb_subset("AO")` and antisymmetrized `ERI = <pq||rs>`, built by
+  **vectorized spin-masked assignment** (no `O(nact⁴)` Python loops): assemble the
+  chemist `(pr|qs)` on the four spin-conserving blocks via `np.ix_`, swap to
+  physicist `<pq|rs>`, antisymmetrize. Property integrals (`mu/m/p/Q`) built for
+  parity; no `L`.
+- `Wavefunction` base: `orbital_basis` kwarg + `_resolve_orbital_basis` (auto:
+  closed-shell RHF → spatial, else spin-orbital; override allowed). The spatial setup
+  moved into `_init_spatial`; new `_init_spinorbital` builds spin-orbital spaces on the
+  ACTIVE subset (ordered α-occ, β-occ, α-vir, β-vir). `L` seeding guarded to the
+  spatial path.
+- `uhf_wfn` fixture (`conftest.py`) and `test_052_spinorbital_hamiltonian.py`:
+  **keystone** SO-RHF MP2 == spatial MP2 == Psi4 RMP2 (all-electron + frozen-core,
+  ~1e-12); auto-dispatch check; UHF SO-MP2 == Psi4 UMP2 (~1e-9). Full suite green
+  (66 passed, no regressions).
+
+**To resume:** read this doc + `git log`. The spin-orbital equation seed lives in
+`~/src/socc` (machine-local, not part of this repo); see `socc/hamiltonian.py` for the
+Fock/ERI build and `socc/ccwfn.py` for the residual kernels.

--- a/pycc/hamiltonian.py
+++ b/pycc/hamiltonian.py
@@ -80,3 +80,106 @@ class Hamiltonian(object):
                 Q_ao = np.asarray(Q_ints[ij])
                 self.Q.append(npCp.T @ Q_ao @ npCr)
                 ij += 1
+
+
+class SpinOrbitalHamiltonian(object):
+    """A molecular spin-orbital Hamiltonian object.
+
+    The spin-orbital sibling of :class:`Hamiltonian`, used for open-shell
+    (UHF/ROHF) references. It exposes the same attribute surface (``F``, ``ERI``,
+    and the property integrals ``mu``/``m``/``p``/``Q``) so the correlation code
+    can read either Hamiltonian uniformly -- with one deliberate difference: the
+    spin-adapted ``L`` does not exist in spin orbitals, so there is no ``L``
+    attribute. The natural object is the antisymmetrized ``ERI = <pq||rs>``.
+
+    Spin orbitals are ordered ``[alpha-occ, beta-occ, alpha-vir, beta-vir]``; the
+    caller supplies the per-spin-orbital ``spin`` (0=alpha, 1=beta) and ``spat``
+    (index into that spin's spatial active space) maps. Everything is built by
+    spin-masked assignment from the spatial MO integrals -- no Python loops over
+    orbital quadruples.
+
+    Attributes
+    ----------
+    F : NumPy array
+        spin-orbital Fock matrix, block-diagonal in spin (can be non-diagonal
+        within a spin block, e.g. ROHF/semicanonical -- not assumed diagonal)
+    ERI : NumPy array
+        antisymmetrized spin-orbital ERIs in Dirac notation: <pq||rs>
+    mu, m, p, Q : list of NumPy array
+        spin-orbital property integrals (electric dipole, magnetic dipole, linear
+        momentum, traceless quadrupole), block-diagonal in spin. Built for parity
+        with :class:`Hamiltonian`; used by later (deferred) response work, not by
+        the energy.
+    """
+    def __init__(self, ref: Any, Ca: Any, Cb: Any, spin: Any, spat: Any) -> None:
+        npCa = np.asarray(Ca)
+        npCb = np.asarray(Cb)
+        nact = spin.shape[0]
+
+        # Spin-orbital indices grouped by spin, and their spatial indices. ix_ on
+        # these reproduces the spin-block structure without explicit loops.
+        a = np.where(spin == 0)[0]   # spin orbitals that are alpha
+        b = np.where(spin == 1)[0]   # spin orbitals that are beta
+        sa = spat[a]                 # their spatial indices (alpha active space)
+        sb = spat[b]                 # (beta active space)
+
+        # Fock matrix: alpha/beta MO Fock placed on the matching spin blocks; the
+        # alpha-beta blocks vanish. The AO-basis Fock ("AO" subset) is symmetry-
+        # collapsed to a single irrep, so it transforms cleanly even when the
+        # reference carries point-group symmetry.
+        Fa_ao = np.asarray(ref.Fa_subset("AO"))
+        Fb_ao = np.asarray(ref.Fb_subset("AO"))
+        Fa = npCa.T @ Fa_ao @ npCa
+        Fb = npCb.T @ Fb_ao @ npCb
+        F = np.zeros((nact, nact))
+        F[np.ix_(a, a)] = Fa[np.ix_(sa, sa)]
+        F[np.ix_(b, b)] = Fb[np.ix_(sb, sb)]
+        self.F = F
+
+        # Antisymmetrized two-electron integrals <pq||rs>. Build the chemist-notation
+        # spin-orbital integral (pr|qs) first -- nonzero only when spin_p==spin_r and
+        # spin_q==spin_s, i.e. on the four spin-conserving blocks -- then convert to
+        # physicist <pq|rs> (swap the middle indices) and antisymmetrize.
+        mints = psi4.core.MintsHelper(ref.basisset())
+        ERI_AA = np.asarray(mints.mo_eri(Ca, Ca, Ca, Ca))  # (pr|qs), alpha electrons
+        ERI_BB = np.asarray(mints.mo_eri(Cb, Cb, Cb, Cb))  # (pr|qs), beta electrons
+        ERI_AB = np.asarray(mints.mo_eri(Ca, Ca, Cb, Cb))  # (aa|bb)
+        ERI_BA = ERI_AB.transpose(2, 3, 0, 1)              # (bb|aa)
+
+        chem = np.zeros((nact, nact, nact, nact))
+        chem[np.ix_(a, a, a, a)] = ERI_AA[np.ix_(sa, sa, sa, sa)]
+        chem[np.ix_(b, b, b, b)] = ERI_BB[np.ix_(sb, sb, sb, sb)]
+        chem[np.ix_(a, a, b, b)] = ERI_AB[np.ix_(sa, sa, sb, sb)]
+        chem[np.ix_(b, b, a, a)] = ERI_BA[np.ix_(sb, sb, sa, sa)]
+
+        phys = chem.swapaxes(1, 2)                  # (pr|qs) -> <pq|rs>
+        self.ERI = phys - phys.swapaxes(2, 3)       # <pq|rs> - <pq|sr> = <pq||rs>
+
+        self.mol = ref.molecule()
+        self.basisset = ref.basisset()
+
+        ## One-electron property integrals (block-diagonal in spin)
+
+        def _spin_block(O_ao):
+            Oa = npCa.T @ O_ao @ npCa
+            Ob = npCb.T @ O_ao @ npCb
+            O = np.zeros((nact, nact))
+            O[np.ix_(a, a)] = Oa[np.ix_(sa, sa)]
+            O[np.ix_(b, b)] = Ob[np.ix_(sb, sb)]
+            return O
+
+        # Electric dipole (length): -e r
+        dipole_ints = mints.ao_dipole()
+        self.mu = [_spin_block(np.asarray(dipole_ints[axis])) for axis in range(3)]
+
+        # Magnetic dipole: -(e/2 m_e) L  (imaginary, matching Hamiltonian's convention)
+        m_ints = mints.ao_angular_momentum()
+        self.m = [_spin_block(np.asarray(m_ints[axis]) * -0.5) * 1.0j for axis in range(3)]
+
+        # Linear momentum: (-e)(-i hbar) Del
+        p_ints = mints.ao_nabla()
+        self.p = [_spin_block(np.asarray(p_ints[axis])) * 1.0j for axis in range(3)]
+
+        # Traceless quadrupole (6 unique Cartesian components)
+        Q_ints = mints.ao_traceless_quadrupole()
+        self.Q = [_spin_block(np.asarray(Q_ints[ij])) for ij in range(6)]

--- a/pycc/tests/conftest.py
+++ b/pycc/tests/conftest.py
@@ -94,6 +94,24 @@ def rhf_wfn(psi4_environment):
 
 
 @pytest.fixture
+def uhf_wfn(psi4_environment):
+    """Factory fixture that builds a UHF reference wavefunction.
+
+    Same interface as :func:`rhf_wfn`, but sets ``reference = 'uhf'`` so open-shell
+    species (radicals, etc.) can be used to exercise the spin-orbital path. The
+    geometry should carry its own charge/multiplicity line (e.g. ``"0 2\\n..."``).
+    """
+    def _build(molecule, basis="cc-pVDZ", geom_extra="", **options):
+        opts = {**DEFAULT_SCF_OPTIONS, 'basis': basis, 'reference': 'uhf', **options}
+        psi4.set_options(opts)
+        geometry = moldict.get(molecule, molecule)  # moldict key, else literal geometry
+        psi4.geometry(geometry + geom_extra)
+        _, wfn = psi4.energy('SCF', return_wfn=True)
+        return wfn
+    return _build
+
+
+@pytest.fixture
 def datadir(tmpdir, request):
     '''
     from: https://stackoverflow.com/a/29631801

--- a/pycc/tests/test_052_spinorbital_hamiltonian.py
+++ b/pycc/tests/test_052_spinorbital_hamiltonian.py
@@ -1,0 +1,94 @@
+"""
+Step 1 of the spin-orbital enhancement (docs/ENHANCEMENT_PLAN_2026-06.md): the
+SpinOrbitalHamiltonian plus the Wavefunction base's orbital_basis dispatch.
+
+Keystone: forcing the spin-orbital path on a closed-shell RHF reference must
+reproduce the spin-adapted spatial MP2 energy (and Psi4's conventional MP2) to
+machine precision. That isolates and validates the Hamiltonian fork -- block Fock,
+antisymmetrized <pq||rs>, active-space counts -- before any open-shell physics. A
+UHF check then confirms the open-shell Hamiltonian against Psi4's UMP2.
+
+MP2 is computed inline here (t2 = <ij||ab>/D, E = 1/4 <ij||ab> t2) rather than via
+MPwfn: the MPwfn spin-orbital branch is step 2. This keeps step 1 a pure test of the
+base + Hamiltonian.
+"""
+
+import numpy as np
+import psi4
+
+import pycc
+from pycc.wavefunction import Wavefunction
+
+# Open-shell doublet for the UHF check (hydroxyl radical).
+OH = """
+0 2
+O  0.000000  0.000000  0.000000
+H  0.000000  0.000000  0.969000
+symmetry c1
+"""
+
+
+def _so_mp2(wfn):
+    """Spin-orbital MP2 correlation energy from a base built on the spin-orbital
+    Hamiltonian: t2 = <ij||ab> / D_ijab, E = 1/4 <ij||ab> t2_ijab."""
+    o, v = wfn.o, wfn.v
+    eps = np.diag(np.asarray(wfn.H.F))
+    eo, ev = eps[o], eps[v]
+    D = (eo.reshape(-1, 1, 1, 1) + eo.reshape(-1, 1, 1)
+         - ev.reshape(-1, 1) - ev)
+    oovv = np.asarray(wfn.H.ERI)[o, o, v, v]
+    t2 = oovv / D
+    return 0.25 * np.einsum('ijab,ijab->', oovv, t2)
+
+
+def test_so_equals_spatial_rhf(rhf_wfn):
+    """All-electron: spin-orbital MP2 (forced) == spatial MP2 == Psi4 RMP2."""
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+
+    e_spatial = pycc.MPwfn(wfn).compute_energy()
+    so = Wavefunction(wfn, orbital_basis="spinorbital", frozen_core=False)
+    assert so.orbital_basis == "spinorbital"
+    e_so = _so_mp2(so)
+
+    assert abs(e_so - e_spatial) < 1e-12
+
+    psi4.energy('mp2')
+    ref = psi4.variable('MP2 CORRELATION ENERGY')
+    assert abs(e_so - ref) < 1e-10
+
+
+def test_so_equals_spatial_rhf_frozen_core(rhf_wfn):
+    """Frozen-core: same equivalence, exercising the active-space counts."""
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="true",
+                  e_convergence=1e-12, d_convergence=1e-12)
+
+    e_spatial = pycc.MPwfn(wfn).compute_energy()
+    so = Wavefunction(wfn, orbital_basis="spinorbital", frozen_core=True)
+    e_so = _so_mp2(so)
+
+    assert abs(e_so - e_spatial) < 1e-12
+
+    psi4.energy('mp2')
+    ref = psi4.variable('MP2 CORRELATION ENERGY')
+    assert abs(e_so - ref) < 1e-10
+
+
+def test_auto_dispatch_rhf_is_spatial(rhf_wfn):
+    """A closed-shell RHF reference auto-selects the spatial path."""
+    wfn = rhf_wfn("H2O", "cc-pVDZ")
+    assert pycc.MPwfn(wfn).orbital_basis == "spatial"
+
+
+def test_uhf_so_mp2(uhf_wfn):
+    """Open-shell UHF auto-selects the spin-orbital path; SO-MP2 == Psi4 UMP2."""
+    wfn = uhf_wfn(OH, "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+
+    so = Wavefunction(wfn, frozen_core=False)  # auto -> spinorbital
+    assert so.orbital_basis == "spinorbital"
+    e_so = _so_mp2(so)
+
+    psi4.energy('mp2')
+    ref = psi4.variable('MP2 CORRELATION ENERGY')
+    assert abs(e_so - ref) < 1e-9

--- a/pycc/wavefunction.py
+++ b/pycc/wavefunction.py
@@ -21,7 +21,7 @@ from typing import Any
 import psi4
 import numpy as np
 
-from .hamiltonian import Hamiltonian
+from .hamiltonian import Hamiltonian, SpinOrbitalHamiltonian
 from .device import DeviceManager
 from .derivatives import Derivatives
 from .exceptions import InvalidKeywordError, PyCCError
@@ -36,19 +36,33 @@ class Wavefunction(object):
         the reference wave function (from Psi4's energy() method)
     eref : float
         reference energy (including nuclear repulsion)
+    orbital_basis : str
+        ``'spatial'`` (spin-adapted, closed-shell RHF) or ``'spinorbital'``
+        (UHF/ROHF). Resolved from the reference (or an explicit override) and read
+        by the method subclasses to select their spatial vs spin-orbital kernels.
+        See :meth:`_init_spatial` / :meth:`_init_spinorbital` for what each path
+        builds.
     nfzc, no, nv, nmo, nact : int
-        frozen-core / active-occupied / active-virtual / total-MO / active counts
+        frozen-core / active-occupied / active-virtual / total-MO / active counts.
+        In the spin-orbital path these are spin-orbital counts (``nmo`` is twice the
+        number of spatial MOs, etc.).
     o, v : slice
-        active occupied and virtual subspaces, as offsets into the full MO space:
-        ``o = slice(nfzc, nfzc+no)`` skips the frozen core and ``v`` is the
-        virtuals. With no frozen core (``nfzc == 0``) ``o`` starts at 0 as usual.
+        active occupied and virtual subspaces. Spatial path: offsets into the full
+        MO space, ``o = slice(nfzc, nfzc+no)`` (skips the frozen core), ``v`` the
+        virtuals. Spin-orbital path: contiguous slices into the active space,
+        ``o = slice(0, no)`` and ``v = slice(no, nact)`` (the frozen core is already
+        excluded via the ACTIVE orbital subset).
     C : Psi4 Matrix
-        full-space MO coefficients (all ``nmo`` columns, global energy order; the
-        frozen core occupies columns ``[0:nfzc]``). The active occupied block is
-        localized in place if ``localize_occ``.
-    H : Hamiltonian
-        full-MO-basis Fock (F), ERIs, spin-adapted ERIs (L), and property integrals,
-        device/precision-seeded
+        (spatial path) full-space MO coefficients (all ``nmo`` columns, global
+        energy order; the frozen core occupies columns ``[0:nfzc]``). The active
+        occupied block is localized in place if ``localize_occ``.
+    Ca, Cb : Psi4 Matrix
+        (spin-orbital path) active alpha/beta MO coefficients.
+    H : Hamiltonian or SpinOrbitalHamiltonian
+        full-MO-basis Fock (F), ERIs, and property integrals, device/precision-seeded.
+        The spatial ``Hamiltonian`` additionally carries the spin-adapted ERIs (L);
+        the ``SpinOrbitalHamiltonian`` has none (its ERI is the antisymmetrized
+        <pq||rs>).
     derivatives : Derivatives
         lazy MO-basis derivative-integral provider (built on first access). Depends
         only on base state (basis set, molecule, ``C``), so derivative property code in
@@ -77,15 +91,22 @@ class Wavefunction(object):
         ``localize_occ`` is True.
     frozen_core : bool
         whether to honor the reference's frozen core (default True, for correlated
-        methods). The Hamiltonian is ALWAYS built over the full MO space; this flag
-        only sets ``nfzc`` -- i.e. how far the active occupied slice ``o`` is offset
-        past the core. False means no core (``nfzc = 0``); HFwfn passes this, since
-        HF properties are all-electron.
+        methods). In the spatial path the Hamiltonian is built over the full MO
+        space and this flag only sets ``nfzc`` -- how far the active occupied slice
+        ``o`` is offset past the core; in the spin-orbital path it selects the
+        ACTIVE (core-excluded) vs ALL orbital subset. False means no core
+        (``nfzc = 0``); HFwfn passes this, since HF properties are all-electron.
+    orbital_basis : str or None
+        force the orbital basis: ``'spatial'`` or ``'spinorbital'``. Default None
+        auto-selects from the reference -- closed-shell RHF uses the spin-adapted
+        spatial path; any open-shell (UHF/ROHF) reference uses spin orbitals.
+        Passing ``'spinorbital'`` on a closed shell is supported (and used to
+        validate the spin-orbital path against the spatial one).
     """
 
     def __init__(self, scf_wfn: Any, *, device: str = 'CPU', precision: str = 'DP',
                  localize_occ: bool = False, local_mos: str = 'PIPEK_MEZEY',
-                 frozen_core: bool = True, **kwargs) -> None:
+                 frozen_core: bool = True, orbital_basis: Any = None, **kwargs) -> None:
         # A subclass may set its own attributes before calling super().__init__;
         # snapshot them so _base_attrs (recorded at the end) captures only what the
         # base itself adds -- which _from_shared_base then replicates.
@@ -104,12 +125,84 @@ class Wavefunction(object):
         self.ref = scf_wfn
         self.eref = self.ref.energy()
 
-        # Always build the FULL-space Hamiltonian; a frozen core is handled purely as
-        # a slice OFFSET -- the active occupied slice ``o`` starts past the core
-        # rather than at 0. ``frozen_core`` only sets how many core orbitals to skip.
-        # This gives every method one MO/integral layout: correlated codes work on
-        # the active blocks via ``o``/``v``, while all-electron properties (HFwfn)
-        # pass frozen_core=False so the slices span the whole space.
+        # Closed-shell RHF takes the spin-adapted spatial path; open-shell
+        # (UHF/ROHF) takes the spin-orbital path. An explicit orbital_basis overrides
+        # the auto-choice (e.g. forcing 'spinorbital' on a closed shell to validate
+        # the spin-orbital code against the spatial one).
+        self.orbital_basis = self._resolve_orbital_basis(orbital_basis)
+
+        if self.orbital_basis == 'spatial':
+            self._init_spatial(localize_occ, frozen_core)
+        else:
+            if localize_occ:
+                raise PyCCError("Local correlation (localize_occ) is not supported "
+                                "in the spin-orbital path.")
+            self._init_spinorbital(frozen_core)
+
+        # Device / precision policy: validates the kwargs (fallback warnings for
+        # GPU-without-torch / GPU-without-CUDA), resolves device0/device1, and
+        # builds the contraction backend.
+        self.device_manager = DeviceManager(device=device, precision=precision)
+        mgr = self.device_manager
+        self.precision = mgr.precision
+        self.device = mgr.device
+        self.device0 = mgr.device0
+        self.device1 = mgr.device1
+        self.contract = mgr.contract
+
+        # Seed the integrals: F is compute-resident (device1); the big ERI/L stay
+        # CPU-resident (device0). On CPU+DP these are no-ops; on CPU+SP they
+        # real-cast to float32; on GPU they become real torch tensors at the
+        # matching width. The spin-adapted L exists only in the spatial path.
+        self.H.F = mgr.seed_compute(self.H.F)
+        self.H.ERI = mgr.seed_store(self.H.ERI)
+        if self.orbital_basis == 'spatial':
+            self.H.L = mgr.seed_store(self.H.L)
+
+        # Derivative-integral provider: built lazily on first access (see the
+        # ``derivatives`` property), so methods that never take derivatives pay
+        # nothing. Recorded here as part of the base so _from_shared_base carries it.
+        self._derivatives = None
+
+        # The base is the final consumer of forwarded kwargs (each subclass pops
+        # its own and passes the remainder through), so anything left over is an
+        # unrecognized keyword -- flag it instead of silently ignoring it.
+        if kwargs:
+            raise PyCCError("Unexpected keyword argument(s): %s" % sorted(kwargs))
+
+        # Record exactly which attributes the base set (excluding anything the
+        # subclass set first), so _from_shared_base can replicate this base onto a
+        # new instance without re-running __init__ (and re-transforming integrals).
+        self._base_attrs = tuple(k for k in vars(self) if k not in _preexisting)
+
+    def _resolve_orbital_basis(self, orbital_basis: Any) -> str:
+        """Resolve the orbital basis from an explicit override or the reference.
+
+        Auto-choice (override is None): a closed-shell RHF reference -- identical
+        alpha/beta orbitals and densities -- uses the spin-adapted spatial path;
+        any open-shell reference (UHF, ROHF) uses spin orbitals. Spin orbitals are
+        always correct; spatial is the closed-shell optimization.
+        """
+        valid = ['spatial', 'spinorbital']
+        if orbital_basis is None:
+            closed_shell = (self.ref.same_a_b_orbs() and self.ref.same_a_b_dens())
+            return 'spatial' if closed_shell else 'spinorbital'
+        ob = str(orbital_basis).lower()
+        if ob not in valid:
+            raise InvalidKeywordError('orbital_basis', orbital_basis, valid)
+        return ob
+
+    def _init_spatial(self, localize_occ: bool, frozen_core: bool) -> None:
+        """Build the spatial (spin-adapted, closed-shell RHF) orbital spaces,
+        coefficients, and Hamiltonian.
+
+        Always builds the FULL-space Hamiltonian; a frozen core is handled purely as
+        a slice OFFSET -- the active occupied slice ``o`` starts past the core rather
+        than at 0. ``frozen_core`` only sets how many core orbitals to skip. This
+        gives every method one MO/integral layout: correlated codes work on the
+        active blocks via ``o``/``v``, while all-electron properties (HFwfn) pass
+        frozen_core=False so the slices span the whole space.
+        """
         self.nfzc = int(sum(self.ref.frzcpi())) if frozen_core else 0
         self.no   = int(sum(self.ref.doccpi())) - self.nfzc
         self.nmo  = self.ref.nmo()
@@ -165,40 +258,52 @@ class Wavefunction(object):
         # MO-basis integrals (built once from the final C).
         self.H = Hamiltonian(self.ref, self.C, self.C, self.C, self.C)
 
-        # Device / precision policy: validates the kwargs (fallback warnings for
-        # GPU-without-torch / GPU-without-CUDA), resolves device0/device1, and
-        # builds the contraction backend.
-        self.device_manager = DeviceManager(device=device, precision=precision)
-        mgr = self.device_manager
-        self.precision = mgr.precision
-        self.device = mgr.device
-        self.device0 = mgr.device0
-        self.device1 = mgr.device1
-        self.contract = mgr.contract
+    def _init_spinorbital(self, frozen_core: bool) -> None:
+        """Build the spin-orbital (UHF/ROHF) orbital spaces, coefficients, and
+        Hamiltonian.
 
-        # Seed the integrals: F is compute-resident (device1); the big ERI/L stay
-        # CPU-resident (device0). On CPU+DP these are no-ops; on CPU+SP they
-        # real-cast to float32; on GPU they become real torch tensors at the
-        # matching width.
-        self.H.F = mgr.seed_compute(self.H.F)
-        self.H.ERI = mgr.seed_store(self.H.ERI)
-        self.H.L = mgr.seed_store(self.H.L)
+        Works on the ACTIVE orbital subset (frozen core already excluded), so the
+        active occupied/virtual slices are contiguous and 0-based. Spin orbitals are
+        ordered ``[alpha-occ, beta-occ, alpha-vir, beta-vir]``; the per-spin-orbital
+        ``spin`` (0=alpha, 1=beta) and ``spat`` (index into that spin's spatial
+        active space) maps drive the integral build.
+        """
+        ref = self.ref
+        self.nfzc = ref.nfrzc() if frozen_core else 0
+        nao = ref.nalpha() - self.nfzc       # active alpha occupied
+        nbo = ref.nbeta() - self.nfzc        # active beta occupied
+        nav = ref.nmo() - ref.nalpha()       # active alpha virtual
+        nbv = ref.nmo() - ref.nbeta()        # active beta virtual
+        self.no   = nao + nbo
+        self.nv   = nav + nbv
+        self.nmo  = 2 * ref.nmo()
+        self.nact = self.no + self.nv
 
-        # Derivative-integral provider: built lazily on first access (see the
-        # ``derivatives`` property), so methods that never take derivatives pay
-        # nothing. Recorded here as part of the base so _from_shared_base carries it.
-        self._derivatives = None
+        print("NMO = %d; NACT = %d; NO = %d; NV = %d" % (self.nmo, self.nact, self.no, self.nv))
 
-        # The base is the final consumer of forwarded kwargs (each subclass pops
-        # its own and passes the remainder through), so anything left over is an
-        # unrecognized keyword -- flag it instead of silently ignoring it.
-        if kwargs:
-            raise PyCCError("Unexpected keyword argument(s): %s" % sorted(kwargs))
+        self.o = slice(0, self.no)
+        self.v = slice(self.no, self.nact)
 
-        # Record exactly which attributes the base set (excluding anything the
-        # subclass set first), so _from_shared_base can replicate this base onto a
-        # new instance without re-running __init__ (and re-transforming integrals).
-        self._base_attrs = tuple(k for k in vars(self) if k not in _preexisting)
+        # Spin-orbital subspaces (ordered alpha-occ, beta-occ, alpha-vir, beta-vir)
+        # and the spin / spatial-index maps the Hamiltonian build needs.
+        ao = slice(0, nao)
+        bo = slice(nao, self.no)
+        av = slice(self.no, self.no + nav)
+        bv = slice(self.no + nav, self.nact)
+        spin = np.zeros(self.nact, dtype=int)
+        spin[bo] = 1
+        spin[bv] = 1
+        spat = np.zeros(self.nact, dtype=int)
+        spat[ao] = np.arange(nao)
+        spat[bo] = np.arange(nbo)
+        spat[av] = np.arange(nao, nao + nav)
+        spat[bv] = np.arange(nbo, nbo + nbv)
+        self.spin = spin
+        self.spat = spat
+
+        self.Ca = ref.Ca_subset("AO", "ACTIVE")
+        self.Cb = ref.Cb_subset("AO", "ACTIVE")
+        self.H = SpinOrbitalHamiltonian(ref, self.Ca, self.Cb, spin, spat)
 
     @property
     def derivatives(self) -> Derivatives:


### PR DESCRIPTION
⏺ ## Spin-orbital Hamiltonian + `orbital_basis` dispatch (UHF/ROHF — step 1)
  
  First step of a new effort (`docs/ENHANCEMENT_PLAN_2026-06.md`): a parallel
  **spin-orbital** correlation path so PyCC can treat **open-shell UHF/ROHF**
  references, coexisting with the existing spin-adapted spatial RHF path under the
  shared `Wavefunction` base. The equation seed is the separate spin-orbital code in
  `~/src/socc`; this step lands the integral/dispatch foundation only.

  This is **not a flag on the existing code.** PyCC's whole correlation layer rides on
  the closed-shell spin-adapted tensor `L = 2·<pq|rs> − <pq|sr>`, which exists only for
  RHF. Spin orbitals are a second formulation whose natural object is the
  antisymmetrized `<pq||rs>` (no `L`). The two share the base scaffolding but not
  equation code — hence dispatch-on-reference rather than a rewrite.

  ### What's in this PR

  - **`SpinOrbitalHamiltonian`** (`pycc/hamiltonian.py`) — the spin-orbital sibling of
    `Hamiltonian`:
    - Block-diagonal Fock from `Fa_subset("AO")`/`Fb_subset("AO")` (the AO subset is
      symmetry-collapsed, so it transforms cleanly under point-group symmetry — plain
      `ref.Fa()` errors there).
    - Antisymmetrized `ERI = <pq||rs>` built by **vectorized spin-masked assignment**
      (no `O(nact⁴)` Python loops): assemble the chemist `(pr|qs)` on the four
      spin-conserving blocks via `np.ix_`, swap to physicist `<pq|rs>`, antisymmetrize.
    - Property integrals (`mu`/`m`/`p`/`Q`) built for attribute parity; **no `L`**.

  - **`Wavefunction` base** (`pycc/wavefunction.py`):
    - `orbital_basis` kwarg + `_resolve_orbital_basis` — auto-selects from the reference
      (closed-shell RHF → `spatial`; any open shell → `spinorbital`), with an explicit
      override (used to force the spin-orbital path on a closed shell for validation).
    - Spatial setup factored into `_init_spatial`; new `_init_spinorbital` builds the
      spin-orbital spaces on the **ACTIVE** subset (ordered α-occ, β-occ, α-vir, β-vir),
      with the `spin`/`spat` maps the integral build needs.
    - `L` seeding guarded to the spatial path.

  - **Tests** — `uhf_wfn` fixture (`conftest.py`) and
    `test_052_spinorbital_hamiltonian.py`.

  ### Keystone validation

  Forcing the spin-orbital path on a closed shell must reproduce the spatial result —
  this isolates the Hamiltonian fork before any open-shell physics:

  | Check | Result |
  |---|---|
  | SO-RHF MP2 == spatial MP2 == Psi4 RMP2 (all-electron) | ~1e-12 / ~1e-10 |
  | SO-RHF MP2 == spatial MP2 == Psi4 RMP2 (frozen-core) | ~1e-12 / ~1e-10 |
  | RHF reference auto-dispatches to `spatial` | ✔ |
  | UHF (·OH doublet) SO-MP2 == Psi4 UMP2 | ~1e-9 |

  MP2 is computed inline in the test (`t2 = <ij||ab>/D`, `E = ¼·<ij||ab>·t2`) rather
  than through `MPwfn` — the `MPwfn` spin-orbital branch is step 2, so this keeps step 1
  a pure test of the base + Hamiltonian.

  ### Scope
  
  Energies-only foundation. `MPwfn.compute_energy` still contracts `L`, so it does not
  yet run in spin-orbital mode (step 2). Lambda/density/response/EOM/real-time/local/
  GPU/CPHF-derivatives remain spatial-RHF-only. ROHF rides the same path where correct
  (both codes already avoid the diagonal-Fock assumption) but is not on the v1 test hook.

  ### Test status

  Full non-slow suite green: **66 passed**, 3 skipped (GPU, no local torch), 8 deselected
  (slow), 1 xfail. No regressions.
