### PR TITLE
CC layer: rename _*_spinorbital methods to the _so_* convention

### DIFF
--- a/pycc/cchbar.py
+++ b/pycc/cchbar.py
@@ -79,7 +79,7 @@ class cchbar(object):
         self.nv = ccwfn.nv
 
         if ccwfn.orbital_basis == 'spinorbital':
-            self._build_spinorbital(o, v, F, ERI, t1, t2)
+            self._so_build(o, v, F, ERI, t1, t2)
             print("\nHBAR constructed in %.3f seconds." % (time.time() - time_init))
             return
 
@@ -113,7 +113,7 @@ class cchbar(object):
     # Hovvo, using an inline Zovov intermediate in Hvvvo/Hovoo.
     # ------------------------------------------------------------------
 
-    def _build_spinorbital(self, o, v, F, ERI, t1, t2):
+    def _so_build(self, o, v, F, ERI, t1, t2):
         self.Hov = self._so_build_Hov(o, v, F, ERI, t1)
         self.Hvv = self._so_build_Hvv(o, v, F, ERI, self.Hov, t1, t2)
         self.Hoo = self._so_build_Hoo(o, v, F, ERI, self.Hov, t1, t2)

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -135,7 +135,7 @@ class cclambda(object):
             # T-dependent CC3 intermediates: t1/t2 are fixed during the Lambda
             # solve, so build them once here and reuse every iteration.
             if self.ccwfn.orbital_basis == 'spinorbital':
-                cc3_ints = self._build_cc3_lambda_intermediates_spinorbital(o, v, t1, t2, F, ERI)
+                cc3_ints = self._so_build_cc3_lambda_intermediates(o, v, t1, t2, F, ERI)
             else:
                 cc3_ints = self._build_cc3_lambda_intermediates(o, v, t1, t2, F, ERI, L)
 
@@ -155,9 +155,9 @@ class cclambda(object):
                     # The spin-orbital Y1/Y2 come out fully antisymmetric already,
                     # so they are added directly (no i<->j / a<->b symmetrization).
                     if self.ccwfn.store_triples:
-                        Y1, Y2 = self._cc3_lambda_triples_full_spinorbital(o, v, l1, l2, t2, F, ERI, cc3_ints)
+                        Y1, Y2 = self._so_cc3_lambda_triples_full(o, v, l1, l2, t2, F, ERI, cc3_ints)
                     else:
-                        Y1, Y2 = self._cc3_lambda_triples_spinorbital(o, v, l1, l2, t2, F, ERI, cc3_ints)
+                        Y1, Y2 = self._so_cc3_lambda_triples(o, v, l1, l2, t2, F, ERI, cc3_ints)
                     r1 += Y1
                     r2 += Y2
                 else:
@@ -258,7 +258,7 @@ class cclambda(object):
                                              
         return r1, r2
 
-    def _build_cc3_lambda_intermediates_spinorbital(self, o, v, t1, t2, F, ERI):
+    def _so_build_cc3_lambda_intermediates(self, o, v, t1, t2, F, ERI):
         """Build the T-dependent spin-orbital CC3 intermediates for the Lambda
         equations: the T1-dressed CC3 W-intermediates plus the once-only T3
         intermediates ``Zijal``/``Ziabd`` (the <0|L2 [[H~,T3],nu1]|0> -> L1 piece,
@@ -301,7 +301,7 @@ class cclambda(object):
                 'Wvovv': Wvovv, 'Wvvvo': Wvvvo, 'Wvvvv': Wvvvv, 'Wovvo': Wovvo,
                 'Zijal': Zijal, 'Ziabd': Ziabd}
 
-    def _cc3_lambda_triples_spinorbital(self, o, v, l1, l2, t2, F, ERI, ints):
+    def _so_cc3_lambda_triples(self, o, v, l1, l2, t2, F, ERI, ints):
         """Spin-orbital CC3 triples contributions (Y1, Y2) to the Lambda residuals.
 
         Loop-over-(i,j,k): per ijk rebuild the ground-state T3 (:func:`t3c_ijk_so`)
@@ -367,7 +367,7 @@ class cclambda(object):
 
         return Y1, Y2
 
-    def _cc3_lambda_triples_full_spinorbital(self, o, v, l1, l2, t2, F, ERI, ints):
+    def _so_cc3_lambda_triples_full(self, o, v, l1, l2, t2, F, ERI, ints):
         """Full-array (store_triples=True) spin-orbital CC3 triples contributions
         (Y1, Y2) to the Lambda residuals.
 
@@ -375,7 +375,7 @@ class cclambda(object):
         antisymmetrization, no per-(i,j,k) batching), stores it on ``self.l3``, and
         folds the connected-triples pieces into Y1/Y2. Uses the stored ground-state
         T3 (``self.ccwfn.t3``). Full-array counterpart of the batched
-        :meth:`_cc3_lambda_triples_spinorbital`; port of socc ``CC3_iter_full``.
+        :meth:`_so_cc3_lambda_triples`; port of socc ``CC3_iter_full``.
         Both paths must give identical Y1/Y2 (hence the same Lambda pseudoenergy)."""
         contract = self.contract
         Fov = ints['Fov']
@@ -663,7 +663,7 @@ class cclambda(object):
         """
         contract = self.contract
         if self.ccwfn.orbital_basis == 'spinorbital':
-            return self._r_L1_spinorbital(o, v, l1, l2, Hov, Hvv, Hoo, Hovvo, Hvvvo,
+            return self._so_r_L1(o, v, l1, l2, Hov, Hvv, Hoo, Hovvo, Hvvvo,
                                           Hovoo, Hvovv, Hooov, Gvv, Goo)
         if self.ccwfn.model == 'CCD':
             r_l1 = zeros_like(l1)
@@ -722,7 +722,7 @@ class cclambda(object):
         """
         contract = self.contract
         if self.ccwfn.orbital_basis == 'spinorbital':
-            return self._r_L2_spinorbital(o, v, l1, l2, self.ccwfn.H.ERI, Hov, Hvv, Hoo,
+            return self._so_r_L2(o, v, l1, l2, self.ccwfn.H.ERI, Hov, Hvv, Hoo,
                                           Hoooo, Hvvvv, Hovvo, Hvvvo, Hovoo, Hvovv, Hooov,
                                           Gvv, Goo)
         if self.ccwfn.model == 'CCD':
@@ -834,7 +834,7 @@ class cclambda(object):
         W = W + contract('mnef,ma,nb->abef', ERI[o,o,v,v], t1, t1)
         return W
                                          
-    def _r_L1_spinorbital(self, o, v, l1, l2, Hov, Hvv, Hoo, Hovvo, Hvvvo, Hovoo,
+    def _so_r_L1(self, o, v, l1, l2, Hov, Hvv, Hoo, Hovvo, Hvvvo, Hovoo,
                           Hvovv, Hooov, Gvv, Goo):
         """Spin-orbital L1 (lambda singles) residual, built from the antisymmetrized
         spin-orbital HBAR blocks (no Hovov)."""
@@ -849,7 +849,7 @@ class cclambda(object):
         r_l1 = r_l1 - contract('mn,mina->ia', Goo, Hooov)
         return r_l1
 
-    def _r_L2_spinorbital(self, o, v, l1, l2, ERI, Hov, Hvv, Hoo, Hoooo, Hvvvv, Hovvo,
+    def _so_r_L2(self, o, v, l1, l2, ERI, Hov, Hvv, Hoo, Hoooo, Hvvvv, Hovvo,
                           Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo):
         """Spin-orbital L2 (lambda doubles) residual. Built as the full residual,
         already antisymmetric in i<->j and a<->b (no separate symmetrization)."""

--- a/pycc/ccresponse.py
+++ b/pycc/ccresponse.py
@@ -240,9 +240,9 @@ class ccresponse(object):
                     "Spatial CC3 response is not implemented; use the spin-orbital "
                     "path (orbital_basis='spinorbital').")
             if self.ccwfn.store_triples:
-                cc3_ints = self._cc3_response_setup_full_spinorbital(pertbar)
+                cc3_ints = self._so_cc3_response_setup_full(pertbar)
             else:
-                cc3_ints = self._cc3_response_setup_spinorbital(pertbar)
+                cc3_ints = self._so_cc3_response_setup(pertbar)
 
         for niter in range(1, maxiter+1):
             pseudo_last = pseudo
@@ -255,9 +255,9 @@ class ccresponse(object):
 
             if self.ccwfn.model == 'CC3':
                 if self.ccwfn.store_triples:
-                    z1, z2 = self._cc3_iter_full_spinorbital(pertbar, omega, cc3_ints)
+                    z1, z2 = self._so_cc3_iter_full(pertbar, omega, cc3_ints)
                 else:
-                    z1, z2 = self._cc3_iter_spinorbital(pertbar, omega, cc3_ints)
+                    z1, z2 = self._so_cc3_iter(pertbar, omega, cc3_ints)
                 r1 += z1
                 r2 += z2
 
@@ -279,7 +279,7 @@ class ccresponse(object):
                         # full X3 was formed and stored each iteration
                         X3 = self.X3
                     else:
-                        X3 = self._cc3_build_X3_spinorbital(pertbar, omega, cc3_ints)
+                        X3 = self._so_cc3_build_X3(pertbar, omega, cc3_ints)
                     return [self.X1, self.X2, X3], pseudo
                 return [self.X1, self.X2], pseudo
 
@@ -382,7 +382,7 @@ class ccresponse(object):
 
         return -2.0*(polar1 + polar2)
 
-    def _cc3_response_setup_spinorbital(self, pertbar):
+    def _so_cc3_response_setup(self, pertbar):
         """Build the T-dependent spin-orbital CC3 response intermediates that are
         reused across solve_right iterations: the CC3 W-intermediates and the
         once-only Yoovo/Yovvv (ground-state T3 . ERI) and Zovoo/Zvvvo
@@ -415,7 +415,7 @@ class ccresponse(object):
                 'Wvvvo': Wvvvo, 'Wvvvv': Wvvvv, 'Wovvo': Wovvo,
                 'Yoovo': Yoovo, 'Yovvv': Yovvv, 'Zovoo': Zovoo, 'Zvvvo': Zvvvo}
 
-    def _cc3_iter_spinorbital(self, pertbar, omega, ints):
+    def _so_cc3_iter(self, pertbar, omega, ints):
         """Per-iteration spin-orbital CC3 contributions (z1, z2) to the perturbed
         r_X1/r_X2. Rebuilds the perturbed triples X3 (loop-over-ijk and -abc, no
         stored X3) from the current X1/X2 and folds them back. Ports socc
@@ -505,11 +505,11 @@ class ccresponse(object):
         z2 += y2.T
         return z1, z2
 
-    def _cc3_build_X3_spinorbital(self, pertbar, omega, ints):
+    def _so_cc3_build_X3(self, pertbar, omega, ints):
         """Build and return the full converged spin-orbital perturbed triples X3
         from the converged X1/X2 (self.X1/self.X2).
 
-        This replicates the X3-block construction inside _cc3_iter_spinorbital
+        This replicates the X3-block construction inside _so_cc3_iter
         (occupied-batched IJK + virtual-batched ABC, omega-shifted denominators)
         but accumulates into the full X3[ijkabc] array instead of folding into
         z1/z2. Called once after solve_right converges so the response-function
@@ -526,7 +526,7 @@ class ccresponse(object):
         Wvvvo, Wvvvv, Wovvo = ints['Wvvvo'], ints['Wvvvv'], ints['Wovvo']
         Zovoo, Zvvvo = ints['Zovoo'], ints['Zvvvo']
 
-        # X1-dressed W intermediates (same as _cc3_iter_spinorbital)
+        # X1-dressed W intermediates (same as _so_cc3_iter)
         Zbcdk = contract('ke,bcde->bcdk', X1, Wvvvv)
         tmp = -contract('lb,lcdk->bcdk', X1, Wovvo)
         Zbcdk += tmp - tmp.swapaxes(0,1)
@@ -567,7 +567,7 @@ class ccresponse(object):
 
         return X3
 
-    def _cc3_response_setup_full_spinorbital(self, pertbar):
+    def _so_cc3_response_setup_full(self, pertbar):
         """Build the T1-dressed CC3 W-intermediates reused across solve_right
         iterations in the full-array (store_triples=True) perturbed-X path.
 
@@ -585,7 +585,7 @@ class ccresponse(object):
         return {'Woooo': Woooo, 'Wovoo': Wovoo, 'Wvvvo': Wvvvo,
                 'Wvvvv': Wvvvv, 'Wovvo': Wovvo}
 
-    def _cc3_iter_full_spinorbital(self, pertbar, omega, ints):
+    def _so_cc3_iter_full(self, pertbar, omega, ints):
         """Full-array (store_triples=True) per-iteration spin-orbital CC3 perturbed
         triples contribution (z1, z2).
 
@@ -593,7 +593,7 @@ class ccresponse(object):
         current X1/X2 with whole-array contractions (permute_triples
         antisymmetrization, omega-shifted denominator), stores it on self.X3, and
         folds it into z1/z2. Port of socc CC3_iter_full (ccresponse). Full-array
-        counterpart of the batched _cc3_iter_spinorbital."""
+        counterpart of the batched _so_cc3_iter."""
         contract = self.contract
         o, v = self.ccwfn.o, self.ccwfn.v
         F = self.ccwfn.H.F
@@ -663,16 +663,16 @@ class ccresponse(object):
 
         return z1, z2
 
-    def _cc3_triples_spinorbital(self):
+    def _so_cc3_triples(self):
         """Return the full ground-state spin-orbital T3 and Lambda-L3 for the CC3
         response-function terms: the arrays stored on ccwfn/cclambda when
         store_triples=True, else materialized (and cached) on the fly from the
-        batched builders via _cc3_full_triples_spinorbital."""
+        batched builders via _so_cc3_full_triples."""
         if self.ccwfn.store_triples:
             return self.ccwfn.t3, self.cclambda.l3
-        return self._cc3_full_triples_spinorbital()
+        return self._so_cc3_full_triples()
 
-    def _cc3_full_triples_spinorbital(self):
+    def _so_cc3_full_triples(self):
         """Build (and cache) the full ground-state spin-orbital connected T3 and
         Lambda-L3 arrays, shape (no, no, no, nv, nv, nv), by looping over (i,j,k)
         and filling with t3c_ijk_so / l3_ijk_so.
@@ -821,7 +821,7 @@ class ccresponse(object):
 
     # ------------------------------------------------------------------
     # Symmetric linear-response assembly. Each component dispatches on
-    # orbital_basis: the spin-orbital form (_*_spinorbital) is implemented;
+    # orbital_basis: the spin-orbital form (_so_*) is implemented;
     # the spin-adapted (spatial) form is phase 9a-ii (stubbed). The call
     # structure (linresp_sym -> LCX / LHX1Y1 / LHX2Y2 / LHX1Y2) is identical
     # for both bases; only the tensor contractions differ.
@@ -870,7 +870,7 @@ class ccresponse(object):
                       + LHX1Y2(X_A, X_B) + LHX1Y2(X_B, X_A)    (LHX1Y2)
         """
         if self.ccwfn.orbital_basis == 'spinorbital':
-            return self._linresp_sym_spinorbital(A, X_A, B, X_B)
+            return self._so_linresp_sym(A, X_A, B, X_B)
         # spin-adapted (spatial) assembly. Identical in structure to the spin-orbital
         # path: LCX/LHX1Y1/LHX2Y2/LHX1Y2 each dispatch to their own spatial code. The
         # only basis-specific piece is the HXY direct term. Spin-summing the
@@ -889,7 +889,7 @@ class ccresponse(object):
         polar += self.LHX1Y2(X_B, X_A)
         return polar
 
-    def _linresp_sym_spinorbital(self, A, X_A, B, X_B):
+    def _so_linresp_sym(self, A, X_A, B, X_B):
         o, v = self.ccwfn.o, self.ccwfn.v
         contract = self.contract
         ERI = self.H.ERI
@@ -909,14 +909,14 @@ class ccresponse(object):
         if self.ccwfn.model == 'CC3':
             # CC3 connected-triples contributions to the symmetric response
             # function (X3 = X[2] is the perturbed triples). socc linresp CC3 block.
-            polar += self._LCX_CC3_spinorbital(A, X_B) + self._LCX_CC3_spinorbital(B, X_A)
-            polar += self._L2HX1Y3_CC3_spinorbital(X_A, X_B) + self._L2HX1Y3_CC3_spinorbital(X_B, X_A)
-            polar += self._L3HX1Y2_CC3_spinorbital(X_A, X_B) + self._L3HX1Y2_CC3_spinorbital(X_B, X_A)
-            polar += self._L3HX1Y1T2_CC3_spinorbital(X_A, X_B)
+            polar += self._so_LCX_CC3(A, X_B) + self._so_LCX_CC3(B, X_A)
+            polar += self._so_L2HX1Y3_CC3(X_A, X_B) + self._so_L2HX1Y3_CC3(X_B, X_A)
+            polar += self._so_L3HX1Y2_CC3(X_A, X_B) + self._so_L3HX1Y2_CC3(X_B, X_A)
+            polar += self._so_L3HX1Y1T2_CC3(X_A, X_B)
 
         return polar
 
-    def _LCX_CC3_spinorbital(self, pert, X):
+    def _so_LCX_CC3(self, pert, X):
         """CC3 triples contribution to the LCX term of the symmetric response
         function, <0|(1+L)[Abar,X]|0>. Port of socc LCX_CC3 (store_triples path).
 
@@ -931,7 +931,7 @@ class ccresponse(object):
         t2 = self.ccwfn.t2
         l2 = self.cclambda.l2
         X1, X2, X3 = X[0], X[1], X[2]
-        t3, l3 = self._cc3_triples_spinorbital()
+        t3, l3 = self._so_cc3_triples()
 
         # <0|L2[C,X3]|0>
         tmp = 0.25 * contract('ijab,ijkabc->kc', l2, X3)
@@ -961,7 +961,7 @@ class ccresponse(object):
 
         return polar_L2CX3 + polar_L3CX3 + polar_L3CX1T3 + polar_L3CX2T2
 
-    def _L2HX1Y3_CC3_spinorbital(self, X, Y):
+    def _so_L2HX1Y3_CC3(self, X, Y):
         """CC3 <0|L2[[H,X1],Y3]|0> term (L2HX1Y3) of the symmetric response
         function. Port of socc L2HX1Y3_CC3. Uses X1 = X[0] and the perturbed
         triples Y3 = Y[2]; needs only l2 and ERI (no ground-state t3/l3)."""
@@ -986,7 +986,7 @@ class ccresponse(object):
 
         return polar
 
-    def _L3HX1Y2_CC3_spinorbital(self, X, Y):
+    def _so_L3HX1Y2_CC3(self, X, Y):
         """CC3 <0|L3[[H,X1],Y2]|0> term (L3HX1Y2). Port of socc L3HX1Y2_CC3. Uses
         the ground-state L3, X1 = X[0], Y2 = Y[1], and the CC3 Woooo/Wvvvv/Wovvo
         intermediates."""
@@ -994,7 +994,7 @@ class ccresponse(object):
         o, v = self.ccwfn.o, self.ccwfn.v
         ERI = self.H.ERI
         t1 = self.ccwfn.t1
-        _, l3 = self._cc3_triples_spinorbital()
+        _, l3 = self._so_cc3_triples()
         Woooo = self.ccwfn._so_build_Woooo_CC3(o, v, ERI, t1)
         Wvvvv = self.ccwfn._so_build_Wvvvv_CC3(o, v, ERI, t1)
         Wovvo = self.ccwfn._so_build_Wovvo_CC3(o, v, ERI, t1)
@@ -1019,7 +1019,7 @@ class ccresponse(object):
 
         return polar
 
-    def _L3HX1Y1T2_CC3_spinorbital(self, X, Y):
+    def _so_L3HX1Y1T2_CC3(self, X, Y):
         """CC3 <0|L3[[[H,X1],Y1],T2]|0> term (L3HX1Y1T2). Port of socc
         L3HX1Y1T2_CC3. Uses the ground-state L3 and T2, X1 = X[0], Y1 = Y[0], and
         the CC3 Wooov/Wvovv. The tau = X1(x)Y1 + Y1(x)X1 construction makes this
@@ -1029,7 +1029,7 @@ class ccresponse(object):
         ERI = self.H.ERI
         t1 = self.ccwfn.t1
         t2 = self.ccwfn.t2
-        _, l3 = self._cc3_triples_spinorbital()
+        _, l3 = self._so_cc3_triples()
         Wooov = self.ccwfn._so_build_Wooov_CC3(o, v, ERI, t1)
         Wvovv = self.ccwfn._so_build_Wvovv_CC3(o, v, ERI, t1)
         X1 = X[0]
@@ -1056,7 +1056,7 @@ class ccresponse(object):
 
     def LCX(self, pert, X):
         """One-particle-density (LCX) term of the symmetric response function:
-        <0|(1+L)[Abar, X]|0>. (Diagram labels match _LCX_spinorbital; this is the same
+        <0|(1+L)[Abar, X]|0>. (Diagram labels match _so_LCX; this is the same
         quantity as the <0|(1+L)[Abar,X(B)]|0> contribution of linresp_asym (polar2).)
 
         Notes
@@ -1074,7 +1074,7 @@ class ccresponse(object):
                 - 1/2 l2_ijab X2_kjab A_ki - 1/2 l2_ijab X2_kiba A_kj  (diagram 7)
         """
         if self.ccwfn.orbital_basis == 'spinorbital':
-            return self._LCX_spinorbital(pert, X)
+            return self._so_LCX(pert, X)
         # spin-adapted (spatial) LCX
         contract = self.contract
         l1 = self.cclambda.l1
@@ -1109,7 +1109,7 @@ class ccresponse(object):
         polar += 0.5 * contract('ac,ac->', tmp, pert.Avv)
         return polar
 
-    def _LCX_spinorbital(self, pert, X):
+    def _so_LCX(self, pert, X):
         contract = self.contract
         l1 = self.cclambda.l1
         l2 = self.cclambda.l2
@@ -1128,7 +1128,7 @@ class ccresponse(object):
 
     def LHX1Y1(self, X, Y):
         """X1*Y1 (LHX1Y1) term of the symmetric response function:
-        <0|L[[HBAR,X1],Y1]|0>. (Diagram labels match _LHX1Y1_spinorbital.)
+        <0|L[[HBAR,X1],Y1]|0>. (Diagram labels match _so_LHX1Y1.)
 
         Notes
         -----
@@ -1150,7 +1150,7 @@ class ccresponse(object):
             LHX1Y1 = l1_ia tmp_ia + 2 l2_ijab tmp_ijab
         """
         if self.ccwfn.orbital_basis == 'spinorbital':
-            return self._LHX1Y1_spinorbital(X, Y)
+            return self._so_LHX1Y1(X, Y)
         # spin-adapted (spatial) LHX1Y1
         contract = self.contract
         o, v = self.ccwfn.o, self.ccwfn.v
@@ -1183,7 +1183,7 @@ class ccresponse(object):
         polar += 2.0 * contract('ijab,ijab->', l2, tmp)
         return polar
 
-    def _LHX1Y1_spinorbital(self, X, Y):
+    def _so_LHX1Y1(self, X, Y):
         contract = self.contract
         o, v = self.ccwfn.o, self.ccwfn.v
         t2 = self.ccwfn.t2
@@ -1209,7 +1209,7 @@ class ccresponse(object):
 
     def LHX2Y2(self, X, Y):
         """X2*Y2 (LHX2Y2) term of the symmetric response function:
-        <0|L[[HBAR,X2],Y2]|0>. (Diagram labels match _LHX2Y2_spinorbital.)
+        <0|L[[HBAR,X2],Y2]|0>. (Diagram labels match _so_LHX2Y2.)
 
         Notes
         -----
@@ -1233,7 +1233,7 @@ class ccresponse(object):
             LHX2Y2 = 2 l2_ijab tmp_ijab
         """
         if self.ccwfn.orbital_basis == 'spinorbital':
-            return self._LHX2Y2_spinorbital(X, Y)
+            return self._so_LHX2Y2(X, Y)
         # spin-adapted (spatial) LHX2Y2
         contract = self.contract
         o, v = self.ccwfn.o, self.ccwfn.v
@@ -1260,7 +1260,7 @@ class ccresponse(object):
         tmp += 0.5 * contract('mj,imab->ijab', -contract('mnef,jnef->mj', L, X2), Y2)
         return 2.0 * contract('ijab,ijab->', l2, tmp)
 
-    def _LHX2Y2_spinorbital(self, X, Y):
+    def _so_LHX2Y2(self, X, Y):
         contract = self.contract
         o, v = self.ccwfn.o, self.ccwfn.v
         l2 = self.cclambda.l2
@@ -1284,7 +1284,7 @@ class ccresponse(object):
 
     def LHX1Y2(self, X, Y):
         """X1*Y2 (LHX1Y2) term of the symmetric response function:
-        <0|L[[HBAR,X1],Y2]|0>. (Diagram labels match _LHX1Y2_spinorbital.)
+        <0|L[[HBAR,X1],Y2]|0>. (Diagram labels match _so_LHX1Y2.)
 
         Notes
         -----
@@ -1317,7 +1317,7 @@ class ccresponse(object):
             LHX1Y2 = l1_ia tmp_ia + 2 l2_ijab tmp_ijab
         """
         if self.ccwfn.orbital_basis == 'spinorbital':
-            return self._LHX1Y2_spinorbital(X, Y)
+            return self._so_LHX1Y2(X, Y)
         # spin-adapted (spatial) LHX1Y2
         contract = self.contract
         o, v = self.ccwfn.o, self.ccwfn.v
@@ -1358,7 +1358,7 @@ class ccresponse(object):
         polar += 2.0 * contract('ijab,ijab->', l2, tmp2)
         return polar
 
-    def _LHX1Y2_spinorbital(self, X, Y):
+    def _so_LHX1Y2(self, X, Y):
         contract = self.contract
         o, v = self.ccwfn.o, self.ccwfn.v
         l1 = self.cclambda.l1

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -316,7 +316,7 @@ class CCwfn(Wavefunction):
         """
 
         if self.orbital_basis == 'spinorbital':
-            return self._residuals_spinorbital(F, t1, t2)
+            return self._so_residuals(F, t1, t2)
 
         contract = self.contract
 
@@ -963,7 +963,7 @@ class CCwfn(Wavefunction):
         Spin-orbital path: E = f_ia t_ia + 1/4 t2_ijab <ij||ab> + 1/2 t_ia t_jb <ij||ab>.
         """
         if self.orbital_basis == 'spinorbital':
-            return self._cc_energy_spinorbital(o, v, F, self.H.ERI, t1, t2)
+            return self._so_cc_energy(o, v, F, self.H.ERI, t1, t2)
         contract = self.contract
         if self.model == 'CCD':
             ecc = contract('ijab,ijab->', t2, L[o,o,v,v])
@@ -1074,7 +1074,7 @@ class CCwfn(Wavefunction):
                    - contract('mb,maij->ijab', t1, ERI[o,v,o,o]))
         return r2
 
-    def _residuals_spinorbital(self, F, t1, t2):
+    def _so_residuals(self, F, t1, t2):
         """Spin-orbital CCSD T1/T2 residuals (the spin-orbital sibling of
         :meth:`residuals`)."""
         o = self.o
@@ -1105,7 +1105,7 @@ class CCwfn(Wavefunction):
 
         return r1, r2
 
-    def _cc_energy_spinorbital(self, o, v, F, ERI, t1, t2):
+    def _so_cc_energy(self, o, v, F, ERI, t1, t2):
         """Spin-orbital CCSD correlation energy. CC3 shares this -- the triples enter
         through the residuals, not the energy expression."""
         contract = self.contract

--- a/pycc/ciwfn.py
+++ b/pycc/ciwfn.py
@@ -144,13 +144,13 @@ class CIwfn(Wavefunction):
         Spin-orbital path: E_c = f_ia c_ia + 1/4 <ij||ab> c_ijab.
         """
         if self.orbital_basis == 'spinorbital':
-            return self._ci_energy_spinorbital(o, v, F, self.H.ERI, c1, c2)
+            return self._so_ci_energy(o, v, F, self.H.ERI, c1, c2)
         contract = self.contract
         e = 2.0 * contract('ia,ia->', F[o, v], c1)
         e = e + contract('ijab,ijab->', c2, L[o, o, v, v])
         return e
 
-    def _ci_energy_spinorbital(self, o, v, F, ERI, c1, c2) -> "Tensor":
+    def _so_ci_energy(self, o, v, F, ERI, c1, c2) -> "Tensor":
         """Spin-orbital CISD correlation energy, E_c = f_ia c_ia + 1/4 <ij||ab> c_ijab."""
         contract = self.contract
         e = contract('ia,ia->', F[o, v], c1)
@@ -170,7 +170,7 @@ class CIwfn(Wavefunction):
             return zeros_like(c1)
 
         if self.orbital_basis == 'spinorbital':
-            return self._sigma1_spinorbital(o, v, F, self.H.ERI, c1, c2)
+            return self._so_sigma1(o, v, F, self.H.ERI, c1, c2)
 
         contract = self.contract
         s1 = clone(F[o, v], device=self.device1)
@@ -182,7 +182,7 @@ class CIwfn(Wavefunction):
         s1 = s1 - contract('mnae,mnie->ia', c2, L[o, o, o, v])
         return s1
 
-    def _sigma1_spinorbital(self, o, v, F, ERI, c1, c2) -> "Tensor":
+    def _so_sigma1(self, o, v, F, ERI, c1, c2) -> "Tensor":
         """Spin-orbital singles sigma vector: the linear part of the spin-orbital CCSD
         T1 residual (t -> c) with the dressed one-body intermediates replaced by the
         bare Fock blocks (Fae -> f_vv, Fmi -> f_oo, Fme -> f_ov)."""
@@ -210,7 +210,7 @@ class CIwfn(Wavefunction):
             sigma2 = sigma2(half) + sigma2(half)[i<->j, a<->b]
         """
         if self.orbital_basis == 'spinorbital':
-            return self._sigma2_spinorbital(o, v, F, self.H.ERI, c1, c2)
+            return self._so_sigma2(o, v, F, self.H.ERI, c1, c2)
 
         contract = self.contract
 
@@ -229,7 +229,7 @@ class CIwfn(Wavefunction):
         s2 = s2 + s2.swapaxes(0, 1).swapaxes(2, 3)
         return s2
 
-    def _sigma2_spinorbital(self, o, v, F, ERI, c1, c2) -> "Tensor":
+    def _so_sigma2(self, o, v, F, ERI, c1, c2) -> "Tensor":
         """Spin-orbital doubles sigma vector: the linear part of the spin-orbital CCSD
         T2 residual (t -> c) with the dressed two-body intermediates replaced by their
         bare antisymmetrized integrals. Built as the full (already i<->j, a<->b


### PR DESCRIPTION
  # CC layer: rename `_*_spinorbital` methods to the `_so_*` convention

  Mechanical, behavior-preserving rename aligning the correlated-method spin-orbital
  helpers to the `_so_*` prefix the rest of PyCC uses (`build_Fae`/`_so_build_Fae`;
  `HFwfn`/`CPHF`/`MPwfn` already converted in #156), replacing the `_*_spinorbital` suffix.
  27 methods across 5 files — defs, call sites, and `:meth:`/comment references:

  ```
  ccwfn:      _residuals_spinorbital -> _so_residuals, _cc_energy_spinorbital -> _so_cc_energy
  cclambda:   _r_L1/_r_L2, _build_cc3_lambda_intermediates, _cc3_lambda_triples[_full]
  cchbar:     _build_spinorbital -> _so_build
  ciwfn:      _ci_energy, _sigma1, _sigma2
  ccresponse: CC3 response setup/iter/triples, _linresp_sym, and the _LCX/_LHX/_CC3
              linear-response diagram builders
  ```

  The transform is uniform (`_X_spinorbital` → `_so_X`). The `'spinorbital'` string literals
  (`orbital_basis == 'spinorbital'`) are untouched, and the spatial paths (inline in the
  public methods) are unchanged. The base `wavefunction._init_spatial`/`_init_spinorbital`
  pair — a deliberate both-labeled dispatch on the *base*, not the CC layer — is left as-is.

  ## Validation

  Full non-slow suite passes (130 passed, 3 skipped, 1 xfailed), exercising the spin-orbital
  CCSD/CCD energy, lambda, CC3 lambda, CC3 response, and CI paths. Diff confirmed to touch no
  string literals.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
