### PR TITLE
Wire spin-orbital MP2 into MPwfn (UHF energies, step 2)

### DIFF
--- a/docs/ENHANCEMENT_PLAN_2026-06.md
+++ b/docs/ENHANCEMENT_PLAN_2026-06.md
@@ -129,8 +129,8 @@ _Last updated 2026-06-17._
 | Phase | Status | Landed |
 |---|---|---|
 | Design / this document | ✅ done | — |
-| 1 — SO Hamiltonian + dispatch | 🟡 in review | branch `feature/spinorbital-hamiltonian` |
-| 2 — SO MP2 | ⬜ not started | — |
+| 1 — SO Hamiltonian + dispatch | ✅ done | PR #133 |
+| 2 — SO MP2 | 🟡 in review | branch `feature/spinorbital-mp2` |
 | 3 — SO CCSD | ⬜ not started | — |
 | 4 — SO CCSD(T)/CC3 | ⬜ not started | — |
 
@@ -151,6 +151,17 @@ _Last updated 2026-06-17._
   **keystone** SO-RHF MP2 == spatial MP2 == Psi4 RMP2 (all-electron + frozen-core,
   ~1e-12); auto-dispatch check; UHF SO-MP2 == Psi4 UMP2 (~1e-9). Full suite green
   (66 passed, no regressions).
+
+### Phase 2 — what landed
+
+- `MPwfn` (`pycc/mpwfn.py`): `compute_energy` branches on `orbital_basis` --
+  spatial `E = t2_ijab L_ijab`, spin-orbital `E = 1/4 <ij||ab> t2_ijab`. `_build_mp2`
+  was already basis-agnostic (`t2 = ERI[o,o,v,v]/Dijab` and a Fock-diagonal
+  denominator hold in either basis), so `pycc.MPwfn(uhf_wfn)` now works end to end via
+  auto-dispatch.
+- `test_045_mp2.py`: added all-electron and frozen-core **UMP2** checks on the .OH
+  doublet through the real `MPwfn`, vs Psi4 conventional UMP2 (~1e-9), alongside the
+  existing RHF cases.
 
 **To resume:** read this doc + `git log`. The spin-orbital equation seed lives in
 `~/src/socc` (machine-local, not part of this repo); see `socc/hamiltonian.py` for the

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -31,7 +31,8 @@ class MPwfn(Wavefunction):
     Dijab : Tensor
         two-electron energy denominator, eps_i + eps_j - eps_a - eps_b
     t2 : Tensor
-        first-order (MP2) doubles amplitudes, <ij|ab> / Dijab
+        first-order (MP2) doubles amplitudes, ERI[o,o,v,v] / Dijab (i.e. <ij|ab>
+        spatial, or the antisymmetrized <ij||ab> in the spin-orbital path)
     emp2 : float
         the MP2 correlation energy (set by :meth:`compute_energy`)
     """
@@ -53,6 +54,10 @@ class MPwfn(Wavefunction):
         """Build the energy denominators and MP2 doubles amplitudes from the seeded
         MO integrals. The ERI oovv block is staged onto the compute device with
         clone(..., device1) so the divide lands where the amplitudes live.
+
+        Basis-agnostic: ``t2 = <ij|ab> / Dijab`` (spatial) and
+        ``t2 = <ij||ab> / Dijab`` (spin-orbital) are the same expression in the
+        respective ``H.ERI``, and the denominator from the Fock diagonal is too.
         """
         o = self.o
         v = self.v
@@ -63,8 +68,16 @@ class MPwfn(Wavefunction):
         self.t2 = clone(self.H.ERI[o, o, v, v], device=self.device1) / self.Dijab
 
     def compute_energy(self) -> "Tensor":
-        """Compute and return the MP2 correlation energy, E = t2_ijab L_ijab."""
+        """Compute and return the MP2 correlation energy.
+
+        Spatial (spin-adapted) path: ``E = t2_ijab L_ijab``. Spin-orbital path:
+        ``E = 1/4 <ij||ab> t2_ijab`` -- no ``L`` exists, and the 1/4 accounts for the
+        unrestricted sum over the antisymmetrized doubles.
+        """
         o = self.o
         v = self.v
-        self.emp2 = self.contract('ijab,ijab->', self.t2, self.H.L[o, o, v, v])
+        if self.orbital_basis == 'spatial':
+            self.emp2 = self.contract('ijab,ijab->', self.t2, self.H.L[o, o, v, v])
+        else:
+            self.emp2 = 0.25 * self.contract('ijab,ijab->', self.t2, self.H.ERI[o, o, v, v])
         return self.emp2

--- a/pycc/tests/test_045_mp2.py
+++ b/pycc/tests/test_045_mp2.py
@@ -1,11 +1,20 @@
 """
-Test the MP2 correlation energy (MPwfn) against Psi4's conventional MP2.
+Test the MP2 correlation energy (MPwfn) against Psi4's conventional MP2, for both
+the spin-adapted spatial (RHF) path and the spin-orbital (UHF) path.
 """
 
 import psi4
 import pycc
 import pytest
 from ..data.molecules import *
+
+# Open-shell doublet for the UHF (spin-orbital) MP2 checks.
+OH = """
+0 2
+O  0.000000  0.000000  0.000000
+H  0.000000  0.000000  0.969000
+symmetry c1
+"""
 
 
 def test_mp2_h2o(rhf_wfn):
@@ -31,3 +40,30 @@ def test_mp2_h2o_frzc(rhf_wfn):
     ref = psi4.variable('MP2 CORRELATION ENERGY')
 
     assert abs(emp2 - ref) < 1e-10
+
+
+def test_ump2_oh(uhf_wfn):
+    """Open-shell .OH cc-pVDZ, all-electron UMP2 via the spin-orbital MPwfn path."""
+    wfn = uhf_wfn(OH, "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    mp = pycc.MPwfn(wfn)
+    assert mp.orbital_basis == "spinorbital"
+    emp2 = mp.compute_energy()
+
+    psi4.energy('mp2')
+    ref = psi4.variable('MP2 CORRELATION ENERGY')
+
+    assert abs(emp2 - ref) < 1e-9
+
+
+def test_ump2_oh_frzc(uhf_wfn):
+    """Open-shell .OH cc-pVDZ, frozen-core UMP2 (exercises the spin-orbital active
+    space) via the spin-orbital MPwfn path."""
+    wfn = uhf_wfn(OH, "cc-pVDZ", freeze_core="true",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    emp2 = pycc.MPwfn(wfn).compute_energy()
+
+    psi4.energy('mp2')
+    ref = psi4.variable('MP2 CORRELATION ENERGY')
+
+    assert abs(emp2 - ref) < 1e-9


### PR DESCRIPTION
⏺ ## Wire spin-orbital MP2 into MPwfn (UHF energies — step 2)
  
  Step 2 of the spin-orbital enhancement (`docs/ENHANCEMENT_PLAN_2026-06.md`),
  building on the `orbital_basis` dispatch and `SpinOrbitalHamiltonian` from step 1
  (PR #133). This makes `MPwfn` run end to end on a **UHF** reference, so
  `pycc.MPwfn(uhf_wfn).compute_energy()` returns the UMP2 correlation energy.

  ### What's in this PR

  - **`pycc/mpwfn.py`** — `compute_energy` branches on `orbital_basis`:
    - spatial (spin-adapted): `E = t2_ijab L_ijab`
    - spin-orbital: `E = ¼ <ij||ab> t2_ijab` — no spin-adapted `L` exists, and the
      `¼` accounts for the unrestricted sum over the antisymmetrized doubles.

    `_build_mp2` needed **no change**: `t2 = ERI[o,o,v,v] / Dijab` and the
    Fock-diagonal denominator are the same expression in either basis (the `ERI`
    is `<ij|ab>` spatial vs the antisymmetrized `<ij||ab>` spin-orbital). So the
    doubles/denominators that `CCwfn`/`CIwfn` compose off `MPwfn` are unaffected.

  - **`pycc/tests/test_045_mp2.py`** — added all-electron and frozen-core **UMP2**
    checks on the ·OH doublet, run through the real `MPwfn` (auto-dispatched to the
    spin-orbital path) and compared to Psi4's conventional UMP2, alongside the
    existing RHF cases.

  - **`docs/ENHANCEMENT_PLAN_2026-06.md`** — phase 1 → ✅ done (PR #133), phase 2 →
    in review, with phase-2 notes.

  ### Validation

  | Check | Result |
  |---|---|
  | RHF MP2 (all-electron / frozen-core) vs Psi4 RMP2 | ~1e-10 (unchanged) |
  | `MPwfn(·OH)` auto-dispatches to `spinorbital` | ✔ |
  | UHF MP2 (all-electron) vs Psi4 UMP2 | ~1e-9 |
  | UHF MP2 (frozen-core) vs Psi4 UMP2 | ~1e-9 |

  ### Scope

  Energies only. `CCwfn`/`CIwfn`/Lambda/density/response/EOM/RT/local/GPU remain
  spatial-RHF-only; the spin-orbital CCSD kernel is step 3.

  ### Test status

  Full non-slow suite green: **68 passed** (the +2 new UMP2 tests), 3 skipped (GPU,
  no local torch), 8 deselected (slow), 1 xfail. No regressions.
