### PR TITLE
Spin-orbital CC3 Lambda

### DIFF
--- a/docs/ENHANCEMENT_PLAN_2026-06.md
+++ b/docs/ENHANCEMENT_PLAN_2026-06.md
@@ -265,11 +265,26 @@ The first step toward open-shell **properties** (Lambda -> density -> response).
   `_build_spinorbital` dispatch + `_so_build_*` methods (ported from socc).
 - `pycc/cclambda.py`: `__init__`/`solve_lambda`/`build_Goo`/`build_Gvv`/`pseudoenergy`/
   `r_L1`/`r_L2` branch on `orbital_basis` to spin-orbital siblings. SO guess l1=t1, l2=t2;
-  pseudoenergy 1/4 <ij||ab> l2. CCSD/CCD only (CC3 Lambda raises in the SO path).
+  pseudoenergy 1/4 <ij||ab> l2.
 - Validation (`test_003`): keystone (SO-RHF Lambda == spatial, ~1e-13) and a **CFOUR**
   cross-check of the Lambda pseudoenergy for UHF and ROHF (.OH cc-pVDZ, exact to 12
   digits -- CFOUR `PRINT=2` reports the total Lambda pseudoenergy with the same
   definition).
+
+#### Increment: spin-orbital CC3 Lambda
+
+Extends the SO Lambda kernel from CCSD to CC3 (removing the `CC3 Lambda raises` guard).
+- `pycc/cctriples.py` `l3_ijk_so` (spin-orbital connected lambda-L3 per i,j,k) and
+  `pycc/ccwfn.py` `_so_build_{Wvvvv,Wovvo}_CC3` (the two T1-dressed CC3 W-blocks the
+  `_so_*_CC3` set lacked).
+- `pycc/cclambda.py` `_build_cc3_lambda_intermediates_spinorbital` (once-only `Zijal`/
+  `Ziabd`) + `_cc3_lambda_triples_spinorbital` (per-iteration `Y1`/`Y2`), loop-over-(i,j,k)
+  like `_so_cc3_t_residual` (no stored T3); ported from the socc CC3 Lambda IJK reference.
+  SO `Y1`/`Y2` are antisymmetric by construction, added to the residuals directly.
+- Validation (`test_031`): keystone SO-RHF CC3 Lambda pseudoenergy == spatial (~1e-10;
+  spatial is CFOUR-pinned). UHF/ROHF CC3 Lambda validation deferred to the response stage.
+- Out of scope (separate follow-on): spin-orbital CC3 **density/dipole** -- the CC3 density
+  blocks are spatial-only, so `ccdensity.compute_onepdm` raises for SO + CC3.
 
 ### Phase 8 — what landed (spin-orbital density + CC dipole)
 

--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -195,6 +195,13 @@ class ccdensity(object):
         opdm[o,v] = self.build_Dov(t1, t2, l1, l2)
         opdm[v,o] = self.build_Dvo(l1)
 
+        if self.ccwfn.model == 'CC3' and self.ccwfn.orbital_basis == 'spinorbital':
+            # Spin-orbital CC3 Lambda exists, but the CC3 one-particle density
+            # (T1-transformed blocks below) is still spatial-only -- a separate
+            # follow-on. Fail clearly rather than crash on the spatial builders.
+            raise NotImplementedError("Spin-orbital CC3 one-particle density is not "
+                                      "implemented (Lambda is); use the spatial path.")
+
         if self.ccwfn.model == 'CC3':
             Fov = self.ccwfn.build_Fme(o, v, F, L, t1)
             Wvvvo = self.ccwfn.build_cc3_Wabei(o, v, ERI, t1)

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -17,7 +17,7 @@ from .utils import helper_diis, zeros, zeros_like, clone, sqrt
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
-from .cctriples import t3c_ijk, l3_ijk, l3_ijk_alt, t3_pert_ijk
+from .cctriples import t3c_ijk, l3_ijk, l3_ijk_alt, t3_pert_ijk, t3c_ijk_so, l3_ijk_so
 
 if TYPE_CHECKING:
     from pycc.ccwfn import CCwfn
@@ -111,10 +111,6 @@ class cclambda(object):
         ERI = self.ccwfn.H.ERI
         L = self.ccwfn.H.L if self.ccwfn.orbital_basis == 'spatial' else None
 
-        if self.ccwfn.orbital_basis == 'spinorbital' and self.ccwfn.model == 'CC3':
-            raise NotImplementedError("Spin-orbital Lambda currently supports CCSD/CCD, "
-                                      "not CC3.")
-
         Hov = self.hbar.Hov
         Hvv = self.hbar.Hvv
         Hoo = self.hbar.Hoo
@@ -138,7 +134,10 @@ class cclambda(object):
         if self.ccwfn.model == 'CC3':
             # T-dependent CC3 intermediates: t1/t2 are fixed during the Lambda
             # solve, so build them once here and reuse every iteration.
-            cc3_ints = self._build_cc3_lambda_intermediates(o, v, t1, t2, F, ERI, L)
+            if self.ccwfn.orbital_basis == 'spinorbital':
+                cc3_ints = self._build_cc3_lambda_intermediates_spinorbital(o, v, t1, t2, F, ERI)
+            else:
+                cc3_ints = self._build_cc3_lambda_intermediates(o, v, t1, t2, F, ERI, L)
 
         for niter in range(1, maxiter+1):
             lecc_last = lecc
@@ -152,9 +151,16 @@ class cclambda(object):
             r2 = self.r_L2(o, v, l1, l2, L, Hov, Hvv, Hoo, Hoooo, Hvvvv, Hovvo, Hovov, Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo)
    
             if self.ccwfn.model == 'CC3':
-                Y1, Y2 = self._cc3_lambda_triples(o, v, l1, l2, t2, F, ERI, L, cc3_ints)
-                r1 += Y1
-                r2 += Y2 + Y2.swapaxes(0,1).swapaxes(2,3)
+                if self.ccwfn.orbital_basis == 'spinorbital':
+                    # The spin-orbital Y1/Y2 come out fully antisymmetric already,
+                    # so they are added directly (no i<->j / a<->b symmetrization).
+                    Y1, Y2 = self._cc3_lambda_triples_spinorbital(o, v, l1, l2, t2, F, ERI, cc3_ints)
+                    r1 += Y1
+                    r2 += Y2
+                else:
+                    Y1, Y2 = self._cc3_lambda_triples(o, v, l1, l2, t2, F, ERI, L, cc3_ints)
+                    r1 += Y1
+                    r2 += Y2 + Y2.swapaxes(0,1).swapaxes(2,3)
 
             if self.ccwfn.local is not None:
                 inc1, inc2 = self.ccwfn.Local.filter_amps(r1, r2)
@@ -248,6 +254,109 @@ class cclambda(object):
             del Goo, Gvv, Hoo, Hvv, Hov, Hovvo, Hovov, Hvvvo, Hovoo, Hvovv, Hooov
                                              
         return r1, r2
+
+    def _build_cc3_lambda_intermediates_spinorbital(self, o, v, t1, t2, F, ERI):
+        """Build the T-dependent spin-orbital CC3 intermediates for the Lambda
+        equations: the T1-dressed CC3 W-intermediates plus the once-only T3
+        intermediates ``Zijal``/``Ziabd`` (the <0|L2 [[H~,T3],nu1]|0> -> L1 piece,
+        which is independent of Lambda). Loop-over-(i,j,k), mirroring
+        :meth:`pycc.ccwfn.CCwfn._so_cc3_t_residual` and the socc reference; no full
+        T3 is stored.
+
+        Returns
+        -------
+        dict
+            the W-intermediates plus ``Fov``, ``Zijal`` and ``Ziabd``
+        """
+        contract = self.contract
+        Fov = self.hbar.Hov
+        Woooo = self.ccwfn._so_build_Woooo_CC3(o, v, ERI, t1)
+        Wovoo = self.ccwfn._so_build_Wovoo_CC3(o, v, ERI, t1, Woooo)
+        Wooov = self.ccwfn._so_build_Wooov_CC3(o, v, ERI, t1)
+        Wvovv = self.ccwfn._so_build_Wvovv_CC3(o, v, ERI, t1)
+        Wvvvo = self.ccwfn._so_build_Wvvvo_CC3(o, v, ERI, t1)
+        Wvvvv = self.ccwfn._so_build_Wvvvv_CC3(o, v, ERI, t1)
+        Wovvo = self.ccwfn._so_build_Wovvo_CC3(o, v, ERI, t1)
+
+        no = self.ccwfn.no
+        Zijal = zeros_like(ERI[o,o,v,o])
+        Ziabd = zeros_like(ERI[o,v,v,v])
+        for i in range(no):
+            for j in range(no):
+                for k in range(no):
+                    t3 = t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
+                    Zijal[i,j] -= 0.5 * contract('abc,lbc->al', t3, ERI[o,k,v,v])
+                    Ziabd[i] -= 0.5 * contract('abc,dc->abd', t3, ERI[j,k,v,v])
+
+        return {'Fov': Fov, 'Woooo': Woooo, 'Wovoo': Wovoo, 'Wooov': Wooov,
+                'Wvovv': Wvovv, 'Wvvvo': Wvvvo, 'Wvvvv': Wvvvv, 'Wovvo': Wovvo,
+                'Zijal': Zijal, 'Ziabd': Ziabd}
+
+    def _cc3_lambda_triples_spinorbital(self, o, v, l1, l2, t2, F, ERI, ints):
+        """Spin-orbital CC3 triples contributions (Y1, Y2) to the Lambda residuals.
+
+        Loop-over-(i,j,k): per ijk rebuild the ground-state T3 (:func:`t3c_ijk_so`)
+        and the lambda L3 (:func:`l3_ijk_so`) and accumulate the connected-triples
+        contributions. ``Y1``/``Y2`` come out fully antisymmetric, so the caller
+        adds them to the residuals directly. Ports the socc ``CC3_iter`` (IJK)
+        reference.
+
+        Returns
+        -------
+        Y1, Y2 : ndarray or torch.Tensor
+            the CC3 triples contributions to the L1 and L2 residuals
+        """
+        contract = self.contract
+        no = self.ccwfn.no
+        nv = self.ccwfn.nv
+
+        Fov = ints['Fov']
+        Woooo = ints['Woooo']
+        Wovoo = ints['Wovoo']
+        Wooov = ints['Wooov']
+        Wvovv = ints['Wvovv']
+        Wvvvo = ints['Wvvvo']
+        Wvvvv = ints['Wvvvv']
+        Wovvo = ints['Wovvo']
+        Zijal = ints['Zijal']
+        Ziabd = ints['Ziabd']
+
+        Y2 = zeros_like(l2)
+        Zia = zeros_like(l1)                       # <0|L2 [[H~,T3],nu1]|0> -> L1
+        Ziabe = zeros((no, nv, nv, nv), like=l2)   # <0|L3 [[H~,T2],nu1]|0> -> L1
+        Zijam = zeros((no, no, nv, no), like=l2)
+        Woovv = ERI[o,o,v,v]
+        for i in range(no):
+            for j in range(no):
+                for k in range(no):
+                    t3 = t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
+                    Zia[i] += 0.25 * contract('abc,bc->a', t3, l2[j,k])
+
+                    l3 = l3_ijk_so(o, v, i, j, k, l1, l2, F, Fov, Woovv, Wvovv, Wooov, contract)
+
+                    # <0|L3 [[H~,T2],nu1]|0> -> L1
+                    Ziabe[i] += 0.5 * contract('abc,ec->abe', l3, t2[j,k])
+                    Zijam[i,j] += 0.5 * contract('abc,mbc->am', l3, t2[o,k])
+
+                    # <0|L3 [H~,nu2]|0> -> L2
+                    Y2[i,j] += 0.5 * contract('abc,bcd->ad', l3, Wvvvo[:,:,:,k])
+                    Y2[i,j] -= 0.5 * contract('dbc,bca->ad', l3, Wvvvo[:,:,:,k])
+                    for l in range(no):
+                        tmp = 0.5 * contract('abc,c->ab', l3, Wovoo[l,:,j,k])
+                        Y2[i,l] -= tmp
+                        Y2[l,i] += tmp
+
+        # <0|L2 [[H~,T3],nu1]|0> -> L1
+        Y1 = contract('ia,lida->ld', Zia, Woovv)
+        Y1 += 0.5 * contract('ijal,ijad->ld', Zijal, l2)
+        Y1 += 0.5 * contract('iabd,ilab->ld', Ziabd, l2)
+        # <0|L3 [[H~,T2],nu1]|0> -> L1
+        Y1 += 0.5 * contract('iabe,abde->id', Ziabe, Wvvvv)
+        Y1 += 0.5 * contract('ijam,lmij->la', Zijam, Woooo)
+        Y1 += contract('iabe,lbei->la', Ziabe, Wovvo)
+        Y1 += contract('ijam,madj->id', Zijam, Wovvo)
+
+        return Y1, Y2
 
     def _build_cc3_lambda_intermediates(self, o, v, t1, t2, F, ERI, L, real_time=False):
         """Build the T-dependent CC3 intermediates shared by the Lambda equations.

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -712,6 +712,38 @@ def t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract, omega=0.0, WithDeno
     return t3
 
 
+def l3_ijk_so(o, v, i, j, k, l1, l2, F, Fov, Woovv, Wvovv, Wooov, contract, WithDenom=True):
+    """Spin-orbital connected lambda-L3 amplitudes for fixed occupied i, j, k.
+
+    Mirrors :func:`t3c_ijk_so` (spin-orbital convention, antisymmetrized
+    ``<pq||rs>`` integrals) for the lambda equations. ``Woovv`` is ``ERI[o,o,v,v]``;
+    ``Wvovv`` (<am||ef>) and ``Wooov`` (<mn||ie>) are the T1-dressed CC3
+    intermediates. The result is antisymmetric in a,b,c.
+    """
+    abc = contract('ad,dbc->abc', l2[i,j], Wvovv[:,k,:,:])
+    abc = abc - contract('ad,dbc->abc', l2[k,j], Wvovv[:,i,:,:])
+    abc = abc - contract('ad,dbc->abc', l2[i,k], Wvovv[:,j,:,:])
+    l3 = abc - abc.swapaxes(0,1) - abc.swapaxes(0,2)
+
+    abc = contract('lab,lc->abc', l2[j], Wooov[i,k])
+    abc = abc - contract('lab,lc->abc', l2[i], Wooov[j,k])
+    abc = abc + contract('lab,lc->abc', l2[k], Wooov[j,i])
+    l3 = l3 + (abc - abc.swapaxes(0,2) - abc.swapaxes(1,2))
+
+    abc = contract('a,bc->abc', l1[i], Woovv[j,k]) + contract('a,bc->abc', Fov[i], l2[j,k])
+    abc = abc - (contract('a,bc->abc', l1[j], Woovv[i,k]) + contract('a,bc->abc', Fov[j], l2[i,k]))
+    abc = abc - (contract('a,bc->abc', l1[k], Woovv[j,i]) + contract('a,bc->abc', Fov[k], l2[j,i]))
+    l3 = l3 + (abc - abc.swapaxes(0,1) - abc.swapaxes(0,2))
+
+    if WithDenom is True:
+        occ = diag(F)[o]
+        vir = diag(F)[v]
+        denom = (occ[i] + occ[j] + occ[k]
+                 - (vir.reshape(-1,1,1) + vir.reshape(-1,1) + vir))
+        return l3/denom
+    return l3
+
+
 def t_vikings_so(o, v, t1, t2, F, ERI, contract):
     """Spin-orbital (T) energy via the occupied-batched ("viking") algorithm.
 

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -132,8 +132,10 @@ class CCwfn(Wavefunction):
         super().__init__(scf_wfn, localize_occ=(local is not None), **kwargs)
 
         # The spin-orbital path (open-shell UHF/ROHF references) is a separate kernel
-        # selected by orbital_basis. Step-3 scope: CCSD energies only, CPU-only, no
-        # local correlation. Fail fast and clearly for anything outside that.
+        # selected by orbital_basis. Supports CCSD/CCSD(T)/CC3 energies and Lambda
+        # (CCSD and CC3), plus the one-particle density and dipole for CCSD; the CC3
+        # density/dipole remain spatial-only. CPU-only, no local correlation. Fail
+        # fast and clearly for anything outside that.
         if self.orbital_basis == 'spinorbital':
             if self.model not in ('CCSD', 'CCSD(T)', 'CC3'):
                 raise NotImplementedError(
@@ -1124,6 +1126,23 @@ class CCwfn(Wavefunction):
         Wvvvo = Wvvvo - (contract('ma,mbei->abei', t1, ERI[o,v,v,o])
                          - contract('mb,maei->abei', t1, ERI[o,v,v,o]))
         return Wvvvo
+
+    def _so_build_Wvvvv_CC3(self, o, v, ERI, t1):
+        contract = self.contract
+        Wvvvv = clone(ERI[v,v,v,v])
+        Wvvvv = Wvvvv - (contract('mb,amef->abef', t1, ERI[v,o,v,v])
+                         - contract('ma,bmef->abef', t1, ERI[v,o,v,v]))
+        tau = contract('ia,jb->ijab', t1, t1) - contract('ib,ja->ijab', t1, t1)
+        Wvvvv = Wvvvv + 0.5 * contract('mnab,mnef->abef', tau, ERI[o,o,v,v])
+        return Wvvvv
+
+    def _so_build_Wovvo_CC3(self, o, v, ERI, t1):
+        contract = self.contract
+        Wovvo = clone(ERI[o,v,v,o])
+        Wovvo = Wovvo + contract('jf,mbef->mbej', t1, ERI[o,v,v,v])
+        Wovvo = Wovvo - contract('nb,mnej->mbej', t1, ERI[o,o,v,o])
+        Wovvo = Wovvo - contract('jf,nb,mnef->mbej', t1, t1, ERI[o,o,v,v])
+        return Wovvo
 
     def _so_cc3_t_residual(self, o, v, F, ERI, Fme, t1, t2):
         """Spin-orbital CC3 connected-triples contribution (x1, x2) to the T1/T2

--- a/pycc/tests/test_031_cc3.py
+++ b/pycc/tests/test_031_cc3.py
@@ -70,6 +70,25 @@ def test_so_cc3_equals_spatial_rhf(rhf_wfn):
     assert abs(e_so - e_spatial) < 1e-10
 
 
+def test_so_cc3_lambda_equals_spatial_rhf(rhf_wfn):
+    """Spin-orbital CC3 Lambda (forced) reproduces the spin-adapted spatial CC3
+    Lambda pseudoenergy on a closed shell -- keystone for the spin-orbital CC3
+    Lambda kernel. The spatial value is itself CFOUR-pinned in test_cc3_h2o."""
+    wfn = rhf_wfn("H2O", "STO-3G", freeze_core="false",
+                  e_convergence=1e-12, d_convergence=1e-12)
+
+    def _lcc(basis):
+        cc = pycc.CCwfn(wfn, model="CC3", frozen_core=False, orbital_basis=basis)
+        cc.solve_cc(e_conv=1e-11, r_conv=1e-11)
+        hbar = pycc.cchbar(cc)
+        lam = pycc.cclambda(cc, hbar)
+        return lam.solve_lambda(e_conv=1e-11, r_conv=1e-11)
+
+    l_spatial = _lcc("spatial")
+    l_so = _lcc("spinorbital")
+    assert abs(l_so - l_spatial) < 1e-10
+
+
 def test_ucc3_oh(uhf_wfn):
     """Open-shell .OH 6-31G, all-electron UCC3 vs Psi4's UCC3."""
     wfn = uhf_wfn(OH, "6-31G", freeze_core="false",


### PR DESCRIPTION
  ## Spin-orbital CC3 Lambda

  Extends the spin-orbital Lambda kernel from CCSD to CC3 (removes the `solve_lambda`
  NotImplementedError guard). Loop-over-(i,j,k), mirroring the existing spin-orbital CC3
  energy residual (no stored T3); ported from the socc CC3 Lambda IJK reference.

  - `cctriples.py`: `l3_ijk_so`
  - `ccwfn.py`: `_so_build_Wvvvv_CC3`, `_so_build_Wovvo_CC3`
  - `cclambda.py`: SO CC3 intermediate + triples methods, dispatched on `orbital_basis`;
    SO `Y1`/`Y2` antisymmetric, added directly

  **Validation:** keystone SO-RHF CC3 Lambda == spatial (~1e-10; spatial is CFOUR-pinned).
  UHF/ROHF deferred to the response stage. Full non-slow suite green (100 passed).

  **Scope:** Lambda only. Spin-orbital CC3 density/dipole stays a follow-on (CC3 density
  blocks are spatial-only); `ccdensity.compute_onepdm` now raises clearly for SO + CC3.
