### PR TITLE
Add spin-orbital CCSD(T) driver (UHF energies, step 4a)

### DIFF
--- a/docs/ENHANCEMENT_PLAN_2026-06.md
+++ b/docs/ENHANCEMENT_PLAN_2026-06.md
@@ -117,10 +117,12 @@ open-shell physics is introduced.
 | 1 | `feature/spinorbital-hamiltonian` | base dispatch + `SpinOrbitalHamiltonian` (vectorized) + keystone SO-RHF==RHF test | **carries essentially all the architectural risk** |
 | 2 | `feature/spinorbital-mp2` | `MPwfn` SO branch + UHF-MP2 test | low |
 | 3 | `feature/spinorbital-ccsd` | `CCwfn` SO CCSD kernel + UHF-CCSD test | medium |
-| 4 | `feature/spinorbital-pt` | CCSD(T)/CC3 SO kernels + tests | low (transcription) |
+| 4a | `feature/spinorbital-pt-ccsdt` | CCSD(T) SO driver (viking) + UHF-CCSD(T) test | low (transcription) |
+| 4b | `feature/spinorbital-cc3` | CC3 SO kernel (iterative triples) + UHF-CC3 test | medium (triples module) |
 
 Step 1 is the real work and the real risk. Steps 2–4 are largely transcription from
-`socc` plus PyCC-style validation.
+`socc` plus PyCC-style validation. Phase 4 is split: CCSD(T) (a non-iterative
+post-convergence correction) lands first; CC3 (an iterative-triples solver) follows.
 
 ## Status / progress
 
@@ -131,8 +133,9 @@ _Last updated 2026-06-17._
 | Design / this document | ✅ done | — |
 | 1 — SO Hamiltonian + dispatch | ✅ done | PR #133 |
 | 2 — SO MP2 | ✅ done | PR #134 |
-| 3 — SO CCSD | 🟡 in review | branch `feature/spinorbital-ccsd` |
-| 4 — SO CCSD(T)/CC3 | ⬜ not started | — |
+| 3 — SO CCSD | ✅ done | PR #135 |
+| 4a — SO CCSD(T) | 🟡 in review | branch `feature/spinorbital-pt-ccsdt` |
+| 4b — SO CC3 | ⬜ not started | — |
 
 ### Phase 1 — what landed
 
@@ -178,6 +181,19 @@ _Last updated 2026-06-17._
   CCSD vs Psi4 UCCSD, all-electron and frozen-core (~1e-10; measured agreement ~7e-14).
 - Folded in the carried-over step-2 cleanup: UHF/SO MP2 test tolerances tightened
   1e-9 → 1e-10.
+
+### Phase 4a — what landed
+
+- `pycc/cctriples.py`: spin-orbital (T) driver `t_vikings_so` + its T3 batch builder
+  `t3c_ijk_so`, ported from `socc` (the occupied-batched "viking" algorithm), working
+  off the antisymmetrized `ERI = <pq||rs>`. The spatial `t_tjl`/`t_vikings(_inverted)`
+  are RHF-specific and untouched.
+- `pycc/ccwfn.py`: the `solve_cc` CCSD(T) block branches to `t_vikings_so` when
+  `orbital_basis == 'spinorbital'`; the `__init__` guard now admits `CCSD(T)` (CC3
+  still rejected). CCSD iterations are unchanged (the (T) is a post-convergence
+  correction).
+- `test_005_ccsd_t_energy.py`: SO-RHF CCSD(T) == spatial CCSD(T) on a closed shell;
+  UHF CCSD(T) vs Psi4 UCCSD(T), all-electron and frozen-core (~1e-10; measured ~7e-14).
 
 **To resume:** read this doc + `git log`. The spin-orbital equation seed lives in
 `~/src/socc` (machine-local, not part of this repo); see `socc/hamiltonian.py` for the

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -678,3 +678,65 @@ def t3_pert_bc(o, v, b, c, t2, V, F, contract, WithDenom=True):
         return t3/denom
     else:
         return t3
+
+
+# ---- Spin-orbital (T) (open-shell UHF/ROHF references) -----------------------
+#
+# The spatial t_tjl / t_vikings(_inverted) drivers above are RHF-specific
+# (spin-adapted). These are the spin-orbital "viking" (T) driver and its T3 batch
+# builder, ported from ~/src/socc: they work directly off the antisymmetrized
+# ERI = <pq||rs> (docs/ENHANCEMENT_PLAN_2026-06.md, phase 4).
+
+def t3c_ijk_so(o, v, i, j, k, t2, F, ERI, contract, omega=0.0, WithDenom=True):
+    """Spin-orbital connected T3 amplitudes for fixed occupied i, j, k.
+
+    Uses the bare similarity-transformed integrals appropriate to (T):
+    Wvvvo = <ab||ei> = ERI[v,v,v,o] and Wovoo = <ia||jk> = ERI[o,v,o,o].
+    """
+    Wvvvo = ERI[v,v,v,o]
+    Wovoo = ERI[o,v,o,o]
+
+    abc = contract('ad,bcd->abc', t2[i,j], Wvvvo[:,:,:,k])
+    abc = abc - contract('ad,bcd->abc', t2[k,j], Wvvvo[:,:,:,i])
+    abc = abc - contract('ad,bcd->abc', t2[i,k], Wvvvo[:,:,:,j])
+    t3 = abc - abc.swapaxes(0,1) - abc.swapaxes(0,2)
+
+    abc = contract('lab,lc->abc', t2[i], Wovoo[:,:,j,k])
+    abc = abc - contract('lab,lc->abc', t2[j], Wovoo[:,:,i,k])
+    abc = abc - contract('lab,lc->abc', t2[k], Wovoo[:,:,j,i])
+    t3 = t3 - (abc - abc.swapaxes(0,2) - abc.swapaxes(1,2))
+
+    if WithDenom is True:
+        occ = diag(F)[o]
+        vir = diag(F)[v]
+        denom = (occ[i] + occ[j] + occ[k] + omega
+                 - (vir.reshape(-1,1,1) + vir.reshape(-1,1) + vir))
+        return t3/denom
+    return t3
+
+
+def t_vikings_so(o, v, t1, t2, F, ERI, contract):
+    """Spin-orbital (T) energy via the occupied-batched ("viking") algorithm.
+
+    Builds the connected T3 in (i,j,k) batches and contracts each batch into the
+    disconnected (x1) and connected (x2) intermediates, then E(T) = t1.x1 +
+    1/4 t2.x2. The spatial RHF (T) drivers (t_tjl/t_vikings) are not used here.
+    """
+    x1 = zeros_like(t1)
+    x2 = zeros_like(t2)
+    no = t1.shape[0]
+
+    for i in range(no):
+        for j in range(no):
+            for k in range(no):
+                t3 = t3c_ijk_so(o, v, i, j, k, t2, F, ERI, contract)
+                x1[i] += 0.25 * contract('bc,abc->a', ERI[j,k,v,v], t3)
+                tmp = 0.5 * contract('dbc,abc->ad', ERI[v,k,v,v], t3)
+                x2[i,j] += tmp - tmp.swapaxes(0,1)
+                for l in range(no):
+                    tmp = 0.5 * contract('c,abc->ab', ERI[j,k,l,v], t3)
+                    x2[i,l] -= tmp
+                    x2[l,i] += tmp
+
+    et = contract('ia,ia->', t1, x1) + 0.25 * contract('ijab,ijab->', t2, x2)
+    return et

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -23,7 +23,7 @@ from .utils import helper_diis, zeros_like, clone, sqrt
 from .wavefunction import Wavefunction
 from .mpwfn import MPwfn
 from .local import Local
-from .cctriples import t_tjl, t3c_ijk, t3d_ijk, t3c_abc, t3d_abc, t3_pert_ijk
+from .cctriples import t_tjl, t3c_ijk, t3d_ijk, t3c_abc, t3d_abc, t3_pert_ijk, t_vikings_so
 from .lccwfn import lccwfn
 from ._typing import Tensor
 from .exceptions import InvalidKeywordError
@@ -135,10 +135,10 @@ class CCwfn(Wavefunction):
         # selected by orbital_basis. Step-3 scope: CCSD energies only, CPU-only, no
         # local correlation. Fail fast and clearly for anything outside that.
         if self.orbital_basis == 'spinorbital':
-            if self.model != 'CCSD':
+            if self.model not in ('CCSD', 'CCSD(T)'):
                 raise NotImplementedError(
-                    "Spin-orbital CC currently supports only model='CCSD' (got %r); "
-                    "CCSD(T)/CC3 are a later step." % self.model)
+                    "Spin-orbital CC currently supports model='CCSD' and 'CCSD(T)' "
+                    "(got %r); CC3 is a later step." % self.model)
             if self.local is not None:
                 raise NotImplementedError("Local correlation is not available in the "
                                           "spin-orbital path.")
@@ -245,7 +245,9 @@ class CCwfn(Wavefunction):
                 print("E(REF)  = %20.15f" % self.eref)
                 if (self.model == 'CCSD(T)'):
                     print("E(CCSD) = %20.15f" % ecc)
-                    if self.make_t3_density is True:
+                    if self.orbital_basis == 'spinorbital':
+                        et = t_vikings_so(o, v, self.t1, self.t2, F, self.H.ERI, contract)
+                    elif self.make_t3_density is True:
                         et = self.t3_density()
                     else:
                         et = t_tjl(self)

--- a/pycc/tests/test_005_ccsd_t_energy.py
+++ b/pycc/tests/test_005_ccsd_t_energy.py
@@ -1,5 +1,6 @@
 """
-Test CCSD equation solution using various molecule test cases.
+Test CCSD(T) energies for the spatial (RHF) and spin-orbital (UHF) kernels
+(docs/ENHANCEMENT_PLAN_2026-06.md, phase 4).
 """
 
 # Import package, test suite, and other packages as needed
@@ -8,6 +9,14 @@ import pycc
 import pytest
 from ..data.molecules import *
 from ..cctriples import t_vikings, t_vikings_inverted, t_tjl
+
+# Open-shell doublet (hydroxyl radical) for the UHF CCSD(T) checks.
+OH = """
+0 2
+O  0.000000  0.000000  0.000000
+H  0.000000  0.000000  0.969000
+symmetry c1
+"""
 
 def test_ccsd_t_h2o(rhf_wfn):
     """H2O cc-pVDZ"""
@@ -36,3 +45,47 @@ def test_ccsd_t_h2o(rhf_wfn):
     assert (abs(epsi4 - et_vik_ijk) < 1e-11)
     assert (abs(epsi4 - et_vik_abc) < 1e-11)
     assert (abs(epsi4 - et_tjl) < 1e-11)
+
+
+def test_so_ccsd_t_equals_spatial_rhf(rhf_wfn):
+    """Spin-orbital CCSD(T) (forced) reproduces spin-adapted spatial CCSD(T) on a
+    closed shell, isolating the spin-orbital (T) driver."""
+    wfn = rhf_wfn("H2O", "STO-3G", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+
+    e_spatial = pycc.CCwfn(wfn, model="CCSD(T)", frozen_core=False).solve_cc(
+        e_conv=1e-11, r_conv=1e-11)
+
+    so = pycc.CCwfn(wfn, model="CCSD(T)", frozen_core=False, orbital_basis="spinorbital")
+    assert so.orbital_basis == "spinorbital"
+    e_so = so.solve_cc(e_conv=1e-11, r_conv=1e-11)
+
+    assert abs(e_so - e_spatial) < 1e-10
+
+
+def test_uccsd_t_oh(uhf_wfn):
+    """Open-shell .OH cc-pVDZ, all-electron UCCSD(T) vs Psi4's UCCSD(T)."""
+    wfn = uhf_wfn(OH, "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+
+    cc = pycc.CCwfn(wfn, model="CCSD(T)", frozen_core=False)
+    assert cc.orbital_basis == "spinorbital"
+    eccsd_t = cc.solve_cc(e_conv=1e-11, r_conv=1e-11)
+
+    psi4.energy('ccsd(t)')
+    ref = psi4.variable('CCSD(T) CORRELATION ENERGY')
+
+    assert abs(eccsd_t - ref) < 1e-10
+
+
+def test_uccsd_t_oh_frzc(uhf_wfn):
+    """Open-shell .OH cc-pVDZ, frozen-core UCCSD(T) vs Psi4's UCCSD(T)."""
+    wfn = uhf_wfn(OH, "cc-pVDZ", freeze_core="true",
+                  e_convergence=1e-12, d_convergence=1e-12)
+
+    eccsd_t = pycc.CCwfn(wfn, model="CCSD(T)").solve_cc(e_conv=1e-11, r_conv=1e-11)
+
+    psi4.energy('ccsd(t)')
+    ref = psi4.variable('CCSD(T) CORRELATION ENERGY')
+
+    assert abs(eccsd_t - ref) < 1e-10


### PR DESCRIPTION
  ## Spin-orbital CCSD(T) driver (UHF energies — step 4a)

  Step 4a of the spin-orbital enhancement (`docs/ENHANCEMENT_PLAN_2026-06.md`),
  building on the spin-orbital CCSD kernel (PR #135). Adds the spin-orbital (T)
  correction, so `pycc.CCwfn(uhf_wfn, model='CCSD(T)').solve_cc()` returns the
  **UCCSD(T)** energy. Phase 4 is split: CCSD(T) here, CC3 next.

  ### What's in this PR

  - **`pycc/cctriples.py`** — `t_vikings_so` (the spin-orbital (T) energy via the
    occupied-batched "viking" algorithm) and its T3 batch builder `t3c_ijk_so`,
    ported from `~/src/socc`. Both work directly off the antisymmetrized
    `ERI = <pq||rs>`. The spatial `t_tjl` / `t_vikings` / `t_vikings_inverted`
    drivers are RHF-specific (spin-adapted) and left untouched.

  - **`pycc/ccwfn.py`** — `solve_cc`'s CCSD(T) block branches to `t_vikings_so`
    when `orbital_basis == 'spinorbital'`; the `__init__` guard now admits
    `CCSD(T)` (CC3 still raises). The CCSD iterations are unchanged — (T) is a
    post-convergence correction applied once at the end.

  - **`pycc/tests/test_005_ccsd_t_energy.py`** — spin-orbital (T) tests alongside
    the RHF cases:
    - `test_so_ccsd_t_equals_spatial_rhf` — forcing the spin-orbital path on a
      closed shell reproduces spatial CCSD(T), isolating the (T) driver.
    - `test_uccsd_t_oh` / `test_uccsd_t_oh_frzc` — UHF CCSD(T) on the ·OH doublet
      vs Psi4's UCCSD(T), all-electron and frozen-core.

  ### Validation
  
  | Check | Result |
  |---|---|
  | RHF CCSD(T) (STO-3G, cc-pVDZ) vs Psi4 | ~1e-11 (unchanged) |
  | SO-RHF CCSD(T) == spatial CCSD(T) (closed shell) | < 1e-10 |
  | UHF CCSD(T) (all-electron) vs Psi4 UCCSD(T) | < 1e-10 (measured ~7e-14) |
  | UHF CCSD(T) (frozen-core) vs Psi4 UCCSD(T) | < 1e-10 (measured ~7e-14) |

  ### Scope

  Spin-orbital path now covers MP2, CCSD, and CCSD(T) energies. CC3 is step 4b;
  Lambda/density/response/EOM/RT/local/GPU remain spatial-RHF-only and raise in the
  SO path.

  ### Test status
  
  Full non-slow suite green: **74 passed** (+3 new SO CCSD(T)), 3 skipped (GPU, no
  local torch), 8 deselected (slow), 1 xfail. No regressions.
