### PR TITLE
Spin-orbital finite-field CC energies (CCSD + CC3)

### DIFF
--- a/docs/ENHANCEMENT_PLAN_2026-06.md
+++ b/docs/ENHANCEMENT_PLAN_2026-06.md
@@ -126,7 +126,7 @@ post-convergence correction) lands first; CC3 (an iterative-triples solver) foll
 
 ## Status / progress
 
-_Last updated 2026-06-19._
+_Last updated 2026-06-21._
 
 | Phase | Status | Landed |
 |---|---|---|
@@ -143,6 +143,9 @@ _Last updated 2026-06-19._
 | 9a-i — SO symmetric polarizability | ✅ done | PR #143 |
 | 9b — SO optical rotation | ✅ done | PR #144 |
 | 9a-ii — spatial spin-adapted response | ✅ done | PR #145 |
+| 7b — SO CC3 Lambda | ✅ done | PR #149 |
+| 9c — SO CC3 linear response | ✅ done | PR #150 |
+| 9d — finite-field SO CC energies | 🚧 in review | this branch |
 
 ### Phase 1 — what landed
 
@@ -388,3 +391,20 @@ pathway, set as a `CCwfn` constructor kwarg (default `False`) and threaded throu
   quantities are invariant, so cross-code checks use scalar values, not tensor elements.
 - Remaining: the batched-triples response function (no full T3/L3/X3) is a planned follow-on
   -- the batched perturbed-X + materialize-at-end machinery is kept for it.
+
+**Phase 9d (finite-field SO CC energies):** static external electric-dipole field for
+finite-difference CC properties -- the last socc capability the SO path was missing (socc
+tests 010/011). A `field` / `field_strength` / `field_axis` kwarg set on `CCwfn` makes
+`SpinOrbitalHamiltonian` add `V = -field_strength*mu[axis]` to the Fock (keeping the
+canonical `F0`); the field-perturbed, non-canonical `F` drives the CCSD residual (and the
+MP2/CC denominators, via `diag(F)`), exactly as socc.
+- CCSD: works through the existing Fock intermediates (already validated for a
+  non-canonical Fock by the ROHF path and `test_055`'s finite-difference).
+- CC3: requires `store_triples=True` -- the field couples the triples, so
+  `_so_cc3_t_residual_full` gains the `[V,T3]` (iterative, reads the previous `self.t3`)
+  and `1/2 [[V,T2],T2]` terms and uses `F0` for the (canonical) T3 denominator; port of
+  socc `CC3_full`'s field branch. `solve_cc` zero-inits `self.t3` so each finite-field
+  point starts clean. Guard: `field + CC3 + not store_triples` raises.
+- Validation (`test_060`): 5-point finite difference of the CC correlation energy
+  (H2O/STO-3G, F=1e-4) -- CCSD `mu_z`/`alpha_zz` vs CFOUR (~5e-10 / ~4e-8), CC3
+  `alpha_zz` vs Dalton 2.9989468 (~7e-8); all non-slow (store_triples CC3 on H2O is cheap).

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -107,6 +107,19 @@ class CCwfn(Wavefunction):
         # memory-lean batched kernels (energy/Lambda only).
         self.store_triples = kwargs.pop('store_triples', False)
 
+        # Static external electric-dipole field (length gauge), for finite-field CC
+        # properties: adds V = -field_strength * mu[field_axis] to the Fock (in
+        # SpinOrbitalHamiltonian). field_axis is 'X'/'Y'/'Z'. The field makes the Fock
+        # non-canonical; CC3 then requires the full T3 (store_triples) because the
+        # perturbation couples the triples ([V,T3]).
+        self.field = kwargs.pop('field', False)
+        self.field_strength = kwargs.pop('field_strength', 0.0)
+        self.field_axis = kwargs.pop('field_axis', 'Z')
+        if self.field and self.model == 'CC3' and not self.store_triples:
+            raise InvalidKeywordError(
+                'store_triples', self.store_triples,
+                ['True (required for finite-field CC3: the field couples the triples)'])
+
         # RT-CC3 calculations requiring additional terms when an external perturbation is present
         self.real_time = kwargs.pop('real_time', False)
 
@@ -222,6 +235,13 @@ class CCwfn(Wavefunction):
         Dijab = self.Dijab
 
         contract = self.contract
+
+        # Spin-orbital CC3 with stored triples: start from a zero full T3, both so the
+        # array exists for the iterative field coupling ([V,T3] reads the previous T3)
+        # and so repeated solve_cc calls (e.g. a finite-field sweep) start clean.
+        if (self.orbital_basis == 'spinorbital' and self.model == 'CC3'
+                and self.store_triples):
+            self.t3 = np.zeros((self.no, self.no, self.no, self.nv, self.nv, self.nv))
 
         ecc = self.cc_energy(o, v, F, L, self.t1, self.t2)
         print("CC Iter %3d: CC Ecorr = %.15f  dE = % .5E  MP2" % (0, ecc, -ecc))
@@ -1192,8 +1212,10 @@ class CCwfn(Wavefunction):
         Builds the whole connected T3 with one set of whole-array contractions
         (no per-(i,j,k) batching), stores it on ``self.t3``, and folds it into the
         residuals. Full-array counterpart of the batched :func:`_so_cc3_t_residual`;
-        port of socc ``CC3_full`` (canonical/no-field case). Both paths must give
-        identical x1/x2 (and hence the same CC3 energy)."""
+        port of socc ``CC3_full``. With a static external field the T3 also picks up
+        the perturbation coupling: ``[V,T3]`` (iterative -- uses the previous
+        ``self.t3``) and ``1/2 [[V,T2],T2]``, and the (canonical) ``F0`` sets the
+        denominator. Without a field the two paths give identical x1/x2."""
         contract = self.contract
         Woooo = self._so_build_Woooo_CC3(o, v, ERI, t1)
         Wovoo = self._so_build_Wovoo_CC3(o, v, ERI, t1, Woooo)
@@ -1207,8 +1229,27 @@ class CCwfn(Wavefunction):
         tmp = -contract('ilab,lcjk->ijkabc', t2, Wovoo)
         t3 = t3 + permute_triples(tmp, 'i/jk', 'c/ab')
 
-        occ = np.diag(F)[o]
-        vir = np.diag(F)[v]
+        if self.field:
+            # Field-perturbed, non-canonical Fock: add the field coupling and use the
+            # canonical F0 for the denominator. Port of socc CC3_full's field branch.
+            V = self.H.V
+            Voo = V[o,o] + contract('ie,me->mi', t1, V[o,v])
+            Vvv = V[v,v] - contract('ma,me->ae', t1, V[o,v])
+            # <mu3|[V,T3]|0>  (uses the previous iteration's full T3)
+            tmp = contract('ijkabc,dc->ijkabd', self.t3, Vvv)
+            t3 = t3 + (tmp - tmp.swapaxes(3,5) - tmp.swapaxes(4,5))
+            tmp = -contract('ijkabc,kl->ijlabc', self.t3, Voo)
+            t3 = t3 + (tmp - tmp.swapaxes(0,2) - tmp.swapaxes(1,2))
+            # 1/2 <mu3|[[V,T2],T2]|0>
+            tmp = contract('lkbc,ld->bcdk', t2, V[o,v])
+            tmp = -contract('bcdk,ijad->ijkabc', tmp, t2)
+            t3 = t3 + permute_triples(tmp, 'k/ij', 'a/bc')
+            Fdenom = self.H.F0
+        else:
+            Fdenom = F
+
+        occ = np.diag(Fdenom)[o]
+        vir = np.diag(Fdenom)[v]
         denom = (occ.reshape(-1,1,1,1,1,1) + occ.reshape(-1,1,1,1,1) + occ.reshape(-1,1,1,1)
                  - vir.reshape(-1,1,1) - vir.reshape(-1,1) - vir)
         self.t3 = t3/denom

--- a/pycc/hamiltonian.py
+++ b/pycc/hamiltonian.py
@@ -112,7 +112,8 @@ class SpinOrbitalHamiltonian(object):
         the energy.
     """
     def __init__(self, ref: Any, Ca: Any, Cb: Any, spin: Any, spat: Any,
-                 nocc_a: int, nocc_b: int) -> None:
+                 nocc_a: int, nocc_b: int,
+                 field_strength: float = 0.0, field_axis: int = 2) -> None:
         npCa = np.asarray(Ca)
         npCb = np.asarray(Cb)
         nact = spin.shape[0]
@@ -197,6 +198,16 @@ class SpinOrbitalHamiltonian(object):
         # Traceless quadrupole (6 unique Cartesian components)
         Q_ints = mints.ao_traceless_quadrupole()
         self.Q = [_spin_block(np.asarray(Q_ints[ij])) for ij in range(6)]
+
+        # Optional static external electric-dipole field (length gauge): add the
+        # perturbation V = -field_strength * mu[axis] to the Fock matrix. The
+        # canonical Fock is retained as F0; the field-perturbed (non-canonical) F
+        # drives the CCSD residual, while CC3 uses F0 for the T3 denominator and V
+        # for the [V,T3] coupling (so finite-field CC3 requires stored triples).
+        if field_strength != 0.0:
+            self.V = -field_strength * self.mu[field_axis]
+            self.F0 = self.F.copy()
+            self.F = self.F + self.V
 
     @staticmethod
     def _semicanonicalize(npC, F_ao, nocc):

--- a/pycc/tests/test_060_field_energies.py
+++ b/pycc/tests/test_060_field_energies.py
@@ -1,0 +1,83 @@
+"""
+Spin-orbital finite-field CC energies (static external electric-dipole field);
+docs/ENHANCEMENT_PLAN_2026-06.md.
+
+A static field is added to the Fock matrix post-SCF (V = -F*mu_z, fixed orbitals),
+making it non-canonical. CCSD handles this through its Fock intermediates; CC3
+additionally needs the iterative [V,T3] coupling, hence store_triples=True. A
+5-point finite difference of the correlation energy w.r.t. the field strength then
+gives the (correlation) dipole and polarizability.
+
+Validation (matches socc tests 010/011):
+  * CCSD mu_z and alpha_zz (H2O/STO-3G) vs CFOUR.
+  * CC3 alpha_zz vs an independent Dalton reference.
+"""
+
+import psi4
+import pycc
+import numpy as np
+import pytest
+
+# socc moldict["H2O"] geometry (Cartesian, bohr).
+H2O = """
+O 0.000000000000000   0.000000000000000   0.143225857166674
+H 0.000000000000000  -1.638037301628121  -1.136549142277225
+H 0.000000000000000   1.638037301628121  -1.136549142277225
+symmetry c1
+units bohr
+"""
+
+FIELD = 0.0001  # finite-difference field strength (a.u.)
+
+
+def _scf_wfn():
+    psi4.core.clean()
+    psi4.core.be_quiet()
+    psi4.geometry(H2O)
+    psi4.set_options({'basis': 'STO-3G', 'scf_type': 'pk', 'mp2_type': 'conv',
+                      'freeze_core': 'false', 'reference': 'rhf',
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12,
+                      'r_convergence': 1e-12})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    return wfn
+
+
+def _findiff(wfn, model, store_triples):
+    """5-point finite-difference mu_z and alpha_zz from the field-on CC correlation
+    energy. The field-free SCF (wfn) is shared; the field is applied in CCwfn."""
+    def E(strength):
+        kw = dict(frozen_core=False, model=model, orbital_basis='spinorbital',
+                  store_triples=store_triples)
+        if strength != 0.0:
+            kw.update(field=True, field_strength=strength, field_axis='Z')
+        return pycc.CCwfn(wfn, **kw).solve_cc(e_conv=1e-12, r_conv=1e-12)
+
+    F = FIELD
+    e0, ep, e2p, em, e2m = E(0.0), E(F), E(2 * F), E(-F), E(-2 * F)
+    mu_z = -(-e2p + 8 * ep - 8 * em + e2m) / (12 * F)
+    alpha_zz = -(-e2p + 16 * ep - 30 * e0 + 16 * em - e2m) / (12 * F * F)
+    return mu_z, alpha_zz
+
+
+def test_ccsd_field_findiff():
+    """CCSD finite-field dipole + polarizability (H2O/STO-3G) vs CFOUR (socc
+    test_010). Exercises the non-canonical-Fock CCSD path under an applied field."""
+    mu_z, alpha_zz = _findiff(_scf_wfn(), 'CCSD', store_triples=False)
+    assert abs(mu_z - 0.0724134575) < 1e-7
+    assert abs(alpha_zz - 2.9745913) < 1e-6
+
+
+def test_cc3_field_findiff():
+    """CC3 finite-field polarizability (H2O/STO-3G) vs Dalton (socc test_011).
+    Requires store_triples=True -- the field couples the triples ([V,T3])."""
+    _, alpha_zz = _findiff(_scf_wfn(), 'CC3', store_triples=True)
+    assert abs(alpha_zz - 2.9989468) < 1e-6
+
+
+def test_cc3_field_requires_store_triples():
+    """Finite-field CC3 without stored triples is rejected: the non-canonical Fock
+    couples the triples, so the full T3 must be retained."""
+    with pytest.raises(Exception):
+        pycc.CCwfn(_scf_wfn(), frozen_core=False, model='CC3',
+                   orbital_basis='spinorbital', field=True, field_strength=0.001,
+                   field_axis='Z')

--- a/pycc/wavefunction.py
+++ b/pycc/wavefunction.py
@@ -331,9 +331,16 @@ class Wavefunction(object):
 
         self.Ca = ref.Ca_subset("AO", "ACTIVE")
         self.Cb = ref.Cb_subset("AO", "ACTIVE")
+        # Optional static external field (finite-field CC properties); only CCwfn sets
+        # these attributes, so default to no field for the other method classes.
+        field_strength, field_axis = 0.0, 2
+        if getattr(self, 'field', False):
+            field_strength = getattr(self, 'field_strength', 0.0)
+            field_axis = {'X': 0, 'Y': 1, 'Z': 2}[str(getattr(self, 'field_axis', 'Z')).upper()]
         # nao/nbo are the per-spin active occupied counts: the Hamiltonian needs them to
         # split each spin's MO set into occ/vir for the semicanonical rotation.
-        self.H = SpinOrbitalHamiltonian(ref, self.Ca, self.Cb, spin, spat, nao, nbo)
+        self.H = SpinOrbitalHamiltonian(ref, self.Ca, self.Cb, spin, spat, nao, nbo,
+                                        field_strength=field_strength, field_axis=field_axis)
 
     @property
     def derivatives(self) -> Derivatives:


### PR DESCRIPTION
  # Spin-orbital finite-field CC energies (CCSD + CC3)

  Adds a static external electric-dipole field to the spin-orbital path for
  finite-difference CC properties — the last socc capability the SO path was
  missing (socc tests 010/011). A full socc-vs-PyCC survey confirms PyCC's
  spin-orbital path now covers all of socc. 1 commit, 5 files.

  ## What's new
  
  `CCwfn` gains `field` / `field_strength` / `field_axis` kwargs. When set,
  `SpinOrbitalHamiltonian` adds `V = −field_strength·μ[axis]` to the Fock matrix,
  retaining the canonical Fock as `F0`. The field-perturbed, **non-canonical** `F`
  then drives the CCSD residual and the MP2/CC denominators (`diag(F)`), exactly as
  socc.

  - **CCSD** needs no new code: the Fock intermediates (`Fae`/`Fmi`/`Fme`) already
    carry the full `F`, and the non-canonical-Fock path is already exercised by the
    ROHF reference and `test_055`'s finite difference.
  - **CC3** requires `store_triples=True` — the field couples the triples. So
    `_so_cc3_t_residual_full` gains the iterative `[V,T3]` term (which reads the
    previous `self.t3`) and `½[[V,T2],T2]`, and uses the canonical `F0` for the T3
    denominator (port of socc `CC3_full`'s field branch). `solve_cc` zero-inits
    `self.t3` so each finite-field point starts clean, and
    `field + CC3 + not store_triples` raises.

  ## Validation (`test_060`, all non-slow)

  5-point finite difference of the CC correlation energy (H2O/STO-3G, F=1e-4):

  | | PyCC | reference | diff |
  |---|---|---|---|
  | CCSD μ_z | 0.0724134570 | CFOUR 0.0724134575 | 4.7e-10 |
  | CCSD α_zz | 2.9745913 | CFOUR 2.9745913 | 4.2e-08 |
  | CC3 α_zz | 2.9989467 | Dalton 2.9989468 | 7.3e-08 |

  Plus a guard test for the `store_triples` requirement. The `store_triples` CC3
  solves are cheap on H2O (~0.3 s each), so all three tests run in the default
  (non-slow) suite (~3 s total). No regressions across the SO Hamiltonian / CCSD /
  CC3 / response tests.

  ## Notes

  - Spin-orbital only; the field is applied in `SpinOrbitalHamiltonian`.
  - Plan doc updated (Phase 9d + progress table).
