### PR TITLE
Block-label Derivatives API + spin-orbital naming convention

### DIFF
--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -47,7 +47,6 @@ from __future__ import annotations
 
 from typing import Any, List
 
-import psi4
 import numpy as np
 
 from .utils import diag
@@ -231,21 +230,19 @@ class CPHF(object):
         provider; the unperturbed L is H.L. Validated to ~1e-8 via the dipole-
         derivative / APT-transpose check against finite difference of the SCF dipole.
 
-        The spin-orbital path dispatches to :meth:`_build_nuclear_spinorbital`.
+        The spin-orbital path dispatches to :meth:`_so_build_nuclear`.
         """
         if self.wfn.orbital_basis == 'spinorbital':
-            return self._build_nuclear_spinorbital(atom)
+            return self._so_build_nuclear(atom)
         o, v, no, nv = self.o, self.v, self.no, self.nv
         eps_o = self.eps[o]
         L = np.asarray(self.wfn.H.L)  # spin-adapted, physicist, unperturbed
 
-        C = np.asarray(self.wfn.C)
-        Call = psi4.core.Matrix.from_array(C)
         d = self.wfn.derivatives
-        Sx = d.overlap(atom, Call, Call)                       # 3 x (nmo,nmo)
-        hx = d.core(atom, Call, Call)                          # 3 x (nmo,nmo)
+        Sx = d.overlap(atom)                                   # 3 x (nmo,nmo)
+        hx = d.core(atom)                                      # 3 x (nmo,nmo)
         gx = [g.swapaxes(1, 2) for g in                        # chemist -> physicist
-              d.eri(atom, Call, Call, Call, Call)]             # 3 x (nmo^4) <pq|rs>^X
+              d.eri(atom)]                                     # 3 x (nmo^4) <pq|rs>^X
 
         Lvooo = L[v, o, o, o]
         B, Foo, Soo = [], [], []
@@ -266,7 +263,7 @@ class CPHF(object):
             Soo.append(Sx[c][o, o])
         return B, Foo, Soo
 
-    def _build_nuclear_spinorbital(self, atom: int):
+    def _so_build_nuclear(self, atom: int):
         """Spin-orbital nuclear CPHF RHS for ``atom`` -- the spin-orbital analogue of
         :meth:`_build_nuclear`. Same structure with the antisymmetrized ``<pq||rs>`` in
         place of the spin-adapted ``L``, the spin-orbital skeleton derivative integrals

--- a/pycc/derivatives.py
+++ b/pycc/derivatives.py
@@ -2,33 +2,34 @@
 derivatives.py: lazy MO-basis derivative-integral provider.
 
 A thin, memory-conscious wrapper around Psi4's MintsHelper MO derivative-integral
-routines (mo_*_deriv1). It serves the *skeleton* (fixed-MO-coefficient) first
-derivatives of the one- and two-electron integrals, the overlap half-derivatives
-(for AATs), and the dipole derivatives (for APTs), in the MO basis -- consistent
-with PyCC's reference-implementation, MO-basis derivative-property formulations.
+routines (mo_*_deriv1/2). It serves the *skeleton* (fixed-MO-coefficient) first and
+second derivatives of the one- and two-electron integrals, the overlap half-derivatives
+(for AATs), and the dipole derivatives (for APTs), in the MO basis -- consistent with
+PyCC's reference-implementation, MO-basis derivative-property formulations.
 
-For the spatial path the caller supplies the MO-coefficient blocks to transform into.
-Those should be the base's symmetry-handled ``self.C`` (or a slice of it): it is a
-single irrep block in global energy order, so derivative integrals work with molecular
-symmetry left on -- no need to drop to C1.
-
-For the spin-orbital path the ``so_*`` methods take just an atom: they spin-block the
-spatial MO derivative integrals (built in the semicanonical MO gauge from the
-spin-orbital Hamiltonian's ``Ca``/``Cb`` + ``spin``/``spat`` maps), mirroring the
-spin-orbital Hamiltonian's own integral construction, so the derivative integrals live
-in the same MO gauge the spin-orbital densities do.
+Block-label interface
+---------------------
+Both the spatial and the spin-orbital methods select the MO block(s) to transform into
+by *label* rather than by passing coefficient matrices: ``'o'`` (occupied), ``'v'``
+(virtual), or ``'all'`` (the full MO space, the default). The provider owns all the MO
+bookkeeping -- the spatial methods slice the base's symmetry-handled ``self.wfn.C`` (a
+single irrep block in global energy order, so symmetry stays on), while the spin-orbital
+``so_*`` methods spin-block the spatial MO derivatives (built in the semicanonical MO
+gauge from the spin-orbital Hamiltonian's ``Ca``/``Cb`` + ``spin``/``spat`` maps), so the
+spin-orbital integrals live in the same MO gauge the spin-orbital densities do. The call
+sites are therefore parallel between the two paths, e.g. ``d.core(atom, 'o', 'o')`` and
+``d.so_core(atom, 'o', 'o')``.
 
 Memory discipline
 -----------------
-One-electron derivatives are small (3*N_atom * nmo**2), so they are served per
-atom directly. Two-electron derivatives (3*N_atom * nmo**4) are the heavy class:
-they are computed one atom at a time (via :meth:`eri` / :meth:`iter_eri`), so the
-caller contracts and discards each atom's block rather than ever materializing all
-3*N_atom of them.
+One-electron derivatives are small (3*N_atom * n**2), so they are served per atom
+directly. Two-electron derivatives (3*N_atom * n**4) are the heavy class: they are
+computed one atom at a time (via :meth:`eri` / :meth:`iter_eri`), so the caller contracts
+and discards each atom's block rather than ever materializing all 3*N_atom of them; a
+caller wanting only the occupied block passes ``'o'`` to keep the transform at n_occ**4.
 
-Created and owned by HFwfn for now; it depends only on base state (the basis set,
-molecule, and MO coefficients), so it can be promoted to the Wavefunction base when
-MP2/CI/CC derivative code needs it too.
+Lives on the Wavefunction base (lazy ``self.derivatives``); it depends only on base state
+(the basis set, molecule, and MO coefficients).
 """
 
 from __future__ import annotations
@@ -45,13 +46,16 @@ class Derivatives(object):
     Parameters
     ----------
     wfn : Wavefunction
-        provides the basis set (``wfn.H.basisset``) and the molecule.
+        provides the basis set (``wfn.H.basisset``), the molecule, the MO coefficients
+        (``wfn.C``, or the spin-orbital Hamiltonian's ``Ca``/``Cb``), and the occupied /
+        virtual block ranges (``wfn.o`` / ``wfn.v``).
 
     Notes
     -----
-    Each ``deriv1`` call returns the three Cartesian (x, y, z) derivatives with
-    respect to the coordinates of a single ``atom``; the returned arrays are NumPy
-    arrays in the MO block defined by the supplied coefficient matrices.
+    Each ``deriv1`` call returns the three Cartesian (x, y, z) derivatives w.r.t. one
+    ``atom``; ``deriv2`` calls return the nine (cart1, cart2) pairs (indexed
+    ``cart1*3 + cart2``) for an ``(atom1, atom2)`` pair. Block labels ('o'/'v'/'all',
+    default 'all') select the MO block(s) to transform into.
     """
 
     def __init__(self, wfn: Any) -> None:
@@ -60,248 +64,272 @@ class Derivatives(object):
         self.mol = wfn.ref.molecule()
         self.natom = self.mol.natom()
 
-    # ---- one-electron (small) ----
-    def overlap(self, atom: int, C1, C2) -> List[np.ndarray]:
-        """Overlap (Sx) derivatives for ``atom``: list of 3 (x, y, z) arrays."""
-        return [np.asarray(m) for m in self.mints.mo_oei_deriv1("OVERLAP", atom, C1, C2)]
+    # ---- MO block selection ----
+    def _mo(self, block: str) -> np.ndarray:
+        """Spatial MO coefficients (AO x block, NumPy) for a block label."""
+        C = np.asarray(self.wfn.C)
+        if block == 'o':
+            return C[:, :self.wfn.no]
+        if block == 'v':
+            return C[:, self.wfn.no:]
+        return C  # 'all'
 
-    def core(self, atom: int, C1, C2) -> List[np.ndarray]:
+    def _moM(self, block: str):
+        """Spatial MO block as a Psi4 Matrix (for the mints deriv routines)."""
+        return psi4.core.Matrix.from_array(self._mo(block))
+
+    def _so_mo(self, block: str):
+        """For a spin-orbital block label, return ``(n, a, b, Ca, Cb)``: the block size,
+        the alpha/beta spin-orbital positions *within the block*, and the alpha/beta
+        semicanonical MOs (Psi4 matrices) pre-sliced to that block's spatial columns (so
+        the mints transforms return arrays already in block order)."""
+        H = self.wfn.H
+        spin = np.asarray(H.spin)
+        spat = np.asarray(H.spat)
+        idx = {'o': self.wfn.o, 'v': self.wfn.v}.get(block, slice(None))
+        spin_b = spin[idx]
+        spat_b = spat[idx]
+        a = np.where(spin_b == 0)[0]
+        b = np.where(spin_b == 1)[0]
+        Ca = psi4.core.Matrix.from_array(np.asarray(H.Ca)[:, spat_b[a]])
+        Cb = psi4.core.Matrix.from_array(np.asarray(H.Cb)[:, spat_b[b]])
+        return len(spin_b), a, b, Ca, Cb
+
+    # ---- spatial one-electron ----
+    def overlap(self, atom: int, b1: str = 'all', b2: str = 'all') -> List[np.ndarray]:
+        """Overlap (Sx) derivatives for ``atom``: 3 (x, y, z) arrays."""
+        return [np.asarray(m) for m in
+                self.mints.mo_oei_deriv1("OVERLAP", atom, self._moM(b1), self._moM(b2))]
+
+    def core(self, atom: int, b1: str = 'all', b2: str = 'all') -> List[np.ndarray]:
         """Core one-electron (kinetic + potential) hx derivatives for ``atom``."""
+        C1, C2 = self._moM(b1), self._moM(b2)
         T = self.mints.mo_oei_deriv1("KINETIC", atom, C1, C2)
         V = self.mints.mo_oei_deriv1("POTENTIAL", atom, C1, C2)
         return [np.asarray(t) + np.asarray(v) for t, v in zip(T, V)]
 
-    def overlap_half(self, atom: int, C1, C2, side: str = "LEFT") -> List[np.ndarray]:
-        """Overlap half-derivatives for ``atom`` (``side`` = 'LEFT' or 'RIGHT');
-        list of 3 arrays. Used by the AAT machinery."""
-        return [np.asarray(m) for m in self.mints.mo_overlap_half_deriv1(side, atom, C1, C2)]
+    def overlap_half(self, atom: int, b1: str = 'all', b2: str = 'all',
+                     side: str = "LEFT") -> List[np.ndarray]:
+        """Overlap half-derivatives for ``atom`` (``side`` = 'LEFT'/'RIGHT'): 3 arrays.
+        Used by the AAT machinery (bra perturbed, ket unperturbed)."""
+        return [np.asarray(m) for m in
+                self.mints.mo_overlap_half_deriv1(side, atom, self._moM(b1), self._moM(b2))]
 
-    def dipole(self, atom: int, C1, C2) -> List[np.ndarray]:
-        """Electric-dipole derivatives for ``atom``: list of 9 arrays, the
-        d(mu_alpha)/d(X_beta) blocks (3 dipole components x 3 Cartesians). Used by
-        the APT machinery.
+    def dipole(self, atom: int, b1: str = 'all', b2: str = 'all') -> List[np.ndarray]:
+        """Electric-dipole derivatives for ``atom``: 9 arrays, the d(mu_alpha)/d(X_beta)
+        blocks (3 dipole components x 3 Cartesians), for the APT machinery.
 
-        The AO-basis derivatives (``ao_elec_dip_deriv1``) are transformed into the
-        (C1, C2) MO block here rather than via ``mo_elec_dip_deriv1`` -- the latter
-        segfaults on the linux build of Psi4 1.10.1 (the mo_oei/mo_tei deriv routines
-        are unaffected). The two routes are numerically identical."""
-        npC1 = np.asarray(C1)
-        npC2 = np.asarray(C2)
-        return [npC1.T @ np.asarray(m) @ npC2
-                for m in self.mints.ao_elec_dip_deriv1(atom)]
+        The AO-basis derivatives (``ao_elec_dip_deriv1``) are transformed into the MO
+        block here rather than via ``mo_elec_dip_deriv1`` -- the latter segfaults on the
+        linux build of Psi4 1.10.1 (the mo_oei/mo_tei deriv routines are unaffected)."""
+        C1, C2 = self._mo(b1), self._mo(b2)
+        return [C1.T @ np.asarray(m) @ C2 for m in self.mints.ao_elec_dip_deriv1(atom)]
 
-    # ---- second derivatives (Hessian skeleton) ----
-    def overlap2(self, atom1: int, atom2: int, C1, C2) -> List[np.ndarray]:
-        """Second overlap derivatives ``S^{XY}`` for the ``(atom1, atom2)`` pair: a
-        list of 9 arrays, the (cart1, cart2) Cartesian-pair blocks indexed
-        ``cart1*3 + cart2``."""
-        return [np.asarray(m)
-                for m in self.mints.mo_oei_deriv2("OVERLAP", atom1, atom2, C1, C2)]
+    # ---- spatial two-electron (heavy: lazy, per atom) ----
+    def eri(self, atom: int, b1: str = 'all', b2: str = 'all',
+            b3: str = 'all', b4: str = 'all') -> List[np.ndarray]:
+        """Two-electron (ERI) derivatives for ``atom``: 3 (x, y, z) arrays, chemist
+        notation ``(pq|rs)^X``. Computed on demand so a caller iterating over atoms never
+        holds more than one atom's block at a time."""
+        return [np.asarray(m) for m in self.mints.mo_tei_deriv1(
+            atom, self._moM(b1), self._moM(b2), self._moM(b3), self._moM(b4))]
 
-    def core2(self, atom1: int, atom2: int, C1, C2) -> List[np.ndarray]:
-        """Second core one-electron (kinetic + potential) derivatives ``h^{XY}`` for
-        the ``(atom1, atom2)`` pair: 9 arrays, indexed ``cart1*3 + cart2``."""
+    def iter_eri(self, b1: str = 'all', b2: str = 'all', b3: str = 'all',
+                 b4: str = 'all') -> Iterator[Tuple[int, List[np.ndarray]]]:
+        """Yield ``(atom, [Ex, Ey, Ez])`` one atom at a time -- the lazy, non-
+        materializing way to sweep the 2-e derivatives."""
+        for atom in range(self.natom):
+            yield atom, self.eri(atom, b1, b2, b3, b4)
+
+    # ---- spatial second derivatives (Hessian skeleton) ----
+    def overlap2(self, atom1: int, atom2: int, b1: str = 'all',
+                 b2: str = 'all') -> List[np.ndarray]:
+        """Second overlap derivatives ``S^{XY}`` for the ``(atom1, atom2)`` pair: 9 arrays,
+        the (cart1, cart2) blocks indexed ``cart1*3 + cart2``."""
+        return [np.asarray(m) for m in
+                self.mints.mo_oei_deriv2("OVERLAP", atom1, atom2, self._moM(b1), self._moM(b2))]
+
+    def core2(self, atom1: int, atom2: int, b1: str = 'all',
+              b2: str = 'all') -> List[np.ndarray]:
+        """Second core one-electron (kinetic + potential) derivatives ``h^{XY}`` for the
+        ``(atom1, atom2)`` pair: 9 arrays, indexed ``cart1*3 + cart2``."""
+        C1, C2 = self._moM(b1), self._moM(b2)
         T = self.mints.mo_oei_deriv2("KINETIC", atom1, atom2, C1, C2)
         V = self.mints.mo_oei_deriv2("POTENTIAL", atom1, atom2, C1, C2)
         return [np.asarray(t) + np.asarray(v) for t, v in zip(T, V)]
 
-    def eri2(self, atom1: int, atom2: int, C1, C2, C3, C4) -> List[np.ndarray]:
-        """Second two-electron (ERI) derivatives for the ``(atom1, atom2)`` pair: 9
-        arrays, indexed ``cart1*3 + cart2``. Chemist/Mulliken notation ``(pq|rs)``,
-        as for :meth:`eri`. The Hessian skeleton needs only the occupied block, so
-        callers pass ``Cocc`` (no**4 per pair) rather than the full MO space."""
-        return [np.asarray(m)
-                for m in self.mints.mo_tei_deriv2(atom1, atom2, C1, C2, C3, C4)]
+    def eri2(self, atom1: int, atom2: int, b1: str = 'all', b2: str = 'all',
+             b3: str = 'all', b4: str = 'all') -> List[np.ndarray]:
+        """Second two-electron (ERI) derivatives for the ``(atom1, atom2)`` pair: 9 arrays,
+        indexed ``cart1*3 + cart2``, chemist notation. The Hessian skeleton needs only the
+        occupied block, so callers pass ``'o'`` (n_occ**4 per pair)."""
+        return [np.asarray(m) for m in self.mints.mo_tei_deriv2(
+            atom1, atom2, self._moM(b1), self._moM(b2), self._moM(b3), self._moM(b4))]
 
     def nuclear_repulsion2(self) -> np.ndarray:
         """Nuclear-repulsion-energy Hessian, shape ``(3*natom, 3*natom)`` indexed
         ``(atom1*3 + cart1, atom2*3 + cart2)``."""
         return np.asarray(self.mol.nuclear_repulsion_energy_deriv2())
 
-    # ---- two-electron (heavy: lazy, per atom) ----
-    def eri(self, atom: int, C1, C2, C3, C4) -> List[np.ndarray]:
-        """Two-electron (ERI) derivatives for ``atom``: list of 3 (x, y, z) arrays.
-        Computed on demand so a caller iterating over atoms never holds more than
-        one atom's block at a time."""
-        return [np.asarray(m) for m in self.mints.mo_tei_deriv1(atom, C1, C2, C3, C4)]
-
-    def iter_eri(self, C1, C2, C3, C4) -> Iterator[Tuple[int, List[np.ndarray]]]:
-        """Yield ``(atom, [Ex, Ey, Ez])`` one atom at a time -- the lazy, non-
-        materializing way to sweep the 2-e derivatives."""
-        for atom in range(self.natom):
-            yield atom, self.eri(atom, C1, C2, C3, C4)
-
-    # ---- spin-orbital (spin-blocked from the spatial MO derivatives) ----
-    def _so_spin_blocks(self):
-        """``(nmo, a, b, sa, sb, Ca, Cb)`` from the spin-orbital Hamiltonian: the
-        spin-orbital count, the alpha/beta spin-orbital index arrays and their spatial
-        indices, and the semicanonical alpha/beta MOs (as Psi4 matrices)."""
-        H = self.wfn.H
-        spin = np.asarray(H.spin)
-        spat = np.asarray(H.spat)
-        a = np.where(spin == 0)[0]
-        b = np.where(spin == 1)[0]
-        Ca = psi4.core.Matrix.from_array(H.Ca)
-        Cb = psi4.core.Matrix.from_array(H.Cb)
-        return spin.shape[0], a, b, spat[a], spat[b], Ca, Cb
-
-    def so_oei(self, atom: int, kind: str) -> List[np.ndarray]:
-        """Spin-orbital one-electron derivative integral (block-diagonal in spin) for
-        ``atom``: 3 (x, y, z) ``nmo x nmo`` arrays. ``kind`` is 'OVERLAP'/'KINETIC'/
-        'POTENTIAL'."""
-        nmo, a, b, sa, sb, Ca, Cb = self._so_spin_blocks()
-        Da = self.mints.mo_oei_deriv1(kind, atom, Ca, Ca)
-        Db = self.mints.mo_oei_deriv1(kind, atom, Cb, Cb)
+    # ---- spin-orbital one-electron (spin-blocked from the spatial MO derivatives) ----
+    def so_oei(self, atom: int, kind: str, b1: str = 'all', b2: str = 'all') -> List[np.ndarray]:
+        """Spin-orbital one-electron derivative integral (block-diagonal in spin): 3
+        (x, y, z) arrays. ``kind`` is 'OVERLAP'/'KINETIC'/'POTENTIAL'."""
+        n1, a1, b1p, Ca1, Cb1 = self._so_mo(b1)
+        n2, a2, b2p, Ca2, Cb2 = self._so_mo(b2)
+        Da = self.mints.mo_oei_deriv1(kind, atom, Ca1, Ca2)
+        Db = self.mints.mo_oei_deriv1(kind, atom, Cb1, Cb2)
         out = []
         for c in range(3):
-            M = np.zeros((nmo, nmo))
-            M[np.ix_(a, a)] = np.asarray(Da[c])[np.ix_(sa, sa)]
-            M[np.ix_(b, b)] = np.asarray(Db[c])[np.ix_(sb, sb)]
+            M = np.zeros((n1, n2))
+            M[np.ix_(a1, a2)] = np.asarray(Da[c])
+            M[np.ix_(b1p, b2p)] = np.asarray(Db[c])
             out.append(M)
         return out
 
-    def so_core(self, atom: int) -> List[np.ndarray]:
+    def so_core(self, atom: int, b1: str = 'all', b2: str = 'all') -> List[np.ndarray]:
         """Spin-orbital core (kinetic + potential) ``h^x`` derivatives for ``atom``."""
-        T = self.so_oei(atom, "KINETIC")
-        V = self.so_oei(atom, "POTENTIAL")
+        T = self.so_oei(atom, "KINETIC", b1, b2)
+        V = self.so_oei(atom, "POTENTIAL", b1, b2)
         return [t + v for t, v in zip(T, V)]
 
-    def so_overlap(self, atom: int) -> List[np.ndarray]:
+    def so_overlap(self, atom: int, b1: str = 'all', b2: str = 'all') -> List[np.ndarray]:
         """Spin-orbital overlap ``S^x`` derivatives for ``atom``."""
-        return self.so_oei(atom, "OVERLAP")
+        return self.so_oei(atom, "OVERLAP", b1, b2)
 
-    def so_eri(self, atom: int) -> List[np.ndarray]:
-        """Spin-orbital antisymmetrized two-electron derivatives ``<pq||rs>^x`` for
-        ``atom``: 3 (x, y, z) ``nmo^4`` arrays. Spin-blocks the spatial chemist
-        derivative integrals, converts to physicist notation, and antisymmetrizes --
-        the derivative analogue of the spin-orbital Hamiltonian's ERI build."""
-        nmo, a, b, sa, sb, Ca, Cb = self._so_spin_blocks()
-        AA = self.mints.mo_tei_deriv1(atom, Ca, Ca, Ca, Ca)
-        BB = self.mints.mo_tei_deriv1(atom, Cb, Cb, Cb, Cb)
-        AB = self.mints.mo_tei_deriv1(atom, Ca, Ca, Cb, Cb)
-        out = []
-        for c in range(3):
-            chem = np.zeros((nmo, nmo, nmo, nmo))
-            chem[np.ix_(a, a, a, a)] = np.asarray(AA[c])[np.ix_(sa, sa, sa, sa)]
-            chem[np.ix_(b, b, b, b)] = np.asarray(BB[c])[np.ix_(sb, sb, sb, sb)]
-            chem[np.ix_(a, a, b, b)] = np.asarray(AB[c])[np.ix_(sa, sa, sb, sb)]
-            chem[np.ix_(b, b, a, a)] = np.asarray(AB[c]).transpose(2, 3, 0, 1)[np.ix_(sb, sb, sa, sa)]
-            phys = chem.swapaxes(1, 2)
-            out.append(phys - phys.swapaxes(2, 3))
-        return out
-
-    def so_dipole(self, atom: int) -> List[np.ndarray]:
-        """Spin-orbital MO electric-dipole derivatives ``d(mu_alpha)/d(X_atom,beta)`` for
-        ``atom``: 9 ``nmo x nmo`` arrays indexed ``alpha*3 + beta`` (block-diagonal in
-        spin). As in :meth:`dipole`, the AO derivatives (``ao_elec_dip_deriv1``) are
-        transformed here (the ``mo_elec_dip_deriv1`` route segfaults on linux Psi4
-        1.10.1); here each spin block is transformed with the semicanonical MOs."""
-        nmo, a, b, sa, sb, _, _ = self._so_spin_blocks()
-        Ca = np.asarray(self.wfn.H.Ca)
-        Cb = np.asarray(self.wfn.H.Cb)
+    def so_dipole(self, atom: int, b1: str = 'all', b2: str = 'all') -> List[np.ndarray]:
+        """Spin-orbital MO electric-dipole derivatives for ``atom``: 9 arrays indexed
+        ``alpha*3 + beta`` (block-diagonal in spin). AO route then spin-blocked, as in
+        :meth:`dipole`."""
+        n1, a1, b1p, Ca1, Cb1 = self._so_mo(b1)
+        n2, a2, b2p, Ca2, Cb2 = self._so_mo(b2)
+        npCa1, npCa2 = np.asarray(Ca1), np.asarray(Ca2)
+        npCb1, npCb2 = np.asarray(Cb1), np.asarray(Cb2)
         aod = self.mints.ao_elec_dip_deriv1(atom)   # 9 x (nao, nao)
         out = []
         for c in range(9):
             ao = np.asarray(aod[c])
-            M = np.zeros((nmo, nmo))
-            M[np.ix_(a, a)] = (Ca.T @ ao @ Ca)[np.ix_(sa, sa)]
-            M[np.ix_(b, b)] = (Cb.T @ ao @ Cb)[np.ix_(sb, sb)]
+            M = np.zeros((n1, n2))
+            M[np.ix_(a1, a2)] = npCa1.T @ ao @ npCa2
+            M[np.ix_(b1p, b2p)] = npCb1.T @ ao @ npCb2
             out.append(M)
         return out
 
-    def so_overlap_half(self, atom: int, side: str = "LEFT") -> List[np.ndarray]:
+    def so_overlap_half(self, atom: int, b1: str = 'all', b2: str = 'all',
+                        side: str = "LEFT") -> List[np.ndarray]:
         """Spin-orbital overlap half-derivatives ``<phi^X_p | phi_q>`` (block-diagonal in
-        spin) for ``atom``: 3 (x, y, z) ``nmo x nmo`` arrays. The bra is the perturbed
-        orbital, the ket the unperturbed (``side='LEFT'``); the matrix is not symmetric.
-        Used by the spin-orbital AAT machinery (which takes the ov block)."""
-        nmo, a, b, sa, sb, Ca, Cb = self._so_spin_blocks()
-        La = self.mints.mo_overlap_half_deriv1(side, atom, Ca, Ca)
-        Lb = self.mints.mo_overlap_half_deriv1(side, atom, Cb, Cb)
+        spin): 3 arrays. Bra perturbed, ket unperturbed (``side='LEFT'``); not symmetric.
+        Used by the spin-orbital AAT machinery."""
+        n1, a1, b1p, Ca1, Cb1 = self._so_mo(b1)
+        n2, a2, b2p, Ca2, Cb2 = self._so_mo(b2)
+        La = self.mints.mo_overlap_half_deriv1(side, atom, Ca1, Ca2)
+        Lb = self.mints.mo_overlap_half_deriv1(side, atom, Cb1, Cb2)
         out = []
         for c in range(3):
-            M = np.zeros((nmo, nmo))
-            M[np.ix_(a, a)] = np.asarray(La[c])[np.ix_(sa, sa)]
-            M[np.ix_(b, b)] = np.asarray(Lb[c])[np.ix_(sb, sb)]
+            M = np.zeros((n1, n2))
+            M[np.ix_(a1, a2)] = np.asarray(La[c])
+            M[np.ix_(b1p, b2p)] = np.asarray(Lb[c])
             out.append(M)
         return out
 
-    # ---- spin-orbital second derivatives (Hessian skeleton; occupied block) ----
-    def _so_occ_blocks(self):
-        """Occupied spin-orbital spin split for the Hessian skeleton: ``(no, a, b,
-        Cocc_a, Cocc_b)`` where ``a``/``b`` are the alpha/beta positions within the
-        occupied block and ``Cocc_a``/``Cocc_b`` the corresponding occupied alpha/beta
-        MOs (as Psi4 matrices, pre-sliced to the occupied spatial columns -- so the
-        deriv2 transforms return arrays already in occupied-block order)."""
-        H = self.wfn.H
-        o = self.wfn.o
-        spin_o = np.asarray(H.spin)[o]
-        spat_o = np.asarray(H.spat)[o]
-        a = np.where(spin_o == 0)[0]
-        b = np.where(spin_o == 1)[0]
-        Cocc_a = psi4.core.Matrix.from_array(np.asarray(H.Ca)[:, spat_o[a]])
-        Cocc_b = psi4.core.Matrix.from_array(np.asarray(H.Cb)[:, spat_o[b]])
-        return self.wfn.no, a, b, Cocc_a, Cocc_b
+    # ---- spin-orbital two-electron ----
+    def _so_eri_blocks(self, blocks):
+        """Per-index ``(size, [(alpha_pos, Ca), (beta_pos, Cb)])`` selectors for the four
+        block labels of a spin-orbital ERI -- the shared spin-blocking bookkeeping for
+        :meth:`so_eri` / :meth:`so_eri2`."""
+        info = [self._so_mo(b) for b in blocks]
+        shape = tuple(x[0] for x in info)
+        sel = [[(x[1], x[3]), (x[2], x[4])] for x in info]   # [alpha:(pos,C), beta:(pos,C)]
+        return shape, sel
 
-    def so_oei2(self, kind: str, atom1: int, atom2: int) -> List[np.ndarray]:
-        """Spin-orbital second one-electron derivative (occupied block, block-diagonal
-        in spin) for the ``(atom1, atom2)`` pair: 9 ``(no, no)`` arrays indexed
-        ``cart1*3 + cart2``. ``kind`` is 'OVERLAP'/'KINETIC'/'POTENTIAL'."""
-        no, a, b, Ca, Cb = self._so_occ_blocks()
-        Da = self.mints.mo_oei_deriv2(kind, atom1, atom2, Ca, Ca)
-        Db = self.mints.mo_oei_deriv2(kind, atom1, atom2, Cb, Cb)
+    def so_eri(self, atom: int, b1: str = 'all', b2: str = 'all',
+               b3: str = 'all', b4: str = 'all') -> List[np.ndarray]:
+        """Spin-orbital antisymmetrized two-electron derivatives ``<pq||rs>^x`` for
+        ``atom``: 3 (x, y, z) arrays. Spin-blocks the spatial chemist derivative integrals
+        over the four spin-conserving combinations ``(s12, s34)``, converts to physicist
+        notation, and antisymmetrizes."""
+        shape, sel = self._so_eri_blocks((b1, b2, b3, b4))
+        chem = [np.zeros(shape) for _ in range(3)]
+        for s12 in (0, 1):
+            p1, C1 = sel[0][s12]
+            p2, C2 = sel[1][s12]
+            if not (p1.size and p2.size):
+                continue
+            for s34 in (0, 1):
+                p3, C3 = sel[2][s34]
+                p4, C4 = sel[3][s34]
+                if not (p3.size and p4.size):
+                    continue
+                G = self.mints.mo_tei_deriv1(atom, C1, C2, C3, C4)
+                for c in range(3):
+                    chem[c][np.ix_(p1, p2, p3, p4)] = np.asarray(G[c])
         out = []
-        for c in range(9):
-            M = np.zeros((no, no))
-            M[np.ix_(a, a)] = np.asarray(Da[c])
-            M[np.ix_(b, b)] = np.asarray(Db[c])
-            out.append(M)
-        return out
-
-    def so_core2(self, atom1: int, atom2: int) -> List[np.ndarray]:
-        """Spin-orbital second core (kinetic + potential) derivatives ``h^{XY}`` (occupied
-        block) for the ``(atom1, atom2)`` pair: 9 ``(no, no)`` arrays."""
-        T = self.so_oei2("KINETIC", atom1, atom2)
-        V = self.so_oei2("POTENTIAL", atom1, atom2)
-        return [t + v for t, v in zip(T, V)]
-
-    def so_overlap2(self, atom1: int, atom2: int) -> List[np.ndarray]:
-        """Spin-orbital second overlap derivatives ``S^{XY}`` (occupied block) for the
-        ``(atom1, atom2)`` pair: 9 ``(no, no)`` arrays."""
-        return self.so_oei2("OVERLAP", atom1, atom2)
-
-    def so_eri2(self, atom1: int, atom2: int) -> List[np.ndarray]:
-        """Spin-orbital second antisymmetrized two-electron derivatives ``<ij||kl>^{XY}``
-        (occupied block) for the ``(atom1, atom2)`` pair: 9 ``(no^4)`` arrays indexed
-        ``cart1*3 + cart2``. Spin-blocked from the occupied-block chemist deriv2 integrals
-        then antisymmetrized, as in :meth:`so_eri`.
-
-        Psi4's ``mo_tei_deriv2(A, B)`` does not satisfy the two-electron integral's
-        electron-exchange symmetry ``(pq|rs) = (rs|pq)`` term by term -- a single (A, B)
-        call gives one ordering of the mixed derivative ``d^2/dXA dXB`` -- so the chemist
-        integral is symmetrized over the bra<->ket swap here. That restores the missing
-        symmetry, which (because the geometric derivative of a symmetric integral is
-        symmetric) also makes the result invariant under the atom-pair swap the molecular
-        Hessian requires. The cross-spin ``ab``/``ba`` blocks are therefore built from
-        independent ``(aa|bb)`` and ``(bb|aa)`` deriv2 calls rather than as transposes of
-        one another (only with both does the symmetrization see the true pair); the
-        same-spin ``aa``/``bb`` blocks need it too (a no-op for their energy trace but it
-        restores the tensor symmetry)."""
-        no, a, b, Ca, Cb = self._so_occ_blocks()
-        AA = self.mints.mo_tei_deriv2(atom1, atom2, Ca, Ca, Ca, Ca)
-        BB = self.mints.mo_tei_deriv2(atom1, atom2, Cb, Cb, Cb, Cb)
-        AB = self.mints.mo_tei_deriv2(atom1, atom2, Ca, Ca, Cb, Cb)
-        BA = self.mints.mo_tei_deriv2(atom1, atom2, Cb, Cb, Ca, Ca)
-        out = []
-        for c in range(9):
-            chem = np.zeros((no, no, no, no))
-            chem[np.ix_(a, a, a, a)] = np.asarray(AA[c])
-            chem[np.ix_(b, b, b, b)] = np.asarray(BB[c])
-            chem[np.ix_(a, a, b, b)] = np.asarray(AB[c])
-            chem[np.ix_(b, b, a, a)] = np.asarray(BA[c])
-            chem = 0.5 * (chem + chem.transpose(2, 3, 0, 1))   # enforce (pq|rs) = (rs|pq)
-            phys = chem.swapaxes(1, 2)
+        for ch in chem:
+            phys = ch.swapaxes(1, 2)
             out.append(phys - phys.swapaxes(2, 3))
         return out
+
+    def so_eri2(self, atom1: int, atom2: int, b1: str = 'all', b2: str = 'all',
+                b3: str = 'all', b4: str = 'all') -> List[np.ndarray]:
+        """Spin-orbital antisymmetrized two-electron *second* derivatives ``<pq||rs>^{XY}``
+        for the ``(atom1, atom2)`` pair: 9 arrays indexed ``cart1*3 + cart2``.
+
+        Psi4's ``mo_tei_deriv2(A, B)`` does not satisfy the integral's electron-exchange
+        symmetry ``(pq|rs) = (rs|pq)`` term by term -- a single (A, B) call is one ordering
+        of ``d^2/dXA dXB`` -- so the chemist integral is symmetrized over the bra<->ket
+        swap here, which (the geometric derivative of a symmetric integral being symmetric)
+        also restores the atom-pair-swap symmetry the molecular Hessian needs. The
+        symmetrization assumes matching bra/ket block pairs (``b1,b2`` == ``b3,b4``), as in
+        the occupied-block Hessian use; all four spin combinations are built independently."""
+        shape, sel = self._so_eri_blocks((b1, b2, b3, b4))
+        chem = [np.zeros(shape) for _ in range(9)]
+        for s12 in (0, 1):
+            p1, C1 = sel[0][s12]
+            p2, C2 = sel[1][s12]
+            if not (p1.size and p2.size):
+                continue
+            for s34 in (0, 1):
+                p3, C3 = sel[2][s34]
+                p4, C4 = sel[3][s34]
+                if not (p3.size and p4.size):
+                    continue
+                G = self.mints.mo_tei_deriv2(atom1, atom2, C1, C2, C3, C4)
+                for c in range(9):
+                    chem[c][np.ix_(p1, p2, p3, p4)] = np.asarray(G[c])
+        out = []
+        for ch in chem:
+            ch = 0.5 * (ch + ch.transpose(2, 3, 0, 1))   # enforce (pq|rs) = (rs|pq)
+            phys = ch.swapaxes(1, 2)
+            out.append(phys - phys.swapaxes(2, 3))
+        return out
+
+    def so_oei2(self, atom1: int, atom2: int, kind: str, b1: str = 'all',
+                b2: str = 'all') -> List[np.ndarray]:
+        """Spin-orbital one-electron *second* derivative (block-diagonal in spin) for the
+        ``(atom1, atom2)`` pair: 9 arrays indexed ``cart1*3 + cart2``."""
+        n1, a1, b1p, Ca1, Cb1 = self._so_mo(b1)
+        n2, a2, b2p, Ca2, Cb2 = self._so_mo(b2)
+        Da = self.mints.mo_oei_deriv2(kind, atom1, atom2, Ca1, Ca2)
+        Db = self.mints.mo_oei_deriv2(kind, atom1, atom2, Cb1, Cb2)
+        out = []
+        for c in range(9):
+            M = np.zeros((n1, n2))
+            M[np.ix_(a1, a2)] = np.asarray(Da[c])
+            M[np.ix_(b1p, b2p)] = np.asarray(Db[c])
+            out.append(M)
+        return out
+
+    def so_core2(self, atom1: int, atom2: int, b1: str = 'all', b2: str = 'all') -> List[np.ndarray]:
+        """Spin-orbital second core (kinetic + potential) derivatives ``h^{XY}`` for the
+        ``(atom1, atom2)`` pair: 9 arrays."""
+        T = self.so_oei2(atom1, atom2, "KINETIC", b1, b2)
+        V = self.so_oei2(atom1, atom2, "POTENTIAL", b1, b2)
+        return [t + v for t, v in zip(T, V)]
+
+    def so_overlap2(self, atom1: int, atom2: int, b1: str = 'all', b2: str = 'all') -> List[np.ndarray]:
+        """Spin-orbital second overlap derivatives ``S^{XY}`` for the ``(atom1, atom2)``
+        pair: 9 arrays."""
+        return self.so_oei2(atom1, atom2, "OVERLAP", b1, b2)
 
     # ---- nuclear repulsion ----
     def nuclear_repulsion(self) -> np.ndarray:

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import psi4
 import numpy as np
 
 from .wavefunction import Wavefunction
@@ -59,24 +58,20 @@ class HFwfn(Wavefunction):
         space, so a frozen core on the reference does not affect the gradient.
 
         The spin-orbital path (open-shell UHF/ROHF, or a closed shell forced to spin
-        orbitals) dispatches to :meth:`_gradient_spinorbital`.
+        orbitals) dispatches to :meth:`_so_gradient`.
         """
         if self.orbital_basis == 'spinorbital':
-            return self._gradient_spinorbital()
+            return self._so_gradient()
         o = self.o
-        no = self.no
-        # Occupied block of the symmetry-handled MO coefficients, and the matching
-        # (energy-ordered) occupied orbital energies from the Fock diagonal.
-        Cocc = psi4.core.Matrix.from_array(np.asarray(self.C)[:, :no])
         eps = np.asarray(diag(self.H.F))[o]
 
         d = self.derivatives
         grad = np.zeros((d.natom, 3))
         Vnn = d.nuclear_repulsion()
         for atom in range(d.natom):
-            Sx = d.overlap(atom, Cocc, Cocc)
-            hx = d.core(atom, Cocc, Cocc)
-            erix = d.eri(atom, Cocc, Cocc, Cocc, Cocc)
+            Sx = d.overlap(atom, 'o', 'o')
+            hx = d.core(atom, 'o', 'o')
+            erix = d.eri(atom, 'o', 'o', 'o', 'o')
             for c in range(3):
                 grad[atom, c] = (2.0 * np.trace(hx[c])
                                  + 2.0 * np.einsum('iijj->', erix[c])
@@ -86,7 +81,7 @@ class HFwfn(Wavefunction):
         self.grad = grad
         return grad
 
-    def _gradient_spinorbital(self) -> np.ndarray:
+    def _so_gradient(self) -> np.ndarray:
         """Spin-orbital Hartree-Fock analytic energy gradient (a.u.), shape (natom, 3).
 
         The spin-orbital form of the CPHF-free HF gradient (i, j over occupied spin
@@ -98,19 +93,18 @@ class HFwfn(Wavefunction):
         The skeleton spin-orbital derivative integrals come from ``self.derivatives``
         (built in the semicanonical MO gauge). For a closed shell this equals the
         spatial RHF gradient term-for-term."""
-        o = self.o
-        eps = np.asarray(diag(self.H.F))[o]
+        eps = np.asarray(diag(self.H.F))[self.o]
         d = self.derivatives
         grad = np.zeros((d.natom, 3))
         Vnn = d.nuclear_repulsion()
         for atom in range(d.natom):
-            hx = d.so_core(atom)
-            Sx = d.so_overlap(atom)
-            erix = d.so_eri(atom)
+            hx = d.so_core(atom, 'o', 'o')
+            Sx = d.so_overlap(atom, 'o', 'o')
+            erix = d.so_eri(atom, 'o', 'o', 'o', 'o')
             for c in range(3):
-                grad[atom, c] = (self.contract('ii->', hx[c][o, o])
-                                 + 0.5 * self.contract('ijij->', erix[c][o, o, o, o])
-                                 - self.contract('i,ii->', eps, Sx[c][o, o])
+                grad[atom, c] = (self.contract('ii->', hx[c])
+                                 + 0.5 * self.contract('ijij->', erix[c])
+                                 - self.contract('i,ii->', eps, Sx[c])
                                  + Vnn[atom, c])
         self.grad = grad
         return grad
@@ -155,23 +149,21 @@ class HFwfn(Wavefunction):
                             - 2 sum_ik S^X_ki (mu_a)_ik            (oo / Pulay response)
                             + 4 sum_ia U^X_ia (mu_a)_ia            (ov / CPHF response)
 
-        The spin-orbital path dispatches to :meth:`_dipole_derivatives_spinorbital`.
+        The spin-orbital path dispatches to :meth:`_so_dipole_derivatives`.
         """
         if self.orbital_basis == 'spinorbital':
-            return self._dipole_derivatives_spinorbital()
+            return self._so_dipole_derivatives()
         o, v = self.o, self.v
         mu = [np.asarray(self.H.mu[a]) for a in range(3)]
         d = self.derivatives
-        C = np.asarray(self.C)
-        Cocc = psi4.core.Matrix.from_array(C[:, o])
         mol = self.ref.molecule()
         natom = mol.natom()
 
         dmu = np.zeros((natom, 3, 3))
         for A in range(natom):
             Ux = self.cphf.solve_nuclear(A)      # cached; shared with the Hessian
-            Sx = d.overlap(A, Cocc, Cocc)        # 3 x (no,no)
-            dip = d.dipole(A, Cocc, Cocc)        # 9 x (no,no): index alpha*3 + beta
+            Sx = d.overlap(A, 'o', 'o')          # 3 x (no,no)
+            dip = d.dipole(A, 'o', 'o')          # 9 x (no,no): index alpha*3 + beta
             for beta in range(3):
                 for alpha in range(3):
                     val = mol.Z(A) if alpha == beta else 0.0
@@ -182,7 +174,7 @@ class HFwfn(Wavefunction):
         self.dipder = dmu
         return self.dipder
 
-    def _dipole_derivatives_spinorbital(self) -> np.ndarray:
+    def _so_dipole_derivatives(self) -> np.ndarray:
         """Spin-orbital nuclear dipole derivatives (APTs), shape ``(natom, 3, 3)`` indexed
         ``[A, beta, alpha]``. The spin-orbital form of :meth:`dipole_derivatives`: singly
         occupied spin orbitals (the one-electron traces carry factor 1, the ov response
@@ -204,13 +196,13 @@ class HFwfn(Wavefunction):
         dmu = np.zeros((natom, 3, 3))
         for A in range(natom):
             Ux = self.cphf.solve_nuclear(A)      # 3 x (no,nv), spin-orbital response
-            Sx = d.so_overlap(A)                 # 3 x (nmo,nmo)
-            dip = d.so_dipole(A)                 # 9 x (nmo,nmo): index alpha*3 + beta
+            Sx = d.so_overlap(A, 'o', 'o')       # 3 x (no,no)
+            dip = d.so_dipole(A, 'o', 'o')       # 9 x (no,no): index alpha*3 + beta
             for beta in range(3):
                 for alpha in range(3):
                     val = mol.Z(A) if alpha == beta else 0.0
-                    val += self.contract('ii->', dip[alpha * 3 + beta][o, o])
-                    val -= self.contract('ki,ki->', Sx[beta][o, o], mu[alpha][o, o])
+                    val += self.contract('ii->', dip[alpha * 3 + beta])
+                    val -= self.contract('ki,ki->', Sx[beta], mu[alpha][o, o])
                     val += 2.0 * self.contract('ia,ia->', Ux[beta], mu[alpha][o, v])
                     dmu[A, beta, alpha] = val
         self.dipder = dmu
@@ -239,15 +231,13 @@ class HFwfn(Wavefunction):
         where ``U^x``/``B^x`` are the cached nuclear response/RHS and ``F^x_ij``/``S^x_ij``
         the skeleton derivative Fock/overlap oo blocks (cached by :meth:`CPHF.solve_nuclear`).
 
-        The spin-orbital path dispatches to :meth:`_hessian_spinorbital`.
+        The spin-orbital path dispatches to :meth:`_so_hessian`.
         """
         if self.orbital_basis == 'spinorbital':
-            return self._hessian_spinorbital()
+            return self._so_hessian()
         o, v = self.o, self.v
         eps_o = np.asarray(diag(self.H.F))[o]
         d = self.derivatives
-        C = np.asarray(self.C)
-        Cocc = psi4.core.Matrix.from_array(C[:, o])
         mol = self.ref.molecule()
         natom = mol.natom()
 
@@ -263,9 +253,9 @@ class HFwfn(Wavefunction):
         H = np.zeros((3 * natom, 3 * natom))
         for A in range(natom):
             for Bat in range(natom):
-                S2 = d.overlap2(A, Bat, Cocc, Cocc)               # 9 x (no,no)
-                h2 = d.core2(A, Bat, Cocc, Cocc)                  # 9 x (no,no)
-                g2 = d.eri2(A, Bat, Cocc, Cocc, Cocc, Cocc)       # 9 x (no,no,no,no) chemist
+                S2 = d.overlap2(A, Bat, 'o', 'o')                 # 9 x (no,no)
+                h2 = d.core2(A, Bat, 'o', 'o')                    # 9 x (no,no)
+                g2 = d.eri2(A, Bat, 'o', 'o', 'o', 'o')           # 9 x (no,no,no,no) chemist
                 for a in range(3):
                     for b in range(3):
                         c = a * 3 + b
@@ -289,7 +279,7 @@ class HFwfn(Wavefunction):
         self.hess = H
         return self.hess
 
-    def _hessian_spinorbital(self) -> np.ndarray:
+    def _so_hessian(self) -> np.ndarray:
         """Spin-orbital RHF/UHF molecular Hessian, shape ``(3*natom, 3*natom)``. The
         spin-orbital form of :meth:`hessian`: singly occupied spin orbitals (the
         closed-shell prefactors halve) with the antisymmetrized ``<ij||kl>``, the
@@ -319,9 +309,9 @@ class HFwfn(Wavefunction):
         H = np.zeros((3 * natom, 3 * natom))
         for A in range(natom):
             for Bat in range(natom):
-                S2 = d.so_overlap2(A, Bat)                # 9 x (no,no)
-                h2 = d.so_core2(A, Bat)                   # 9 x (no,no)
-                g2 = d.so_eri2(A, Bat)                    # 9 x (no^4) <ij||kl>^{ab}
+                S2 = d.so_overlap2(A, Bat, 'o', 'o')      # 9 x (no,no)
+                h2 = d.so_core2(A, Bat, 'o', 'o')         # 9 x (no,no)
+                g2 = d.so_eri2(A, Bat, 'o', 'o', 'o', 'o')  # 9 x (no^4) <ij||kl>^{ab}
                 for a in range(3):
                     for b in range(3):
                         c = a * 3 + b
@@ -361,22 +351,18 @@ class HFwfn(Wavefunction):
         their ``i`` (so the response and AAT are real); the full VCD AAT adds the nuclear
         term ``(Z_lambda/4) eps_{alpha,beta,gamma} R_{lambda,gamma}``.
 
-        The spin-orbital path dispatches to :meth:`_atomic_axial_tensors_spinorbital`.
+        The spin-orbital path dispatches to :meth:`_so_atomic_axial_tensors`.
         """
         if self.orbital_basis == 'spinorbital':
-            return self._atomic_axial_tensors_spinorbital()
-        o, v = self.o, self.v
+            return self._so_atomic_axial_tensors()
         d = self.derivatives
-        C = np.asarray(self.C)
-        Cocc = psi4.core.Matrix.from_array(C[:, o])
-        Cvir = psi4.core.Matrix.from_array(C[:, v])
         natom = self.ref.molecule().natom()
 
         Ub = [self.cphf.solve_magnetic(beta) for beta in range(3)]   # 3 x (no,nv), real
         aat = np.zeros((natom, 3, 3))
         for lam in range(natom):
             Ur = self.cphf.solve_nuclear(lam)                        # 3 x (no,nv), cached
-            Shalf = d.overlap_half(lam, Cocc, Cvir, side="LEFT")     # 3 x (no,nv)
+            Shalf = d.overlap_half(lam, 'o', 'v', side="LEFT")       # 3 x (no,nv)
             for alpha in range(3):
                 for beta in range(3):
                     aat[lam, alpha, beta] = 2.0 * (
@@ -385,7 +371,7 @@ class HFwfn(Wavefunction):
         self.aat = aat
         return self.aat
 
-    def _atomic_axial_tensors_spinorbital(self) -> np.ndarray:
+    def _so_atomic_axial_tensors(self) -> np.ndarray:
         """Spin-orbital RHF/UHF atomic axial tensors (AATs), shape ``(natom, 3, 3)``. The
         spin-orbital form of :meth:`atomic_axial_tensors`: singly occupied spin orbitals
         (the closed-shell prefactor 2 -> 1), with the spin-orbital nuclear response
@@ -399,7 +385,6 @@ class HFwfn(Wavefunction):
         implementation to validate against; the closed-shell keystone (SO-RHF == the
         DALTON-validated spatial AAT) validates the spin-orbital machinery, and the UHF
         result runs through the same code path."""
-        o, v = self.o, self.v
         d = self.derivatives
         natom = self.ref.molecule().natom()
 
@@ -407,11 +392,11 @@ class HFwfn(Wavefunction):
         aat = np.zeros((natom, 3, 3))
         for lam in range(natom):
             Ur = self.cphf.solve_nuclear(lam)                        # 3 x (no,nv), cached
-            Shalf = d.so_overlap_half(lam, side="LEFT")             # 3 x (nmo,nmo)
+            Shalf = d.so_overlap_half(lam, 'o', 'v', side="LEFT")    # 3 x (no,nv)
             for alpha in range(3):
                 for beta in range(3):
                     aat[lam, alpha, beta] = (
                         self.contract('ia,ia->', Ur[alpha], Ub[beta])
-                        + self.contract('ia,ia->', Ub[beta], Shalf[alpha][o, v]))
+                        + self.contract('ia,ia->', Ub[beta], Shalf[alpha]))
         self.aat = aat
         return self.aat

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -299,12 +299,11 @@ class MPwfn(Wavefunction):
         I = self._energy_weighted_opdm(Ip, z)
 
         d = self.derivatives
-        C = self.C
         grad = np.zeros((d.natom, 3))
         for atom in range(d.natom):
-            hx = d.core(atom, C, C)
-            Sx = d.overlap(atom, C, C)
-            ERIx = d.eri(atom, C, C, C, C)            # chemist (pq|rs)^X
+            hx = d.core(atom)
+            Sx = d.overlap(atom)
+            ERIx = d.eri(atom)                        # chemist (pq|rs)^X
             for c in range(3):
                 phys = ERIx[c].transpose(0, 2, 1, 3)  # -> physicist <pq|rs>^X
                 Lx = 2.0 * phys - phys.transpose(0, 1, 3, 2)

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -16,7 +16,6 @@ Validation:
 import psi4
 import pycc
 import numpy as np
-import pytest
 
 WATER = """
 O
@@ -73,7 +72,6 @@ def test_sa_mp2_relaxed_dipole_631g():
                - _ff_corr_dipole(geom, '6-31G')) < 1e-8
 
 
-@pytest.mark.slow
 def test_mp2_relaxed_dipole_ccpvdz():
     """Relaxed MP2 dipole vs finite field, H2O/cc-pVDZ (C2v: polarization functions
     and A2-irrep MOs). Exercises symmetry-adapted MOs in the relaxed density."""
@@ -124,14 +122,12 @@ def test_mp2_gradient_spatial_vs_so_631g():
                          - _pycc_gradient(geom, '6-31G', orbital_basis='spinorbital'))) < 1e-10
 
 
-@pytest.mark.slow
 def test_mp2_gradient_ccpvdz():
     """Spin-orbital MP2 gradient vs Psi4, H2O/cc-pVDZ (C2v: polarization + A2-irrep MOs)."""
     assert np.max(np.abs(_pycc_gradient(WATER, 'cc-pVDZ')
                          - _psi4_mp2_gradient(WATER, 'cc-pVDZ'))) < 1e-8
 
 
-@pytest.mark.slow
 def test_sa_mp2_gradient_ccpvdz():
     """Spin-adapted MP2 gradient vs Psi4, H2O/cc-pVDZ (C2v: polarization + A2-irrep MOs)."""
     assert np.max(np.abs(_pycc_gradient(WATER, 'cc-pVDZ', orbital_basis='spatial')

--- a/pycc/tests/test_064_spinorbital_hf_apt.py
+++ b/pycc/tests/test_064_spinorbital_hf_apt.py
@@ -55,7 +55,6 @@ def test_so_rhf_apt_vs_spatial_631g():
     assert np.max(np.abs(apt_so - apt_spatial)) < 1e-10
 
 
-@pytest.mark.slow
 def test_so_rhf_apt_vs_spatial_ccpvdz():
     """Keystone (C2v: polarization functions + A2-irrep MOs): SO-RHF == spatial RHF APT."""
     wfn = _scf_wfn(WATER, 'cc-pVDZ', 'rhf')
@@ -64,7 +63,6 @@ def test_so_rhf_apt_vs_spatial_ccpvdz():
     assert np.max(np.abs(apt_so - apt_spatial)) < 1e-10
 
 
-@pytest.mark.slow
 def test_uhf_apt_vs_finite_difference():
     """Open-shell UHF APT (OH doublet) vs finite difference of the SCF dipole."""
     wfn = _scf_wfn(_oh_geom(OH_COORDS), '6-31G', 'uhf')

--- a/pycc/tests/test_066_spinorbital_hf_aat.py
+++ b/pycc/tests/test_066_spinorbital_hf_aat.py
@@ -66,7 +66,6 @@ def test_so_rhf_aat_vs_spatial_631g():
     assert np.max(np.abs(a_so - a_spatial)) < 1e-10
 
 
-@pytest.mark.slow
 def test_so_rhf_aat_vs_spatial_h2o2():
     """Keystone on the canonical VCD molecule (H2O2, C1): SO-RHF == spatial RHF AAT (the
     spatial AAT is validated against DALTON in test_050)."""


### PR DESCRIPTION
  # Block-label Derivatives API + spin-orbital naming convention

  A behavior-preserving cleanup of the derivative-integral infrastructure: unify the
  spatial and spin-orbital call interfaces, align method names to PyCC's `_so_*`
  convention, and run the fast symmetry keystones by default. 2 commits, 7 files.

  ## Block-label interface (the main change)

  Previously the spatial `Derivatives` methods took MO-coefficient matrices (callers built
  `Cocc`/`Cvir`/`Call`) while the spin-orbital methods hid the MOs internally — so the
  gradient/property code called them inconsistently:

  ```python
  d.core(atom, Cocc, Cocc)     # spatial
  d.so_core(atom)              # spin-orbital
  ```

  Both families now select the MO block(s) by **label** — `'o'` (occupied), `'v'`
  (virtual), or `'all'` (full MO, the default) — and the provider owns all the MO
  bookkeeping (spatial slices `self.wfn.C`; spin-orbital spin-blocks `Ca`/`Cb`). The call
  sites are now parallel:

  ```python
  d.core(atom, 'o', 'o')       # spatial
  d.so_core(atom, 'o', 'o')    # spin-orbital
  ```

  New helpers `_mo`/`_moM` (spatial) and `_so_mo` (spin-orbital), plus a general 4-block
  spin selector so `so_eri`/`so_eri2` handle arbitrary block labels (the four
  spin-conserving combinations) rather than hardcoded full/occ. Call sites updated in
  `HFwfn` (gradient/Hessian/APT/AAT), `CPHF._build_nuclear`, and `MPwfn.gradient`; the MP2
  gradients use the `'all'` default.

  ## Naming convention

  The recent spin-orbital derivative methods used a `_*_spinorbital` suffix; renamed to the
  `_so_*` prefix the rest of PyCC uses (`build_Fae`/`_so_build_Fae`):

  | from | to |
  |---|---|
  | `HFwfn._gradient_spinorbital` | `_so_gradient` |
  | `HFwfn._hessian_spinorbital` | `_so_hessian` |
  | `HFwfn._dipole_derivatives_spinorbital` | `_so_dipole_derivatives` |
  | `HFwfn._atomic_axial_tensors_spinorbital` | `_so_atomic_axial_tensors` |
  | `CPHF._build_nuclear_spinorbital` | `_so_build_nuclear` |

  The CC layer's own `_*_spinorbital` methods (cclambda/ccwfn/ccresponse/…) are a separate,
  larger convention question, left untouched. Now-unused `psi4` imports dropped from
  `hfwfn.py`/`cphf.py`.

  ## Test markers

  The 6 cc-pVDZ (C2v / A2-irrep MO) and UHF-finite-difference keystones for the MP2
  gradient, relaxed dipole, APT, and AAT were marked `slow` but each runs in 1–4 s — un-marked
  so they run by default (~16 s of added symmetry/open-shell coverage). Only the cc-pVDZ
  molecular Hessian (~63 s) stays `slow`.

  ## Validation
  
  Behavior-preserving. Full HF derivative suite (gradient/polarizability/APT/Hessian/AAT) and
  MP2 gradient pass for **both** the spatial and spin-orbital paths, including the cc-pVDZ
  keystones; full non-slow suite green (124 passed before the marker change; +6 now run by
  default).

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
