### PR TITLE
Spin-orbital CCSD optical rotation + lazy pertbar + MO summary (phase 9b)

### DIFF
--- a/docs/ENHANCEMENT_PLAN_2026-06.md
+++ b/docs/ENHANCEMENT_PLAN_2026-06.md
@@ -140,7 +140,8 @@ _Last updated 2026-06-17._
 | 6 — SO CISD/CID (UHF/ROHF) | ✅ done | PR #139 |
 | 7 — SO Lambda (CCSD) | ✅ done | PR #140 |
 | 8 — SO density + CC dipole | ✅ done | PR #142 |
-| 9a — SO symmetric polarizability | 🟡 in review | branch `feature/spinorbital-response-polar` |
+| 9a — SO symmetric polarizability | ✅ done | PR #143 |
+| 9b — SO optical rotation | 🟡 in review | branch `feature/spinorbital-response-optrot` |
 
 ### Phase 1 — what landed
 
@@ -305,6 +306,19 @@ contributions. Split: 9a polarizability (9a-i spin-orbital, 9a-ii spatial spin-a
   finite difference of the CCSD energy (~1e-8/1e-9). No code does open-shell CC
   *dynamic* polarizabilities, so static-via-finite-difference is the open-shell check
   (the dynamic kernel is validated for RHF and is identical for UHF/ROHF).
+
+**Phase 9b (SO optical rotation):**
+- `pycc/ccresponse.py`: new top-level `optrot(omega)` (length gauge, `<<mu;m>>` two-term
+  assembly), reusing the X-solver + `linresp_sym`. Also made `pertbar` construction
+  **lazy**: the constructor no longer builds all operators (MU/M/M*/P/P*/Q); `self.pertbar`
+  is a `_PertbarCache` that builds each via `_build_pertbar` on first access, so a response
+  function pays only for the operators it uses (socc's efficiency, transparent to the
+  deprecated asymmetric callers/tests).
+- Validation (`test_056`): SO-RHF optical-rotation tensor (chiral H2O2/STO-3G,
+  omega=0.077357) == Psi4 CCSD optrot (length gauge) ~6.5e-13 (also confirms the SO
+  magnetic-dipole H.m integrals). UHF/ROHF: no open-shell CC optrot reference exists (a
+  dynamic magnetic property, no finite-difference), so validated by composition; the tests
+  only confirm the open-shell path runs and returns a finite tensor.
 
 **To resume:** read this doc + `git log`. The spin-orbital equation seed lives in
 `~/src/socc` (machine-local, not part of this repo); see `socc/hamiltonian.py` for the

--- a/pycc/ccresponse.py
+++ b/pycc/ccresponse.py
@@ -58,46 +58,50 @@ class ccresponse(object):
         # Cartesian indices
         self.cart = ["X", "Y", "Z"]
 
-        # Build dictionary of similarity-transformed property integrals
-        self.pertbar = {}
-
-        # Electric-dipole operator (length)
-        for axis in range(3):
-            key = "MU_" + self.cart[axis]
-            self.pertbar[key] = pertbar(self.H.mu[axis], self.ccwfn)
-
-        # Magnetic-dipole (m) and velocity-gauge electric-dipole / linear-momentum (p)
-        # integrals are stored *pure imaginary* in hamiltonian.py (H.m, H.p = i * real)
-        # because the RT-CC code relies on that. For response, factor the i out here so
-        # the perturbed amplitudes X1/X2 stay real: a pure-imaginary perturbation i*A
-        # gives X = i*x (x real), and the pseudoresponse/polarizability are bilinear in
-        # the perturbation (~ conj(c)*c = |c|^2), so dropping the i leaves every property
-        # value unchanged while halving the amplitude storage and removing complex
-        # arithmetic. np.real(-1.0j * pert) returns a real-dtype A (not a complex array
-        # with zero imaginary part); the -1.0j is applied to the conjugate operators too,
-        # so M* = -M (and P* = -P) stays distinct from M (P).
-        for axis in range(3):
-            self.pertbar["M_" + self.cart[axis]] = pertbar(np.real(-1.0j * self.H.m[axis]), self.ccwfn)
-            self.pertbar["M*_" + self.cart[axis]] = pertbar(np.real(-1.0j * np.conj(self.H.m[axis])), self.ccwfn)
-            self.pertbar["P_" + self.cart[axis]] = pertbar(np.real(-1.0j * self.H.p[axis]), self.ccwfn)
-            self.pertbar["P*_" + self.cart[axis]] = pertbar(np.real(-1.0j * np.conj(self.H.p[axis])), self.ccwfn)
-
-        # Traceless quadrupole
-        ij = 0
-        for axis1 in range(3):
-            for axis2 in range(axis1,3):
-                key = "Q_" + self.cart[axis1] + self.cart[axis2]
-                self.pertbar[key] = pertbar(self.H.Q[ij], self.ccwfn)
-                if (axis1 != axis2):
-                    key2 = "Q_" + self.cart[axis2] + self.cart[axis1]
-                    self.pertbar[key2] = self.pertbar[key]
-                ij += 1
+        # Similarity-transformed property integrals are built lazily, on first access
+        # (see _build_pertbar / _PertbarCache), so each response function constructs only
+        # the operators it actually uses -- polarizability needs MU, optical rotation
+        # needs MU and M/M* -- rather than all of them (MU, M, M*, P, P*, Q) up front.
+        self.pertbar = _PertbarCache(self)
 
         # HBAR-based denominators
         eps_occ = np.diag(self.hbar.Hoo)
         eps_vir = np.diag(self.hbar.Hvv)
         self.Dia = eps_occ.reshape(-1,1) - eps_vir
         self.Dijab = eps_occ.reshape(-1,1,1,1) + eps_occ.reshape(-1,1,1) - eps_vir.reshape(-1,1) - eps_vir
+
+    def _build_pertbar(self, key):
+        """Build the similarity-transformed perturbation operator for a single key
+        (e.g. 'MU_X', 'M_Y', 'M*_Z', 'P_X', 'Q_XY'). Called lazily by ``self.pertbar``
+        on first access, so a response function pays only for the operators it uses.
+
+        The magnetic-dipole (M) and velocity-gauge (P) integrals are stored *pure
+        imaginary* in hamiltonian.py (H.m, H.p = i * real) for the RT-CC code; the i is
+        factored out here so the perturbed amplitudes stay real (the property values are
+        bilinear in the perturbation, so dropping the i changes nothing). np.real(-1.0j *
+        pert) returns a real-dtype operator; applied to the conjugates too, so M* = -M
+        (P* = -P) stays distinct from M (P).
+        """
+        ax = {"X": 0, "Y": 1, "Z": 2}
+        name, comp = key.split("_", 1)
+        if name == "MU":
+            pert = self.H.mu[ax[comp]]
+        elif name == "M":
+            pert = np.real(-1.0j * self.H.m[ax[comp]])
+        elif name == "M*":
+            pert = np.real(-1.0j * np.conj(self.H.m[ax[comp]]))
+        elif name == "P":
+            pert = np.real(-1.0j * self.H.p[ax[comp]])
+        elif name == "P*":
+            pert = np.real(-1.0j * np.conj(self.H.p[ax[comp]]))
+        elif name == "Q":
+            a1, a2 = sorted((ax[comp[0]], ax[comp[1]]))
+            # H.Q is ordered XX, XY, XZ, YY, YZ, ZZ
+            qidx = {(0,0): 0, (0,1): 1, (0,2): 2, (1,1): 3, (1,2): 4, (2,2): 5}[(a1, a2)]
+            pert = self.H.Q[qidx]
+        else:
+            raise KeyError("Unknown perturbation operator key: %r" % key)
+        return pertbar(pert, self.ccwfn)
 
     def pertcheck(self, omega: float, e_conv: float = 1e-13, r_conv: float = 1e-13, maxiter: int = 200, max_diis: int = 8, start_diis: int = 1):
         """
@@ -906,6 +910,48 @@ class ccresponse(object):
                 polar[a, b] = -1.0 * self.linresp_sym(A, Xm[a], B, Xp[b])
         return polar
 
+    def optrot(self, omega, e_conv=1e-12, r_conv=1e-12, maxiter=200,
+               max_diis=7, start_diis=1):
+        """Optical-rotation tensor (length gauge, <<mu;m>>) at frequency omega via the
+        symmetric response function. Returns a 3x3 array.
+
+        G'_omega = (1/2) <<mu; m>>_omega + (1/2) <<mu; m*>>_{-omega}, assembled from the
+        right-hand perturbed amplitudes X(mu,-omega), X(m,+omega), X(mu,+omega),
+        X(m*,-omega).
+        """
+        if self.ccwfn.orbital_basis != 'spinorbital':
+            raise NotImplementedError("The symmetric optical rotation is currently "
+                                      "implemented for the spin-orbital path only.")
+        if omega == 0.0:
+            raise ValueError("Optical rotation requires a nonzero field frequency.")
+        args = (e_conv, r_conv, maxiter, max_diis, start_diis)
+
+        Xmu_p, Xmu_m, Xm_p, Xmstar_m = [], [], [], []
+        for axis in range(3):
+            X1, X2, _ = self.solve_right(self.pertbar["MU_" + self.cart[axis]], omega, *args)
+            Xmu_p.append([X1.copy(), X2.copy()])
+            X1, X2, _ = self.solve_right(self.pertbar["MU_" + self.cart[axis]], -omega, *args)
+            Xmu_m.append([X1.copy(), X2.copy()])
+            X1, X2, _ = self.solve_right(self.pertbar["M_" + self.cart[axis]], omega, *args)
+            Xm_p.append([X1.copy(), X2.copy()])
+            X1, X2, _ = self.solve_right(self.pertbar["M*_" + self.cart[axis]], -omega, *args)
+            Xmstar_m.append([X1.copy(), X2.copy()])
+
+        tensor = np.zeros((3, 3))
+        # (1/2) <<mu; m>>_omega  with X(mu,-omega) and X(m,+omega)
+        for a in range(3):
+            A = self.pertbar["MU_" + self.cart[a]]
+            for b in range(3):
+                B = self.pertbar["M_" + self.cart[b]]
+                tensor[a, b] = 0.5 * self.linresp_sym(A, Xmu_m[a], B, Xm_p[b])
+        # (1/2) <<mu; m*>>_{-omega}  with X(mu,+omega) and X(m*,-omega)
+        for a in range(3):
+            A = self.pertbar["MU_" + self.cart[a]]
+            for b in range(3):
+                B = self.pertbar["M*_" + self.cart[b]]
+                tensor[a, b] += 0.5 * self.linresp_sym(A, Xmu_p[a], B, Xmstar_m[b])
+        return tensor
+
     def linresp_sym(self, A, X_A, B, X_B):
         """Symmetric CC linear-response function value <<A;B>>_omega, built from the
         right-hand perturbed amplitudes X_A = X(A,-omega), X_B = X(B,+omega)."""
@@ -1066,3 +1112,18 @@ class pertbar(object):
         self.Avvoo -= contract('mjab,mi->ijab', t2, self.Aoo)
 #self.Avvoo = self.Avvoo + self.Avvoo.swapaxes(0,1).swapaxes(2,3)
         self.Avvoo = 0.5*(self.Avvoo + self.Avvoo.swapaxes(0,1).swapaxes(2,3))
+
+
+class _PertbarCache(dict):
+    """A dict of similarity-transformed perturbation operators (pertbar objects) that
+    builds each entry on first access via ``ccresponse._build_pertbar``. This defers
+    pertbar construction so a response function only builds the operators it uses,
+    instead of building all of them (MU, M, M*, P, P*, Q) in the constructor."""
+    def __init__(self, owner):
+        super().__init__()
+        self._owner = owner
+
+    def __missing__(self, key):
+        value = self._owner._build_pertbar(key)
+        self[key] = value
+        return value

--- a/pycc/tests/test_056_spinorbital_optrot.py
+++ b/pycc/tests/test_056_spinorbital_optrot.py
@@ -1,0 +1,83 @@
+"""
+Spin-orbital CCSD optical rotation (length gauge) via the symmetric linear-response
+function (docs/ENHANCEMENT_PLAN_2026-06.md).
+
+Validation:
+  * SO-RHF optical-rotation tensor (chiral H2O2) vs Psi4's CCSD optical rotation --
+    the symmetric kernel reproduces the spin-adapted result (and confirms the
+    spin-orbital magnetic-dipole integrals H.m, which optrot is the first to use).
+  * UHF/ROHF: no code computes open-shell CC optical rotation (a dynamic magnetic
+    property, with no finite-difference analog), so these are validated by
+    composition -- the kernel is validated for RHF above and is identical for
+    UHF/ROHF, on already-validated orbitals/integrals. The tests here only confirm
+    the open-shell path runs and returns a finite, real tensor.
+"""
+
+import psi4
+import pycc
+import numpy as np
+
+# Chiral H2O2 (from Dalton), for the optical-rotation reference. No "symmetry c1":
+# Psi4 detects C2 and produces symmetry-adapted MOs (transforming as the C2 irreps).
+# The spin-orbital result must be identical to the C1 case (and matches Psi4 to ~1e-13),
+# confirming that the occ/vir ordering of Ca_subset("AO","ACTIVE") holds under symmetry.
+H2O2 = """
+O   1.3133596569   0.0000000000  -0.0932359644
+O  -1.3133596569  -0.0000000000  -0.0932359644
+H   1.6917745981   0.7334825768   1.4797224976
+H  -1.6917745981  -0.7334825768   1.4797224976
+units bohr
+"""
+
+# Open-shell doublet (hydroxyl radical) for the open-shell smoke checks.
+OH = """
+0 2
+O 0.0 0.0 0.0
+H 0.0 0.0 1.83
+units bohr
+no_com
+no_reorient
+symmetry c1
+"""
+
+# Psi4 CCSD optical-rotation tensor (length gauge, omega=0.077357, H2O2/STO-3G,
+# frozen core) -- the same reference socc uses.
+PSI4_OPTROT = np.array([[-0.012969077546209,  0.238413335857954, 0.0],
+                        [-0.039665773503841,  0.124406421486684, 0.0],
+                        [ 0.0, 0.0, -0.112853202255656]])
+
+
+def _optrot(wfn, omega, **cckwargs):
+    cc = pycc.CCwfn(wfn, **cckwargs)
+    cc.solve_cc(e_conv=1e-12, r_conv=1e-11)
+    hbar = pycc.cchbar(cc)
+    lam = pycc.cclambda(cc, hbar); lam.solve_lambda(e_conv=1e-12, r_conv=1e-11)
+    dens = pycc.ccdensity(cc, lam, onlyone=True)
+    return pycc.ccresponse(dens).optrot(omega)
+
+
+def test_so_rhf_optrot_vs_psi4(rhf_wfn):
+    """SO-RHF CCSD optical-rotation tensor (H2O2/STO-3G) vs Psi4 (length gauge)."""
+    wfn = rhf_wfn(H2O2, "STO-3G", freeze_core="true",
+                  e_convergence=1e-12, d_convergence=1e-12, r_convergence=1e-12)
+    optrot = _optrot(wfn, 0.077357, orbital_basis="spinorbital")
+    assert np.max(np.abs(optrot - PSI4_OPTROT)) < 1e-10
+
+
+def test_uhf_optrot_runs(uhf_wfn):
+    """Open-shell UHF optical rotation: runs and returns a finite, real tensor (no
+    external open-shell reference exists)."""
+    wfn = uhf_wfn(OH, "STO-3G", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+    optrot = _optrot(wfn, 0.077357, frozen_core=False)
+    assert optrot.shape == (3, 3)
+    assert np.all(np.isfinite(optrot))
+
+
+def test_rohf_optrot_runs(rohf_wfn):
+    """Open-shell ROHF optical rotation: runs and returns a finite, real tensor."""
+    wfn = rohf_wfn(OH, "STO-3G", freeze_core="false",
+                   e_convergence=1e-12, d_convergence=1e-12)
+    optrot = _optrot(wfn, 0.077357, frozen_core=False)
+    assert optrot.shape == (3, 3)
+    assert np.all(np.isfinite(optrot))

--- a/pycc/wavefunction.py
+++ b/pycc/wavefunction.py
@@ -281,6 +281,34 @@ class Wavefunction(object):
 
         print("NMO = %d; NACT = %d; NO = %d; NV = %d" % (self.nmo, self.nact, self.no, self.nv))
 
+        # Reference MO summary, alpha and beta side by side -- the spin-orbital analog of
+        # the _init_spatial table. Shows the symmetry-adapted SCF MOs Psi4 produced (their
+        # irreps and energies) with an occupied marker per spin. These are the reference
+        # orbital energies; for ROHF the semicanonical energies actually used in the
+        # correlation are the diagonal of the (rotated) per-spin Fock, self.H.F.
+        nirrep = ref.nirrep()
+        irrep_labels = ref.molecule().irrep_labels()
+        nmopi = ref.nmopi()
+        mo_irreps = np.array([h for h in range(nirrep) for _ in range(nmopi[h])])
+
+        def _spin_mos(eps_subset):
+            eps = np.concatenate([np.array(eps_subset.nph[h]) for h in range(nirrep)])
+            order = np.argsort(eps, kind='stable')
+            return eps[order], [irrep_labels[mo_irreps[i]] for i in order]
+
+        a_eps, a_lab = _spin_mos(ref.epsilon_a_subset("SO", "ALL"))
+        b_eps, b_lab = _spin_mos(ref.epsilon_b_subset("SO", "ALL"))
+        na, nb = ref.nalpha(), ref.nbeta()
+
+        print("\nMOs by energy (alpha | beta):")
+        print(f"  {'#':>4}   {'irr':>5} {'o':>1} {'energy':>16}    {'irr':>5} {'o':>1} {'energy':>16}")
+        print(f"  {'-'*4}   {'-'*5} {'-'*1} {'-'*16}    {'-'*5} {'-'*1} {'-'*16}")
+        for i in range(ref.nmo()):
+            aocc = 'o' if i < na else ' '
+            bocc = 'o' if i < nb else ' '
+            print(f"  {i:>4}   {a_lab[i]:>5} {aocc:>1} {a_eps[i]:>16.10f}"
+                  f"    {b_lab[i]:>5} {bocc:>1} {b_eps[i]:>16.10f}")
+
         self.o = slice(0, self.no)
         self.v = slice(self.no, self.nact)
 


### PR DESCRIPTION
  ## Spin-orbital CCSD optical rotation + lazy pertbar + MO summary (phase 9b)

  Second response property for the spin-orbital path: **optical rotation** (length gauge),
  via the symmetric linear-response function (right-hand X amplitudes only), reusing the
  X-solver and symmetric assembly from 9a-i (PRs #133–#143). Plus two cleanups.

  ### Optical rotation

  - **`pycc/ccresponse.py`** — new top-level **`optrot(omega)`**: the `<<μ;m>>` two-term
    assembly `G'_ω = ½⟨⟨μ;m⟩⟩_ω + ½⟨⟨μ;m*⟩⟩_{-ω}`, built from the right-hand perturbed
    amplitudes `X(μ,±ω)`, `X(m,+ω)`, `X(m*,-ω)`. Spin-orbital; the spatial branch raises
    (the spin-adapted symmetric assembly is phase 9a-ii).

  ### Lazy pertbar (efficiency)

  - The `ccresponse` constructor no longer eagerly builds every perturbation operator
    (MU/M/M*/P/P*/Q). `self.pertbar` is now a `_PertbarCache` that builds each operator via
    `_build_pertbar` **on first access**, so a response function pays only for the operators
    it uses (polarizability → MU; optrot → MU, M, M*). Transparent to the deprecated
    asymmetric callers and their tests (they index `self.pertbar[...]` exactly as before).

  ### MO symmetry summary

  - **`pycc/wavefunction.py`** — `_init_spinorbital` now prints the per-MO irrep/energy
    table that `_init_spatial` always has (it was an omission). The spin-orbital version
    shows the symmetry-adapted reference MOs **α and β side by side**, each energy-sorted,
    with an occupied marker per spin. For RHF the columns match; for UHF they diverge; for
    ROHF they share energies (one orbital set) with the SOMO occupied-in-α / virtual-in-β.
    (These are the reference orbital energies; for ROHF the semicanonical energies used in
    the correlation are `diag(self.H.F)`, noted in a comment.)

  ### Validation

  | Check | Result |
  |---|---|
  | SO-RHF optical-rotation tensor (chiral H2O2/STO-3G, ω=0.077357, length gauge) vs Psi4 CCSD | ~6.5e-13 |
  | Same with C2 symmetry (no `symmetry c1`, symmetry-adapted MOs) | identical (~6.6e-13) |
  | UHF/ROHF optrot | runs, finite tensor (composition) |

  The RHF check also validates the spin-orbital magnetic-dipole integrals `H.m`, exercised
  here for the first time. No code computes open-shell CC optical rotation (a dynamic
  magnetic property with no finite-difference analog), so UHF/ROHF are validated by
  composition — the kernel is validated for RHF and is identical for UHF/ROHF on
  already-validated orbitals/integrals. The MO-print change is print-only, verified for
  RHF/UHF/ROHF, C2v-symmetric input, and the nβ=0 triplet edge case.

  ### Test status
  
  Full non-slow suite green: **95 passed**, 3 skipped (GPU), 8 deselected (slow), 1 xfail.
  No regressions — the lazy pertbar leaves the spatial asymmetric response path unaffected.

  ### Files
  - `pycc/ccresponse.py` — `optrot`, lazy `_PertbarCache`/`_build_pertbar`
  - `pycc/wavefunction.py` — α/β MO summary print in `_init_spinorbital`
  - `pycc/tests/test_056_spinorbital_optrot.py` — new
  - `docs/ENHANCEMENT_PLAN_2026-06.md` — phase 9b status
