### PR TITLE
Add spin-orbital CCSD Lambda (UHF/ROHF) to cchbar/cclambda

### DIFF
--- a/docs/ENHANCEMENT_PLAN_2026-06.md
+++ b/docs/ENHANCEMENT_PLAN_2026-06.md
@@ -137,7 +137,8 @@ _Last updated 2026-06-17._
 | 4a — SO CCSD(T) | ✅ done | PR #136 |
 | 4b — SO CC3 | ✅ done | PR #137 |
 | 5 — ROHF (semicanonical) | ✅ done | PR #138 |
-| 6 — SO CISD/CID (UHF/ROHF) | 🟡 in review | branch `feature/spinorbital-cisd` |
+| 6 — SO CISD/CID (UHF/ROHF) | ✅ done | PR #139 |
+| 7 — SO Lambda (CCSD) | 🟡 in review | branch `feature/spinorbital-lambda` |
 
 ### Phase 1 — what landed
 
@@ -250,6 +251,21 @@ Beyond the original energies-first scope, extends `CIwfn` to UHF/ROHF.
   FCI (exact) for UHF/ROHF vs Psi4 FCI; and a **CFOUR** cross-check (UHF/ROHF x CISD/CID,
   .OH cc-pVDZ, ~1e-13). Note: Psi4 has no UHF-CISD, and its DETCI ROHF-CISD is
   spin-adapted -- a different method that disagrees with both PyCC and CFOUR (~3e-4).
+
+### Phase 7 — what landed (spin-orbital Lambda)
+
+The first step toward open-shell **properties** (Lambda -> density -> response).
+
+- `pycc/cchbar.py`: `cchbar` builds the 10 spin-orbital HBAR blocks (no separate `Hovov`;
+  an inline `Zovov` feeds `Hvvvo`/`Hovoo`) from the antisymmetrized ERI, via a
+  `_build_spinorbital` dispatch + `_so_build_*` methods (ported from socc).
+- `pycc/cclambda.py`: `__init__`/`solve_lambda`/`build_Goo`/`build_Gvv`/`pseudoenergy`/
+  `r_L1`/`r_L2` branch on `orbital_basis` to spin-orbital siblings. SO guess l1=t1, l2=t2;
+  pseudoenergy 1/4 <ij||ab> l2. CCSD/CCD only (CC3 Lambda raises in the SO path).
+- Validation (`test_003`): keystone (SO-RHF Lambda == spatial, ~1e-13) and a **CFOUR**
+  cross-check of the Lambda pseudoenergy for UHF and ROHF (.OH cc-pVDZ, exact to 12
+  digits -- CFOUR `PRINT=2` reports the total Lambda pseudoenergy with the same
+  definition).
 
 **To resume:** read this doc + `git log`. The spin-orbital equation seed lives in
 `~/src/socc` (machine-local, not part of this repo); see `socc/hamiltonian.py` for the

--- a/o.dat
+++ b/o.dat
@@ -1,0 +1,445 @@
+
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on rigel.local
+*** at Wed Jun 17 17:23:28 2026
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry O          line   198 file /Users/crawdad/miniconda3/envs/p4env/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry H          line    22 file /Users/crawdad/miniconda3/envs/p4env/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,   1907 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C_inf_v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000     0.000000000000    15.994914619570
+         H            0.000000000000     0.000000000000     1.830000000000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A = ************  B =     17.83639  C =     17.83639 [cm^-1]
+  Rotational constants: A = ************  B = 534721.45904  C = 534721.45904 [MHz]
+  Nuclear repulsion =    4.371584699453551
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis functions: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:               9
+      Number of primitives:             27
+      Number of atomic orbitals:        20
+      Number of basis functions:        19
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 36290 doubles for integral storage.
+  We computed 1035 shell quartets total.
+  Whereas there are 1035 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:             1430
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 5.0667620432E-02.
+  Reciprocal condition number of the overlap matrix is 1.7273898371E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         19      19 
+   -------------------------
+    Total      19      19
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.31420993696061   -7.53142e+01   0.00000e+00 
+   @UHF iter   1:   -75.30388332668853    1.03266e-02   2.36754e-02 ADIIS/DIIS
+   @UHF iter   2:   -75.38314397497882   -7.92606e-02   8.82451e-03 ADIIS/DIIS
+   @UHF iter   3:   -75.39332550251279   -1.01815e-02   1.50203e-03 ADIIS/DIIS
+   @UHF iter   4:   -75.39378212236200   -4.56620e-04   4.43272e-04 ADIIS/DIIS
+   @UHF iter   5:   -75.39385184154656   -6.97192e-05   1.89514e-04 ADIIS/DIIS
+   @UHF iter   6:   -75.39387128145600   -1.94399e-05   6.76104e-05 DIIS
+   @UHF iter   7:   -75.39387464462595   -3.36317e-06   2.02674e-05 DIIS
+   @UHF iter   8:   -75.39387495901620   -3.14390e-07   4.42318e-06 DIIS
+   @UHF iter   9:   -75.39387496901232   -9.99611e-09   8.41949e-07 DIIS
+   @UHF iter  10:   -75.39387496929542   -2.83109e-10   1.09174e-07 DIIS
+   @UHF iter  11:   -75.39387496929984   -4.41958e-12   1.21489e-08 DIIS
+   @UHF iter  12:   -75.39387496929993   -8.52651e-14   2.09004e-09 DIIS
+   @UHF iter  13:   -75.39387496929994   -1.42109e-14   3.83575e-10 DIIS
+   @UHF iter  14:   -75.39387496929993    1.42109e-14   4.69802e-11 DIIS
+   @UHF iter  15:   -75.39387496929996   -2.84217e-14   7.75254e-12 DIIS
+   @UHF iter  16:   -75.39387496929992    4.26326e-14   1.28845e-12 DIIS
+   @UHF iter  17:   -75.39387496929990    1.42109e-14   3.89723e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   4.583431845E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.545834318E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -20.626138     2A     -1.374839     3A     -0.666906  
+       4A     -0.638661     5A     -0.545046  
+
+    Alpha Virtual:                                                        
+
+       6A      0.185077     7A      0.794737     8A      1.101772  
+       9A      1.147448    10A      1.163498    11A      1.514851  
+      12A      1.536380    13A      1.640010    14A      2.384449  
+      15A      2.875788    16A      2.876902    17A      3.210079  
+      18A      3.271054    19A      3.979019  
+
+    Beta Occupied:                                                        
+
+       1A    -20.586195     2A     -1.219300     3A     -0.623964  
+       4A     -0.499246  
+
+    Beta Virtual:                                                         
+
+       5A      0.137623     6A      0.196868     7A      0.805905  
+       8A      1.169577     9A      1.187474    10A      1.305130  
+      11A      1.533860    12A      1.545140    13A      1.685712  
+      14A      2.409093    15A      2.996989    16A      2.998496  
+      17A      3.287515    18A      3.312596    19A      4.013407  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+    NA   [     5 ]
+    NB   [     4 ]
+
+  @UHF Final Energy:   -75.39387496929990
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3715846994535514
+    One-Electron Energy =                -112.7506257231979134
+    Two-Electron Energy =                  32.9851660544444627
+    Total Energy =                        -75.3938749692999011
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9995069
+  HONO-1 :    4  A 1.9983687
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0016313
+  LUNO+1 :    7  A 0.0004931
+  LUNO+2 :    8  A 0.0001686
+  LUNO+3 :    9  A 0.0000002
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Z            :         -1.1209245            1.8300000            0.7090755
+ Magnitude           :                                                    0.7090755
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on rigel.local at Wed Jun 17 17:23:28 2026
+Module time:
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on rigel.local
+*** at Wed Jun 17 17:23:31 2026
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry O          line   198 file /Users/crawdad/miniconda3/envs/p4env/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry H          line    22 file /Users/crawdad/miniconda3/envs/p4env/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             ROHF Reference
+                        1 Threads,   1907 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C_inf_v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000     0.000000000000    15.994914619570
+         H            0.000000000000     0.000000000000     1.830000000000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A = ************  B =     17.83639  C =     17.83639 [cm^-1]
+  Rotational constants: A = ************  B = 534721.45904  C = 534721.45904 [MHz]
+  Nuclear repulsion =    4.371584699453551
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-12
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 9
+    Number of basis functions: 19
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:               9
+      Number of primitives:             27
+      Number of atomic orbitals:        20
+      Number of basis functions:        19
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 36290 doubles for integral storage.
+  We computed 1035 shell quartets total.
+  Whereas there are 1035 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:             1430
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 5.0667620432E-02.
+  Reciprocal condition number of the overlap matrix is 1.7273898371E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         19      19 
+   -------------------------
+    Total      19      19
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @ROHF iter SAD:   -75.31420993696061   -7.53142e+01   0.00000e+00 
+   @ROHF iter   1:   -75.30388332668851    1.03266e-02   1.77342e-02 DIIS
+   @ROHF iter   2:   -75.37780593379401   -7.39226e-02   7.19656e-03 DIIS
+   @ROHF iter   3:   -75.38980614047118   -1.20002e-02   8.88057e-04 DIIS
+   @ROHF iter   4:   -75.39002987748913   -2.23737e-04   1.44775e-04 DIIS
+   @ROHF iter   5:   -75.39004085256784   -1.09751e-05   2.81190e-05 DIIS
+   @ROHF iter   6:   -75.39004122408775   -3.71520e-07   3.95269e-06 DIIS
+   @ROHF iter   7:   -75.39004123766631   -1.35786e-08   7.13498e-07 DIIS
+   @ROHF iter   8:   -75.39004123812940   -4.63089e-10   6.39067e-08 DIIS
+   @ROHF iter   9:   -75.39004123813169   -2.28795e-12   4.31601e-09 DIIS
+   @ROHF iter  10:   -75.39004123813160    8.52651e-14   6.33045e-10 DIIS
+   @ROHF iter  11:   -75.39004123813169   -8.52651e-14   6.96504e-11 DIIS
+   @ROHF iter  12:   -75.39004123813169    0.00000e+00   5.52774e-12 DIIS
+   @ROHF iter  13:   -75.39004123813173   -4.26326e-14   8.38124e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.607359     2A     -1.295389     3A     -0.645939  
+       4A     -0.522570  
+
+    Singly Occupied:                                                      
+
+       5A     -0.228764  
+
+    Virtual:                                                              
+
+       6A      0.190688     7A      0.799786     8A      1.158194  
+       9A      1.175002    10A      1.182043    11A      1.530046  
+      12A      1.534977    13A      1.662518    14A      2.396749  
+      15A      2.936055    16A      2.936088    17A      3.260708  
+      18A      3.279001    19A      3.995228  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+    NA   [     5 ]
+    NB   [     4 ]
+
+  @ROHF Final Energy:   -75.39004123813173
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              4.3715846994535514
+    One-Electron Energy =                -112.7507071528195581
+    Two-Electron Energy =                  32.9890812152342789
+    Total Energy =                        -75.3900412381317295
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Z            :         -1.1200437            1.8300000            0.7099563
+ Magnitude           :                                                    0.7099563
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on rigel.local at Wed Jun 17 17:23:31 2026
+Module time:
+	user time   =       0.18 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.24 seconds =       0.04 minutes
+	system time =       0.72 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes

--- a/pycc/cchbar.py
+++ b/pycc/cchbar.py
@@ -70,13 +70,18 @@ class cchbar(object):
  
         F = ccwfn.H.F
         ERI = ccwfn.H.ERI
-        L = ccwfn.H.L
+        L = ccwfn.H.L if ccwfn.orbital_basis == 'spatial' else None  # no L in spin orbitals
         t1 = ccwfn.t1
         t2 = ccwfn.t2
         o = self.o = ccwfn.o
         v = self.v = ccwfn.v
         self.no = ccwfn.no
         self.nv = ccwfn.nv
+
+        if ccwfn.orbital_basis == 'spinorbital':
+            self._build_spinorbital(o, v, F, ERI, t1, t2)
+            print("\nHBAR constructed in %.3f seconds." % (time.time() - time_init))
+            return
 
         self.Hov = self.build_Hov(o, v, F, L, t1)
         self.Hvv = self.build_Hvv(o, v, F, L, t1, t2)
@@ -97,6 +102,124 @@ class cchbar(object):
     2-index tensors are stored on GPU
     4-index tensors are stored on CPU
     """
+
+    # ------------------------------------------------------------------
+    # Spin-orbital HBAR (open-shell UHF/ROHF references)
+    #
+    # The spatial blocks above ride on the spin-adapted L tensor (no L in spin
+    # orbitals). These siblings build the HBAR blocks directly from the
+    # antisymmetrized ERI = <pq||rs>, ported from ~/src/socc. There is no separate
+    # Hovov block; the spin-orbital Lambda residuals fold it into the antisymmetrized
+    # Hovvo, using an inline Zovov intermediate in Hvvvo/Hovoo.
+    # ------------------------------------------------------------------
+
+    def _build_spinorbital(self, o, v, F, ERI, t1, t2):
+        self.Hov = self._so_build_Hov(o, v, F, ERI, t1)
+        self.Hvv = self._so_build_Hvv(o, v, F, ERI, self.Hov, t1, t2)
+        self.Hoo = self._so_build_Hoo(o, v, F, ERI, self.Hov, t1, t2)
+        self.Hoooo = self._so_build_Hoooo(o, v, ERI, t1, t2)
+        self.Hvvvv = self._so_build_Hvvvv(o, v, ERI, t1, t2)
+        self.Hvovv = self._so_build_Hvovv(o, v, ERI, t1)
+        self.Hooov = self._so_build_Hooov(o, v, ERI, t1)
+        self.Hovvo = self._so_build_Hovvo(o, v, ERI, t1, t2)
+        Zovov = self._so_build_Zovov(o, v, ERI, t2)
+        self.Hvvvo = self._so_build_Hvvvo(o, v, ERI, self.Hov, self.Hvvvv, Zovov, t1, t2)
+        self.Hovoo = self._so_build_Hovoo(o, v, ERI, self.Hov, self.Hoooo, Zovov, t1, t2)
+
+    def _so_build_Hov(self, o, v, F, ERI, t1):
+        contract = self.contract
+        Hov = clone(F[o,v])
+        Hov = Hov + contract('nf,mnef->me', t1, ERI[o,o,v,v])
+        return Hov
+
+    def _so_build_Hvv(self, o, v, F, ERI, Hov, t1, t2):
+        contract = self.contract
+        taut = self.ccwfn._so_build_tau(t1, t2, 1.0, 0.5)
+        Hvv = clone(F[v,v])
+        Hvv = Hvv - 0.5 * contract('me,ma->ae', F[o,v], t1)
+        Hvv = Hvv - 0.5 * contract('me,ma->ae', Hov, t1)
+        Hvv = Hvv + contract('mf,amef->ae', t1, ERI[v,o,v,v])
+        Hvv = Hvv - 0.5 * contract('mnaf,mnef->ae', taut, ERI[o,o,v,v])
+        return Hvv
+
+    def _so_build_Hoo(self, o, v, F, ERI, Hov, t1, t2):
+        contract = self.contract
+        taut = self.ccwfn._so_build_tau(t1, t2, 1.0, 0.5)
+        Hoo = clone(F[o,o])
+        Hoo = Hoo + 0.5 * contract('ie,me->mi', t1, F[o,v])
+        Hoo = Hoo + 0.5 * contract('ie,me->mi', t1, Hov)
+        Hoo = Hoo + contract('ne,mnie->mi', t1, ERI[o,o,o,v])
+        Hoo = Hoo + 0.5 * contract('inef,mnef->mi', taut, ERI[o,o,v,v])
+        return Hoo
+
+    def _so_build_Hoooo(self, o, v, ERI, t1, t2):
+        contract = self.contract
+        tau = self.ccwfn._so_build_tau(t1, t2)
+        Hoooo = clone(ERI[o,o,o,o])
+        Hoooo = Hoooo + (contract('je,mnie->mnij', t1, ERI[o,o,o,v])
+                         - contract('ie,mnje->mnij', t1, ERI[o,o,o,v]))
+        Hoooo = Hoooo + 0.5 * contract('ijef,mnef->mnij', tau, ERI[o,o,v,v])
+        return Hoooo
+
+    def _so_build_Hvvvv(self, o, v, ERI, t1, t2):
+        contract = self.contract
+        tau = self.ccwfn._so_build_tau(t1, t2)
+        Hvvvv = clone(ERI[v,v,v,v])
+        Hvvvv = Hvvvv - (contract('mb,amef->abef', t1, ERI[v,o,v,v])
+                         - contract('ma,bmef->abef', t1, ERI[v,o,v,v]))
+        Hvvvv = Hvvvv + 0.5 * contract('mnab,mnef->abef', tau, ERI[o,o,v,v])
+        return Hvvvv
+
+    def _so_build_Hvovv(self, o, v, ERI, t1):
+        contract = self.contract
+        Hvovv = clone(ERI[v,o,v,v])
+        Hvovv = Hvovv - contract('na,nmef->amef', t1, ERI[o,o,v,v])
+        return Hvovv
+
+    def _so_build_Hooov(self, o, v, ERI, t1):
+        contract = self.contract
+        Hooov = clone(ERI[o,o,o,v])
+        Hooov = Hooov + contract('if,mnfe->mnie', t1, ERI[o,o,v,v])
+        return Hooov
+
+    def _so_build_Hovvo(self, o, v, ERI, t1, t2):
+        contract = self.contract
+        Hovvo = clone(ERI[o,v,v,o])
+        Hovvo = Hovvo + contract('jf,mbef->mbej', t1, ERI[o,v,v,v])
+        Hovvo = Hovvo - contract('nb,mnej->mbej', t1, ERI[o,o,v,o])
+        tau = t2 + contract('ia,jb->ijab', t1, t1)
+        Hovvo = Hovvo - contract('jnfb,mnef->mbej', tau, ERI[o,o,v,v])
+        return Hovvo
+
+    def _so_build_Zovov(self, o, v, ERI, t2):
+        contract = self.contract
+        return clone(ERI[o,v,o,v]) + contract('nibf,mnef->mbie', t2, ERI[o,o,v,v])
+
+    def _so_build_Hvvvo(self, o, v, ERI, Hov, Hvvvv, Zovov, t1, t2):
+        contract = self.contract
+        tau = self.ccwfn._so_build_tau(t1, t2)
+        Hvvvo = clone(ERI[v,v,v,o])
+        Hvvvo = Hvvvo - contract('me,miab->abei', Hov, t2)
+        Hvvvo = Hvvvo + contract('if,abef->abei', t1, Hvvvv)
+        Hvvvo = Hvvvo + 0.5 * contract('mnab,mnei->abei', tau, ERI[o,o,v,o])
+        Hvvvo = Hvvvo - (contract('miaf,mbef->abei', t2, ERI[o,v,v,v])
+                         - contract('mibf,maef->abei', t2, ERI[o,v,v,v]))
+        Hvvvo = Hvvvo + (contract('ma,mbie->abei', t1, Zovov)
+                         - contract('mb,maie->abei', t1, Zovov))
+        return Hvvvo
+
+    def _so_build_Hovoo(self, o, v, ERI, Hov, Hoooo, Zovov, t1, t2):
+        contract = self.contract
+        tau = self.ccwfn._so_build_tau(t1, t2)
+        Hovoo = clone(ERI[o,v,o,o])
+        Hovoo = Hovoo - contract('me,ijbe->mbij', Hov, t2)
+        Hovoo = Hovoo - contract('nb,mnij->mbij', t1, Hoooo)
+        Hovoo = Hovoo + 0.5 * contract('ijef,mbef->mbij', tau, ERI[o,v,v,v])
+        Hovoo = Hovoo + (contract('jnbe,mnie->mbij', t2, ERI[o,o,o,v])
+                         - contract('inbe,mnje->mbij', t2, ERI[o,o,o,v]))
+        Hovoo = Hovoo - (contract('ie,mbje->mbij', t1, Zovov)
+                         - contract('je,mbie->mbij', t1, Zovov))
+        return Hovoo
     def build_Hov(self, o, v, F, L, t1):
         """Build the occupied-virtual block H_me of the one-body HBAR.
 

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -62,10 +62,16 @@ class cclambda(object):
 
         self.ccwfn = ccwfn
         self.hbar = hbar
-        self.contract = self.ccwfn.contract 
+        self.contract = self.ccwfn.contract
 
-        self.l1 = 2.0 * self.ccwfn.t1
-        self.l2 = 2.0 * (2.0 * self.ccwfn.t2 - self.ccwfn.t2.swapaxes(2, 3))
+        if self.ccwfn.orbital_basis == 'spinorbital':
+            # Spin-orbital guess: l1 = t1, l2 = t2 (the spin-adapted 2*t1 / 2(2t2-t2.T)
+            # form has no analog without L).
+            self.l1 = clone(self.ccwfn.t1)
+            self.l2 = clone(self.ccwfn.t2)
+        else:
+            self.l1 = 2.0 * self.ccwfn.t1
+            self.l2 = 2.0 * (2.0 * self.ccwfn.t2 - self.ccwfn.t2.swapaxes(2, 3))
 
     def solve_lambda(self, e_conv: float = 1e-7, r_conv: float = 1e-7, maxiter: int = 100, max_diis: int = 8, start_diis: int = 1) -> float:
         """
@@ -103,7 +109,11 @@ class cclambda(object):
         Dijab = self.ccwfn.Dijab
         F = self.ccwfn.H.F
         ERI = self.ccwfn.H.ERI
-        L = self.ccwfn.H.L
+        L = self.ccwfn.H.L if self.ccwfn.orbital_basis == 'spatial' else None
+
+        if self.ccwfn.orbital_basis == 'spinorbital' and self.ccwfn.model == 'CC3':
+            raise NotImplementedError("Spin-orbital Lambda currently supports CCSD/CCD, "
+                                      "not CC3.")
 
         Hov = self.hbar.Hov
         Hvv = self.hbar.Hvv
@@ -113,7 +123,7 @@ class cclambda(object):
         Hvovv = self.hbar.Hvovv
         Hooov = self.hbar.Hooov
         Hovvo = self.hbar.Hovvo
-        Hovov = self.hbar.Hovov
+        Hovov = self.hbar.Hovov if self.ccwfn.orbital_basis == 'spatial' else None
         Hvvvo = self.hbar.Hvvvo
         Hovoo = self.hbar.Hovoo
 
@@ -422,6 +432,8 @@ class cclambda(object):
             G_mi = t2_mjab l2_ijab
         """
         contract = self.contract
+        if self.ccwfn.orbital_basis == 'spinorbital':
+            return 0.5 * contract('mnef,inef->mi', t2, l2)
         return contract('mjab,ijab->mi', t2, l2)
 
 
@@ -440,6 +452,8 @@ class cclambda(object):
             G_ae = - t2_ijeb l2_ijab
         """
         contract = self.contract
+        if self.ccwfn.orbital_basis == 'spinorbital':
+            return -0.5 * contract('mnef,mnaf->ae', t2, l2)
         return -1.0 * contract('ijeb,ijab->ae', t2, l2)
 
 
@@ -467,6 +481,9 @@ class cclambda(object):
                     - G_mn (2 H_mina - H_imna)
         """
         contract = self.contract
+        if self.ccwfn.orbital_basis == 'spinorbital':
+            return self._r_L1_spinorbital(o, v, l1, l2, Hov, Hvv, Hoo, Hovvo, Hvvvo,
+                                          Hovoo, Hvovv, Hooov, Gvv, Goo)
         if self.ccwfn.model == 'CCD':
             r_l1 = zeros_like(l1)
         else:
@@ -523,6 +540,10 @@ class cclambda(object):
                       + G_ae L_ijeb - G_mi L_mjab
         """
         contract = self.contract
+        if self.ccwfn.orbital_basis == 'spinorbital':
+            return self._r_L2_spinorbital(o, v, l1, l2, self.ccwfn.H.ERI, Hov, Hvv, Hoo,
+                                          Hoooo, Hvvvv, Hovvo, Hvvvo, Hovoo, Hvovv, Hooov,
+                                          Gvv, Goo)
         if self.ccwfn.model == 'CCD':
             r_l2 = clone(L[o,o,v,v], device=self.ccwfn.device1)
 
@@ -632,6 +653,44 @@ class cclambda(object):
         W = W + contract('mnef,ma,nb->abef', ERI[o,o,v,v], t1, t1)
         return W
                                          
+    def _r_L1_spinorbital(self, o, v, l1, l2, Hov, Hvv, Hoo, Hovvo, Hvvvo, Hovoo,
+                          Hvovv, Hooov, Gvv, Goo):
+        """Spin-orbital L1 (lambda singles) residual, built from the antisymmetrized
+        spin-orbital HBAR blocks (no Hovov)."""
+        contract = self.contract
+        r_l1 = clone(Hov)
+        r_l1 = r_l1 + contract('ie,ea->ia', l1, Hvv)
+        r_l1 = r_l1 - contract('ma,im->ia', l1, Hoo)
+        r_l1 = r_l1 + 0.5 * contract('imef,efam->ia', l2, Hvvvo)
+        r_l1 = r_l1 - 0.5 * contract('mnae,iemn->ia', l2, Hovoo)
+        r_l1 = r_l1 + contract('me,ieam->ia', l1, Hovvo)
+        r_l1 = r_l1 - contract('ef,eifa->ia', Gvv, Hvovv)
+        r_l1 = r_l1 - contract('mn,mina->ia', Goo, Hooov)
+        return r_l1
+
+    def _r_L2_spinorbital(self, o, v, l1, l2, ERI, Hov, Hvv, Hoo, Hoooo, Hvvvv, Hovvo,
+                          Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo):
+        """Spin-orbital L2 (lambda doubles) residual. Built as the full residual,
+        already antisymmetric in i<->j and a<->b (no separate symmetrization)."""
+        contract = self.contract
+        r_l2 = clone(ERI[o,o,v,v])
+        r_l2 = r_l2 + (contract('ia,jb->ijab', l1, Hov) - contract('ja,ib->ijab', l1, Hov))
+        r_l2 = r_l2 + (contract('jb,ia->ijab', l1, Hov) - contract('ib,ja->ijab', l1, Hov))
+        r_l2 = r_l2 + (contract('ijae,eb->ijab', l2, Hvv) - contract('ijbe,ea->ijab', l2, Hvv))
+        r_l2 = r_l2 - (contract('imab,jm->ijab', l2, Hoo) - contract('jmab,im->ijab', l2, Hoo))
+        r_l2 = r_l2 + 0.5 * contract('ijef,efab->ijab', l2, Hvvvv)
+        r_l2 = r_l2 + 0.5 * contract('mnab,ijmn->ijab', l2, Hoooo)
+        r_l2 = r_l2 + (contract('ie,ejab->ijab', l1, Hvovv) - contract('je,eiab->ijab', l1, Hvovv))
+        r_l2 = r_l2 - (contract('ma,ijmb->ijab', l1, Hooov) - contract('mb,ijma->ijab', l1, Hooov))
+        tmp = contract('imae,jebm->ijab', l2, Hovvo)
+        r_l2 = r_l2 + (tmp - tmp.swapaxes(0,1) - tmp.swapaxes(2,3)
+                       + tmp.swapaxes(0,1).swapaxes(2,3))
+        r_l2 = r_l2 + (contract('be,ijae->ijab', Gvv, ERI[o,o,v,v])
+                       - contract('ae,ijbe->ijab', Gvv, ERI[o,o,v,v]))
+        r_l2 = r_l2 - (contract('mj,imab->ijab', Goo, ERI[o,o,v,v])
+                       - contract('mi,jmab->ijab', Goo, ERI[o,o,v,v]))
+        return r_l2
+
     def pseudoenergy(self, o, v, ERI, l2):
         """Compute the CC pseudoenergy from the L2 amplitudes.
 
@@ -641,4 +700,6 @@ class cclambda(object):
             The lambda pseudoenergy 1/2 <ij|ab> l2_ijab.
         """
         contract = self.contract
+        if self.ccwfn.orbital_basis == 'spinorbital':
+            return 0.25 * contract('ijab,ijab->', ERI[o,o,v,v], l2)
         return 0.5 * contract('ijab,ijab->',ERI[o,o,v,v], l2)

--- a/pycc/tests/test_003_ccsd_lambda.py
+++ b/pycc/tests/test_003_ccsd_lambda.py
@@ -1,5 +1,7 @@
 """
-Test CCSD Lambda equation solution using various molecule test cases.
+Test CCSD Lambda equation solution using various molecule test cases, for both the
+spin-adapted spatial (RHF) and spin-orbital (UHF/ROHF) kernels
+(docs/ENHANCEMENT_PLAN_2026-06.md).
 """
 
 # Import package, test suite, and other packages as needed
@@ -7,6 +9,28 @@ import psi4
 import pycc
 import pytest
 from ..data.molecules import *
+
+# OH doublet at 1.83 bohr (verbatim for both codes); CFOUR Lambda pseudoenergies
+# (cc-pVDZ, all-electron, semicanonical -- CFOUR PRINT=2 reports the total Lambda
+# pseudoenergy, defined as PyCC's 1/4 <ij||ab> l2_ijab).
+OH_BOHR = """
+0 2
+O 0.0 0.0 0.0
+H 0.0 0.0 1.83
+units bohr
+no_com
+no_reorient
+symmetry c1
+"""
+CFOUR_UHF_LAMBDA = -0.162890511230
+CFOUR_ROHF_LAMBDA = -0.163565638102
+
+
+def _lambda(wfn, **cckwargs):
+    cc = pycc.CCwfn(wfn, **cckwargs)
+    cc.solve_cc(e_conv=1e-11, r_conv=1e-11)
+    hbar = pycc.cchbar(cc)
+    return pycc.cclambda(cc, hbar).solve_lambda(e_conv=1e-11, r_conv=1e-11)
 
 
 def test_lambda_ccsd_h2o(rhf_wfn):
@@ -37,3 +61,29 @@ def test_lambda_ccsd_h2o(rhf_wfn):
     lpsi4 = -0.217838951550509
     assert (abs(epsi4 - eccsd) < 1e-11)
     assert (abs(lpsi4 - lccsd) < 1e-11)
+
+
+def test_so_lambda_equals_spatial_rhf(rhf_wfn):
+    """Spin-orbital Lambda (forced) reproduces the spin-adapted spatial Lambda
+    pseudoenergy on a closed shell, isolating the spin-orbital HBAR + Lambda kernel."""
+    wfn = rhf_wfn("H2O", "STO-3G")
+    l_spatial = _lambda(wfn)
+    l_so = _lambda(wfn, orbital_basis="spinorbital")
+    assert abs(l_so - l_spatial) < 1e-10
+
+
+def test_uhf_lambda_vs_cfour(uhf_wfn):
+    """Open-shell .OH cc-pVDZ: spin-orbital UHF Lambda pseudoenergy vs CFOUR."""
+    wfn = uhf_wfn(OH_BOHR, "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    lcc = _lambda(wfn, frozen_core=False)
+    assert abs(lcc - CFOUR_UHF_LAMBDA) < 1e-10
+
+
+def test_rohf_lambda_vs_cfour(rohf_wfn):
+    """Open-shell .OH cc-pVDZ: spin-orbital ROHF Lambda pseudoenergy vs CFOUR
+    (semicanonical, as CFOUR uses)."""
+    wfn = rohf_wfn(OH_BOHR, "cc-pVDZ", freeze_core="false",
+                   e_convergence=1e-12, d_convergence=1e-12)
+    lcc = _lambda(wfn, frozen_core=False)
+    assert abs(lcc - CFOUR_ROHF_LAMBDA) < 1e-10


### PR DESCRIPTION
## Spin-orbital CCSD Lambda for UHF/ROHF (cchbar + cclambda)
  
  First step toward open-shell **properties** (Lambda → density → response): extends
  the similarity-transformed Hamiltonian and the Lambda solver to the spin-orbital
  path, building on the spin-orbital CC infrastructure (PRs #133–#139).

  ### What's in this PR

  - **`pycc/cchbar.py`** — `cchbar` branches on `orbital_basis`. `_build_spinorbital`
    + `_so_build_*` build the **10 spin-orbital HBAR blocks** (`Hov, Hvv, Hoo, Hoooo,
    Hvvvv, Hvovv, Hooov, Hovvo, Hvvvo, Hovoo`) directly from the antisymmetrized
    `ERI = <pq||rs>` (ported from `socc`). There is no separate `Hovov`; an inline
    `Zovov` feeds `Hvvvo`/`Hovoo`. The spatial (L-based) path is untouched.

  - **`pycc/cclambda.py`** — `__init__`, `solve_lambda`, `build_Goo`, `build_Gvv`,
    `pseudoenergy`, and `r_L1`/`r_L2` branch on `orbital_basis` to spin-orbital
    siblings (`_r_L1/_r_L2_spinorbital`). Spin-orbital guess `l1=t1, l2=t2`;
    pseudoenergy `1/4 <ij||ab> l2`; `L`/`Hovov` fetches guarded. CCSD/CCD only —
    CC3 Lambda raises in the spin-orbital path.

  - **`pycc/tests/test_003_ccsd_lambda.py`** — spin-orbital validation alongside the
    existing RHF cases.

  ### Validation

  | Check | Result |
  |---|---|
  | Keystone: SO-RHF Lambda pseudoenergy == spatial | ~1e-13 |
  | UHF Lambda pseudoenergy vs CFOUR (·OH cc-pVDZ) | exact (12 digits) |
  | ROHF Lambda pseudoenergy vs CFOUR (·OH cc-pVDZ) | exact (12 digits) |

  CFOUR (`PRINT=2` with `DERIV_LEVEL=1`) reports the total Lambda pseudoenergy with
  the same definition as ours and uses semicanonical ROHF, matching our approach;
  the references are hardcoded constants (CFOUR doesn't run in CI), generated at an
  exact bohr geometry to avoid the CFOUR/Psi4 Å-conversion mismatch.

  ### Scope

  The spin-orbital path now covers MP2/CCSD/CCSD(T)/CC3/CISD/CID energies **plus CCSD
  Lambda** for UHF and ROHF. Density/response/EOM/RT/local/GPU remain spatial-RHF-only.
  The natural next step is the one-particle density → CC dipole (dipole-vs-CFOUR).

  ### Test status

  Full non-slow suite green: **86 passed**, 3 skipped (GPU), 8 deselected (slow),
  1 xfail. No regressions — the spatial `cchbar`/`cclambda`/density/response paths are
  unaffected (every branch fires only for `orbital_basis == 'spinorbital'`).