### PR TITLE
Add ROHF support via semicanonical orbitals (phase 5)

### DIFF
--- a/docs/ENHANCEMENT_PLAN_2026-06.md
+++ b/docs/ENHANCEMENT_PLAN_2026-06.md
@@ -135,7 +135,8 @@ _Last updated 2026-06-17._
 | 2 — SO MP2 | ✅ done | PR #134 |
 | 3 — SO CCSD | ✅ done | PR #135 |
 | 4a — SO CCSD(T) | ✅ done | PR #136 |
-| 4b — SO CC3 | 🟡 in review | branch `feature/spinorbital-cc3` |
+| 4b — SO CC3 | ✅ done | PR #137 |
+| 5 — ROHF (semicanonical) | 🟡 in review | branch `feature/spinorbital-rohf` |
 
 ### Phase 1 — what landed
 
@@ -211,6 +212,28 @@ _Last updated 2026-06-17._
   Frozen-core UCC3 is deliberately not retested -- the SO frozen-core active space is
   covered by the MP2/CCSD/CCSD(T) frozen-core tests, and CC3 is the costliest solve.
 - Spin-orbital energies are now **complete for v1**: MP2, CCSD, CCSD(T), CC3.
+
+### Phase 5 — what landed (ROHF via semicanonical orbitals)
+
+Completes the plan's "UHF **and ROHF**" goal. ROHF auto-dispatches to the spin-orbital
+path (open shell), and the SO machinery is made correct for a non-canonical reference:
+
+- `pycc/hamiltonian.py`: `SpinOrbitalHamiltonian` semicanonicalizes each spin --
+  `_semicanonicalize` diagonalizes the occ-occ and vir-vir blocks of the MO Fock and
+  rotates the occ/vir MO column-blocks by the eigenvectors, then all AO->MO transforms
+  (Fock, ERI, properties) use the rotated coefficients. Well-defined orbital energies
+  (hence non-iterative MP2/(T)/CC3 denominators) for ROHF; a no-op for canonical
+  RHF/UHF (blocks already diagonal). The base passes the per-spin occupied counts so the
+  Hamiltonian knows the occ/vir split.
+- `pycc/mpwfn.py`: MP2 gains the first-order **singles** `t1 = f_ia/Dia` and the
+  `f_ia t1_ia` energy term (spin-orbital path) -- nonzero only for a non-canonical
+  reference. `CCwfn` starts its spin-orbital `t1` from this MP1 guess.
+- `pycc/cctriples.py`: the viking (T) gains the non-canonical occ-vir-Fock term
+  `x2[i,j] += f_kc t3` (the bare-Fock analog of CC3's `Fme[k]` term); zero for canonical
+  refs, so RHF/UHF (T) are unchanged. (Also folded in a CC3 micro-opt: the `Wvovv`
+  antisymmetrization now reuses one contraction via `tmp - tmp.swapaxes(0,1)`.)
+- `conftest.py` `rohf_wfn` fixture; `test_054_rohf.py`: ROHF MP2/CCSD/CCSD(T) (cc-pVDZ)
+  and CC3 (6-31G) on .OH vs Psi4's semicanonical CCENERGY (all ~1e-13/1e-14).
 
 **To resume:** read this doc + `git log`. The spin-orbital equation seed lives in
 `~/src/socc` (machine-local, not part of this repo); see `socc/hamiltonian.py` for the

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -730,6 +730,9 @@ def t_vikings_so(o, v, t1, t2, F, ERI, contract):
             for k in range(no):
                 t3 = t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
                 x1[i] += 0.25 * contract('bc,abc->a', ERI[j,k,v,v], t3)
+                # Occ-vir Fock term (cf. the CC3 Fme[k] term): nonzero only for a
+                # non-canonical (semicanonical ROHF) reference, where f_kc != 0.
+                x2[i,j] += contract('c,abc->ab', F[k,v], t3)
                 tmp = 0.5 * contract('dbc,abc->ad', ERI[v,k,v,v], t3)
                 x2[i,j] += tmp - tmp.swapaxes(0,1)
                 for l in range(no):

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -170,6 +170,11 @@ class CCwfn(Wavefunction):
         if local is not None:
             self.t1, self.t2 = self.Local.filter_amps(np.zeros((self.no, self.nv)),
                                                        self.H.ERI[o,o,v,v])
+        elif self.orbital_basis == 'spinorbital':
+            # Start from the MP1 guess: doubles from MP2 and singles t1 = f_ia/Dia
+            # (zero for a canonical reference, nonzero for ROHF).
+            self.t1 = clone(self.mp.t1)
+            self.t2 = clone(self.mp.t2)
         else:
             self.t1 = mgr.seed_compute(np.zeros((self.no, self.nv)))
             self.t2 = clone(self.mp.t2)
@@ -1140,8 +1145,8 @@ class CCwfn(Wavefunction):
                     t3 = t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
                     x1[i] += 0.25 * contract('bc,abc->a', ERI[j,k,v,v], t3)
                     x2[i,j] += contract('c,abc->ab', Fme[k], t3)
-                    x2[i,j] += 0.5 * contract('dbc,abc->ad', Wvovv[:,k,:,:], t3)
-                    x2[i,j] -= 0.5 * contract('abc,dbc->ad', Wvovv[:,k,:,:], t3)
+                    tmp = 0.5 * contract('dbc,abc->ad', Wvovv[:,k,:,:], t3)
+                    x2[i,j] += tmp - tmp.swapaxes(0,1)
                     for l in range(no):
                         tmp = 0.5 * contract('c,abc->ab', Wooov[j,k,l,:], t3)
                         x2[i,l] -= tmp

--- a/pycc/hamiltonian.py
+++ b/pycc/hamiltonian.py
@@ -111,7 +111,8 @@ class SpinOrbitalHamiltonian(object):
         with :class:`Hamiltonian`; used by later (deferred) response work, not by
         the energy.
     """
-    def __init__(self, ref: Any, Ca: Any, Cb: Any, spin: Any, spat: Any) -> None:
+    def __init__(self, ref: Any, Ca: Any, Cb: Any, spin: Any, spat: Any,
+                 nocc_a: int, nocc_b: int) -> None:
         npCa = np.asarray(Ca)
         npCb = np.asarray(Cb)
         nact = spin.shape[0]
@@ -123,18 +124,31 @@ class SpinOrbitalHamiltonian(object):
         sa = spat[a]                 # their spatial indices (alpha active space)
         sb = spat[b]                 # (beta active space)
 
-        # Fock matrix: alpha/beta MO Fock placed on the matching spin blocks; the
-        # alpha-beta blocks vanish. The AO-basis Fock ("AO" subset) is symmetry-
-        # collapsed to a single irrep, so it transforms cleanly even when the
-        # reference carries point-group symmetry.
+        # Semicanonicalize each spin: form the MO Fock, diagonalize its occ-occ and
+        # vir-vir blocks, and rotate the occupied/virtual MO column-blocks by the
+        # eigenvectors. This makes each spin's Fock block-diagonal (occ and vir
+        # separately), so the orbital energies -- and hence the non-iterative MP2/(T)/CC3
+        # denominators -- are well-defined even for ROHF (whose occ-vir Fock block stays
+        # nonzero, feeding the MP2 singles). The AO-basis Fock ("AO" subset) is
+        # symmetry-collapsed to a single irrep, so it transforms cleanly under symmetry.
+        # For a canonical reference (RHF/UHF) the blocks are already diagonal, so the
+        # rotation is the identity -- a no-op. ROHF feeds identical Ca/Cb but distinct
+        # Fa/Fb, so its semicanonical alpha/beta orbitals diverge (UHF-like), as intended.
         Fa_ao = np.asarray(ref.Fa_subset("AO"))
         Fb_ao = np.asarray(ref.Fb_subset("AO"))
-        Fa = npCa.T @ Fa_ao @ npCa
-        Fb = npCb.T @ Fb_ao @ npCb
+        npCa, Fa = self._semicanonicalize(npCa, Fa_ao, nocc_a)
+        npCb, Fb = self._semicanonicalize(npCb, Fb_ao, nocc_b)
+
+        # Spin-orbital Fock: alpha/beta MO Fock placed on the matching spin blocks; the
+        # alpha-beta blocks vanish.
         F = np.zeros((nact, nact))
         F[np.ix_(a, a)] = Fa[np.ix_(sa, sa)]
         F[np.ix_(b, b)] = Fb[np.ix_(sb, sb)]
         self.F = F
+
+        # All subsequent AO->MO transforms use the semicanonical MOs.
+        Ca = psi4.core.Matrix.from_array(npCa)
+        Cb = psi4.core.Matrix.from_array(npCb)
 
         # Antisymmetrized two-electron integrals <pq||rs>. Build the chemist-notation
         # spin-orbital integral (pr|qs) first -- nonzero only when spin_p==spin_r and
@@ -183,3 +197,24 @@ class SpinOrbitalHamiltonian(object):
         # Traceless quadrupole (6 unique Cartesian components)
         Q_ints = mints.ao_traceless_quadrupole()
         self.Q = [_spin_block(np.asarray(Q_ints[ij])) for ij in range(6)]
+
+    @staticmethod
+    def _semicanonicalize(npC, F_ao, nocc):
+        """Rotate the occupied and virtual MO blocks of ``npC`` so the occ-occ and
+        vir-vir blocks of the MO Fock become diagonal (semicanonical).
+
+        ``npC`` columns are ordered [occupied (nocc), virtual]. Returns the rotated
+        coefficients and the resulting MO Fock; its occ-occ and vir-vir blocks are
+        diagonal (orbital energies on the diagonal), while the occ-vir block may be
+        nonzero (as for ROHF -- this is what feeds the MP2 singles). For a canonical
+        reference both blocks are already diagonal and the rotation is the identity.
+        """
+        Fmo = npC.T @ F_ao @ npC
+        C = npC.copy()
+        if nocc > 0:
+            _, Uo = np.linalg.eigh(Fmo[:nocc, :nocc])
+            C[:, :nocc] = npC[:, :nocc] @ Uo
+        if nocc < npC.shape[1]:
+            _, Uv = np.linalg.eigh(Fmo[nocc:, nocc:])
+            C[:, nocc:] = npC[:, nocc:] @ Uv
+        return C, C.T @ F_ao @ C

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -33,6 +33,9 @@ class MPwfn(Wavefunction):
     t2 : Tensor
         first-order (MP2) doubles amplitudes, ERI[o,o,v,v] / Dijab (i.e. <ij|ab>
         spatial, or the antisymmetrized <ij||ab> in the spin-orbital path)
+    Dia, t1 : Tensor
+        (spin-orbital path only) the singles denominator and first-order singles
+        t1 = f_ia / Dia, nonzero for a non-canonical (ROHF) reference
     emp2 : float
         the MP2 correlation energy (set by :meth:`compute_energy`)
     """
@@ -67,17 +70,27 @@ class MPwfn(Wavefunction):
                       - self.eps_vir.reshape(-1, 1) - self.eps_vir)
         self.t2 = clone(self.H.ERI[o, o, v, v], device=self.device1) / self.Dijab
 
+        # First-order singles. For a semicanonical (e.g. ROHF) reference the occ-vir
+        # Fock block f_ia is nonzero, so t1 = f_ia / Dia contributes to MP2; for a
+        # canonical RHF/UHF reference f_ia = 0, so t1 vanishes. Only the spin-orbital
+        # path uses these (the spatial energy is the spin-adapted t2.L form).
+        if self.orbital_basis == 'spinorbital':
+            self.Dia = self.eps_occ.reshape(-1, 1) - self.eps_vir
+            self.t1 = clone(self.H.F[o, v], device=self.device1) / self.Dia
+
     def compute_energy(self) -> "Tensor":
         """Compute and return the MP2 correlation energy.
 
         Spatial (spin-adapted) path: ``E = t2_ijab L_ijab``. Spin-orbital path:
-        ``E = 1/4 <ij||ab> t2_ijab`` -- no ``L`` exists, and the 1/4 accounts for the
-        unrestricted sum over the antisymmetrized doubles.
+        ``E = f_ia t1_ia + 1/4 <ij||ab> t2_ijab`` -- no ``L`` exists, the 1/4 accounts
+        for the unrestricted sum over the antisymmetrized doubles, and the singles term
+        is nonzero only for a non-canonical (e.g. ROHF) reference.
         """
         o = self.o
         v = self.v
         if self.orbital_basis == 'spatial':
             self.emp2 = self.contract('ijab,ijab->', self.t2, self.H.L[o, o, v, v])
         else:
-            self.emp2 = 0.25 * self.contract('ijab,ijab->', self.t2, self.H.ERI[o, o, v, v])
+            self.emp2 = (0.25 * self.contract('ijab,ijab->', self.t2, self.H.ERI[o, o, v, v])
+                         + self.contract('ia,ia->', self.H.F[o, v], self.t1))
         return self.emp2

--- a/pycc/tests/conftest.py
+++ b/pycc/tests/conftest.py
@@ -112,6 +112,24 @@ def uhf_wfn(psi4_environment):
 
 
 @pytest.fixture
+def rohf_wfn(psi4_environment):
+    """Factory fixture that builds an ROHF reference wavefunction.
+
+    Same interface as :func:`rhf_wfn`, but sets ``reference = 'rohf'`` for open-shell
+    species. The spin-orbital path semicanonicalizes the ROHF orbitals internally.
+    The geometry should carry its own charge/multiplicity line (e.g. ``"0 2\\n..."``).
+    """
+    def _build(molecule, basis="cc-pVDZ", geom_extra="", **options):
+        opts = {**DEFAULT_SCF_OPTIONS, 'basis': basis, 'reference': 'rohf', **options}
+        psi4.set_options(opts)
+        geometry = moldict.get(molecule, molecule)  # moldict key, else literal geometry
+        psi4.geometry(geometry + geom_extra)
+        _, wfn = psi4.energy('SCF', return_wfn=True)
+        return wfn
+    return _build
+
+
+@pytest.fixture
 def datadir(tmpdir, request):
     '''
     from: https://stackoverflow.com/a/29631801

--- a/pycc/tests/test_054_rohf.py
+++ b/pycc/tests/test_054_rohf.py
@@ -1,0 +1,55 @@
+"""
+Spin-orbital coupled cluster on a ROHF reference, via semicanonical orbitals
+(docs/ENHANCEMENT_PLAN_2026-06.md, phase 5).
+
+SpinOrbitalHamiltonian semicanonicalizes the ROHF orbitals (diagonalizing the
+occ-occ and vir-vir Fock blocks per spin), giving well-defined MP2/(T)/CC3
+denominators; the residual occ-vir Fock block feeds the MP2 singles (t1 = f_ia/Dia).
+Psi4's CCENERGY module semicanonicalizes a ROHF reference the same way, so its
+reported MP2/CCSD/CCSD(T)/CC3 correlation energies are the cross-checks.
+"""
+
+import psi4
+import pycc
+
+# Open-shell doublet (hydroxyl radical).
+OH = """
+0 2
+O  0.000000  0.000000  0.000000
+H  0.000000  0.000000  0.969000
+symmetry c1
+"""
+
+
+def test_rohf_mp2_ccsd_ccsd_t_oh(rohf_wfn):
+    """ROHF .OH cc-pVDZ: spin-orbital MP2, CCSD, and CCSD(T) vs Psi4 (semicanonical
+    CCENERGY). A single energy('ccsd(t)') run populates all three reference variables
+    (plain energy('ccsd') does not set MP2 CORRELATION ENERGY for ROHF)."""
+    wfn = rohf_wfn(OH, "cc-pVDZ", freeze_core="false",
+                   e_convergence=1e-12, d_convergence=1e-12)
+
+    mp = pycc.MPwfn(wfn)
+    assert mp.orbital_basis == "spinorbital"
+    emp2 = mp.compute_energy()
+    eccsd = pycc.CCwfn(wfn, frozen_core=False).solve_cc(e_conv=1e-11, r_conv=1e-11)
+    eccsd_t = pycc.CCwfn(wfn, model="CCSD(T)", frozen_core=False).solve_cc(
+        e_conv=1e-11, r_conv=1e-11)
+
+    psi4.energy('ccsd(t)')
+    assert abs(emp2 - psi4.variable('MP2 CORRELATION ENERGY')) < 1e-10
+    assert abs(eccsd - psi4.variable('CCSD CORRELATION ENERGY')) < 1e-10
+    assert abs(eccsd_t - psi4.variable('CCSD(T) CORRELATION ENERGY')) < 1e-10
+
+
+def test_rohf_cc3_oh(rohf_wfn):
+    """ROHF .OH 6-31G: spin-orbital CC3 vs Psi4's ROHF-CC3 (small basis for the
+    iterative spin-orbital solve)."""
+    wfn = rohf_wfn(OH, "6-31G", freeze_core="false",
+                   e_convergence=1e-12, d_convergence=1e-12)
+
+    e = pycc.CCwfn(wfn, model="CC3", frozen_core=False).solve_cc(e_conv=1e-11, r_conv=1e-11)
+
+    psi4.energy('cc3')
+    ref = psi4.variable('CC3 CORRELATION ENERGY')
+
+    assert abs(e - ref) < 1e-10

--- a/pycc/wavefunction.py
+++ b/pycc/wavefunction.py
@@ -303,7 +303,9 @@ class Wavefunction(object):
 
         self.Ca = ref.Ca_subset("AO", "ACTIVE")
         self.Cb = ref.Cb_subset("AO", "ACTIVE")
-        self.H = SpinOrbitalHamiltonian(ref, self.Ca, self.Cb, spin, spat)
+        # nao/nbo are the per-spin active occupied counts: the Hamiltonian needs them to
+        # split each spin's MO set into occ/vir for the semicanonical rotation.
+        self.H = SpinOrbitalHamiltonian(ref, self.Ca, self.Cb, spin, spat, nao, nbo)
 
     @property
     def derivatives(self) -> Derivatives:


### PR DESCRIPTION
  ## ROHF support via semicanonical orbitals (phase 5)

  Completes the spin-orbital enhancement's "UHF **and ROHF**" goal
  (`docs/ENHANCEMENT_PLAN_2026-06.md`). An ROHF reference auto-dispatches to the
  spin-orbital path, and the machinery is made correct for a non-canonical reference
  via semicanonical orbitals.

  ### What's in this PR
  
  - **`pycc/hamiltonian.py`** — `SpinOrbitalHamiltonian` semicanonicalizes each spin:
    `_semicanonicalize` diagonalizes the occ-occ and vir-vir blocks of the MO Fock and
    rotates the occupied/virtual MO column-blocks by the eigenvectors; all subsequent
    AO→MO transforms (Fock, ERI, properties) use the rotated coefficients. This gives
    well-defined orbital energies — hence non-iterative, well-defined MP2/(T)/CC3
    denominators — for ROHF, whose occ–vir Fock block stays nonzero. **A no-op for
    canonical RHF/UHF** (blocks already diagonal). ROHF feeds identical `Ca`/`Cb` but
    distinct `Fa`/`Fb`, so its semicanonical α/β orbitals diverge (UHF-like).

  - **`pycc/mpwfn.py`** — MP2 picks up the first-order **singles** `t1 = f_ia/Dia` and
    the `f_ia·t1_ia` energy term (spin-orbital path), nonzero only for a non-canonical
    reference. `CCwfn` starts its spin-orbital `t1` from this MP1 guess.

  - **`pycc/cctriples.py`** — the viking `(T)` gains the non-canonical occ–vir-Fock
    term `x2[i,j] += f_kc·t3` (the bare-Fock analog of CC3's `Fme[k]` term); zero for
    canonical references, so RHF/UHF `(T)` are unchanged. Also a small CC3 cleanup: the
    `Wvovv` antisymmetrization reuses one contraction via `tmp - tmp.swapaxes(0,1)`.

  - **`pycc/tests/`** — `rohf_wfn` fixture (`conftest.py`); `test_054_rohf.py`: ROHF
    MP2/CCSD/CCSD(T) (cc-pVDZ) and CC3 (6-31G) on the ·OH doublet vs Psi4's
    semicanonical CCENERGY.

  ### Validation
  
  | Check | Result |
  |---|---|
  | ROHF MP2 vs Psi4 (semicanonical, singles incl.) | ~1e-12 |
  | ROHF CCSD vs Psi4 | ~1e-12 |
  | ROHF CCSD(T) vs Psi4 | ~4e-14 (the new `f_kc·t3` term closed a ~1.2e-6 gap) |
  | ROHF CC3 vs Psi4 | ~1e-13 |
  | UHF/RHF (T) and CC3 (existing) | unchanged (new terms are no-ops for canonical) |

  ### Scope

  The spin-orbital path now covers MP2/CCSD/CCSD(T)/CC3 energies for **UHF and ROHF**.
  Lambda/density/response/EOM/RT/local/GPU remain spatial-RHF-only.

  ### Test status

  Full non-slow suite green: **78 passed** (+2 ROHF), 3 skipped (GPU), 8 deselected
  (slow), 1 xfail. No regressions.
