### PR TITLE
Add spin-orbital CC3 kernel to CCwfn (UHF energies, step 4b)

### DIFF
--- a/docs/ENHANCEMENT_PLAN_2026-06.md
+++ b/docs/ENHANCEMENT_PLAN_2026-06.md
@@ -134,8 +134,8 @@ _Last updated 2026-06-17._
 | 1 — SO Hamiltonian + dispatch | ✅ done | PR #133 |
 | 2 — SO MP2 | ✅ done | PR #134 |
 | 3 — SO CCSD | ✅ done | PR #135 |
-| 4a — SO CCSD(T) | 🟡 in review | branch `feature/spinorbital-pt-ccsdt` |
-| 4b — SO CC3 | ⬜ not started | — |
+| 4a — SO CCSD(T) | ✅ done | PR #136 |
+| 4b — SO CC3 | 🟡 in review | branch `feature/spinorbital-cc3` |
 
 ### Phase 1 — what landed
 
@@ -194,6 +194,23 @@ _Last updated 2026-06-17._
   correction).
 - `test_005_ccsd_t_energy.py`: SO-RHF CCSD(T) == spatial CCSD(T) on a closed shell;
   UHF CCSD(T) vs Psi4 UCCSD(T), all-electron and frozen-core (~1e-10; measured ~7e-14).
+
+### Phase 4b — what landed
+
+- `pycc/ccwfn.py`: spin-orbital CC3. `_residuals_spinorbital` adds the connected-triples
+  contribution (`_so_cc3_t_residual`) to the CCSD residuals when `model == 'CC3'`; the
+  T1/T2 equations stay CCSD and T3 is rebuilt each iteration from the five T1-dressed
+  CC3 W-intermediates (`_so_build_W{oooo,ovoo,ooov,vovv,vvvo}_CC3`). `__init__` guard now
+  admits CC3.
+- `pycc/cctriples.py`: `t3c_ijk_so` refactored to take `Wvvvo`/`Wovoo` explicitly (bare
+  ERI slices for (T), T1-dressed intermediates for CC3); `t_vikings_so` updated to pass
+  the slices. Only the memory-light batched driver is ported -- the `store_triples`/field
+  CC3 path (socc `CC3_full`/`permute_triples`) is out of scope.
+- `test_031_cc3.py`: SO-RHF CC3 == spatial CC3 on a closed shell; UHF CC3 vs Psi4 UCC3,
+  all-electron (6-31G to keep the iterative SO run quick; ~1e-10, measured ~1e-13).
+  Frozen-core UCC3 is deliberately not retested -- the SO frozen-core active space is
+  covered by the MP2/CCSD/CCSD(T) frozen-core tests, and CC3 is the costliest solve.
+- Spin-orbital energies are now **complete for v1**: MP2, CCSD, CCSD(T), CC3.
 
 **To resume:** read this doc + `git log`. The spin-orbital equation seed lives in
 `~/src/socc` (machine-local, not part of this repo); see `socc/hamiltonian.py` for the

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -687,15 +687,12 @@ def t3_pert_bc(o, v, b, c, t2, V, F, contract, WithDenom=True):
 # builder, ported from ~/src/socc: they work directly off the antisymmetrized
 # ERI = <pq||rs> (docs/ENHANCEMENT_PLAN_2026-06.md, phase 4).
 
-def t3c_ijk_so(o, v, i, j, k, t2, F, ERI, contract, omega=0.0, WithDenom=True):
+def t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract, omega=0.0, WithDenom=True):
     """Spin-orbital connected T3 amplitudes for fixed occupied i, j, k.
 
-    Uses the bare similarity-transformed integrals appropriate to (T):
-    Wvvvo = <ab||ei> = ERI[v,v,v,o] and Wovoo = <ia||jk> = ERI[o,v,o,o].
+    ``Wvvvo`` (<ab||ei>) and ``Wovoo`` (<ia||jk>) are passed explicitly: bare ERI
+    slices for (T), or the T1-dressed CC3 intermediates for CC3.
     """
-    Wvvvo = ERI[v,v,v,o]
-    Wovoo = ERI[o,v,o,o]
-
     abc = contract('ad,bcd->abc', t2[i,j], Wvvvo[:,:,:,k])
     abc = abc - contract('ad,bcd->abc', t2[k,j], Wvvvo[:,:,:,i])
     abc = abc - contract('ad,bcd->abc', t2[i,k], Wvvvo[:,:,:,j])
@@ -725,11 +722,13 @@ def t_vikings_so(o, v, t1, t2, F, ERI, contract):
     x1 = zeros_like(t1)
     x2 = zeros_like(t2)
     no = t1.shape[0]
+    Wvvvo = ERI[v,v,v,o]
+    Wovoo = ERI[o,v,o,o]
 
     for i in range(no):
         for j in range(no):
             for k in range(no):
-                t3 = t3c_ijk_so(o, v, i, j, k, t2, F, ERI, contract)
+                t3 = t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
                 x1[i] += 0.25 * contract('bc,abc->a', ERI[j,k,v,v], t3)
                 tmp = 0.5 * contract('dbc,abc->ad', ERI[v,k,v,v], t3)
                 x2[i,j] += tmp - tmp.swapaxes(0,1)

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -23,7 +23,7 @@ from .utils import helper_diis, zeros_like, clone, sqrt
 from .wavefunction import Wavefunction
 from .mpwfn import MPwfn
 from .local import Local
-from .cctriples import t_tjl, t3c_ijk, t3d_ijk, t3c_abc, t3d_abc, t3_pert_ijk, t_vikings_so
+from .cctriples import t_tjl, t3c_ijk, t3d_ijk, t3c_abc, t3d_abc, t3_pert_ijk, t_vikings_so, t3c_ijk_so
 from .lccwfn import lccwfn
 from ._typing import Tensor
 from .exceptions import InvalidKeywordError
@@ -135,10 +135,10 @@ class CCwfn(Wavefunction):
         # selected by orbital_basis. Step-3 scope: CCSD energies only, CPU-only, no
         # local correlation. Fail fast and clearly for anything outside that.
         if self.orbital_basis == 'spinorbital':
-            if self.model not in ('CCSD', 'CCSD(T)'):
+            if self.model not in ('CCSD', 'CCSD(T)', 'CC3'):
                 raise NotImplementedError(
-                    "Spin-orbital CC currently supports model='CCSD' and 'CCSD(T)' "
-                    "(got %r); CC3 is a later step." % self.model)
+                    "Spin-orbital CC currently supports model in {'CCSD', 'CCSD(T)', "
+                    "'CC3'} (got %r)." % self.model)
             if self.local is not None:
                 raise NotImplementedError("Local correlation is not available in the "
                                           "spin-orbital path.")
@@ -1055,15 +1055,98 @@ class CCwfn(Wavefunction):
 
         r1 = self._so_r_T1(o, v, F, ERI, t1, t2, Fae, Fme, Fmi)
         r2 = self._so_r_T2(o, v, F, ERI, t1, t2, Fae, Fme, Fmi, Wmnij, Wabef, Wmbej)
+
+        # CC3: add the connected-triples contribution to the CCSD residuals (the T1/T2
+        # equations are CCSD; T3 is built per-iteration from T1-dressed integrals).
+        if self.model == 'CC3':
+            x1, x2 = self._so_cc3_t_residual(o, v, F, ERI, Fme, t1, t2)
+            r1 = r1 + x1
+            r2 = r2 + x2
+
         return r1, r2
 
     def _cc_energy_spinorbital(self, o, v, F, ERI, t1, t2):
-        """Spin-orbital CCSD correlation energy."""
+        """Spin-orbital CCSD correlation energy. CC3 shares this -- the triples enter
+        through the residuals, not the energy expression."""
         contract = self.contract
         ecc = contract('ia,ia->', F[o,v], t1)
         ecc = ecc + 0.25 * contract('ijab,ijab->', t2, ERI[o,o,v,v])
         ecc = ecc + 0.5 * contract('ia,jb,ijab->', t1, t1, ERI[o,o,v,v])
         return ecc
+
+    # --- Spin-orbital CC3: T1-dressed W-intermediates + connected-triples residual ---
+
+    def _so_build_Woooo_CC3(self, o, v, ERI, t1):
+        contract = self.contract
+        Woooo = clone(ERI[o,o,o,o])
+        Woooo = Woooo + (contract('je,mnie->mnij', t1, ERI[o,o,o,v])
+                         - contract('ie,mnje->mnij', t1, ERI[o,o,o,v]))
+        tau = contract('ia,jb->ijab', t1, t1) - contract('ib,ja->ijab', t1, t1)
+        Woooo = Woooo + 0.5 * contract('ijef,mnef->mnij', tau, ERI[o,o,v,v])
+        return Woooo
+
+    def _so_build_Wovoo_CC3(self, o, v, ERI, t1, Woooo):
+        contract = self.contract
+        Wovoo = clone(ERI[o,v,o,o])
+        Wovoo = Wovoo - contract('nb,mnij->mbij', t1, Woooo)
+        tau = contract('ia,jb->ijab', t1, t1) - contract('ib,ja->ijab', t1, t1)
+        Wovoo = Wovoo + 0.5 * contract('ijef,mbef->mbij', tau, ERI[o,v,v,v])
+        Wovoo = Wovoo + (contract('ie,mbej->mbij', t1, ERI[o,v,v,o])
+                         - contract('je,mbei->mbij', t1, ERI[o,v,v,o]))
+        return Wovoo
+
+    def _so_build_Wooov_CC3(self, o, v, ERI, t1):
+        contract = self.contract
+        Wooov = clone(ERI[o,o,o,v])
+        Wooov = Wooov - contract('if,mnef->mnie', t1, ERI[o,o,v,v])
+        return Wooov
+
+    def _so_build_Wvovv_CC3(self, o, v, ERI, t1):
+        contract = self.contract
+        Wvovv = clone(ERI[v,o,v,v])
+        Wvovv = Wvovv - contract('na,nmef->amef', t1, ERI[o,o,v,v])
+        return Wvovv
+
+    def _so_build_Wvvvo_CC3(self, o, v, ERI, t1):
+        contract = self.contract
+        Z1 = contract('if,amef->amei', t1, ERI[v,o,v,v])
+        Z2 = clone(ERI[o,o,v,o]) + contract('if,mnef->mnei', t1, ERI[o,o,v,v])
+        tau = contract('ia,jb->ijab', t1, t1) - contract('ib,ja->ijab', t1, t1)
+        Wvvvo = clone(ERI[v,v,v,o])
+        Wvvvo = Wvvvo + contract('if,abef->abei', t1, ERI[v,v,v,v])
+        Wvvvo = Wvvvo - (contract('mb,amei->abei', t1, Z1) - contract('ma,bmei->abei', t1, Z1))
+        Wvvvo = Wvvvo + 0.5 * contract('mnei,mnab->abei', Z2, tau)
+        Wvvvo = Wvvvo - (contract('ma,mbei->abei', t1, ERI[o,v,v,o])
+                         - contract('mb,maei->abei', t1, ERI[o,v,v,o]))
+        return Wvvvo
+
+    def _so_cc3_t_residual(self, o, v, F, ERI, Fme, t1, t2):
+        """Spin-orbital CC3 connected-triples contribution (x1, x2) to the T1/T2
+        residuals, via per-(i,j,k) batched T3 built from the T1-dressed
+        intermediates."""
+        contract = self.contract
+        Woooo = self._so_build_Woooo_CC3(o, v, ERI, t1)
+        Wovoo = self._so_build_Wovoo_CC3(o, v, ERI, t1, Woooo)
+        Wooov = self._so_build_Wooov_CC3(o, v, ERI, t1)
+        Wvovv = self._so_build_Wvovv_CC3(o, v, ERI, t1)
+        Wvvvo = self._so_build_Wvvvo_CC3(o, v, ERI, t1)
+
+        x1 = zeros_like(t1)
+        x2 = zeros_like(t2)
+        no = t1.shape[0]
+        for i in range(no):
+            for j in range(no):
+                for k in range(no):
+                    t3 = t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
+                    x1[i] += 0.25 * contract('bc,abc->a', ERI[j,k,v,v], t3)
+                    x2[i,j] += contract('c,abc->ab', Fme[k], t3)
+                    x2[i,j] += 0.5 * contract('dbc,abc->ad', Wvovv[:,k,:,:], t3)
+                    x2[i,j] -= 0.5 * contract('abc,dbc->ad', Wvovv[:,k,:,:], t3)
+                    for l in range(no):
+                        tmp = 0.5 * contract('c,abc->ab', Wooov[j,k,l,:], t3)
+                        x2[i,l] -= tmp
+                        x2[l,i] += tmp
+        return x1, x2
 
     def t3_density(self):
         """

--- a/pycc/tests/test_031_cc3.py
+++ b/pycc/tests/test_031_cc3.py
@@ -1,5 +1,7 @@
 """
-Test CC3 equation solution using various molecule test cases.
+Test CC3 equation solution using various molecule test cases, for both the
+spatial (RHF) and spin-orbital (UHF) kernels (docs/ENHANCEMENT_PLAN_2026-06.md,
+phase 4b).
 """
 
 # Import package, test suite, and other packages as needed
@@ -8,6 +10,15 @@ import pycc
 import pytest
 from ..data.molecules import *
 import numpy as np
+
+# Open-shell doublet (hydroxyl radical) for the UHF CC3 checks. CC3 rebuilds the
+# triples every iteration, so a small basis keeps the spin-orbital runs quick.
+OH = """
+0 2
+O  0.000000  0.000000  0.000000
+H  0.000000  0.000000  0.969000
+symmetry c1
+"""
 
 # H2O/cc-pVDZ
 def test_cc3_h2o(rhf_wfn):
@@ -41,4 +52,39 @@ def test_cc3_h2o(rhf_wfn):
 
     assert (abs(ref[1] - np.real(mu_y)) < 1E-10)
     assert (abs(ref[2] - np.real(mu_z)) < 1E-10)
+
+
+def test_so_cc3_equals_spatial_rhf(rhf_wfn):
+    """Spin-orbital CC3 (forced) reproduces spin-adapted spatial CC3 on a closed
+    shell, isolating the spin-orbital CC3 kernel."""
+    wfn = rhf_wfn("H2O", "STO-3G", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+
+    e_spatial = pycc.CCwfn(wfn, model="CC3", frozen_core=False).solve_cc(
+        e_conv=1e-11, r_conv=1e-11)
+
+    so = pycc.CCwfn(wfn, model="CC3", frozen_core=False, orbital_basis="spinorbital")
+    assert so.orbital_basis == "spinorbital"
+    e_so = so.solve_cc(e_conv=1e-11, r_conv=1e-11)
+
+    assert abs(e_so - e_spatial) < 1e-10
+
+
+def test_ucc3_oh(uhf_wfn):
+    """Open-shell .OH 6-31G, all-electron UCC3 vs Psi4's UCC3."""
+    wfn = uhf_wfn(OH, "6-31G", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+
+    cc = pycc.CCwfn(wfn, model="CC3", frozen_core=False)
+    assert cc.orbital_basis == "spinorbital"
+    ecc3 = cc.solve_cc(e_conv=1e-11, r_conv=1e-11)
+
+    psi4.energy('cc3')
+    ref = psi4.variable('CC3 CORRELATION ENERGY')
+
+    assert abs(ecc3 - ref) < 1e-10
+    # Frozen-core UCC3 is intentionally not retested here: the spin-orbital
+    # frozen-core active space is already validated by the MP2/CCSD/CCSD(T)
+    # frozen-core tests (CC3 reuses the same o/v slicing), and the iterative CC3
+    # solve is the costliest in the suite.
 


### PR DESCRIPTION
  ## Spin-orbital CC3 kernel in CCwfn (UHF energies — step 4b)

  Step 4b of the spin-orbital enhancement (`docs/ENHANCEMENT_PLAN_2026-06.md`),
  completing the v1 spin-orbital energy set: **MP2, CCSD, CCSD(T), CC3** on a UHF
  reference. Ported from `~/src/socc`.

  ### What's in this PR

  - **`pycc/ccwfn.py`** — spin-orbital CC3:
    - `_residuals_spinorbital` adds the connected-triples contribution
      (`_so_cc3_t_residual`) to the CCSD residuals when `model == 'CC3'`. The T1/T2
      equations stay CCSD; T3 is rebuilt every iteration from five T1-dressed CC3
      W-intermediates (`_so_build_W{oooo,ovoo,ooov,vovv,vvvo}_CC3`). `cc_energy` is
      unchanged — the triples enter through the residuals, not the energy.
    - The `__init__` guard now admits `CC3` (the spin-orbital path covers
      `{CCSD, CCSD(T), CC3}`).

  - **`pycc/cctriples.py`** — `t3c_ijk_so` refactored to take `Wvvvo`/`Wovoo`
    explicitly (bare ERI slices for (T); T1-dressed intermediates for CC3);
    `t_vikings_so` updated to pass the slices. Only the memory-light batched driver
    is ported — the `store_triples`/field CC3 path (`socc`'s `CC3_full` /
    `permute_triples`) is out of scope.

  - **`pycc/tests/test_031_cc3.py`** — spin-orbital CC3 tests alongside the RHF case:
    - `test_so_cc3_equals_spatial_rhf` — forcing the spin-orbital path on a closed
      shell reproduces spatial CC3, isolating the CC3 kernel.
    - `test_ucc3_oh` — UHF CC3 on the ·OH doublet vs Psi4's UCC3 (6-31G, to keep the
      iterative spin-orbital solve quick). Frozen-core UCC3 is intentionally omitted:
      the SO frozen-core active space is covered by the MP2/CCSD/CCSD(T) frozen-core
      tests, and CC3 is the costliest solve in the suite.

  ### Validation

  | Check | Result |
  |---|---|
  | RHF CC3 (cc-pVDZ) vs Psi4/CFOUR + Lambda/dipole | unchanged |
  | SO-RHF CC3 == spatial CC3 (closed shell) | < 1e-10 |
  | UHF CC3 (all-electron, 6-31G) vs Psi4 UCC3 | < 1e-10 (measured ~1e-13) |

  ### Scope

  Spin-orbital path is now complete for energies (MP2/CCSD/CCSD(T)/CC3).
  Lambda/density/response/EOM/RT/local/GPU remain spatial-RHF-only and raise in the
  spin-orbital path.

  ### Test status

  Full non-slow suite green (77 passed with all CC3 cases; one frozen-core UCC3
  trimmed post-review). CI re-runs the whole suite.
