### PR TITLE
Separate the CPHF solver from the HF property tensors

### DIFF
--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -22,14 +22,22 @@ The two-electron part of ``G`` is written with the spin-adapted integrals
     magnetic (imaginary perturbations -- e.g. AATs):
         G_iajb = (e_a - e_i) d_ij d_ab + L[a,j,i,b] - L[a,b,i,j]
 
-The first validation target is the static dipole polarizability (electric-field
-response): the field does not move the basis functions, so its right-hand side
-is just the (negated) MO dipole integrals (``B = -mu``, since the field enters as
-``-mu . E``) with no overlap/Pulay terms -- it exercises the solver in isolation.
+The simplest perturbation is the electric field: it does not move the basis
+functions, so its right-hand side is just the (negated) MO dipole integrals
+(``B = -mu``, since the field enters as ``-mu . E``) with no overlap/Pulay terms --
+it exercises the solver in isolation.
 
-Created and owned by HFwfn for now; it depends only on base state (``o``/``v``,
-the Fock diagonal, ``H.L``) plus the property integrals (``H.mu``), so it can be
-promoted to the Wavefunction base when MP2/CI/CC orbital response is needed.
+Scope: this class computes only quantities intrinsic to the CPHF equations -- the
+orbital Hessian, the perturbation right-hand sides (field / magnetic / nuclear),
+and the response coefficients ``U`` (and the cached nuclear by-products the Hessian
+reuses). The HF *property tensors* built from ``U`` -- polarizability, dipole
+derivatives (APTs), molecular Hessian, atomic axial tensors -- live on :class:`HFwfn`,
+which asks this solver for the relevant ``U`` and contracts it with the property
+integrals.
+
+Lives on the Wavefunction base (lazy ``self.cphf``); it depends only on base state
+(``o``/``v``, the Fock diagonal, the orbital-Hessian integrals) plus the dipole
+integrals, and is shared by HF, MP2, and CC orbital response.
 
 This is reference, CPU/NumPy code, consistent with the rest of the HF derivative
 engine (the explicit orbital Hessian is solved directly with ``numpy.linalg``).
@@ -282,176 +290,3 @@ class CPHF(object):
         if atom not in self._S_nuc:
             self.solve_nuclear(atom)
         return self._S_nuc[atom]
-
-    def dipole_derivatives(self) -> np.ndarray:
-        """Analytic nuclear dipole derivatives ``d(mu_alpha)/d(X_A,beta)`` (a.u.),
-        shape ``(natom, 3, 3)`` indexed ``[A, beta, alpha]`` -- the atomic polar
-        tensors (APTs), transposed.
-
-        Built from the nuclear CPHF response, so the ov term probes ``U^X`` directly
-        (unlike the energy gradient, which is variationally insensitive to it). The
-        assembly is nuclear + explicit electronic + overlap (Pulay) + CPHF response::
-
-            d mu_a / d X_Ab = Z_A delta_ab                         (nuclear)
-                            + 2 sum_i (d mu_a / d X_Ab)_ii         (explicit electronic)
-                            - 2 sum_ik S^X_ki (mu_a)_ik            (oo / Pulay response)
-                            + 4 sum_ia U^X_ia (mu_a)_ia            (ov / CPHF response)
-        """
-        o, v = self.o, self.v
-        mu = [np.asarray(self.wfn.H.mu[a]) for a in range(3)]
-        d = self.wfn.derivatives
-        C = np.asarray(self.wfn.C)
-        Cocc = psi4.core.Matrix.from_array(C[:, o])
-        mol = self.wfn.ref.molecule()
-        natom = mol.natom()
-
-        dmu = np.zeros((natom, 3, 3))
-        for A in range(natom):
-            Ux = self.solve_nuclear(A)           # cached; shared with the Hessian
-            Sx = d.overlap(A, Cocc, Cocc)        # 3 x (no,no)
-            dip = d.dipole(A, Cocc, Cocc)        # 9 x (no,no): index alpha*3 + beta
-            for beta in range(3):
-                for alpha in range(3):
-                    val = mol.Z(A) if alpha == beta else 0.0
-                    val += 2.0 * np.trace(dip[alpha * 3 + beta])
-                    val -= 2.0 * np.einsum('ki,ki->', Sx[beta], mu[alpha][o, o])
-                    val += 4.0 * np.einsum('ia,ia->', Ux[beta], mu[alpha][o, v])
-                    dmu[A, beta, alpha] = val
-        return dmu
-
-    def molecular_hessian(self) -> np.ndarray:
-        """RHF nuclear (molecular) Hessian ``d^2 E / dX_Aa dX_Bb`` (a.u.), shape
-        ``(3*natom, 3*natom)`` indexed ``(A*3 + a, B*3 + b)`` -- the force-constant
-        matrix, matching ``psi4.hessian('scf')`` layout (gate 4).
-
-        Built from (i) the second-derivative ("skeleton") integral terms -- the
-        gradient's integrals differentiated a second time -- and (ii) the first-order
-        CPHF response, which is where the nuclear ``U^X`` (and its RHS ``B^X``) enter.
-        The response is taken from the shared :meth:`solve_nuclear` cache, so the
-        3*natom solves done here are reused for free by :meth:`dipole_derivatives`
-        (the APTs) in an IR workflow.
-
-        The assembly has two parts. (i) The skeleton second-derivative terms mirror the
-        validated CPHF-free gradient with the integrals differentiated twice::
-
-            2 h^{ab}_ii + (2(ii|jj) - (ij|ij))^{ab} - 2 eps_i S^{ab}_ii + V_NN^{ab}
-
-        (ii) The first-order CPHF response and the first-derivative *product* cross
-        terms (x = (A,a), y = (B,b); i,j,n,m occupied; spin-adapted ``L`` = H.L)::
-
-            -4 U^x_ai B^y_ai - 2 S^x_ij F^y_ij - 2 S^y_ij F^x_ij
-            + 4 eps_i S^x_ij S^y_ij + 2 S^x_ij S^y_nm L_imjn
-
-        where ``U^x``/``B^x`` are the cached nuclear response/RHS and ``F^x_ij``/``S^x_ij``
-        are the skeleton derivative Fock and overlap oo blocks (cached by-products of
-        :meth:`solve_nuclear`). Validated against ``psi4.hessian('scf')`` (gate 4).
-        """
-        o, v = self.o, self.v
-        eps_o = self.eps[o]
-        d = self.wfn.derivatives
-        C = np.asarray(self.wfn.C)
-        Cocc = psi4.core.Matrix.from_array(C[:, o])
-        mol = self.wfn.ref.molecule()
-        natom = mol.natom()
-
-        Loooo = np.asarray(self.wfn.H.L)[o, o, o, o]       # i,m,j,n (spin-adapted)
-        Vnn2 = d.nuclear_repulsion2()                      # (3*natom, 3*natom)
-        # Pre-solve & cache the nuclear response for every atom (shared with the APTs).
-        # All four come from a single heavy per-atom pass (solve_nuclear).
-        U = [self.solve_nuclear(A) for A in range(natom)]          # U[A][a] -> (no,nv)
-        B = [self.rhs_nuclear_cached(A) for A in range(natom)]     # B[A][a] -> (no,nv)
-        Foo = [self.fock_nuclear_cached(A) for A in range(natom)]  # F^X_ij -> (no,no)
-        Soo = [self.overlap_nuclear_cached(A) for A in range(natom)]  # S^X_ij -> (no,no)
-
-        H = np.zeros((3 * natom, 3 * natom))
-        for A in range(natom):
-            for Bat in range(natom):
-                S2 = d.overlap2(A, Bat, Cocc, Cocc)               # 9 x (no,no)
-                h2 = d.core2(A, Bat, Cocc, Cocc)                  # 9 x (no,no)
-                g2 = d.eri2(A, Bat, Cocc, Cocc, Cocc, Cocc)       # 9 x (no,no,no,no) chemist
-                for a in range(3):
-                    for b in range(3):
-                        c = a * 3 + b
-                        Ux, Uy = U[A][a], U[Bat][b]
-                        Bx, By = B[A][a], B[Bat][b]
-                        Sx, Sy = Soo[A][a], Soo[Bat][b]
-                        Fx, Fy = Foo[A][a], Foo[Bat][b]
-                        # --- skeleton (second-derivative integrals), as in the gradient ---
-                        skel = (2.0 * np.trace(h2[c])
-                                + 2.0 * np.einsum('iijj->', g2[c])
-                                - np.einsum('ijij->', g2[c])
-                                - 2.0 * np.einsum('i,ii->', eps_o, S2[c])
-                                + Vnn2[A * 3 + a, Bat * 3 + b])
-                        # --- first-order CPHF response + first-derivative cross terms:
-                        #   -4 U^x_ai B^y_ai - 2 S^x_ij F^y_ij - 2 S^y_ij F^x_ij
-                        #   + 4 eps_i S^x_ij S^y_ij + 2 S^x_ij S^y_nm L_imjn
-                        resp = (-4.0 * np.einsum('ia,ia->', Ux, By)
-                                - 2.0 * np.einsum('ij,ij->', Sx, Fy)
-                                - 2.0 * np.einsum('ij,ij->', Sy, Fx)
-                                + 4.0 * np.einsum('i,ij,ij->', eps_o, Sx, Sy)
-                                + 2.0 * np.einsum('ij,nm,imjn->', Sx, Sy, Loooo))
-                        H[A * 3 + a, Bat * 3 + b] = skel + resp
-        return H
-
-    def atomic_axial_tensors(self) -> np.ndarray:
-        """RHF atomic axial tensors (AATs) ``I^lambda_{alpha,beta}`` (a.u.), shape
-        ``(natom, 3, 3)`` indexed ``[lambda, alpha, beta]`` -- the overlap of the
-        nuclear (``R_{lambda,alpha}``) and magnetic-field (``B_beta``) wavefunction
-        derivatives, the electronic part of the magnetic-dipole vibrational transition
-        moment (common gauge origin).
-
-        Implements Eq. (16) of the AAT note (CPHF coefficients over dependent pairs
-        already cancelled analytically)::
-
-            I^lambda_{alpha,beta} = 2 sum_{ia} [ U^{R}_{ai} U^{B}_{ai}
-                                                 + U^{B}_{ai} <phi^{R}_i | phi_a> ]
-
-        with ``U^{R}`` the nuclear CPHF response (shared cache, :meth:`solve_nuclear`),
-        ``U^{B}`` the magnetic-field response (:meth:`solve_magnetic`, antisymmetric
-        Hessian), and ``<phi^R_i|phi_a>`` the nuclear half-derivative overlap (occupied
-        derivative against the unperturbed virtual; ``Derivatives.overlap_half`` 'LEFT').
-
-        This is the electronic part only (the magnetic-dipole vibrational transition
-        moment); the full VCD AAT adds the nuclear term
-        ``(Z_lambda / 4) eps_{alpha,beta,gamma} R_{lambda,gamma}``. The magnetic-dipole
-        integrals are stripped of their ``i`` (:meth:`_m_ov`) so the magnetic response
-        and the AAT are real -- the VCD rotatory strength takes the imaginary component
-        of the APT*AAT product, not of the AAT. Validated against DALTON's STO-3G H2O2
-        electronic AATs (via the psi4numpy SCF-VCD reference) to ~5e-9.
-        """
-        o, v = self.o, self.v
-        d = self.wfn.derivatives
-        C = np.asarray(self.wfn.C)
-        Cocc = psi4.core.Matrix.from_array(C[:, o])
-        Cvir = psi4.core.Matrix.from_array(C[:, v])
-        natom = self.wfn.ref.molecule().natom()
-
-        Ub = [self.solve_magnetic(beta) for beta in range(3)]      # 3 x (no,nv), real
-        aat = np.zeros((natom, 3, 3))
-        for lam in range(natom):
-            Ur = self.solve_nuclear(lam)                           # 3 x (no,nv), cached
-            Shalf = d.overlap_half(lam, Cocc, Cvir, side="LEFT")   # 3 x (no,nv)
-            for alpha in range(3):
-                for beta in range(3):
-                    aat[lam, alpha, beta] = 2.0 * (
-                        np.einsum('ia,ia->', Ur[alpha], Ub[beta])
-                        + np.einsum('ia,ia->', Ub[beta], Shalf[alpha]))
-        return aat
-
-    # ---- property drivers ----
-    def polarizability(self) -> np.ndarray:
-        """Static electric-dipole polarizability tensor (a.u.), shape ``(3, 3)``.
-
-        Solves the electric-field CPHF response for each Cartesian axis and contracts
-        with the dipole integrals: ``alpha_ab = -4 sum_ia mu^a_ia U^b_ia`` (closed
-        shell), where ``U^b`` solves ``G U^b = -mu^b`` in the ov block. (The two minus
-        signs -- the ``-mu`` RHS and the ``-4`` contraction -- make alpha positive
-        definite, and cancel against each other so the tensor is unchanged.)
-        """
-        mu = [self._mu_ov(c) for c in range(3)]
-        U = [self.solve(self.rhs_field(b), kind="electric") for b in range(3)]
-        alpha = np.zeros((3, 3))
-        for a in range(3):
-            for b in range(3):
-                alpha[a, b] = -4.0 * np.einsum('ia,ia->', mu[a], U[b])
-        return alpha

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -81,51 +81,166 @@ class HFwfn(Wavefunction):
         self.grad = grad
         return grad
 
-    def hessian(self) -> np.ndarray:
-        """RHF nuclear (molecular) Hessian (a.u.), shape ``(3*natom, 3*natom)`` --
-        the force-constant matrix, ``psi4.hessian('scf')`` layout.
+    def polarizability(self) -> np.ndarray:
+        """Static electric-dipole polarizability tensor (a.u.), shape ``(3, 3)``.
 
-        Solves the nuclear CPHF orbital response for every atom (cached and shared
-        with :meth:`dipole_derivatives`, so a Hessian-then-APT IR workflow does the
-        3*natom solves only once) and assembles it with the second-derivative
-        skeleton integrals. Delegates to :class:`CPHF`.
+        The field perturbation does not move the basis functions, so the response has
+        no overlap/Pulay contribution: solve the electric-field CPHF response for each
+        Cartesian axis (:class:`CPHF`) and contract with the MO dipole integrals,
+        ``alpha_ab = -4 sum_ia mu^a_ia U^b_ia`` (closed shell), where ``U^b`` solves
+        ``G U^b = -mu^b`` in the ov block. (The two minus signs -- the ``-mu`` RHS and
+        the ``-4`` contraction -- make alpha positive definite and cancel.)
         """
-        self.hess = self.cphf.molecular_hessian()
+        o, v = self.o, self.v
+        mu = [np.asarray(self.H.mu[c])[o, v] for c in range(3)]
+        U = [self.cphf.solve(self.cphf.rhs_field(b), kind="electric") for b in range(3)]
+        alpha = np.zeros((3, 3))
+        for a in range(3):
+            for b in range(3):
+                alpha[a, b] = -4.0 * np.einsum('ia,ia->', mu[a], U[b])
+        self.alpha = alpha
+        return self.alpha
+
+    def dipole_derivatives(self) -> np.ndarray:
+        """Analytic nuclear dipole derivatives ``d(mu_alpha)/d(X_A,beta)`` (a.u.),
+        shape ``(natom, 3, 3)`` indexed ``[A, beta, alpha]`` -- the atomic polar
+        tensors (APTs), transposed.
+
+        Built from the nuclear CPHF response (:meth:`CPHF.solve_nuclear`), so the ov
+        term probes ``U^X`` directly (unlike the energy gradient, which is variationally
+        insensitive to it). The assembly is nuclear + explicit electronic + overlap
+        (Pulay) + CPHF response::
+
+            d mu_a / d X_Ab = Z_A delta_ab                         (nuclear)
+                            + 2 sum_i (d mu_a / d X_Ab)_ii         (explicit electronic)
+                            - 2 sum_ik S^X_ki (mu_a)_ik            (oo / Pulay response)
+                            + 4 sum_ia U^X_ia (mu_a)_ia            (ov / CPHF response)
+        """
+        o, v = self.o, self.v
+        mu = [np.asarray(self.H.mu[a]) for a in range(3)]
+        d = self.derivatives
+        C = np.asarray(self.C)
+        Cocc = psi4.core.Matrix.from_array(C[:, o])
+        mol = self.ref.molecule()
+        natom = mol.natom()
+
+        dmu = np.zeros((natom, 3, 3))
+        for A in range(natom):
+            Ux = self.cphf.solve_nuclear(A)      # cached; shared with the Hessian
+            Sx = d.overlap(A, Cocc, Cocc)        # 3 x (no,no)
+            dip = d.dipole(A, Cocc, Cocc)        # 9 x (no,no): index alpha*3 + beta
+            for beta in range(3):
+                for alpha in range(3):
+                    val = mol.Z(A) if alpha == beta else 0.0
+                    val += 2.0 * np.trace(dip[alpha * 3 + beta])
+                    val -= 2.0 * np.einsum('ki,ki->', Sx[beta], mu[alpha][o, o])
+                    val += 4.0 * np.einsum('ia,ia->', Ux[beta], mu[alpha][o, v])
+                    dmu[A, beta, alpha] = val
+        self.dipder = dmu
+        return self.dipder
+
+    def hessian(self) -> np.ndarray:
+        """RHF nuclear (molecular) Hessian ``d^2 E / dX_Aa dX_Bb`` (a.u.), shape
+        ``(3*natom, 3*natom)`` indexed ``(A*3 + a, B*3 + b)`` -- the force-constant
+        matrix, matching ``psi4.hessian('scf')`` layout.
+
+        Built from (i) the second-derivative ("skeleton") integral terms -- the
+        gradient's integrals differentiated a second time -- and (ii) the first-order
+        nuclear CPHF response (:meth:`CPHF.solve_nuclear`), taken from the shared cache
+        so the 3*natom solves are reused for free by :meth:`dipole_derivatives` in an IR
+        workflow. The skeleton terms mirror the CPHF-free gradient with the integrals
+        differentiated twice::
+
+            2 h^{ab}_ii + (2(ii|jj) - (ij|ij))^{ab} - 2 eps_i S^{ab}_ii + V_NN^{ab}
+
+        and the response + first-derivative product cross terms (x = (A,a), y = (B,b);
+        i,j,n,m occupied; spin-adapted ``L`` = H.L)::
+
+            -4 U^x_ai B^y_ai - 2 S^x_ij F^y_ij - 2 S^y_ij F^x_ij
+            + 4 eps_i S^x_ij S^y_ij + 2 S^x_ij S^y_nm L_imjn
+
+        where ``U^x``/``B^x`` are the cached nuclear response/RHS and ``F^x_ij``/``S^x_ij``
+        the skeleton derivative Fock/overlap oo blocks (cached by :meth:`CPHF.solve_nuclear`).
+        """
+        o, v = self.o, self.v
+        eps_o = np.asarray(diag(self.H.F))[o]
+        d = self.derivatives
+        C = np.asarray(self.C)
+        Cocc = psi4.core.Matrix.from_array(C[:, o])
+        mol = self.ref.molecule()
+        natom = mol.natom()
+
+        Loooo = np.asarray(self.H.L)[o, o, o, o]       # i,m,j,n (spin-adapted)
+        Vnn2 = d.nuclear_repulsion2()                  # (3*natom, 3*natom)
+        # Pre-solve & cache the nuclear response for every atom (shared with the APTs);
+        # all four come from a single heavy per-atom pass (CPHF.solve_nuclear).
+        U = [self.cphf.solve_nuclear(A) for A in range(natom)]            # U[A][a]->(no,nv)
+        B = [self.cphf.rhs_nuclear_cached(A) for A in range(natom)]       # B[A][a]->(no,nv)
+        Foo = [self.cphf.fock_nuclear_cached(A) for A in range(natom)]    # F^X_ij->(no,no)
+        Soo = [self.cphf.overlap_nuclear_cached(A) for A in range(natom)]  # S^X_ij->(no,no)
+
+        H = np.zeros((3 * natom, 3 * natom))
+        for A in range(natom):
+            for Bat in range(natom):
+                S2 = d.overlap2(A, Bat, Cocc, Cocc)               # 9 x (no,no)
+                h2 = d.core2(A, Bat, Cocc, Cocc)                  # 9 x (no,no)
+                g2 = d.eri2(A, Bat, Cocc, Cocc, Cocc, Cocc)       # 9 x (no,no,no,no) chemist
+                for a in range(3):
+                    for b in range(3):
+                        c = a * 3 + b
+                        Ux, Uy = U[A][a], U[Bat][b]
+                        By = B[Bat][b]
+                        Sx, Sy = Soo[A][a], Soo[Bat][b]
+                        Fx, Fy = Foo[A][a], Foo[Bat][b]
+                        # --- skeleton (second-derivative integrals), as in the gradient ---
+                        skel = (2.0 * np.trace(h2[c])
+                                + 2.0 * np.einsum('iijj->', g2[c])
+                                - np.einsum('ijij->', g2[c])
+                                - 2.0 * np.einsum('i,ii->', eps_o, S2[c])
+                                + Vnn2[A * 3 + a, Bat * 3 + b])
+                        # --- first-order CPHF response + first-derivative cross terms ---
+                        resp = (-4.0 * np.einsum('ia,ia->', Ux, By)
+                                - 2.0 * np.einsum('ij,ij->', Sx, Fy)
+                                - 2.0 * np.einsum('ij,ij->', Sy, Fx)
+                                + 4.0 * np.einsum('i,ij,ij->', eps_o, Sx, Sy)
+                                + 2.0 * np.einsum('ij,nm,imjn->', Sx, Sy, Loooo))
+                        H[A * 3 + a, Bat * 3 + b] = skel + resp
+        self.hess = H
         return self.hess
 
     def atomic_axial_tensors(self) -> np.ndarray:
         """RHF atomic axial tensors (AATs) ``I^lambda_{alpha,beta}`` (a.u.), shape
-        ``(natom, 3, 3)`` -- the electronic magnetic-dipole vibrational transition
-        moment (common gauge origin), for VCD.
+        ``(natom, 3, 3)`` indexed ``[lambda, alpha, beta]`` -- the electronic part of
+        the magnetic-dipole vibrational transition moment (common gauge origin), for VCD.
 
-        Solves the magnetic-field CPHF response (antisymmetric Hessian) and reuses the
-        cached nuclear response plus the nuclear half-derivative overlaps. Delegates to
-        :class:`CPHF`.
+        Eq. (16) of the AAT note (CPHF coefficients over dependent pairs already
+        cancelled analytically)::
+
+            I^lambda_{alpha,beta} = 2 sum_ia [ U^R_ai U^B_ai + U^B_ai <phi^R_i | phi_a> ]
+
+        with ``U^R`` the nuclear CPHF response (:meth:`CPHF.solve_nuclear`, shared cache),
+        ``U^B`` the magnetic-field response (:meth:`CPHF.solve_magnetic`, antisymmetric
+        Hessian), and ``<phi^R_i|phi_a>`` the nuclear half-derivative overlap
+        (``Derivatives.overlap_half`` 'LEFT'). The magnetic integrals are stripped of
+        their ``i`` (so the response and AAT are real); the full VCD AAT adds the nuclear
+        term ``(Z_lambda/4) eps_{alpha,beta,gamma} R_{lambda,gamma}``.
         """
-        self.aat = self.cphf.atomic_axial_tensors()
+        o, v = self.o, self.v
+        d = self.derivatives
+        C = np.asarray(self.C)
+        Cocc = psi4.core.Matrix.from_array(C[:, o])
+        Cvir = psi4.core.Matrix.from_array(C[:, v])
+        natom = self.ref.molecule().natom()
+
+        Ub = [self.cphf.solve_magnetic(beta) for beta in range(3)]   # 3 x (no,nv), real
+        aat = np.zeros((natom, 3, 3))
+        for lam in range(natom):
+            Ur = self.cphf.solve_nuclear(lam)                        # 3 x (no,nv), cached
+            Shalf = d.overlap_half(lam, Cocc, Cvir, side="LEFT")     # 3 x (no,nv)
+            for alpha in range(3):
+                for beta in range(3):
+                    aat[lam, alpha, beta] = 2.0 * (
+                        np.einsum('ia,ia->', Ur[alpha], Ub[beta])
+                        + np.einsum('ia,ia->', Ub[beta], Shalf[alpha]))
+        self.aat = aat
         return self.aat
-
-    def polarizability(self) -> np.ndarray:
-        """Static electric-dipole polarizability tensor (a.u.), shape (3, 3).
-
-        Solves the electric-field CPHF orbital response (:class:`CPHF`) and contracts
-        with the MO dipole integrals. This is the first validation target for the
-        CPHF machinery: the field perturbation does not move the basis functions, so
-        the response has no overlap/Pulay contribution.
-        """
-        self.alpha = self.cphf.polarizability()
-        return self.alpha
-
-    def dipole_derivatives(self) -> np.ndarray:
-        """Nuclear dipole derivatives ``d(mu_alpha)/d(X_A,beta)`` (a.u.), shape
-        ``(natom, 3, 3)`` indexed ``[A, beta, alpha]`` -- the atomic polar tensors
-        (APTs), transposed.
-
-        Solves the nuclear CPHF orbital response (:class:`CPHF`) for each atom and
-        contracts it (plus the skeleton and overlap/Pulay terms) with the MO dipole
-        integrals. Unlike the energy gradient, the dipole derivative is sensitive to
-        the occupied-virtual orbital response, so this is what validates the nuclear
-        CPHF solution (against finite difference of the SCF dipole).
-        """
-        self.dipder = self.cphf.dipole_derivatives()
-        return self.dipder


### PR DESCRIPTION
  # Separate the CPHF solver from the HF property tensors

  `CPHF` was computing both the orbital-response *equations* and the HF *property
  tensors* built from them. This restores the separation of concerns.

  **`CPHF` now computes only what's intrinsic to the CPHF equations:** the orbital
  Hessian, the perturbation RHS builders (field/magnetic/nuclear), and the response
  coefficients `U` (plus the cached nuclear by-products the Hessian reuses). Its
  solve/RHS/cache API is unchanged.

  **The HF property tensors move to `HFwfn`**, which asks the solver for the relevant
  `U` and contracts it with the property integrals:

  | moved | from → to |
  |---|---|
  | polarizability | `CPHF` → `HFwfn.polarizability` |
  | dipole derivatives (APTs) | `CPHF` → `HFwfn.dipole_derivatives` |
  | molecular Hessian | `CPHF` → `HFwfn.hessian` |
  | atomic axial tensors (AATs) | `CPHF` → `HFwfn.atomic_axial_tensors` |

  **Why:** it matches where `HFwfn.gradient` already lives (removing the inconsistency
  where the gradient was assembled in `HFwfn` but the other four delegated into `CPHF`),
  and it puts property/occupation concerns — e.g. the polarizability's closed-shell
  prefactor — in the property class rather than the equation solver.

  Behavior-preserving relocation. Validated: spatial polarizability/APT/Hessian/AAT/
  gradient (`test_046`–`050`) all pass.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

