### PR TITLE
Spin-adapted (closed-shell RHF) MP2 analytic gradient

### DIFF
--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -138,9 +138,23 @@ sum_m <pm||qm>^X` is the skeleton Fock derivative. Validated (`test_061`):
 `MPwfn.gradient()` == `psi4.gradient('mp2')` to ~1e-14 (H2O/6-31G C1, and H2O/cc-pVDZ C2v
 -- polarization functions and A2-irrep MOs).
 
-**Spin-orbital MP2 analytic gradient complete.** Next: spin-adapt (the deferred decision 4,
-reusing the spatial `cphf`/density seeds), frozen core, then the MP2 property path (APT /
-Hessian) or CC gradients (swap the densities; the Z-vector + assembly carry over).
+**Spin-orbital MP2 analytic gradient complete.**
+
+**Spin-adapted (closed-shell RHF) MP2 gradient -- DONE (the original decision 4).**
+`MPwfn.gradient()` now has the spatial path inline (dispatching to `_so_gradient` for the
+spin-orbital case), with unlabeled spatial density helpers `_mp2_corr_opdm` / `_mp2_cumulant`
+/ `_mp2_lagrangian` / `_mp2_zvector` / `_energy_weighted_opdm` alongside their `_so_*`
+siblings (PyCC convention: spatial unlabeled, spin-orbital `_so_*`). The spin-adaptation
+carries the spin sum in `l2 = 2(2 t2 - t2.swap)` and the cumulant `Gamma = 2 t2 - t2.swap`,
+writes the two-electron 1-PDM/`W` terms with the spin-adapted `L` (= `H.L`), and assembles
+with the full-spatial-MO derivative integrals (`f^X = h^X + sum_m L[p,m,q,m]^X`, no extra
+prefactor on the spin-summed densities). The Z-vector reuses the basis-aware
+`self.cphf.solve` (closed-shell singlet Hessian via `H.L`). Validated (`test_061`):
+`MPwfn.gradient()` == `psi4.gradient('mp2')` ~1e-14 (6-31G C1, cc-pVDZ C2v), and the
+keystone -- spin-adapted == spin-orbital on a closed shell -- to machine precision (~1e-16).
+
+Next: frozen core, then the MP2 property path (APT / Hessian) or CC gradients (swap the
+densities; the Z-vector + assembly carry over).
 
 The original spatial Phases A (`MPwfn.cphf` access to the CPHF Z-vector solver) and B (the
 spatial MP2 `Doo`/`Dvv` and `oovv` 2-PDM in the `l2 = 2u` convention) were committed while

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -165,12 +165,16 @@ class MPwfn(Wavefunction):
         return Doo, Dvv, Gam, Ip, z
 
     def mp2_relaxed_opdm(self) -> np.ndarray:
-        """Spin-orbital relaxed MP2 one-particle correlation density (``nmo x nmo``):
-        the unrelaxed ``Doo``/``Dvv`` plus the orbital-relaxation off-diagonal blocks
-        ``D_ai = D_ia = -z_ai`` from the Z-vector solve. Spin-orbital only."""
+        """Relaxed MP2 one-particle correlation density (``nmo x nmo``): the unrelaxed
+        ``Doo``/``Dvv`` plus the orbital-relaxation off-diagonal blocks
+        ``D_ai = D_ia = -z_ai`` from the Z-vector solve. Dispatches on ``orbital_basis``
+        (spin-orbital or spin-adapted closed-shell RHF)."""
         o, v = self.o, self.v
         nmo = self.no + self.nv
-        Doo, Dvv, Gam, Ip, z = self._so_mp2_zvector()
+        if self.orbital_basis == 'spinorbital':
+            Doo, Dvv, Gam, Ip, z = self._so_mp2_zvector()
+        else:
+            Doo, Dvv, Gam, Ip, z = self._mp2_zvector()
         D = np.zeros((nmo, nmo))
         D[o, o] = np.asarray(Doo)
         D[v, v] = np.asarray(Dvv)
@@ -196,21 +200,124 @@ class MPwfn(Wavefunction):
         I[v, o] = Ip[o, v].T + z * eps[o][None, :]
         return I
 
-    # ---- spin-orbital MP2 nuclear gradient ----
+    # ---- spin-adapted (closed-shell RHF) MP2 relaxed-gradient densities ----
+    # The closed-shell analogue of the spin-orbital densities: the spin sum is carried by
+    # the spin-adapted lambda ``l2 = 2(2 t2 - t2.swap)`` and the spin-adapted ``L`` (= H.L,
+    # 2<pq|rs>-<pq|sr>) in the two-electron 1-PDM term, with the cumulant ``Gamma = 2 t2 -
+    # t2.swap``. Validated against the spin-orbital path (same physics) and Psi4.
+
+    def _mp2_corr_opdm(self):
+        """Spin-adapted unrelaxed MP2 one-particle correlation density blocks ``(Doo,
+        Dvv)``: ``Doo = -t_imef l2_jmef``, ``Dvv = t_mnbe l2_mnae``, with the spin-adapted
+        lambda ``l2 = 2(2 t2 - t2.swap)`` (the factor-2 carries the closed-shell spin sum)."""
+        c = self.contract
+        t2 = self.t2
+        l2 = 2.0 * (2.0 * t2 - t2.swapaxes(2, 3))
+        Doo = -c('imef,jmef->ij', t2, l2)
+        Dvv = c('mnbe,mnae->ab', t2, l2)
+        return Doo, Dvv
+
+    def _mp2_cumulant(self) -> np.ndarray:
+        """Spin-adapted MP2 cumulant 2-PDM ``Gamma_ijab = 2 t2 - t2.swap`` (``oovv``/``vvoo``)."""
+        o, v = self.o, self.v
+        nmo = self.no + self.nv
+        t2 = np.asarray(self.t2)
+        u = 2.0 * t2 - t2.transpose(0, 1, 3, 2)
+        Gam = np.zeros((nmo, nmo, nmo, nmo))
+        Gam[o, o, v, v] = u
+        Gam[v, v, o, o] = u.transpose(2, 3, 0, 1)
+        return Gam
+
+    def _mp2_lagrangian(self, Doo, Dvv, Gam) -> np.ndarray:
+        """Spin-adapted orbital-gradient Lagrangian ``I'_pq`` -- the closed-shell analogue
+        of :meth:`_so_mp2_lagrangian`. Same structure, with the two-electron 1-PDM term
+        written with the spin-adapted ``L`` (= H.L) in place of the antisymmetrized
+        ``<rp||sq>``, and the 2-PDM term with ``<pr|st>`` (= H.ERI) and cumulant ``Gamma``."""
+        o, v = self.o, self.v
+        nmo = self.no + self.nv
+        ERI = np.asarray(self.H.ERI)
+        L = np.asarray(self.H.L)
+        eps = np.diag(np.asarray(self.H.F))
+        D = np.zeros((nmo, nmo))
+        D[o, o] = np.asarray(Doo)
+        D[v, v] = np.asarray(Dvv)
+        termA = eps[:, None] * (D + D.T)
+        termB = np.zeros((nmo, nmo))
+        termB[:, o] = (np.einsum('rs,rpsq->pq', D, L[:, :, :, o])
+                       + np.einsum('rs,rqsp->pq', D, L[:, o, :, :]))
+        termC = 4.0 * np.einsum('prst,qrst->pq', ERI, Gam)
+        return -0.5 * (termA + termB + termC)
+
+    def _mp2_zvector(self):
+        """Solve the spin-adapted MP2 Z-vector. Returns ``(Doo, Dvv, Gam, Ip, z)`` as for
+        :meth:`_so_mp2_zvector`; the orbital Hessian is the closed-shell singlet CPHF
+        (``H.L``), reached through the basis-aware ``self.cphf``."""
+        o, v = self.o, self.v
+        Doo, Dvv = self._mp2_corr_opdm()
+        Gam = self._mp2_cumulant()
+        Ip = self._mp2_lagrangian(Doo, Dvv, Gam)
+        X = Ip[o, v] - Ip[v, o].T
+        z = self.cphf.solve(X).T
+        return Doo, Dvv, Gam, Ip, z
+
+    def _energy_weighted_opdm(self, Ip, z) -> np.ndarray:
+        """Spin-adapted MP2 energy-weighted density ``I_pq`` -- the closed-shell analogue
+        of :meth:`_so_energy_weighted_opdm`, with the spin-adapted ``L`` in the oo block."""
+        o, v = self.o, self.v
+        nmo = self.no + self.nv
+        L = np.asarray(self.H.L)
+        eps = np.diag(np.asarray(self.H.F))
+        I = np.zeros((nmo, nmo))
+        I[o, o] = (Ip[o, o] + np.einsum('ak,aikj->ij', z, L[v, o, o, o])
+                   + np.einsum('ak,ajki->ij', z, L[v, o, o, o]))
+        I[v, v] = Ip[v, v]
+        I[o, v] = Ip[o, v] + (z * eps[o][None, :]).T
+        I[v, o] = Ip[o, v].T + z * eps[o][None, :]
+        return I
+
+    # ---- MP2 nuclear gradient ----
 
     def gradient(self) -> np.ndarray:
-        """Spin-orbital MP2 analytic nuclear energy gradient (a.u.), shape (natom, 3).
+        """MP2 analytic nuclear energy gradient (a.u.), shape (natom, 3): the SCF
+        (``HFwfn``) gradient plus the correlation contribution
 
-        The SCF (``HFwfn``) gradient plus the correlation contribution
-
-            dE_corr/dX = sum_pq D_pq f^X_pq + sum_pqrs Gamma_pqrs <pq||rs>^X
+            dE_corr/dX = sum_pq D_pq f^X_pq + sum_pqrs Gamma_pqrs <pq|rs>^X
                          + sum_pq I_pq S^X_pq
 
-        with the relaxed 1-PDM ``D``, cumulant 2-PDM ``Gamma``, and energy-weighted
-        density ``I`` (spin-orbital CC gradient formulation, Gauss/Stanton/Bartlett). The
-        skeleton spin-orbital derivative integrals come from ``self.derivatives`` (built
-        in the same semicanonical MO gauge the densities live in); ``f^X = h^X +
-        sum_m <pm||qm>^X`` is the skeleton Fock derivative. Spin-orbital only."""
+        with the relaxed 1-PDM ``D``, cumulant 2-PDM ``Gamma``, and energy-weighted density
+        ``I`` (Gauss/Stanton/Bartlett). This is the spin-adapted (closed-shell RHF) path:
+        the skeleton derivative integrals come from ``self.derivatives`` in the full spatial
+        MO basis (chemist ``(pq|rs)^X``, converted to physicist here) and ``f^X = h^X +
+        sum_m L[p,m,q,m]^X`` is the closed-shell skeleton Fock derivative (the spin-summed
+        densities carry no extra prefactor). The spin-orbital path is :meth:`_so_gradient`."""
+        if self.orbital_basis == 'spinorbital':
+            return self._so_gradient()
+        from .hfwfn import HFwfn
+        o = self.o
+        Doo, Dvv, Gam, Ip, z = self._mp2_zvector()
+        D = self.mp2_relaxed_opdm()
+        I = self._energy_weighted_opdm(Ip, z)
+
+        d = self.derivatives
+        C = self.C
+        grad = np.zeros((d.natom, 3))
+        for atom in range(d.natom):
+            hx = d.core(atom, C, C)
+            Sx = d.overlap(atom, C, C)
+            ERIx = d.eri(atom, C, C, C, C)            # chemist (pq|rs)^X
+            for c in range(3):
+                phys = ERIx[c].transpose(0, 2, 1, 3)  # -> physicist <pq|rs>^X
+                Lx = 2.0 * phys - phys.transpose(0, 1, 3, 2)
+                fx = hx[c] + np.einsum('pmqm->pq', Lx[:, o, :, o])  # closed-shell Fock deriv
+                grad[atom, c] = (np.einsum('pq,pq->', D, fx)
+                                 + np.einsum('pqrs,pqrs->', Gam, phys)
+                                 + np.einsum('pq,pq->', I, Sx[c]))
+        return HFwfn(self.ref).gradient() + grad
+
+    def _so_gradient(self) -> np.ndarray:
+        """Spin-orbital MP2 gradient: the antisymmetrized ``<pq||rs>^X`` from the
+        spin-orbital ``self.derivatives.so_*`` (semicanonical gauge), ``f^X = h^X +
+        sum_m <pm||qm>^X``."""
         from .hfwfn import HFwfn
         o = self.o
         Doo, Dvv, Gam, Ip, z = self._so_mp2_zvector()

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -1,15 +1,16 @@
 """
-Spin-orbital MP2 relaxed (orbital-response) one-particle density and analytic nuclear
-gradient; docs/DERIVATIVES_PLAN_2026-06.md.
+MP2 relaxed (orbital-response) one-particle density and analytic nuclear gradient, both
+the spin-orbital and the spin-adapted (closed-shell RHF) paths; docs/DERIVATIVES_PLAN_2026-06.md.
 
 The relaxed density adds the orbital-relaxation (Z-vector) contribution to the
 unrelaxed MP2 correlation density; the gradient assembles it with the cumulant 2-PDM
 and energy-weighted density against the skeleton derivative integrals. Both follow the
-spin-orbital CC gradient formulation (Gauss, Stanton & Bartlett, JCP 95, 2623 (1991)).
+CC gradient formulation (Gauss, Stanton & Bartlett, JCP 95, 2623 (1991)).
 
 Validation:
   * relaxed MP2 dipole -Tr(D_relaxed mu) vs a 5-point finite field of (E_MP2 - E_SCF);
-  * analytic MP2 gradient vs psi4.gradient('mp2').
+  * analytic MP2 gradient vs psi4.gradient('mp2');
+  * keystone: the spin-adapted and spin-orbital gradients agree on a closed shell.
 """
 
 import psi4
@@ -44,24 +45,31 @@ def _ff_corr_dipole(geom, basis, F=0.0005):
     return mu('mp2') - mu('scf')
 
 
-def _pycc_corr_dipole(geom, basis):
-    """PyCC spin-orbital relaxed-MP2 electronic correlation mu_z."""
+def _pycc_corr_dipole(geom, basis, orbital_basis='spinorbital'):
+    """PyCC relaxed-MP2 electronic correlation mu_z (spin-orbital or spin-adapted)."""
     psi4.core.clean()
     psi4.core.clean_options()
     psi4.geometry(geom)
     psi4.set_options({'basis': basis, 'scf_type': 'pk',
                       'e_convergence': 1e-12, 'd_convergence': 1e-12})
     _, wfn = psi4.energy('scf', return_wfn=True)
-    mp = pycc.MPwfn(wfn, orbital_basis='spinorbital')
+    mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
     D = mp.mp2_relaxed_opdm()
     return -np.einsum('pq,pq->', D, np.asarray(mp.H.mu[2]))
 
 
 def test_mp2_relaxed_dipole_631g():
-    """Relaxed MP2 dipole (mu_z) vs finite field, H2O/6-31G (C1)."""
+    """Relaxed spin-orbital MP2 dipole (mu_z) vs finite field, H2O/6-31G (C1)."""
     geom = WATER + "symmetry c1\n"
     assert abs(_pycc_corr_dipole(geom, '6-31G')
+               - _ff_corr_dipole(geom, '6-31G')) < 1e-8
+
+
+def test_sa_mp2_relaxed_dipole_631g():
+    """Relaxed spin-adapted (closed-shell RHF) MP2 dipole vs finite field, H2O/6-31G."""
+    geom = WATER + "symmetry c1\n"
+    assert abs(_pycc_corr_dipole(geom, '6-31G', orbital_basis='spatial')
                - _ff_corr_dipole(geom, '6-31G')) < 1e-8
 
 
@@ -73,14 +81,14 @@ def test_mp2_relaxed_dipole_ccpvdz():
                - _ff_corr_dipole(WATER, 'cc-pVDZ')) < 1e-8
 
 
-def _pycc_gradient(geom, basis):
+def _pycc_gradient(geom, basis, orbital_basis='spinorbital'):
     psi4.core.clean()
     psi4.core.clean_options()
     psi4.geometry(geom)
     psi4.set_options({'basis': basis, 'scf_type': 'pk',
                       'e_convergence': 1e-12, 'd_convergence': 1e-12})
     _, wfn = psi4.energy('scf', return_wfn=True)
-    mp = pycc.MPwfn(wfn, orbital_basis='spinorbital')
+    mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
     return mp.gradient()
 
@@ -96,15 +104,35 @@ def _psi4_mp2_gradient(geom, basis):
 
 
 def test_mp2_gradient_631g():
-    """MP2 analytic nuclear gradient vs Psi4, H2O/6-31G (C1)."""
+    """Spin-orbital MP2 analytic nuclear gradient vs Psi4, H2O/6-31G (C1)."""
     geom = WATER + "symmetry c1\n"
     assert np.max(np.abs(_pycc_gradient(geom, '6-31G')
                          - _psi4_mp2_gradient(geom, '6-31G'))) < 1e-8
 
 
+def test_sa_mp2_gradient_631g():
+    """Spin-adapted (closed-shell RHF) MP2 gradient vs Psi4, H2O/6-31G (C1)."""
+    geom = WATER + "symmetry c1\n"
+    assert np.max(np.abs(_pycc_gradient(geom, '6-31G', orbital_basis='spatial')
+                         - _psi4_mp2_gradient(geom, '6-31G'))) < 1e-8
+
+
+def test_mp2_gradient_spatial_vs_so_631g():
+    """Keystone: the spin-adapted and spin-orbital MP2 gradients agree on a closed shell."""
+    geom = WATER + "symmetry c1\n"
+    assert np.max(np.abs(_pycc_gradient(geom, '6-31G', orbital_basis='spatial')
+                         - _pycc_gradient(geom, '6-31G', orbital_basis='spinorbital'))) < 1e-10
+
+
 @pytest.mark.slow
 def test_mp2_gradient_ccpvdz():
-    """MP2 analytic nuclear gradient vs Psi4, H2O/cc-pVDZ (C2v: polarization functions
-    and A2-irrep MOs)."""
+    """Spin-orbital MP2 gradient vs Psi4, H2O/cc-pVDZ (C2v: polarization + A2-irrep MOs)."""
     assert np.max(np.abs(_pycc_gradient(WATER, 'cc-pVDZ')
+                         - _psi4_mp2_gradient(WATER, 'cc-pVDZ'))) < 1e-8
+
+
+@pytest.mark.slow
+def test_sa_mp2_gradient_ccpvdz():
+    """Spin-adapted MP2 gradient vs Psi4, H2O/cc-pVDZ (C2v: polarization + A2-irrep MOs)."""
+    assert np.max(np.abs(_pycc_gradient(WATER, 'cc-pVDZ', orbital_basis='spatial')
                          - _psi4_mp2_gradient(WATER, 'cc-pVDZ'))) < 1e-8


### PR DESCRIPTION
  # Spin-adapted (closed-shell RHF) MP2 analytic gradient

  Adds the spatial branch of the MP2 analytic nuclear gradient (the original decision 4),
  completing the MP2 gradient for closed-shell RHF alongside the existing spin-orbital path.
  1 commit, 3 files, +179/−30.

  ## What's new
  
  `MPwfn.gradient()` now contains the **spatial assembly inline** and dispatches to
  `_so_gradient()` for the spin-orbital case — following PyCC's convention (spatial unlabeled,
  spin-orbital `_so_*`, like `build_Fae`/`_so_build_Fae`). New unlabeled spatial density
  helpers sit alongside their `_so_*` siblings:

  | spatial (new) | spin-orbital (existing) |
  |---|---|
  | `_mp2_corr_opdm` | `_so_mp2_corr_opdm` |
  | `_mp2_cumulant` | `_so_mp2_cumulant` |
  | `_mp2_lagrangian` | `_so_mp2_lagrangian` |
  | `_mp2_zvector` | `_so_mp2_zvector` |
  | `_energy_weighted_opdm` | `_so_energy_weighted_opdm` |

  `mp2_relaxed_opdm()` dispatches likewise.

  ## Spin-adaptation

  The closed-shell spin sum is carried by the lambda `l2 = 2(2·t2 − t2.swap)` and the cumulant
  `Γ = 2·t2 − t2.swap`; the two-electron 1-PDM and energy-weighted (`W`) terms use the
  spin-adapted `L` (= `H.L`) in place of the antisymmetrized `⟨rp‖sq⟩`; and the assembly uses
  the full-spatial-MO derivative integrals (chemist `(pq|rs)^X` → physicist; closed-shell
  skeleton Fock derivative `f^X = h^X + Σ_m L[p,m,q,m]^X`; spin-summed densities carry no extra
  prefactor). The Z-vector reuses the basis-aware `self.cphf.solve` (closed-shell singlet
  orbital Hessian via `H.L`) — no new orbital-response code.

  ## Validation (`test_061`)

  - spin-adapted gradient == `psi4.gradient('mp2')` to ~1e-14 (H2O/6-31G C1 and H2O/cc-pVDZ
    C2v — polarization functions + A2-irrep MOs);
  - relaxed MP2 dipole vs a 5-point finite field;
  - **keystone**: spin-adapted == spin-orbital gradient on a closed shell, to ~1e-16.

  Full non-slow suite passes (124 passed, 3 skipped, 1 xfailed).

  ## Follow-ups

  Frozen core, then the MP2 property path (APT / Hessian) or CC gradients (swap the densities;
  the Z-vector + assembly carry over). Separately queued: renaming the merged `HFwfn`
  `_*_spinorbital` methods to the `_so_*` prefix for convention consistency.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
