### PR TITLE
Add Read the Docs build configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# Read the Docs build configuration. See:
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+# autodoc imports pycc to read docstrings/signatures, so the package and its
+# pip-installable deps (numpy, scipy, opt_einsum) must be installed. psi4 is
+# conda-only and mocked in docs/conf.py; torch is optional and guarded in the
+# package, so neither is installed here.
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .


### PR DESCRIPTION
RTD v2 config so the Sphinx docs build on readthedocs.org. Installs the docs requirements (sphinx + sphinx_rtd_theme) and the package via pip (autodoc imports pycc to read docstrings/signatures, pulling its pip-installable deps numpy/scipy/opt_einsum). psi4 is conda-only and mocked in docs/conf.py; torch is optional and guarded, so neither is installed in the build.