### PR TITLE
Spin-orbital Hartree-Fock analytic derivative properties (RHF/UHF)

### DIFF
--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -171,3 +171,24 @@ Phases A-C are shared sunk cost. After the Phase-D keystone, decide between:
 
 Beyond spatial RHF: UHF/ROHF and spin-orbital MP2/CC gradients, and frozen-core handling,
 are later increments on the same machinery.
+
+## Spin-orbital HFwfn properties (branch `feature/spinorbital-hf-gradient`)
+
+To reach open-shell (UHF/ROHF) derivative properties -- and to supply the SCF gradient
+the open-shell correlated gradients need -- the `HFwfn` derivative methods get a
+spin-orbital route (dispatch on `orbital_basis`, reusing the now basis-aware
+`Derivatives`/`CPHF`).
+
+- **HF gradient -- DONE.** `HFwfn._gradient_spinorbital`: the CPHF-free spin-orbital HF
+  gradient `dE/dX = sum_i h^x_ii + 1/2 sum_ij <ij||ij>^x - sum_i eps_i S^x_ii + dV_NN/dX`
+  (i, j occupied spin orbitals), using `self.derivatives.so_*`. `gradient()` dispatches.
+  Validated (`test_062`): keystone closed-shell RHF-forced-to-SO == spatial RHF gradient
+  (6-31G C1 and cc-pVDZ C2v) ~1e-15, and **UHF / ROHF gradients vs Psi4 ~1e-15** -- the
+  open-shell HF gradient works for all three references.
+- **CPHF-dependent HF properties (Hessian, polarizability, APT, AAT) -- TODO.** These need
+  the spin-orbital `CPHF` RHS builders (field / magnetic / nuclear), the layer deferred when
+  `CPHF` was made basis-aware. Build that, then add the SO branches to `HFwfn.hessian`/
+  `polarizability`/`dipole_derivatives`/`atomic_axial_tensors`.
+
+Once the SO HF gradient is in, `MPwfn.gradient()` can use an SO `HFwfn` for the SCF term,
+lifting the closed-shell-only restriction on the spin-orbital MP2 gradient.

--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -198,10 +198,23 @@ spin-orbital route (dispatch on `orbital_basis`, reusing the now basis-aware
   (docc-socc, socc-virt couplings), which are not uniquely defined. `CPHF.solve` raises
   `NotImplementedError` for ROHF (detected via `same_a_b_orbs and not same_a_b_dens`). The
   CPHF-free ROHF HF gradient is unaffected -- it does not solve the response.
-- **Remaining CPHF-dependent HF properties (Hessian, APT, AAT) -- TODO.** These need the
-  spin-orbital `CPHF` RHS builders (nuclear / magnetic), the layer deferred when `CPHF` was
-  made basis-aware. Build those, then add the SO branches to `HFwfn.hessian`/
-  `dipole_derivatives`/`atomic_axial_tensors`.
+- **APT (nuclear dipole derivatives) -- DONE (RHF/UHF).** A mixed field-nuclear second
+  derivative: it needed the spin-orbital *nuclear* CPHF RHS builder -- the deferred layer,
+  now built as `CPHF._build_nuclear_spinorbital` (the antisymmetrized `<pq||rs>` in place
+  of `L`, the spin-orbital skeleton derivative integrals from `Derivatives.so_*`, same
+  `B = -Q` structure) -- plus the spin-orbital dipole derivatives (`Derivatives.so_dipole`).
+  The assembly (`HFwfn._dipole_derivatives_spinorbital`) halves the closed-shell prefactors
+  (singly occupied spin orbitals). Validated (`test_064`): keystone RHF-forced-to-SO ==
+  spatial APT (6-31G C1 and cc-pVDZ C2v) ~1e-15, and UHF vs finite-difference of the SCF
+  dipole ~6e-10. ROHF raises (the nuclear response goes through `CPHF.solve`).
+- **Molecular Hessian -- TODO (assembly only).** The spin-orbital nuclear response/RHS and
+  the cached `F^X_ij`/`S^X_ij` oo by-products are now available from
+  `_build_nuclear_spinorbital`; what remains is the SO branch of `HFwfn.hessian` -- the
+  second-derivative skeleton terms (`so` analogues of `core2`/`eri2`/`overlap2`) plus the
+  response/cross terms with spin-orbital prefactors.
+- **AAT -- TODO.** Needs the spin-orbital *magnetic* CPHF RHS builder (`rhs_magnetic`/
+  `_m_ov` for the SO magnetic-dipole integral) plus the SO branch of
+  `HFwfn.atomic_axial_tensors` (and `Derivatives.overlap_half` for spin orbitals).
 
 Once the SO HF gradient is in, `MPwfn.gradient()` can use an SO `HFwfn` for the SCF term,
 lifting the closed-shell-only restriction on the spin-orbital MP2 gradient.

--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -207,11 +207,21 @@ spin-orbital route (dispatch on `orbital_basis`, reusing the now basis-aware
   (singly occupied spin orbitals). Validated (`test_064`): keystone RHF-forced-to-SO ==
   spatial APT (6-31G C1 and cc-pVDZ C2v) ~1e-15, and UHF vs finite-difference of the SCF
   dipole ~6e-10. ROHF raises (the nuclear response goes through `CPHF.solve`).
-- **Molecular Hessian -- TODO (assembly only).** The spin-orbital nuclear response/RHS and
-  the cached `F^X_ij`/`S^X_ij` oo by-products are now available from
-  `_build_nuclear_spinorbital`; what remains is the SO branch of `HFwfn.hessian` -- the
-  second-derivative skeleton terms (`so` analogues of `core2`/`eri2`/`overlap2`) plus the
-  response/cross terms with spin-orbital prefactors.
+- **Molecular Hessian -- DONE (RHF/UHF).** `HFwfn._hessian_spinorbital`: second-derivative
+  skeleton terms (`Derivatives.so_core2`/`so_eri2`/`so_overlap2`, occupied block) plus the
+  spin-orbital nuclear CPHF response/cache, with the closed-shell prefactors halved. Subtle
+  point: Psi4's `mo_tei_deriv2(A,B)` two-electron second derivative does not satisfy the
+  integral's electron-exchange symmetry `(pq|rs) = (rs|pq)` term by term. For the energy
+  trace the same-spin terms absorb the resulting bra<->ket relabel (so RHF and the aa/bb
+  blocks are already symmetric), but the UHF **cross-spin Coulomb** term
+  `sum_{i in a, j in b}(ii|jj)^{ab}` does not -- it carried the entire spurious antisymmetric
+  part. Fixed at the integral level: `Derivatives.so_eri2` symmetrizes the chemist deriv2
+  over the bra<->ket swap (building the cross-spin `ab`/`ba` blocks from independent
+  `(aa|bb)`/`(bb|aa)` calls), which -- since the geometric derivative of a symmetric integral
+  is symmetric -- also restores the atom-pair-swap symmetry the Hessian needs, so the
+  assembled Hessian is symmetric with no global `0.5*(H+H.T)`. Validated (`test_065`): keystone
+  RHF-forced-to-SO == spatial (6-31G C1, cc-pVDZ C2v) ~1e-15; UHF naturally symmetric (~1e-14)
+  and vs `psi4.hessian('scf')` ~3e-12. ROHF raises.
 - **AAT -- TODO.** Needs the spin-orbital *magnetic* CPHF RHS builder (`rhs_magnetic`/
   `_m_ov` for the SO magnetic-dipole integral) plus the SO branch of
   `HFwfn.atomic_axial_tensors` (and `Derivatives.overlap_half` for spin orbitals).

--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -222,9 +222,20 @@ spin-orbital route (dispatch on `orbital_basis`, reusing the now basis-aware
   assembled Hessian is symmetric with no global `0.5*(H+H.T)`. Validated (`test_065`): keystone
   RHF-forced-to-SO == spatial (6-31G C1, cc-pVDZ C2v) ~1e-15; UHF naturally symmetric (~1e-14)
   and vs `psi4.hessian('scf')` ~3e-12. ROHF raises.
-- **AAT -- TODO.** Needs the spin-orbital *magnetic* CPHF RHS builder (`rhs_magnetic`/
-  `_m_ov` for the SO magnetic-dipole integral) plus the SO branch of
-  `HFwfn.atomic_axial_tensors` (and `Derivatives.overlap_half` for spin orbitals).
+- **AAT -- DONE (RHF; UHF unvalidated).** The spin-orbital magnetic-dipole integral `H.m`
+  was already built on `SpinOrbitalHamiltonian`, so `CPHF._m_ov`/`rhs_magnetic`/
+  `solve_magnetic` already work for spin orbitals; the only new pieces are
+  `Derivatives.so_overlap_half` (spin-blocked nuclear half-derivative overlaps) and the SO
+  branch `HFwfn._atomic_axial_tensors_spinorbital` (`I^lam_{a,b} = sum_ia [U^R_ai U^B_ai +
+  U^B_ai <phi^R_i|phi_a>]`, prefactor 1 vs the closed-shell 2). Validated (`test_066`):
+  keystone SO-RHF == spatial AAT (the DALTON-validated `test_050` path) ~1e-15.
+  **Caveat:** there is no prior open-shell UHF AAT implementation anywhere to compare
+  against, so the UHF result is only checked to run and return a sane (finite, real,
+  nonzero) tensor through the same code path the keystone validates. ROHF raises.
+
+**All five spin-orbital HF analytic properties (gradient, polarizability, APT, Hessian,
+AAT) are implemented for RHF/UHF** (ROHF response deferred, guarded). Next: spin-adapt the
+correlated (MP2) gradient, frozen core, then CC gradients / the MP2 property path.
 
 Once the SO HF gradient is in, `MPwfn.gradient()` can use an SO `HFwfn` for the SCF term,
 lifting the closed-shell-only restriction on the spin-orbital MP2 gradient.

--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -185,10 +185,23 @@ spin-orbital route (dispatch on `orbital_basis`, reusing the now basis-aware
   Validated (`test_062`): keystone closed-shell RHF-forced-to-SO == spatial RHF gradient
   (6-31G C1 and cc-pVDZ C2v) ~1e-15, and **UHF / ROHF gradients vs Psi4 ~1e-15** -- the
   open-shell HF gradient works for all three references.
-- **CPHF-dependent HF properties (Hessian, polarizability, APT, AAT) -- TODO.** These need
-  the spin-orbital `CPHF` RHS builders (field / magnetic / nuclear), the layer deferred when
-  `CPHF` was made basis-aware. Build that, then add the SO branches to `HFwfn.hessian`/
-  `polarizability`/`dipole_derivatives`/`atomic_axial_tensors`.
+- **Polarizability -- DONE (RHF/UHF).** The simplest second-derivative property: a pure
+  electric-field CPHF response, no derivative integrals. `CPHF.polarizability` is now
+  basis-aware -- the only change from the spatial path is the prefactor (closed-shell
+  double occupancy `k=4` vs spin orbitals `k=2`); the dipole RHS (`H.mu[o,v]`) and the
+  orbital Hessian were already basis-aware. Validated (`test_063`): keystone RHF-forced-
+  to-SO == spatial == Psi4 (~1e-13), and UHF vs Psi4 (~1e-6, set by Psi4's iterative
+  UHF-CPHF; the direct SO solve matches finite field to ~2e-9).
+- **ROHF CPHF response -- DEFERRED (guarded).** The semicanonical spin-orbital response is
+  UHF-like and does *not* reproduce the restricted ROHF response (off ~5e-3 vs finite
+  field); matching it needs the reference's ROHF Brillouin / orbital-rotation conventions
+  (docc-socc, socc-virt couplings), which are not uniquely defined. `CPHF.solve` raises
+  `NotImplementedError` for ROHF (detected via `same_a_b_orbs and not same_a_b_dens`). The
+  CPHF-free ROHF HF gradient is unaffected -- it does not solve the response.
+- **Remaining CPHF-dependent HF properties (Hessian, APT, AAT) -- TODO.** These need the
+  spin-orbital `CPHF` RHS builders (nuclear / magnetic), the layer deferred when `CPHF` was
+  made basis-aware. Build those, then add the SO branches to `HFwfn.hessian`/
+  `dipole_derivatives`/`atomic_axial_tensors`.
 
 Once the SO HF gradient is in, `MPwfn.gradient()` can use an SO `HFwfn` for the SCF term,
 lifting the closed-shell-only restriction on the spin-orbital MP2 gradient.

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -230,7 +230,11 @@ class CPHF(object):
         differ). The first-derivative integrals come from the (full-MO) Derivatives
         provider; the unperturbed L is H.L. Validated to ~1e-8 via the dipole-
         derivative / APT-transpose check against finite difference of the SCF dipole.
+
+        The spin-orbital path dispatches to :meth:`_build_nuclear_spinorbital`.
         """
+        if self.wfn.orbital_basis == 'spinorbital':
+            return self._build_nuclear_spinorbital(atom)
         o, v, no, nv = self.o, self.v, self.no, self.nv
         eps_o = self.eps[o]
         L = np.asarray(self.wfn.H.L)  # spin-adapted, physicist, unperturbed
@@ -260,6 +264,41 @@ class CPHF(object):
             B.append(-Q)
             Foo.append(Fx[o, o])
             Soo.append(Sx[c][o, o])
+        return B, Foo, Soo
+
+    def _build_nuclear_spinorbital(self, atom: int):
+        """Spin-orbital nuclear CPHF RHS for ``atom`` -- the spin-orbital analogue of
+        :meth:`_build_nuclear`. Same structure with the antisymmetrized ``<pq||rs>`` in
+        place of the spin-adapted ``L``, the spin-orbital skeleton derivative integrals
+        from ``Derivatives.so_*``, and singly occupied spin orbitals::
+
+            F^X_pq = h^X_pq + sum_k(occ) <pk||qk>^X        (skeleton Fock derivative)
+            B^X_ia = -[ F^X_ia - eps_i S^X_ia
+                        - 1/2 sum_kl S^X_kl ( <ak||il> + <al||ik> ) ]
+
+        Returns ``(B, Foo, Soo)`` as for the spatial path."""
+        o, v = self.o, self.v
+        eps_o = self.eps[o]
+        ERI = np.asarray(self.wfn.H.ERI)         # antisymmetrized, unperturbed
+        d = self.wfn.derivatives
+        hx = d.so_core(atom)                     # 3 x (nmo,nmo)
+        Sxa = d.so_overlap(atom)                 # 3 x (nmo,nmo)
+        gx = d.so_eri(atom)                      # 3 x (nmo^4), antisymmetrized <pq||rs>^X
+
+        Evooo = ERI[v, o, o, o]
+        B, Foo, Soo = [], [], []
+        for c in range(3):
+            # skeleton derivative Fock F^X_pq = h^X + sum_k(occ) <pk||qk>^X
+            Fx = hx[c] + np.einsum('pkqk->pq', gx[c][:, o, :, o])
+            Sx = Sxa[c]
+            # Pulay coupling of the overlap-determined U^X_kl = -1/2 S^X_kl into the ov
+            # block: -1/2 sum_kl S^X_kl ( <ak||il> + <al||ik> ).
+            coupling = (np.einsum('akil,kl->ia', Evooo, Sx[o, o])
+                        + np.einsum('alik,kl->ia', Evooo, Sx[o, o]))
+            Q = Fx[o, v] - eps_o[:, None] * Sx[o, v] - 0.5 * coupling
+            B.append(-Q)
+            Foo.append(Fx[o, o])
+            Soo.append(Sx[o, o])
         return B, Foo, Soo
 
     def rhs_nuclear(self, atom: int) -> List[np.ndarray]:

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -79,6 +79,11 @@ class CPHF(object):
         # HFwfn builds the full MO space).
         self.eps = np.asarray(diag(wfn.H.F))
         self._G: dict = {}  # kind -> reshaped (no*nv, no*nv) orbital Hessian
+        # ROHF: restricted orbitals (same_a_b_orbs) but spin-polarized occupation
+        # (not same_a_b_dens). UHF has same_a_b_orbs False; RHF has both True. The
+        # CPHF orbital response is not supported for ROHF yet -- see solve().
+        ref = wfn.ref
+        self.is_rohf = bool(ref.same_a_b_orbs() and not ref.same_a_b_dens())
         # Persistent nuclear response, keyed by atom (geometry-bound -- valid for the
         # life of this CPHF object, which is tied to one wfn / structure). Built once
         # by solve_nuclear() and SHARED by every consumer of the nuclear response (the
@@ -132,7 +137,21 @@ class CPHF(object):
 
     # ---- linear solve ----
     def solve(self, B: np.ndarray, kind: str = "electric") -> np.ndarray:
-        """Solve ``G U = B`` for the ov response. ``B`` is ``(no, nv)``; returns ``(no, nv)``."""
+        """Solve ``G U = B`` for the ov response. ``B`` is ``(no, nv)``; returns ``(no, nv)``.
+
+        Not implemented for ROHF: the semicanonical spin-orbital response lets alpha and
+        beta relax independently (UHF-like) and so does not reproduce the *restricted*
+        ROHF response. Matching it requires adopting the reference's ROHF Brillouin /
+        orbital-rotation conventions (docc-socc, socc-virt couplings), which are not
+        uniquely defined. RHF and UHF are supported. The CPHF-free HF gradient is
+        unaffected (it does not call this)."""
+        if self.is_rohf:
+            raise NotImplementedError(
+                "CPHF orbital response is not implemented for ROHF references: the "
+                "semicanonical spin-orbital response does not reproduce the restricted "
+                "ROHF response, and the ROHF Brillouin/orbital-rotation conventions "
+                "(not uniquely defined) must match the reference. RHF and UHF are "
+                "supported; the CPHF-free HF gradient works for ROHF.")
         G = self.hessian(kind)
         U = np.linalg.solve(G, np.asarray(B).reshape(-1))
         return U.reshape(self.no, self.nv)

--- a/pycc/derivatives.py
+++ b/pycc/derivatives.py
@@ -209,6 +209,22 @@ class Derivatives(object):
             out.append(M)
         return out
 
+    def so_overlap_half(self, atom: int, side: str = "LEFT") -> List[np.ndarray]:
+        """Spin-orbital overlap half-derivatives ``<phi^X_p | phi_q>`` (block-diagonal in
+        spin) for ``atom``: 3 (x, y, z) ``nmo x nmo`` arrays. The bra is the perturbed
+        orbital, the ket the unperturbed (``side='LEFT'``); the matrix is not symmetric.
+        Used by the spin-orbital AAT machinery (which takes the ov block)."""
+        nmo, a, b, sa, sb, Ca, Cb = self._so_spin_blocks()
+        La = self.mints.mo_overlap_half_deriv1(side, atom, Ca, Ca)
+        Lb = self.mints.mo_overlap_half_deriv1(side, atom, Cb, Cb)
+        out = []
+        for c in range(3):
+            M = np.zeros((nmo, nmo))
+            M[np.ix_(a, a)] = np.asarray(La[c])[np.ix_(sa, sa)]
+            M[np.ix_(b, b)] = np.asarray(Lb[c])[np.ix_(sb, sb)]
+            out.append(M)
+        return out
+
     # ---- spin-orbital second derivatives (Hessian skeleton; occupied block) ----
     def _so_occ_blocks(self):
         """Occupied spin-orbital spin split for the Hessian skeleton: ``(no, a, b,

--- a/pycc/derivatives.py
+++ b/pycc/derivatives.py
@@ -190,6 +190,25 @@ class Derivatives(object):
             out.append(phys - phys.swapaxes(2, 3))
         return out
 
+    def so_dipole(self, atom: int) -> List[np.ndarray]:
+        """Spin-orbital MO electric-dipole derivatives ``d(mu_alpha)/d(X_atom,beta)`` for
+        ``atom``: 9 ``nmo x nmo`` arrays indexed ``alpha*3 + beta`` (block-diagonal in
+        spin). As in :meth:`dipole`, the AO derivatives (``ao_elec_dip_deriv1``) are
+        transformed here (the ``mo_elec_dip_deriv1`` route segfaults on linux Psi4
+        1.10.1); here each spin block is transformed with the semicanonical MOs."""
+        nmo, a, b, sa, sb, _, _ = self._so_spin_blocks()
+        Ca = np.asarray(self.wfn.H.Ca)
+        Cb = np.asarray(self.wfn.H.Cb)
+        aod = self.mints.ao_elec_dip_deriv1(atom)   # 9 x (nao, nao)
+        out = []
+        for c in range(9):
+            ao = np.asarray(aod[c])
+            M = np.zeros((nmo, nmo))
+            M[np.ix_(a, a)] = (Ca.T @ ao @ Ca)[np.ix_(sa, sa)]
+            M[np.ix_(b, b)] = (Cb.T @ ao @ Cb)[np.ix_(sb, sb)]
+            out.append(M)
+        return out
+
     # ---- nuclear repulsion ----
     def nuclear_repulsion(self) -> np.ndarray:
         """Nuclear-repulsion-energy gradient, shape (natom, 3)."""

--- a/pycc/derivatives.py
+++ b/pycc/derivatives.py
@@ -209,6 +209,84 @@ class Derivatives(object):
             out.append(M)
         return out
 
+    # ---- spin-orbital second derivatives (Hessian skeleton; occupied block) ----
+    def _so_occ_blocks(self):
+        """Occupied spin-orbital spin split for the Hessian skeleton: ``(no, a, b,
+        Cocc_a, Cocc_b)`` where ``a``/``b`` are the alpha/beta positions within the
+        occupied block and ``Cocc_a``/``Cocc_b`` the corresponding occupied alpha/beta
+        MOs (as Psi4 matrices, pre-sliced to the occupied spatial columns -- so the
+        deriv2 transforms return arrays already in occupied-block order)."""
+        H = self.wfn.H
+        o = self.wfn.o
+        spin_o = np.asarray(H.spin)[o]
+        spat_o = np.asarray(H.spat)[o]
+        a = np.where(spin_o == 0)[0]
+        b = np.where(spin_o == 1)[0]
+        Cocc_a = psi4.core.Matrix.from_array(np.asarray(H.Ca)[:, spat_o[a]])
+        Cocc_b = psi4.core.Matrix.from_array(np.asarray(H.Cb)[:, spat_o[b]])
+        return self.wfn.no, a, b, Cocc_a, Cocc_b
+
+    def so_oei2(self, kind: str, atom1: int, atom2: int) -> List[np.ndarray]:
+        """Spin-orbital second one-electron derivative (occupied block, block-diagonal
+        in spin) for the ``(atom1, atom2)`` pair: 9 ``(no, no)`` arrays indexed
+        ``cart1*3 + cart2``. ``kind`` is 'OVERLAP'/'KINETIC'/'POTENTIAL'."""
+        no, a, b, Ca, Cb = self._so_occ_blocks()
+        Da = self.mints.mo_oei_deriv2(kind, atom1, atom2, Ca, Ca)
+        Db = self.mints.mo_oei_deriv2(kind, atom1, atom2, Cb, Cb)
+        out = []
+        for c in range(9):
+            M = np.zeros((no, no))
+            M[np.ix_(a, a)] = np.asarray(Da[c])
+            M[np.ix_(b, b)] = np.asarray(Db[c])
+            out.append(M)
+        return out
+
+    def so_core2(self, atom1: int, atom2: int) -> List[np.ndarray]:
+        """Spin-orbital second core (kinetic + potential) derivatives ``h^{XY}`` (occupied
+        block) for the ``(atom1, atom2)`` pair: 9 ``(no, no)`` arrays."""
+        T = self.so_oei2("KINETIC", atom1, atom2)
+        V = self.so_oei2("POTENTIAL", atom1, atom2)
+        return [t + v for t, v in zip(T, V)]
+
+    def so_overlap2(self, atom1: int, atom2: int) -> List[np.ndarray]:
+        """Spin-orbital second overlap derivatives ``S^{XY}`` (occupied block) for the
+        ``(atom1, atom2)`` pair: 9 ``(no, no)`` arrays."""
+        return self.so_oei2("OVERLAP", atom1, atom2)
+
+    def so_eri2(self, atom1: int, atom2: int) -> List[np.ndarray]:
+        """Spin-orbital second antisymmetrized two-electron derivatives ``<ij||kl>^{XY}``
+        (occupied block) for the ``(atom1, atom2)`` pair: 9 ``(no^4)`` arrays indexed
+        ``cart1*3 + cart2``. Spin-blocked from the occupied-block chemist deriv2 integrals
+        then antisymmetrized, as in :meth:`so_eri`.
+
+        Psi4's ``mo_tei_deriv2(A, B)`` does not satisfy the two-electron integral's
+        electron-exchange symmetry ``(pq|rs) = (rs|pq)`` term by term -- a single (A, B)
+        call gives one ordering of the mixed derivative ``d^2/dXA dXB`` -- so the chemist
+        integral is symmetrized over the bra<->ket swap here. That restores the missing
+        symmetry, which (because the geometric derivative of a symmetric integral is
+        symmetric) also makes the result invariant under the atom-pair swap the molecular
+        Hessian requires. The cross-spin ``ab``/``ba`` blocks are therefore built from
+        independent ``(aa|bb)`` and ``(bb|aa)`` deriv2 calls rather than as transposes of
+        one another (only with both does the symmetrization see the true pair); the
+        same-spin ``aa``/``bb`` blocks need it too (a no-op for their energy trace but it
+        restores the tensor symmetry)."""
+        no, a, b, Ca, Cb = self._so_occ_blocks()
+        AA = self.mints.mo_tei_deriv2(atom1, atom2, Ca, Ca, Ca, Ca)
+        BB = self.mints.mo_tei_deriv2(atom1, atom2, Cb, Cb, Cb, Cb)
+        AB = self.mints.mo_tei_deriv2(atom1, atom2, Ca, Ca, Cb, Cb)
+        BA = self.mints.mo_tei_deriv2(atom1, atom2, Cb, Cb, Ca, Ca)
+        out = []
+        for c in range(9):
+            chem = np.zeros((no, no, no, no))
+            chem[np.ix_(a, a, a, a)] = np.asarray(AA[c])
+            chem[np.ix_(b, b, b, b)] = np.asarray(BB[c])
+            chem[np.ix_(a, a, b, b)] = np.asarray(AB[c])
+            chem[np.ix_(b, b, a, a)] = np.asarray(BA[c])
+            chem = 0.5 * (chem + chem.transpose(2, 3, 0, 1))   # enforce (pq|rs) = (rs|pq)
+            phys = chem.swapaxes(1, 2)
+            out.append(phys - phys.swapaxes(2, 3))
+        return out
+
     # ---- nuclear repulsion ----
     def nuclear_repulsion(self) -> np.ndarray:
         """Nuclear-repulsion-energy gradient, shape (natom, 3)."""

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -238,7 +238,11 @@ class HFwfn(Wavefunction):
 
         where ``U^x``/``B^x`` are the cached nuclear response/RHS and ``F^x_ij``/``S^x_ij``
         the skeleton derivative Fock/overlap oo blocks (cached by :meth:`CPHF.solve_nuclear`).
+
+        The spin-orbital path dispatches to :meth:`_hessian_spinorbital`.
         """
+        if self.orbital_basis == 'spinorbital':
+            return self._hessian_spinorbital()
         o, v = self.o, self.v
         eps_o = np.asarray(diag(self.H.F))[o]
         d = self.derivatives
@@ -281,6 +285,61 @@ class HFwfn(Wavefunction):
                                 - 2.0 * np.einsum('ij,ij->', Sy, Fx)
                                 + 4.0 * np.einsum('i,ij,ij->', eps_o, Sx, Sy)
                                 + 2.0 * np.einsum('ij,nm,imjn->', Sx, Sy, Loooo))
+                        H[A * 3 + a, Bat * 3 + b] = skel + resp
+        self.hess = H
+        return self.hess
+
+    def _hessian_spinorbital(self) -> np.ndarray:
+        """Spin-orbital RHF/UHF molecular Hessian, shape ``(3*natom, 3*natom)``. The
+        spin-orbital form of :meth:`hessian`: singly occupied spin orbitals (the
+        closed-shell prefactors halve) with the antisymmetrized ``<ij||kl>``, the
+        spin-orbital second-derivative integrals (:meth:`Derivatives.so_core2` /
+        ``so_eri2`` / ``so_overlap2``, occupied block), and the spin-orbital nuclear CPHF
+        response/cache (:meth:`CPHF.solve_nuclear`)::
+
+            skeleton:  h^{ab}_ii + 1/2 <ij||ij>^{ab} - eps_i S^{ab}_ii + V_NN^{ab}
+            response:  -2 U^x_ai B^y_ai - S^x_ij F^y_ij - S^y_ij F^x_ij
+                       + 2 eps_i S^x_ij S^y_ij + S^x_ij S^y_nm <im||jn>
+
+        Valid for UHF as well as a closed-shell RHF reference forced to spin orbitals;
+        ROHF raises (the nuclear response goes through :meth:`CPHF.solve`)."""
+        o = self.o
+        eps_o = np.asarray(diag(self.H.F))[o]
+        ERIoooo = np.asarray(self.H.ERI)[o, o, o, o]   # i,m,j,n (antisymmetrized)
+        d = self.derivatives
+        mol = self.ref.molecule()
+        natom = mol.natom()
+
+        Vnn2 = d.nuclear_repulsion2()
+        U = [self.cphf.solve_nuclear(A) for A in range(natom)]            # U[A][a]->(no,nv)
+        B = [self.cphf.rhs_nuclear_cached(A) for A in range(natom)]       # B[A][a]->(no,nv)
+        Foo = [self.cphf.fock_nuclear_cached(A) for A in range(natom)]    # F^X_ij->(no,no)
+        Soo = [self.cphf.overlap_nuclear_cached(A) for A in range(natom)]  # S^X_ij->(no,no)
+
+        H = np.zeros((3 * natom, 3 * natom))
+        for A in range(natom):
+            for Bat in range(natom):
+                S2 = d.so_overlap2(A, Bat)                # 9 x (no,no)
+                h2 = d.so_core2(A, Bat)                   # 9 x (no,no)
+                g2 = d.so_eri2(A, Bat)                    # 9 x (no^4) <ij||kl>^{ab}
+                for a in range(3):
+                    for b in range(3):
+                        c = a * 3 + b
+                        Ux, Uy = U[A][a], U[Bat][b]
+                        By = B[Bat][b]
+                        Sx, Sy = Soo[A][a], Soo[Bat][b]
+                        Fx, Fy = Foo[A][a], Foo[Bat][b]
+                        # --- skeleton (second-derivative integrals), as in the gradient ---
+                        skel = (self.contract('ii->', h2[c])
+                                + 0.5 * self.contract('ijij->', g2[c])
+                                - self.contract('i,ii->', eps_o, S2[c])
+                                + Vnn2[A * 3 + a, Bat * 3 + b])
+                        # --- first-order CPHF response + first-derivative cross terms ---
+                        resp = (-2.0 * self.contract('ia,ia->', Ux, By)
+                                - self.contract('ij,ij->', Sx, Fy)
+                                - self.contract('ij,ij->', Sy, Fx)
+                                + 2.0 * self.contract('i,ij,ij->', eps_o, Sx, Sy)
+                                + self.contract('ij,nm,imjn->', Sx, Sy, ERIoooo))
                         H[A * 3 + a, Bat * 3 + b] = skel + resp
         self.hess = H
         return self.hess

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -154,7 +154,11 @@ class HFwfn(Wavefunction):
                             + 2 sum_i (d mu_a / d X_Ab)_ii         (explicit electronic)
                             - 2 sum_ik S^X_ki (mu_a)_ik            (oo / Pulay response)
                             + 4 sum_ia U^X_ia (mu_a)_ia            (ov / CPHF response)
+
+        The spin-orbital path dispatches to :meth:`_dipole_derivatives_spinorbital`.
         """
+        if self.orbital_basis == 'spinorbital':
+            return self._dipole_derivatives_spinorbital()
         o, v = self.o, self.v
         mu = [np.asarray(self.H.mu[a]) for a in range(3)]
         d = self.derivatives
@@ -174,6 +178,40 @@ class HFwfn(Wavefunction):
                     val += 2.0 * np.trace(dip[alpha * 3 + beta])
                     val -= 2.0 * np.einsum('ki,ki->', Sx[beta], mu[alpha][o, o])
                     val += 4.0 * np.einsum('ia,ia->', Ux[beta], mu[alpha][o, v])
+                    dmu[A, beta, alpha] = val
+        self.dipder = dmu
+        return self.dipder
+
+    def _dipole_derivatives_spinorbital(self) -> np.ndarray:
+        """Spin-orbital nuclear dipole derivatives (APTs), shape ``(natom, 3, 3)`` indexed
+        ``[A, beta, alpha]``. The spin-orbital form of :meth:`dipole_derivatives`: singly
+        occupied spin orbitals (the one-electron traces carry factor 1, the ov response
+        factor 2, vs 2 and 4 closed-shell), with the spin-orbital nuclear CPHF response
+        (:meth:`CPHF.solve_nuclear`) and spin-orbital dipole derivatives
+        (:meth:`Derivatives.so_dipole`)::
+
+            d mu_a / d X_Ab = Z_A delta_ab + sum_i (d mu_a / d X_Ab)_ii
+                            - sum_ik S^X_ki (mu_a)_ik + 2 sum_ia U^X_ia (mu_a)_ia
+
+        Valid for UHF as well as a closed-shell RHF reference forced to spin orbitals;
+        ROHF raises (the nuclear response goes through :meth:`CPHF.solve`)."""
+        o, v = self.o, self.v
+        mu = [np.asarray(self.H.mu[a]) for a in range(3)]
+        d = self.derivatives
+        mol = self.ref.molecule()
+        natom = mol.natom()
+
+        dmu = np.zeros((natom, 3, 3))
+        for A in range(natom):
+            Ux = self.cphf.solve_nuclear(A)      # 3 x (no,nv), spin-orbital response
+            Sx = d.so_overlap(A)                 # 3 x (nmo,nmo)
+            dip = d.so_dipole(A)                 # 9 x (nmo,nmo): index alpha*3 + beta
+            for beta in range(3):
+                for alpha in range(3):
+                    val = mol.Z(A) if alpha == beta else 0.0
+                    val += self.contract('ii->', dip[alpha * 3 + beta][o, o])
+                    val -= self.contract('ki,ki->', Sx[beta][o, o], mu[alpha][o, o])
+                    val += 2.0 * self.contract('ia,ia->', Ux[beta], mu[alpha][o, v])
                     dmu[A, beta, alpha] = val
         self.dipder = dmu
         return self.dipder

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -57,7 +57,12 @@ class HFwfn(Wavefunction):
         ``self.C`` (single irrep block, global energy order), so this works with
         molecular symmetry left on. HFwfn always uses the full (all-electron) MO
         space, so a frozen core on the reference does not affect the gradient.
+
+        The spin-orbital path (open-shell UHF/ROHF, or a closed shell forced to spin
+        orbitals) dispatches to :meth:`_gradient_spinorbital`.
         """
+        if self.orbital_basis == 'spinorbital':
+            return self._gradient_spinorbital()
         o = self.o
         no = self.no
         # Occupied block of the symmetry-handled MO coefficients, and the matching
@@ -77,6 +82,35 @@ class HFwfn(Wavefunction):
                                  + 2.0 * np.einsum('iijj->', erix[c])
                                  - np.einsum('ijij->', erix[c])
                                  - 2.0 * np.einsum('i,ii->', eps, Sx[c])
+                                 + Vnn[atom, c])
+        self.grad = grad
+        return grad
+
+    def _gradient_spinorbital(self) -> np.ndarray:
+        """Spin-orbital Hartree-Fock analytic energy gradient (a.u.), shape (natom, 3).
+
+        The spin-orbital form of the CPHF-free HF gradient (i, j over occupied spin
+        orbitals; ``<ij||ij>`` antisymmetrized), valid for UHF/ROHF as well as a
+        closed-shell RHF reference forced to spin orbitals::
+
+            dE/dX = sum_i h^x_ii + 1/2 sum_ij <ij||ij>^x - sum_i eps_i S^x_ii + dV_NN/dX
+
+        The skeleton spin-orbital derivative integrals come from ``self.derivatives``
+        (built in the semicanonical MO gauge). For a closed shell this equals the
+        spatial RHF gradient term-for-term."""
+        o = self.o
+        eps = np.asarray(diag(self.H.F))[o]
+        d = self.derivatives
+        grad = np.zeros((d.natom, 3))
+        Vnn = d.nuclear_repulsion()
+        for atom in range(d.natom):
+            hx = d.so_core(atom)
+            Sx = d.so_overlap(atom)
+            erix = d.so_eri(atom)
+            for c in range(3):
+                grad[atom, c] = (self.contract('ii->', hx[c][o, o])
+                                 + 0.5 * self.contract('ijij->', erix[c][o, o, o, o])
+                                 - self.contract('i,ii->', eps, Sx[c][o, o])
                                  + Vnn[atom, c])
         self.grad = grad
         return grad

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -360,7 +360,11 @@ class HFwfn(Wavefunction):
         (``Derivatives.overlap_half`` 'LEFT'). The magnetic integrals are stripped of
         their ``i`` (so the response and AAT are real); the full VCD AAT adds the nuclear
         term ``(Z_lambda/4) eps_{alpha,beta,gamma} R_{lambda,gamma}``.
+
+        The spin-orbital path dispatches to :meth:`_atomic_axial_tensors_spinorbital`.
         """
+        if self.orbital_basis == 'spinorbital':
+            return self._atomic_axial_tensors_spinorbital()
         o, v = self.o, self.v
         d = self.derivatives
         C = np.asarray(self.C)
@@ -378,5 +382,36 @@ class HFwfn(Wavefunction):
                     aat[lam, alpha, beta] = 2.0 * (
                         np.einsum('ia,ia->', Ur[alpha], Ub[beta])
                         + np.einsum('ia,ia->', Ub[beta], Shalf[alpha]))
+        self.aat = aat
+        return self.aat
+
+    def _atomic_axial_tensors_spinorbital(self) -> np.ndarray:
+        """Spin-orbital RHF/UHF atomic axial tensors (AATs), shape ``(natom, 3, 3)``. The
+        spin-orbital form of :meth:`atomic_axial_tensors`: singly occupied spin orbitals
+        (the closed-shell prefactor 2 -> 1), with the spin-orbital nuclear response
+        (:meth:`CPHF.solve_nuclear`), magnetic response (:meth:`CPHF.solve_magnetic`), and
+        nuclear half-derivative overlaps (:meth:`Derivatives.so_overlap_half`)::
+
+            I^lam_{a,b} = sum_ia [ U^R_ai U^B_ai + U^B_ai <phi^R_i | phi_a> ]
+
+        Valid for UHF as well as a closed-shell RHF reference forced to spin orbitals
+        (ROHF raises, via :meth:`CPHF.solve`). Note: there is no prior open-shell UHF AAT
+        implementation to validate against; the closed-shell keystone (SO-RHF == the
+        DALTON-validated spatial AAT) validates the spin-orbital machinery, and the UHF
+        result runs through the same code path."""
+        o, v = self.o, self.v
+        d = self.derivatives
+        natom = self.ref.molecule().natom()
+
+        Ub = [self.cphf.solve_magnetic(beta) for beta in range(3)]   # 3 x (no,nv), real
+        aat = np.zeros((natom, 3, 3))
+        for lam in range(natom):
+            Ur = self.cphf.solve_nuclear(lam)                        # 3 x (no,nv), cached
+            Shalf = d.so_overlap_half(lam, side="LEFT")             # 3 x (nmo,nmo)
+            for alpha in range(3):
+                for beta in range(3):
+                    aat[lam, alpha, beta] = (
+                        self.contract('ia,ia->', Ur[alpha], Ub[beta])
+                        + self.contract('ia,ia->', Ub[beta], Shalf[alpha][o, v]))
         self.aat = aat
         return self.aat

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -121,17 +121,22 @@ class HFwfn(Wavefunction):
         The field perturbation does not move the basis functions, so the response has
         no overlap/Pulay contribution: solve the electric-field CPHF response for each
         Cartesian axis (:class:`CPHF`) and contract with the MO dipole integrals,
-        ``alpha_ab = -4 sum_ia mu^a_ia U^b_ia`` (closed shell), where ``U^b`` solves
-        ``G U^b = -mu^b`` in the ov block. (The two minus signs -- the ``-mu`` RHS and
-        the ``-4`` contraction -- make alpha positive definite and cancel.)
+        ``alpha_ab = -k sum_ia mu^a_ia U^b_ia``, where ``U^b`` solves ``G U^b = -mu^b``
+        in the ov block. The prefactor counts the ``ov``+``vo`` response (factor 2) and,
+        on the spatial closed-shell path, the double occupancy (another factor 2 ->
+        ``k = 4``); the spin-orbital path has singly occupied spin orbitals, so ``k = 2``
+        and the orbital Hessian carries the spin structure. (The two minus signs -- the
+        ``-mu`` RHS and the ``-k`` contraction -- make alpha positive definite and
+        cancel.) Basis-aware.
         """
         o, v = self.o, self.v
+        k = 2.0 if self.orbital_basis == 'spinorbital' else 4.0
         mu = [np.asarray(self.H.mu[c])[o, v] for c in range(3)]
         U = [self.cphf.solve(self.cphf.rhs_field(b), kind="electric") for b in range(3)]
         alpha = np.zeros((3, 3))
         for a in range(3):
             for b in range(3):
-                alpha[a, b] = -4.0 * np.einsum('ia,ia->', mu[a], U[b])
+                alpha[a, b] = -k * np.einsum('ia,ia->', mu[a], U[b])
         self.alpha = alpha
         return self.alpha
 

--- a/pycc/tests/conftest.py
+++ b/pycc/tests/conftest.py
@@ -36,6 +36,21 @@ DEFAULT_SCF_OPTIONS = {
 }
 
 
+@pytest.fixture(autouse=True)
+def _psi4_clean_state():
+    """Autouse: reset Psi4's global options before every test (and clean scratch after).
+
+    A leftover option -- most importantly a non-default ``reference`` left by an earlier
+    test -- otherwise leaks into any later test that drives Psi4 itself rather than going
+    through the ``rhf_wfn``/``uhf_wfn``/``rohf_wfn`` factories (which already clear options
+    via :func:`psi4_environment`). This runs for *every* test regardless, so order can
+    never matter. (The factory path's own ``clean_options`` is now redundant but harmless.)
+    """
+    psi4.core.clean_options()
+    yield
+    psi4.core.clean()
+
+
 @pytest.fixture
 def psi4_environment():
     """Put Psi4 in a clean, quiet state around a test.

--- a/pycc/tests/test_062_spinorbital_hf_gradient.py
+++ b/pycc/tests/test_062_spinorbital_hf_gradient.py
@@ -1,0 +1,81 @@
+"""
+Spin-orbital Hartree-Fock analytic nuclear gradient (HFwfn, orbital_basis='spinorbital')
+-- the open-shell-capable form of the CPHF-free RHF gradient;
+docs/DERIVATIVES_PLAN_2026-06.md.
+
+    dE/dX = sum_i h^x_ii + 1/2 sum_ij <ij||ij>^x - sum_i eps_i S^x_ii + dV_NN/dX   (i,j occ)
+
+Validation:
+  * keystone -- a closed-shell RHF reference forced to spin orbitals gives the same
+    gradient as the spatial RHF path (and Psi4); and
+  * open-shell UHF and ROHF gradients vs Psi4.
+"""
+
+import psi4
+import pycc
+import numpy as np
+
+
+WATER = """
+O
+H 1 0.96
+H 1 0.96 2 104.5
+"""
+OH = """
+0 2
+O 0.0 0.0 0.0
+H 0.0 0.0 1.0
+symmetry c1
+"""
+
+
+def _scf_wfn(geom, basis, reference):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'reference': reference,
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    return wfn
+
+
+def _psi4_scf_gradient(geom, basis, reference):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'reference': reference,
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    return np.asarray(psi4.gradient('scf'))
+
+
+def test_so_rhf_gradient_vs_spatial_631g():
+    """Keystone (C1): closed-shell RHF forced to spin orbitals == spatial RHF gradient."""
+    geom = WATER + "symmetry c1\n"
+    wfn = _scf_wfn(geom, '6-31G', 'rhf')
+    g_so = pycc.HFwfn(wfn, orbital_basis='spinorbital').gradient()
+    g_spatial = pycc.HFwfn(wfn).gradient()
+    assert np.max(np.abs(g_so - g_spatial)) < 1e-11
+    assert np.max(np.abs(g_so - _psi4_scf_gradient(geom, '6-31G', 'rhf'))) < 1e-10
+
+
+def test_so_rhf_gradient_vs_spatial_ccpvdz():
+    """Keystone (C2v: polarization functions + A2-irrep MOs): SO-RHF == spatial RHF."""
+    wfn = _scf_wfn(WATER, 'cc-pVDZ', 'rhf')
+    g_so = pycc.HFwfn(wfn, orbital_basis='spinorbital').gradient()
+    g_spatial = pycc.HFwfn(wfn).gradient()
+    assert np.max(np.abs(g_so - g_spatial)) < 1e-11
+    assert np.max(np.abs(g_so - _psi4_scf_gradient(WATER, 'cc-pVDZ', 'rhf'))) < 1e-10
+
+
+def test_uhf_gradient_vs_psi4():
+    """Open-shell UHF gradient (OH doublet) vs Psi4."""
+    wfn = _scf_wfn(OH, '6-31G', 'uhf')
+    g_so = pycc.HFwfn(wfn, orbital_basis='spinorbital').gradient()
+    assert np.max(np.abs(g_so - _psi4_scf_gradient(OH, '6-31G', 'uhf'))) < 1e-10
+
+
+def test_rohf_gradient_vs_psi4():
+    """Open-shell ROHF gradient (OH doublet, semicanonical orbitals) vs Psi4."""
+    wfn = _scf_wfn(OH, '6-31G', 'rohf')
+    g_so = pycc.HFwfn(wfn, orbital_basis='spinorbital').gradient()
+    assert np.max(np.abs(g_so - _psi4_scf_gradient(OH, '6-31G', 'rohf'))) < 1e-10

--- a/pycc/tests/test_063_spinorbital_hf_polarizability.py
+++ b/pycc/tests/test_063_spinorbital_hf_polarizability.py
@@ -1,0 +1,85 @@
+"""
+Spin-orbital Hartree-Fock static dipole polarizability (HFwfn, orbital_basis=
+'spinorbital') -- the open-shell-capable electric-field CPHF response;
+docs/DERIVATIVES_PLAN_2026-06.md.
+
+    alpha_ab = -2 sum_ia mu^a_ia U^b_ia,   G U^b = -mu^b   (spin orbitals)
+
+A pure field response: the perturbation does not move the basis functions, so there is
+no overlap/derivative-integral (Pulay) contribution -- the simplest second-derivative
+property.
+
+Validation:
+  * keystone -- closed-shell RHF forced to spin orbitals == spatial RHF == Psi4 CPHF;
+  * open-shell UHF vs Psi4 CPHF (Psi4's iterative UHF-CPHF sets the ~1e-6 agreement).
+
+ROHF is intentionally not supported: the semicanonical spin-orbital response is UHF-like
+and does not reproduce the restricted ROHF response (the ROHF Brillouin/orbital-rotation
+conventions are not uniquely defined). The CPHF response raises NotImplementedError.
+"""
+
+import psi4
+import pycc
+import numpy as np
+import pytest
+
+
+WATER = """
+O
+H 1 0.96
+H 1 0.96 2 104.5
+"""
+OH = """
+0 2
+O 0.0 0.0 0.0
+H 0.0 0.0 1.0
+symmetry c1
+"""
+
+
+def _scf_wfn(geom, basis, reference):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'reference': reference,
+                      'e_convergence': 1e-11, 'd_convergence': 1e-11})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    return wfn
+
+
+def _psi4_polarizability(geom, basis, reference):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'reference': reference,
+                      'e_convergence': 1e-11, 'd_convergence': 1e-11})
+    psi4.properties('scf', properties=['DIPOLE_POLARIZABILITIES'])
+    ax = 'XYZ'
+    return np.array([[psi4.variable(f'DIPOLE POLARIZABILITY {ax[i]}{ax[j]}')
+                      for j in range(3)] for i in range(3)])
+
+
+def test_so_rhf_polarizability_vs_spatial():
+    """Keystone (cc-pVDZ, C2v): closed-shell RHF forced to spin orbitals == spatial
+    RHF polarizability (== Psi4 CPHF)."""
+    wfn = _scf_wfn(WATER, 'cc-pVDZ', 'rhf')
+    a_so = pycc.HFwfn(wfn, orbital_basis='spinorbital').polarizability()
+    a_spatial = pycc.HFwfn(wfn).polarizability()
+    assert np.max(np.abs(a_so - a_spatial)) < 1e-11
+    assert np.max(np.abs(a_so - _psi4_polarizability(WATER, 'cc-pVDZ', 'rhf'))) < 1e-9
+
+
+def test_uhf_polarizability_vs_psi4():
+    """Open-shell UHF polarizability (OH doublet) vs Psi4 CPHF (Psi4's iterative
+    UHF-CPHF convergence sets the agreement; the direct SO solve is exact)."""
+    wfn = _scf_wfn(OH, '6-31G', 'uhf')
+    a_so = pycc.HFwfn(wfn, orbital_basis='spinorbital').polarizability()
+    assert np.max(np.abs(a_so - _psi4_polarizability(OH, '6-31G', 'uhf'))) < 1e-6
+
+
+def test_rohf_polarizability_not_implemented():
+    """ROHF CPHF response is intentionally unsupported (restricted-orbital response /
+    non-unique Brillouin conventions): the response solve raises NotImplementedError."""
+    wfn = _scf_wfn(OH, '6-31G', 'rohf')
+    with pytest.raises(NotImplementedError):
+        pycc.HFwfn(wfn, orbital_basis='spinorbital').polarizability()

--- a/pycc/tests/test_064_spinorbital_hf_apt.py
+++ b/pycc/tests/test_064_spinorbital_hf_apt.py
@@ -1,0 +1,98 @@
+"""
+Spin-orbital Hartree-Fock atomic polar tensors (APTs / nuclear dipole derivatives),
+HFwfn.dipole_derivatives with orbital_basis='spinorbital'; docs/DERIVATIVES_PLAN_2026-06.md.
+
+A mixed field-nuclear second derivative: it uses the spin-orbital *nuclear* CPHF response
+(the deferred nuclear-RHS layer, now built) plus the spin-orbital dipole/overlap
+derivative integrals. Singly occupied spin orbitals halve the closed-shell prefactors::
+
+    d mu_a / d X_Ab = Z_A delta_ab + sum_i (d mu_a / d X_Ab)_ii
+                    - sum_ik S^X_ki (mu_a)_ik + 2 sum_ia U^X_ia (mu_a)_ia
+
+Validation:
+  * keystone -- closed-shell RHF forced to spin orbitals == spatial RHF APT;
+  * open-shell UHF APT vs finite difference of the SCF dipole.
+
+ROHF is guarded (the nuclear response goes through CPHF.solve): raises NotImplementedError.
+"""
+
+import psi4
+import pycc
+import numpy as np
+import pytest
+
+
+WATER = """
+O
+H 1 0.96
+H 1 0.96 2 104.5
+"""
+# OH doublet in explicit bohr coordinates (for clean finite differencing).
+OH_COORDS = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.8]])
+
+
+def _oh_geom(coords):
+    s = "0 2\n" + "\n".join(f"{el} {c[0]:.12f} {c[1]:.12f} {c[2]:.12f}"
+                            for el, c in zip(['O', 'H'], coords))
+    return s + "\nunits bohr\nsymmetry c1\nno_com\nno_reorient\n"
+
+
+def _scf_wfn(geom, basis, reference):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'reference': reference,
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    return wfn
+
+
+def test_so_rhf_apt_vs_spatial_631g():
+    """Keystone (C1): closed-shell RHF forced to spin orbitals == spatial RHF APT."""
+    wfn = _scf_wfn(WATER + "symmetry c1\n", '6-31G', 'rhf')
+    apt_so = pycc.HFwfn(wfn, orbital_basis='spinorbital').dipole_derivatives()
+    apt_spatial = pycc.HFwfn(wfn).dipole_derivatives()
+    assert np.max(np.abs(apt_so - apt_spatial)) < 1e-10
+
+
+@pytest.mark.slow
+def test_so_rhf_apt_vs_spatial_ccpvdz():
+    """Keystone (C2v: polarization functions + A2-irrep MOs): SO-RHF == spatial RHF APT."""
+    wfn = _scf_wfn(WATER, 'cc-pVDZ', 'rhf')
+    apt_so = pycc.HFwfn(wfn, orbital_basis='spinorbital').dipole_derivatives()
+    apt_spatial = pycc.HFwfn(wfn).dipole_derivatives()
+    assert np.max(np.abs(apt_so - apt_spatial)) < 1e-10
+
+
+@pytest.mark.slow
+def test_uhf_apt_vs_finite_difference():
+    """Open-shell UHF APT (OH doublet) vs finite difference of the SCF dipole."""
+    wfn = _scf_wfn(_oh_geom(OH_COORDS), '6-31G', 'uhf')
+    apt = pycc.HFwfn(wfn, orbital_basis='spinorbital').dipole_derivatives()
+
+    def dipole(coords):
+        psi4.core.clean()
+        psi4.core.clean_options()
+        psi4.geometry(_oh_geom(coords))
+        psi4.set_options({'basis': '6-31G', 'scf_type': 'pk', 'reference': 'uhf',
+                          'e_convergence': 1e-12, 'd_convergence': 1e-12})
+        psi4.energy('scf')
+        return np.asarray(psi4.variable('SCF DIPOLE'))
+
+    h = 1e-4
+    fd = np.zeros((2, 3, 3))
+    for A in range(2):
+        for beta in range(3):
+            gp = OH_COORDS.copy(); gp[A, beta] += h
+            gm = OH_COORDS.copy(); gm[A, beta] -= h
+            dp, dm = dipole(gp), dipole(gm)
+            for alpha in range(3):
+                fd[A, beta, alpha] = (dp[alpha] - dm[alpha]) / (2 * h)
+    assert np.max(np.abs(apt - fd)) < 1e-7
+
+
+def test_rohf_apt_not_implemented():
+    """ROHF APT goes through the (unsupported) ROHF CPHF response: NotImplementedError."""
+    wfn = _scf_wfn(_oh_geom(OH_COORDS), '6-31G', 'rohf')
+    with pytest.raises(NotImplementedError):
+        pycc.HFwfn(wfn, orbital_basis='spinorbital').dipole_derivatives()

--- a/pycc/tests/test_065_spinorbital_hf_hessian.py
+++ b/pycc/tests/test_065_spinorbital_hf_hessian.py
@@ -1,0 +1,92 @@
+"""
+Spin-orbital Hartree-Fock molecular (nuclear) Hessian, HFwfn.hessian with
+orbital_basis='spinorbital'; docs/DERIVATIVES_PLAN_2026-06.md.
+
+The spin-orbital form of the CPHF Hessian: the second-derivative skeleton integrals plus
+the spin-orbital nuclear CPHF response (shared cache), with the closed-shell prefactors
+halved for singly occupied spin orbitals.
+
+Note on the cross-spin Coulomb second derivative: Psi4's mo_tei_deriv2(A,B) does not
+satisfy the integral's electron-exchange symmetry (pq|rs) = (rs|pq) term by term. For the
+energy trace the same-spin terms absorb the resulting bra<->ket relabel (so RHF/SO-RHF are
+already symmetric), but the UHF cross-spin Coulomb term sum_{i in a, j in b}(ii|jj) does
+not -- it carries a spurious antisymmetric part. Derivatives.so_eri2 fixes this at the
+integral level (symmetrizing the chemist deriv2 over the bra<->ket swap), so the assembled
+Hessian is symmetric with no global symmetrization.
+
+Validation:
+  * keystone -- closed-shell RHF forced to spin orbitals == spatial RHF Hessian;
+  * open-shell UHF Hessian vs psi4.hessian('scf').
+
+ROHF is guarded (the nuclear response goes through CPHF.solve): NotImplementedError.
+"""
+
+import psi4
+import pycc
+import numpy as np
+import pytest
+
+
+WATER = """
+O
+H 1 0.96
+H 1 0.96 2 104.5
+"""
+OH = """
+0 2
+O 0.0 0.0 0.0
+H 0.0 0.0 1.8
+units bohr
+symmetry c1
+"""
+
+
+def _scf_wfn(geom, basis, reference):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'reference': reference,
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    return wfn
+
+
+def _psi4_hessian(geom, basis, reference):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'reference': reference,
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    return np.asarray(psi4.hessian('scf'))
+
+
+def test_so_rhf_hessian_vs_spatial_631g():
+    """Keystone (C1): closed-shell RHF forced to spin orbitals == spatial RHF Hessian."""
+    wfn = _scf_wfn(WATER + "symmetry c1\n", '6-31G', 'rhf')
+    h_so = pycc.HFwfn(wfn, orbital_basis='spinorbital').hessian()
+    h_spatial = pycc.HFwfn(wfn).hessian()
+    assert np.max(np.abs(h_so - h_spatial)) < 1e-10
+
+
+@pytest.mark.slow
+def test_so_rhf_hessian_vs_spatial_ccpvdz():
+    """Keystone (C2v: polarization functions + A2-irrep MOs): SO-RHF == spatial RHF."""
+    wfn = _scf_wfn(WATER, 'cc-pVDZ', 'rhf')
+    h_so = pycc.HFwfn(wfn, orbital_basis='spinorbital').hessian()
+    h_spatial = pycc.HFwfn(wfn).hessian()
+    assert np.max(np.abs(h_so - h_spatial)) < 1e-10
+
+
+def test_uhf_hessian_vs_psi4():
+    """Open-shell UHF molecular Hessian (OH doublet) vs psi4.hessian('scf')."""
+    wfn = _scf_wfn(OH, '6-31G', 'uhf')
+    h_so = pycc.HFwfn(wfn, orbital_basis='spinorbital').hessian()
+    assert np.max(np.abs(h_so - h_so.T)) < 1e-10       # naturally symmetric (so_eri2 fix)
+    assert np.max(np.abs(h_so - _psi4_hessian(OH, '6-31G', 'uhf'))) < 1e-8
+
+
+def test_rohf_hessian_not_implemented():
+    """ROHF Hessian goes through the (unsupported) ROHF CPHF response: NotImplementedError."""
+    wfn = _scf_wfn(OH, '6-31G', 'rohf')
+    with pytest.raises(NotImplementedError):
+        pycc.HFwfn(wfn, orbital_basis='spinorbital').hessian()

--- a/pycc/tests/test_066_spinorbital_hf_aat.py
+++ b/pycc/tests/test_066_spinorbital_hf_aat.py
@@ -1,0 +1,94 @@
+"""
+Spin-orbital Hartree-Fock atomic axial tensors (AATs), HFwfn.atomic_axial_tensors with
+orbital_basis='spinorbital'; docs/DERIVATIVES_PLAN_2026-06.md.
+
+The electronic magnetic-dipole vibrational transition moment (for VCD): the overlap of the
+nuclear- and magnetic-field wavefunction derivatives, reusing the spin-orbital nuclear CPHF
+response, the magnetic-field response (antisymmetric Hessian), and the nuclear half-
+derivative overlaps. Singly occupied spin orbitals drop the closed-shell prefactor 2 -> 1.
+
+Validation:
+  * keystone -- closed-shell RHF forced to spin orbitals == spatial RHF AAT (which is
+    validated against DALTON's analytic SCF AATs in test_050);
+  * open-shell UHF -- there is NO prior open-shell UHF AAT implementation to compare to, so
+    this only checks that the spin-orbital path runs and returns a sane (finite, real,
+    nonzero) tensor; it shares the code path the closed-shell keystone validates.
+
+ROHF is guarded (the responses go through CPHF.solve): NotImplementedError.
+"""
+
+import psi4
+import pycc
+import numpy as np
+import pytest
+
+
+WATER = """
+O
+H 1 0.96
+H 1 0.96 2 104.5
+symmetry c1
+"""
+H2O2 = """
+O   0.0000000000   1.3192641900  -0.0952542913
+O  -0.0000000000  -1.3192641900  -0.0952542913
+H   1.6464858700   1.6841036400   0.7620343300
+H  -1.6464858700  -1.6841036400   0.7620343300
+symmetry c1
+units bohr
+noreorient
+no_com
+"""
+OH = """
+0 2
+O 0.0 0.0 0.0
+H 0.0 0.0 1.8
+units bohr
+symmetry c1
+"""
+
+
+def _scf_wfn(geom, basis, reference):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'reference': reference,
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    return wfn
+
+
+def test_so_rhf_aat_vs_spatial_631g():
+    """Keystone (C1): closed-shell RHF forced to spin orbitals == spatial RHF AAT."""
+    wfn = _scf_wfn(WATER, '6-31G', 'rhf')
+    a_so = pycc.HFwfn(wfn, orbital_basis='spinorbital').atomic_axial_tensors()
+    a_spatial = pycc.HFwfn(wfn).atomic_axial_tensors()
+    assert np.max(np.abs(a_so - a_spatial)) < 1e-10
+
+
+@pytest.mark.slow
+def test_so_rhf_aat_vs_spatial_h2o2():
+    """Keystone on the canonical VCD molecule (H2O2, C1): SO-RHF == spatial RHF AAT (the
+    spatial AAT is validated against DALTON in test_050)."""
+    wfn = _scf_wfn(H2O2, 'sto-3g', 'rhf')
+    a_so = pycc.HFwfn(wfn, orbital_basis='spinorbital').atomic_axial_tensors()
+    a_spatial = pycc.HFwfn(wfn).atomic_axial_tensors()
+    assert np.max(np.abs(a_so - a_spatial)) < 1e-10
+
+
+def test_uhf_aat_runs():
+    """Open-shell UHF AAT (OH doublet): no prior implementation to validate against, so
+    only check the spin-orbital path runs and returns a finite, real, nonzero tensor."""
+    wfn = _scf_wfn(OH, '6-31G', 'uhf')
+    aat = pycc.HFwfn(wfn, orbital_basis='spinorbital').atomic_axial_tensors()
+    assert aat.shape == (2, 3, 3)
+    assert np.all(np.isfinite(aat))
+    assert np.isrealobj(aat)
+    assert np.max(np.abs(aat)) > 1e-6
+
+
+def test_rohf_aat_not_implemented():
+    """ROHF AAT goes through the (unsupported) ROHF CPHF response: NotImplementedError."""
+    wfn = _scf_wfn(OH, '6-31G', 'rohf')
+    with pytest.raises(NotImplementedError):
+        pycc.HFwfn(wfn, orbital_basis='spinorbital').atomic_axial_tensors()


### PR DESCRIPTION
  # Spin-orbital Hartree-Fock analytic derivative properties (RHF/UHF)

  Adds the full suite of spin-orbital HF analytic derivative properties, extending the now
  basis-aware `Derivatives`/`CPHF` infrastructure to open-shell (UHF) references. 6 commits,
  10 files, +880/−5.

  ## What's new
  
  `HFwfn` gains spin-orbital branches (dispatched on `orbital_basis`) for all five
  first/second-derivative properties, each reusing the shared `self.derivatives` /
  `self.cphf` and validated by a **keystone**: a closed-shell RHF reference forced to spin
  orbitals reproduces the existing spatial result to machine precision.

  | property | method | RHF (keystone) | UHF | ROHF |
  |---|---|---|---|---|
  | nuclear gradient | `HFwfn._gradient_spinorbital` | ✓ ~1e-15 | ✓ vs Psi4 | ✓ (CPHF-free) |
  | dipole polarizability | `HFwfn.polarizability` | ✓ ~1e-13 | ✓ (FD ~2e-9) | guarded |
  | APT (dipole derivatives) | `HFwfn._dipole_derivatives_spinorbital` | ✓ ~1e-15 | ✓ vs FD dipole | guarded |
  | molecular Hessian | `HFwfn._hessian_spinorbital` | ✓ ~1e-15 | ✓ vs Psi4 | guarded |
  | AAT | `HFwfn._atomic_axial_tensors_spinorbital` | ✓ ~1e-15 | ⚠ unvalidated | guarded |

  New supporting machinery:
  - **`Derivatives`**: spin-orbital skeleton derivative integrals `so_core`/`so_overlap`/
    `so_eri`/`so_dipole`/`so_overlap_half`, second derivatives `so_core2`/`so_eri2`/
    `so_overlap2` (occupied block), all spin-blocked from the spatial `mints` MO derivatives
    in the semicanonical gauge.
  - **`CPHF`**: spin-orbital nuclear RHS builder `_build_nuclear_spinorbital` (the deferred
    nuclear-response layer); the magnetic RHS / `solve_magnetic` already worked for spin
    orbitals (`H.m` is built on the SO Hamiltonian). Property prefactors (closed-shell vs
    singly-occupied) live in `HFwfn`, not `CPHF`.

  ## Notable subtleties (and how they're handled)

  - **ROHF response is guarded.** The semicanonical spin-orbital CPHF response is UHF-like and
    does not reproduce the *restricted* ROHF response (off ~5e-3 vs finite field); reproducing
    it needs Psi4's ROHF Brillouin / orbital-rotation conventions, which are not uniquely
    defined. `CPHF.solve` raises `NotImplementedError` for ROHF — so the CPHF-*free* ROHF HF
    gradient still works, but the response-dependent properties are deferred.
  - **Cross-spin Coulomb second derivative (Hessian).** Psi4's `mo_tei_deriv2(A,B)` does not
    satisfy the integral's electron-exchange symmetry `(pq|rs)=(rs|pq)` term-by-term. For the
    energy trace the same-spin terms absorb the resulting bra↔ket relabel (so RHF is fine), but
    the UHF cross-spin Coulomb term does not. Fixed at the integral level in `so_eri2`
    (symmetrizing over the bra↔ket swap), so the Hessian is symmetric with no global
    symmetrization.
  - **UHF AAT is unvalidated.** No prior open-shell UHF AAT implementation exists to compare
    against; the RHF keystone (== the Dalton-validated spatial AAT) validates the machinery, and
    the UHF test only checks the same code path runs and returns a sane tensor. Flagged in the
    code, test, and design doc.

  ## Test hygiene
  
  Adds an autouse `conftest` fixture that resets Psi4 options before every test (and cleans
  scratch after), so a leaked option — most importantly a non-default `reference` — can't make
  results depend on test order. Verified: full non-slow suite passes (121 passed, 3 skipped,
  1 xfailed).

  ## Scope / follow-ups

  Spatial RHF behavior is unchanged (`test_046`–`050` untouched). Spin-orbital only here; the
  correlated (MP2) spin-adapted gradient, frozen core, ROHF response (pending the Brillouin
  convention), and CC gradients are later increments. Design-of-record: `docs/DERIVATIVES_PLAN_2026-06.md`.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
