### PR TITLE
Spin-orbital CISD/CID for UHF/ROHF (CIwfn)

### DIFF
--- a/docs/ENHANCEMENT_PLAN_2026-06.md
+++ b/docs/ENHANCEMENT_PLAN_2026-06.md
@@ -136,7 +136,8 @@ _Last updated 2026-06-17._
 | 3 — SO CCSD | ✅ done | PR #135 |
 | 4a — SO CCSD(T) | ✅ done | PR #136 |
 | 4b — SO CC3 | ✅ done | PR #137 |
-| 5 — ROHF (semicanonical) | 🟡 in review | branch `feature/spinorbital-rohf` |
+| 5 — ROHF (semicanonical) | ✅ done | PR #138 |
+| 6 — SO CISD/CID (UHF/ROHF) | 🟡 in review | branch `feature/spinorbital-cisd` |
 
 ### Phase 1 — what landed
 
@@ -234,6 +235,21 @@ path (open shell), and the SO machinery is made correct for a non-canonical refe
   antisymmetrization now reuses one contraction via `tmp - tmp.swapaxes(0,1)`.)
 - `conftest.py` `rohf_wfn` fixture; `test_054_rohf.py`: ROHF MP2/CCSD/CCSD(T) (cc-pVDZ)
   and CC3 (6-31G) on .OH vs Psi4's semicanonical CCENERGY (all ~1e-13/1e-14).
+
+### Phase 6 — what landed (spin-orbital CISD/CID)
+
+Beyond the original energies-first scope, extends `CIwfn` to UHF/ROHF.
+
+- `pycc/ciwfn.py`: `ci_energy`/`sigma1`/`sigma2` branch on `orbital_basis` to spin-orbital
+  siblings -- the linear part of the spin-orbital CCSD residual with bare integrals.
+  The doubles sigma carries an extra **non-canonical singles->doubles Fock coupling**
+  `<Phi_ij^ab|F_N|Phi_k^c> = P(ij)P(ab) f_jb c1_ia`: zero for canonical refs and for CID,
+  absorbed by the T1 transformation in CCSD, but required explicitly in linear CISD for
+  ROHF. (Found via CFOUR: ROHF-CID matched but ROHF-CISD was 5.5e-5 off until this term.)
+- Validation (`test_051`): closed-shell keystone (SO-RHF == spatial); 2-electron CISD =
+  FCI (exact) for UHF/ROHF vs Psi4 FCI; and a **CFOUR** cross-check (UHF/ROHF x CISD/CID,
+  .OH cc-pVDZ, ~1e-13). Note: Psi4 has no UHF-CISD, and its DETCI ROHF-CISD is
+  spin-adapted -- a different method that disagrees with both PyCC and CFOUR (~3e-4).
 
 **To resume:** read this doc + `git log`. The spin-orbital equation seed lives in
 `~/src/socc` (machine-local, not part of this repo); see `socc/hamiltonian.py` for the

--- a/pycc/ciwfn.py
+++ b/pycc/ciwfn.py
@@ -93,7 +93,8 @@ class CIwfn(Wavefunction):
         ci_tstart = time.time()
 
         o, v = self.o, self.v
-        F, ERI, L = self.H.F, self.H.ERI, self.H.L
+        F, ERI = self.H.F, self.H.ERI
+        L = self.H.L if self.orbital_basis == 'spatial' else None  # no L in spin orbitals
         Dia, Dijab = self.Dia, self.Dijab
         contract = self.contract
 
@@ -139,10 +140,21 @@ class CIwfn(Wavefunction):
 
         The singles term is kept general (non-zero only for non-Brillouin references);
         the doubles term is the linear (CI) form of the CC energy (no t1.t1).
+
+        Spin-orbital path: E_c = f_ia c_ia + 1/4 <ij||ab> c_ijab.
         """
+        if self.orbital_basis == 'spinorbital':
+            return self._ci_energy_spinorbital(o, v, F, self.H.ERI, c1, c2)
         contract = self.contract
         e = 2.0 * contract('ia,ia->', F[o, v], c1)
         e = e + contract('ijab,ijab->', c2, L[o, o, v, v])
+        return e
+
+    def _ci_energy_spinorbital(self, o, v, F, ERI, c1, c2) -> "Tensor":
+        """Spin-orbital CISD correlation energy, E_c = f_ia c_ia + 1/4 <ij||ab> c_ijab."""
+        contract = self.contract
+        e = contract('ia,ia->', F[o, v], c1)
+        e = e + 0.25 * contract('ijab,ijab->', c2, ERI[o, o, v, v])
         return e
 
     def sigma1(self, o, v, F, ERI, L, c1, c2) -> "Tensor":
@@ -157,6 +169,9 @@ class CIwfn(Wavefunction):
         if not self.need_singles:
             return zeros_like(c1)
 
+        if self.orbital_basis == 'spinorbital':
+            return self._sigma1_spinorbital(o, v, F, self.H.ERI, c1, c2)
+
         contract = self.contract
         s1 = clone(F[o, v], device=self.device1)
         s1 = s1 + contract('ie,ae->ia', c1, F[v, v])
@@ -165,6 +180,20 @@ class CIwfn(Wavefunction):
         s1 = s1 + contract('nf,nafi->ia', c1, L[o, v, v, o])
         s1 = s1 + contract('amef,imef->ia', L[v, o, v, v], c2)
         s1 = s1 - contract('mnae,mnie->ia', c2, L[o, o, o, v])
+        return s1
+
+    def _sigma1_spinorbital(self, o, v, F, ERI, c1, c2) -> "Tensor":
+        """Spin-orbital singles sigma vector: the linear part of the spin-orbital CCSD
+        T1 residual (t -> c) with the dressed one-body intermediates replaced by the
+        bare Fock blocks (Fae -> f_vv, Fmi -> f_oo, Fme -> f_ov)."""
+        contract = self.contract
+        s1 = clone(F[o, v], device=self.device1)
+        s1 = s1 + contract('ie,ae->ia', c1, F[v, v])
+        s1 = s1 - contract('ma,mi->ia', c1, F[o, o])
+        s1 = s1 + contract('imae,me->ia', c2, F[o, v])
+        s1 = s1 - contract('nf,naif->ia', c1, ERI[o, v, o, v])
+        s1 = s1 - 0.5 * contract('imef,maef->ia', c2, ERI[o, v, v, v])
+        s1 = s1 - 0.5 * contract('mnae,nmei->ia', c2, ERI[o, o, v, o])
         return s1
 
     def sigma2(self, o, v, F, ERI, L, c1, c2) -> "Tensor":
@@ -180,6 +209,9 @@ class CIwfn(Wavefunction):
                          + c1_ie <ab|ej> - c1_ma <mb|ij>
             sigma2 = sigma2(half) + sigma2(half)[i<->j, a<->b]
         """
+        if self.orbital_basis == 'spinorbital':
+            return self._sigma2_spinorbital(o, v, F, self.H.ERI, c1, c2)
+
         contract = self.contract
 
         s2 = 0.5 * clone(ERI[o, o, v, v], device=self.device1)
@@ -195,4 +227,37 @@ class CIwfn(Wavefunction):
             s2 = s2 - contract('ma,mbij->ijab', c1, ERI[o, v, o, o])
 
         s2 = s2 + s2.swapaxes(0, 1).swapaxes(2, 3)
+        return s2
+
+    def _sigma2_spinorbital(self, o, v, F, ERI, c1, c2) -> "Tensor":
+        """Spin-orbital doubles sigma vector: the linear part of the spin-orbital CCSD
+        T2 residual (t -> c) with the dressed two-body intermediates replaced by their
+        bare antisymmetrized integrals. Built as the full (already i<->j, a<->b
+        antisymmetric) residual, as in the spin-orbital ``_so_r_T2`` -- no separate
+        symmetrization step."""
+        contract = self.contract
+
+        s2 = clone(ERI[o, o, v, v], device=self.device1)
+        s2 = s2 + (contract('ijae,be->ijab', c2, F[v, v])
+                   - contract('ijbe,ae->ijab', c2, F[v, v]))
+        s2 = s2 - (contract('imab,mj->ijab', c2, F[o, o])
+                   - contract('jmab,mi->ijab', c2, F[o, o]))
+        s2 = s2 + 0.5 * contract('mnab,mnij->ijab', c2, ERI[o, o, o, o])
+        s2 = s2 + 0.5 * contract('ijef,abef->ijab', c2, ERI[v, v, v, v])
+        s2 = s2 + contract('imae,mbej->ijab', c2, ERI[o, v, v, o])
+        s2 = s2 - contract('imbe,maej->ijab', c2, ERI[o, v, v, o])
+        s2 = s2 - contract('jmae,mbei->ijab', c2, ERI[o, v, v, o])
+        s2 = s2 + contract('jmbe,maei->ijab', c2, ERI[o, v, v, o])
+        if self.need_singles:
+            s2 = s2 + (contract('ie,abej->ijab', c1, ERI[v, v, v, o])
+                       - contract('je,abei->ijab', c1, ERI[v, v, v, o]))
+            s2 = s2 - (contract('ma,mbij->ijab', c1, ERI[o, v, o, o])
+                       - contract('mb,maij->ijab', c1, ERI[o, v, o, o]))
+            # Bare-Fock singles->doubles coupling <Phi_ij^ab|F_N|Phi_k^c> =
+            # P(ij)P(ab) f_jb c1_ia. Zero for a canonical reference (f_ov = 0); in CCSD
+            # it is absorbed by the T1 similarity transformation, but linear CISD needs
+            # it explicitly for a non-canonical (ROHF) reference.
+            tmp = contract('ia,jb->ijab', c1, F[o, v])
+            s2 = s2 + (tmp - tmp.swapaxes(0, 1) - tmp.swapaxes(2, 3)
+                       + tmp.swapaxes(0, 1).swapaxes(2, 3))
         return s2

--- a/pycc/tests/test_051_cisd.py
+++ b/pycc/tests/test_051_cisd.py
@@ -62,3 +62,95 @@ def test_cid_h2o_frozen_core(rhf_wfn):
                   e_convergence=1e-12, d_convergence=1e-12)
     ecid = pycc.CIwfn(wfn, model="CID").solve_ci(e_conv=1e-12, r_conv=1e-12)
     assert abs(ecid - CID_REF_FC) < 1e-11
+
+
+# --- Spin-orbital CISD/CID (UHF/ROHF) -------------------------------------------
+# These are spin-orbital (determinant) CISD/CID. The external reference is CFOUR, which
+# computes the same spin-orbital CISD/CID (matching to ~1e-13 for UHF and ROHF, CISD and
+# CID). Psi4 cannot validate this: it has no UHF-CISD, and its DETCI ROHF-CISD is
+# spin-adapted (CSF) -- a genuinely different method that disagrees with both PyCC and
+# CFOUR for open shells. The kernel is additionally validated by the closed-shell
+# keystone (SO-RHF == spatial) and the 2-electron identity CISD = FCI (exact,
+# orbital-invariant) vs Psi4 FCI.
+
+# Triplet H2 at 1.4 bohr: 2 electrons, so CISD = FCI exactly.
+H2_TRIPLET = """
+0 3
+H 0.0 0.0 0.0
+H 0.0 0.0 1.4
+units bohr
+no_com
+no_reorient
+symmetry c1
+"""
+# Exact FCI total energy for H2_TRIPLET / 6-31G (Psi4 FCI; = CISD for 2 electrons).
+FCI_TOTAL_H2T = -0.757409321179
+
+
+def test_so_cisd_cid_equals_spatial_rhf(rhf_wfn):
+    """Spin-orbital CISD and CID (forced) reproduce the spin-adapted spatial values on a
+    closed shell, isolating the spin-orbital CI kernel."""
+    wfn = rhf_wfn(H2O, "6-31G", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    for model in ("CISD", "CID"):
+        e_spatial = pycc.CIwfn(wfn, frozen_core=False, model=model).solve_ci(
+            e_conv=1e-11, r_conv=1e-11)
+        so = pycc.CIwfn(wfn, frozen_core=False, model=model, orbital_basis="spinorbital")
+        assert so.orbital_basis == "spinorbital"
+        e_so = so.solve_ci(e_conv=1e-11, r_conv=1e-11)
+        assert abs(e_so - e_spatial) < 1e-10
+
+
+def test_uhf_cisd_equals_fci(uhf_wfn):
+    """2-electron triplet: UHF-CISD = FCI (exact, orbital-invariant oracle)."""
+    wfn = uhf_wfn(H2_TRIPLET, "6-31G", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    ecisd = pycc.CIwfn(wfn, frozen_core=False).solve_ci(e_conv=1e-11, r_conv=1e-11)
+    assert abs((wfn.energy() + ecisd) - FCI_TOTAL_H2T) < 1e-10
+
+
+def test_rohf_cisd_equals_fci(rohf_wfn):
+    """2-electron triplet: ROHF-CISD = FCI (exact); validates the ROHF code path."""
+    wfn = rohf_wfn(H2_TRIPLET, "6-31G", freeze_core="false",
+                   e_convergence=1e-12, d_convergence=1e-12)
+    ecisd = pycc.CIwfn(wfn, frozen_core=False).solve_ci(e_conv=1e-11, r_conv=1e-11)
+    assert abs((wfn.energy() + ecisd) - FCI_TOTAL_H2T) < 1e-10
+
+
+# OH doublet at 1.83 bohr (verbatim for both codes); CFOUR spin-orbital CISD/CID
+# correlation energies, cc-pVDZ, all-electron.
+OH_BOHR = """
+0 2
+O 0.0 0.0 0.0
+H 0.0 0.0 1.83
+units bohr
+no_com
+no_reorient
+symmetry c1
+"""
+CFOUR_UHF_CISD = -0.161059480423
+CFOUR_UHF_CID = -0.160472710690
+CFOUR_ROHF_CISD = -0.164616502232
+CFOUR_ROHF_CID = -0.161769562501
+
+
+def test_uhf_cisd_cid_vs_cfour(uhf_wfn):
+    """Multi-electron UHF CISD and CID (.OH cc-pVDZ) vs CFOUR's spin-orbital CISD/CID."""
+    wfn = uhf_wfn(OH_BOHR, "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    ecisd = pycc.CIwfn(wfn, frozen_core=False, model="CISD").solve_ci(e_conv=1e-11, r_conv=1e-11)
+    ecid = pycc.CIwfn(wfn, frozen_core=False, model="CID").solve_ci(e_conv=1e-11, r_conv=1e-11)
+    assert abs(ecisd - CFOUR_UHF_CISD) < 1e-10
+    assert abs(ecid - CFOUR_UHF_CID) < 1e-10
+
+
+def test_rohf_cisd_cid_vs_cfour(rohf_wfn):
+    """Multi-electron ROHF CISD and CID (.OH cc-pVDZ) vs CFOUR's spin-orbital CISD/CID.
+    Exercises the non-canonical singles->doubles Fock coupling that distinguishes
+    spin-orbital CISD from the spin-adapted (DETCI) variant."""
+    wfn = rohf_wfn(OH_BOHR, "cc-pVDZ", freeze_core="false",
+                   e_convergence=1e-12, d_convergence=1e-12)
+    ecisd = pycc.CIwfn(wfn, frozen_core=False, model="CISD").solve_ci(e_conv=1e-11, r_conv=1e-11)
+    ecid = pycc.CIwfn(wfn, frozen_core=False, model="CID").solve_ci(e_conv=1e-11, r_conv=1e-11)
+    assert abs(ecisd - CFOUR_ROHF_CISD) < 1e-10
+    assert abs(ecid - CFOUR_ROHF_CID) < 1e-10


### PR DESCRIPTION
## Spin-orbital CISD/CID for UHF/ROHF (CIwfn)
  
  Extends the configuration-interaction wavefunction to open-shell **UHF and ROHF**
  references via the spin-orbital path, building on the spin-orbital Hamiltonian /
  semicanonical-ROHF infrastructure (PRs #133–#138).

  ### What's in this PR

  - **`pycc/ciwfn.py`** — `ci_energy`, `sigma1`, and `sigma2` branch on
    `orbital_basis` to spin-orbital siblings (`_ci_energy/_sigma1/_sigma2_spinorbital`).
    These are the **linear part of the spin-orbital CCSD residual** (t → c) with the
    dressed intermediates replaced by bare Fock blocks and antisymmetrized integrals;
    `solve_ci` guards the (nonexistent) spin-adapted `L`.
  - **The non-canonical singles→doubles Fock coupling.** The doubles sigma adds
    `⟨Φ_ij^ab|F_N|Φ_k^c⟩ = P(ij)P(ab) f_jb c1_ia`. This is **zero for a canonical
    reference** (`f_ov = 0`, so UHF/RHF unchanged) and **zero for CID** (`c1 = 0`); in
    CCSD it is absorbed by the T1 similarity transformation, but linear CISD needs it
    explicitly for a non-canonical (ROHF) reference. Without it, ROHF-CISD was 5.5e-5
    off CFOUR; with it, exact.
  - **`pycc/tests/test_051_cisd.py`** — spin-orbital validation alongside the existing
    RHF CISD/CID tests.
  - **`docs/ENHANCEMENT_PLAN_2026-06.md`** — records phase 6.

  ### Validation

  | Check | Result |
  |---|---|
  | Keystone: SO-RHF CISD/CID == spatial (closed shell) | < 1e-10 |
  | UHF-CISD == Psi4 FCI (2e⁻ triplet, exact) | ~1e-15 |
  | ROHF-CISD == Psi4 FCI (2e⁻ triplet, exact) | ~1e-15 |
  | UHF CISD & CID vs CFOUR (·OH cc-pVDZ) | ~1e-13 |
  | ROHF CISD & CID vs CFOUR (·OH cc-pVDZ) | ~1e-13 |

  **On the reference choice:** Psi4 has no UHF-CISD (`MissingMethodError`), and its
  DETCI ROHF-CISD is **spin-adapted (CSF)** — a genuinely different method that
  disagrees with both PyCC and CFOUR (~3e-4) for open shells. CFOUR computes the same
  **spin-orbital (determinant)** CISD/CID and agrees to ~1e-13, so it is the correct
  external oracle here. The CFOUR references are hardcoded constants (CFOUR does not run
  in CI), generated at an exact bohr geometry to avoid the CFOUR/Psi4 Å-conversion
  mismatch.

  ### Scope

  The spin-orbital path now covers MP2, CCSD, CCSD(T), CC3, and **CISD/CID** for UHF and
  ROHF. Lambda/density/response/EOM/RT/local/GPU remain spatial-RHF-only.

  ### Test status

  Full non-slow suite green: **83 passed**, 3 skipped (GPU), 8 deselected (slow), 1 xfail.
  No regressions. The spatial RHF CISD/CID path is untouched (all branches fire only for
  `orbital_basis == 'spinorbital'`).
