### PR TITLE
Add spin-orbital CCSD density + CC dipole (UHF/ROHF)

### DIFF
--- a/docs/ENHANCEMENT_PLAN_2026-06.md
+++ b/docs/ENHANCEMENT_PLAN_2026-06.md
@@ -138,7 +138,8 @@ _Last updated 2026-06-17._
 | 4b — SO CC3 | ✅ done | PR #137 |
 | 5 — ROHF (semicanonical) | ✅ done | PR #138 |
 | 6 — SO CISD/CID (UHF/ROHF) | ✅ done | PR #139 |
-| 7 — SO Lambda (CCSD) | 🟡 in review | branch `feature/spinorbital-lambda` |
+| 7 — SO Lambda (CCSD) | ✅ done | PR #140 |
+| 8 — SO density + CC dipole | 🟡 in review | branch `feature/spinorbital-density` |
 
 ### Phase 1 — what landed
 
@@ -266,6 +267,22 @@ The first step toward open-shell **properties** (Lambda -> density -> response).
   cross-check of the Lambda pseudoenergy for UHF and ROHF (.OH cc-pVDZ, exact to 12
   digits -- CFOUR `PRINT=2` reports the total Lambda pseudoenergy with the same
   definition).
+
+### Phase 8 — what landed (spin-orbital density + CC dipole)
+
+Turns Lambda into an open-shell **property** -- the first CC dipole for UHF/ROHF.
+
+- `pycc/ccdensity.py`: `build_Doo`/`build_Dvv`/`build_Dov` branch on `orbital_basis` to
+  the spin-orbital one-particle density blocks (socc's, no RHF spin factors; `Dvo = l1.T`
+  is shared). A new `ccdensity.dipole(t1,t2,l1,l2)` returns the unrelaxed (expectation-
+  value) CC dipole `sum_pq mu_pq D_pq` (correlation only; reference/nuclear not included),
+  CCSD/CCD. The spin-orbital two-particle density is not implemented (one-particle/dipole
+  only -- pass `onlyone=True`; raises otherwise).
+- Validation (`test_007`): keystone (SO-RHF CC dipole == spatial, ~1e-12) and a **CFOUR**
+  cross-check of the UHF/ROHF CC dipole (.OH cc-pVDZ) via `PROP=FIRST_ORDER`,
+  `DIFF_TYPE=UNRELAXED`, `CC_PROG=ECC`, `ABCDTYPE=AOBASIS`, plus `FIXGEOM=ON` (Cartesian
+  input) so CFOUR keeps the input frame -- its SCF dipole then matches Psi4's exactly and
+  the reference is simply CFOUR's `CCSD - SCF` electronic dipole (~1e-10).
 
 **To resume:** read this doc + `git log`. The spin-orbital equation seed lives in
 `~/src/socc` (machine-local, not part of this repo); see `socc/hamiltonian.py` for the

--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -84,7 +84,7 @@ class ccdensity(object):
         nv = ccwfn.nv
         F = ccwfn.H.F
         ERI = ccwfn.H.ERI
-        L = ccwfn.H.L
+        L = ccwfn.H.L if ccwfn.orbital_basis == 'spatial' else None  # no L in spin orbitals
         t1 = ccwfn.t1
         t2 = ccwfn.t2
         l1 = cclambda.l1
@@ -96,6 +96,11 @@ class ccdensity(object):
         self.Doo = self.build_Doo(t1, t2, l1, l2)
 
         self.onlyone = onlyone
+
+        if onlyone is False and ccwfn.orbital_basis == 'spinorbital':
+            raise NotImplementedError("Spin-orbital two-particle density is not "
+                                      "implemented; pass onlyone=True (the dipole needs "
+                                      "only the one-particle density).")
 
         if onlyone is False:
             self.Doooo = self.build_Doooo(t1, t2, l2)
@@ -182,8 +187,8 @@ class ccdensity(object):
         nt = no + nv
         F = self.ccwfn.H.F
         ERI = self.ccwfn.H.ERI
-        L = self.ccwfn.H.L
- 
+        L = self.ccwfn.H.L if self.ccwfn.orbital_basis == 'spatial' else None
+
         opdm = zeros((nt, nt), like=t1)
         opdm[o,o] = self.build_Doo(t1, t2, l1, l2)
         opdm[v,v] = self.build_Dvv(t1, t2, l1, l2)
@@ -210,8 +215,27 @@ class ccdensity(object):
         else:
             return opdm
 
+    def dipole(self, t1, t2, l1, l2):
+        """Correlated (CC) contribution to the electric dipole moment.
+
+        Returns the three Cartesian components of ``mu_axis = sum_pq mu_pq D_pq`` --
+        the CC one-particle (correlation) density contracted with the MO-basis dipole
+        integrals (``H.mu``). The reference (SCF) and nuclear dipole are NOT included;
+        add them separately for the total molecular dipole. CCSD/CCD only -- the CC3
+        dipole (T1-transformed integrals) is handled by ``rtcc.dipole``.
+        """
+        if self.ccwfn.model == 'CC3':
+            raise NotImplementedError("CC3 dipole: use rtcc.dipole.")
+        contract = self.contract
+        opdm = self.compute_onepdm(t1, t2, l1, l2)
+        mu = self.ccwfn.H.mu
+        return [contract('pq,pq->', mu[axis], opdm) for axis in range(3)]
+
     def build_Doo(self, t1, t2, l1, l2):  # complete
         contract = self.contract
+        if self.ccwfn.orbital_basis == 'spinorbital':
+            return (-1.0 * contract('ie,je->ij', t1, l1)
+                    - 0.5 * contract('imef,jmef->ij', t2, l2))
         if self.ccwfn.model == 'CCD':
             Doo = -contract('imef,jmef->ij', t2, l2)
         else:
@@ -226,6 +250,9 @@ class ccdensity(object):
 
     def build_Dvv(self, t1, t2, l1, l2):  # complete
         contract = self.contract
+        if self.ccwfn.orbital_basis == 'spinorbital':
+            return (contract('mb,ma->ab', t1, l1)
+                    + 0.5 * contract('mnbe,mnae->ab', t2, l2))
         if self.ccwfn.model == 'CCD':
             Dvv = contract('mnbe,mnae->ab', t2, l2)
         else:
@@ -243,6 +270,15 @@ class ccdensity(object):
 
     def build_Dov(self, t1, t2, l1, l2):  # complete
         contract = self.contract
+        if self.ccwfn.orbital_basis == 'spinorbital':
+            Dov = clone(t1)
+            Dov = Dov + contract('me,imae->ia', l1, t2)
+            Dov = Dov - contract('me,ie,ma->ia', l1, t1, t1)
+            tmp = contract('mnef,mnaf->ea', l2, t2)
+            Dov = Dov - 0.5 * contract('ea,ie->ia', tmp, t1)
+            tmp = contract('mnef,inef->mi', l2, t2)
+            Dov = Dov - 0.5 * contract('mi,ma->ia', tmp, t1)
+            return Dov
         if self.ccwfn.model == 'CCD':
             Dov = zeros_like(t1)
         else:

--- a/pycc/tests/test_007_dipole.py
+++ b/pycc/tests/test_007_dipole.py
@@ -1,5 +1,7 @@
 """
-Test CCSD electric and magnetic dipole on H2 dimer.
+Test CCSD electric and magnetic dipole on H2 dimer (spatial RHF), and the
+spin-orbital (UHF/ROHF) CC dipole from ccdensity.dipole
+(docs/ENHANCEMENT_PLAN_2026-06.md).
 """
 
 # Import package, test suite, and other packages as needed
@@ -8,6 +10,62 @@ import pycc
 import pytest
 import numpy as np
 from ..data.molecules import *
+
+# OH doublet at 1.83 bohr (verbatim for both codes). CFOUR unrelaxed CCSD-minus-SCF
+# electronic dipole (z, cc-pVDZ, all-electron), generated with CFOUR PROP=FIRST_ORDER,
+# DIFF_TYPE=UNRELAXED, CC_PROG=ECC, ABCDTYPE=AOBASIS, and FIXGEOM=ON (Cartesian input)
+# so CFOUR keeps the input frame -- its SCF dipole then matches Psi4's exactly, and the
+# value below is simply CFOUR's (CCSD - SCF) electronic dipole.
+OH_BOHR = """
+0 2
+O 0.0 0.0 0.0
+H 0.0 0.0 1.83
+units bohr
+no_com
+no_reorient
+symmetry c1
+"""
+CFOUR_UHF_DIPOLE_Z = -0.0434209710
+CFOUR_ROHF_DIPOLE_Z = -0.0443023197
+
+
+def _cc_dipole(wfn, **cckwargs):
+    cc = pycc.CCwfn(wfn, **cckwargs)
+    cc.solve_cc(e_conv=1e-11, r_conv=1e-11)
+    hbar = pycc.cchbar(cc)
+    lam = pycc.cclambda(cc, hbar); lam.solve_lambda(e_conv=1e-11, r_conv=1e-11)
+    dens = pycc.ccdensity(cc, lam, onlyone=True)
+    return np.array(dens.dipole(cc.t1, cc.t2, lam.l1, lam.l2), dtype=float)
+
+
+def test_so_dipole_equals_spatial_rhf(rhf_wfn):
+    """Spin-orbital CC dipole (forced) reproduces the spatial CC dipole on a closed
+    shell, isolating the spin-orbital density kernel."""
+    wfn = rhf_wfn("H2O", "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    d_spatial = _cc_dipole(wfn, frozen_core=False)
+    d_so = _cc_dipole(wfn, frozen_core=False, orbital_basis="spinorbital")
+    assert np.max(np.abs(d_so - d_spatial)) < 1e-10
+
+
+def test_uhf_dipole_vs_cfour(uhf_wfn):
+    """Open-shell .OH cc-pVDZ: spin-orbital UHF CC dipole vs CFOUR (unrelaxed)."""
+    wfn = uhf_wfn(OH_BOHR, "cc-pVDZ", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    d = _cc_dipole(wfn, frozen_core=False)
+    assert abs(d[0]) < 1e-10 and abs(d[1]) < 1e-10
+    assert abs(d[2] - CFOUR_UHF_DIPOLE_Z) < 1e-8
+
+
+def test_rohf_dipole_vs_cfour(rohf_wfn):
+    """Open-shell .OH cc-pVDZ: spin-orbital ROHF CC dipole vs CFOUR (unrelaxed,
+    semicanonical)."""
+    wfn = rohf_wfn(OH_BOHR, "cc-pVDZ", freeze_core="false",
+                   e_convergence=1e-12, d_convergence=1e-12)
+    d = _cc_dipole(wfn, frozen_core=False)
+    assert abs(d[0]) < 1e-10 and abs(d[1]) < 1e-10
+    assert abs(d[2] - CFOUR_ROHF_DIPOLE_Z) < 1e-8
+
 
 def test_dipole_h2_2_cc_pvdz(rhf_wfn):
     """H4 cc-pVDZ"""


### PR DESCRIPTION
  ## Spin-orbital CCSD density + CC dipole (UHF/ROHF)

  Turns spin-orbital Lambda into an open-shell **property** — the first CC dipole for
  UHF/ROHF references (PRs #133–#140).

  ### What's in this PR

  - **`pycc/ccdensity.py`** — `build_Doo`/`build_Dvv`/`build_Dov` branch on
    `orbital_basis` to the spin-orbital one-particle density blocks (ported from `socc`;
    no RHF spin factors, ½ on the `t2·l2` terms; `Dvo = l1.T` is shared). New
    **`ccdensity.dipole(t1,t2,l1,l2)`** returns the unrelaxed (expectation-value) CC
    dipole `Σ_pq μ_pq D_pq` — correlation only (reference/nuclear not included), CCSD/CCD.
    The spin-orbital two-particle density is not implemented; pass `onlyone=True` (the
    dipole needs only the one-particle density), else it raises.

  - **`pycc/tests/test_007_dipole.py`** — spin-orbital validation alongside the existing
    RHF case.

  ### Validation

  | Check | Result |
  |---|---|
  | Keystone: SO-RHF CC dipole == spatial | ~1e-12 |
  | UHF CC dipole vs CFOUR (·OH cc-pVDZ, unrelaxed) | ~1e-10 |
  | ROHF CC dipole vs CFOUR (·OH cc-pVDZ, unrelaxed) | ~1e-10 |

  CFOUR references: `PROP=FIRST_ORDER`, `DIFF_TYPE=UNRELAXED`, `CC_PROG=ECC`,
  `ABCDTYPE=AOBASIS`, `FIXGEOM=ON` (Cartesian input). `DIFF_TYPE=UNRELAXED` gives the
  expectation-value density that matches PyCC's convention (a gradient/`DERIV_LEVEL=1`
  gives the *relaxed* dipole, ~1.4e-3 different); `FIXGEOM=ON` keeps CFOUR in the input
  frame, so its SCF dipole matches Psi4's exactly and the reference is simply CFOUR's
  `CCSD − SCF` electronic dipole.

  ### Scope
  
  Spin-orbital path now reaches a property: MP2/CCSD/CCSD(T)/CC3/CISD/CID energies, CCSD
  Lambda, and the CCSD **dipole** for UHF and ROHF. The spin-orbital two-particle density,
  response, EOM, RT, local, and GPU remain out of scope.

  ### Test status

  Full non-slow suite green: **89 passed**, 3 skipped (GPU), 8 deselected (slow), 1 xfail.
  No regressions — the spatial density/dipole path is untouched (every branch fires only
  for `orbital_basis == 'spinorbital'`).

  This closes the loop from Lambda to an actual open-shell property. The next natural layer, whenever you want it, is
  response (polarizability / optical rotation), which builds on this density machinery and which socc also has.
