### PR TITLE
Frozen-core spin-adapted MP2 analytic gradient

### DIFF
--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -112,7 +112,7 @@ on `MPwfn` (MP2-specific, per the decision above).
 
 ## Status / progress
 
-_Last updated 2026-06-21._
+_Last updated 2026-06-22._
 
 | Phase | Status | Landed |
 |---|---|---|
@@ -120,6 +120,8 @@ _Last updated 2026-06-21._
 | A/B — spatial CPHF access + MP2 densities | exploratory; **code removed** | this branch |
 | C — **spin-orbital** relaxed density (GSB Lagrangian + Z-vector) | ✅ done | this branch |
 | D — **spin-orbital** gradient assembly (keystone) | ✅ done | this branch |
+| **spin-adapted** (closed-shell RHF) MP2 gradient | ✅ done | merged |
+| **frozen-core** spin-adapted MP2 gradient | ✅ done | `feature/mp2-frozen-core-gradient` |
 
 Phase D (SO): `MPwfn.gradient()` assembles the MP2 analytic nuclear gradient
 
@@ -143,18 +145,43 @@ sum_m <pm||qm>^X` is the skeleton Fock derivative. Validated (`test_061`):
 **Spin-adapted (closed-shell RHF) MP2 gradient -- DONE (the original decision 4).**
 `MPwfn.gradient()` now has the spatial path inline (dispatching to `_so_gradient` for the
 spin-orbital case), with unlabeled spatial density helpers `_mp2_corr_opdm` / `_mp2_cumulant`
-/ `_mp2_lagrangian` / `_mp2_zvector` / `_energy_weighted_opdm` alongside their `_so_*`
-siblings (PyCC convention: spatial unlabeled, spin-orbital `_so_*`). The spin-adaptation
-carries the spin sum in `l2 = 2(2 t2 - t2.swap)` and the cumulant `Gamma = 2 t2 - t2.swap`,
-writes the two-electron 1-PDM/`W` terms with the spin-adapted `L` (= `H.L`), and assembles
-with the full-spatial-MO derivative integrals (`f^X = h^X + sum_m L[p,m,q,m]^X`, no extra
-prefactor on the spin-summed densities). The Z-vector reuses the basis-aware
-`self.cphf.solve` (closed-shell singlet Hessian via `H.L`). Validated (`test_061`):
-`MPwfn.gradient()` == `psi4.gradient('mp2')` ~1e-14 (6-31G C1, cc-pVDZ C2v), and the
-keystone -- spin-adapted == spin-orbital on a closed shell -- to machine precision (~1e-16).
+/ `_mp2_lagrangian` / `_mp2_relaxed_densities` alongside their `_so_*` siblings (PyCC
+convention: spatial unlabeled, spin-orbital `_so_*`). The spin-adaptation carries the spin
+sum in `l2 = 2(2 t2 - t2.swap)` and the cumulant `Gamma = 2 t2 - t2.swap`, writes the
+two-electron 1-PDM/`W` terms with the spin-adapted `L` (= `H.L`), and assembles with the
+full-spatial-MO derivative integrals (`f^X = h^X + sum_m L[p,m,q,m]^X`, no extra prefactor
+on the spin-summed densities). The Z-vector reuses the basis-aware `self.cphf.solve`
+(closed-shell singlet Hessian via `H.L`). Validated (`test_061`): `MPwfn.gradient()` ==
+`psi4.gradient('mp2')` ~1e-14 (6-31G C1, cc-pVDZ C2v), and the keystone -- spin-adapted ==
+spin-orbital on a closed shell -- to machine precision (~1e-16).
 
-Next: frozen core, then the MP2 property path (APT / Hessian) or CC gradients (swap the
-densities; the Z-vector + assembly carry over).
+**Frozen-core spin-adapted MP2 gradient -- DONE.** The spatial path is now frozen-core
+aware (the all-electron case is `nfzc=0`, no separate branch). The unrelaxed correlation
+density stays on the active blocks, but the **orbital response spans the full occupied
+space**, leveraging the full-MO Hamiltonian integrals (`H.ERI`/`H.F` are full `nmo`, not
+active-only):
+
+  * **core <-> active-occupied** rotations are non-redundant for frozen-core MP2 (they move
+    the frozen/active partition, so the MP2 energy responds) but leave the HF energy
+    invariant, so their orbital Hessian is just the orbital-energy difference -- a **direct
+    divide** `P_co = (I'_ci - I'_ic)/(eps_c - eps_i)`, not a CPHF solve;
+  * the **occupied-virtual Z-vector** runs over the full `ndocc x nv` space (incl.
+    core-virtual), with `P_co` coupled into the RHS (`X_ai -= sum_jc[<aj||ic>+<ac||ij>]z_jc`),
+    solved with the all-electron `HFwfn(ref).cphf` (whose occupied space is the full `ndocc`);
+  * `W = I'(D_r)` -- the Lagrangian at the relaxed density -- supplies the core-active
+    energy-weighted-density (`z_kc`) term automatically; `f^X` sums `m` over the full occ.
+
+`_mp2_lagrangian` now takes a full-MO `D` (1-PDM term's column over the full occupied space),
+and `_mp2_zvector`/`_energy_weighted_opdm` are consolidated into `_mp2_relaxed_densities`.
+Validated (`test_061`, H2O/6-31G C1): relaxed frozen-core dipole vs finite field, and the
+gradient vs a **5-point finite difference of PyCC's own frozen-core MP2 energy** to <1e-8
+(the ground-truth oracle -- Psi4's *analytic* frozen-core MP2 gradient is itself inconsistent
+with its *own energy's* finite difference at ~7e-6, so it is not used as the oracle).
+
+Next: the MP2 property path (APT / Hessian) or CC gradients (swap the densities; the
+Z-vector + assembly carry over). Frozen-core CC gradients reuse the same full-occ response
+machinery. The spin-orbital frozen-core gradient remains deferred (its Hamiltonian is
+active-only, so it lacks the core integrals the response needs).
 
 The original spatial Phases A (`MPwfn.cphf` access to the CPHF Z-vector solver) and B (the
 spatial MP2 `Doo`/`Dvv` and `oovv` 2-PDM in the `l2 = 2u` convention) were committed while

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -166,15 +166,15 @@ class MPwfn(Wavefunction):
 
     def mp2_relaxed_opdm(self) -> np.ndarray:
         """Relaxed MP2 one-particle correlation density (``nmo x nmo``): the unrelaxed
-        ``Doo``/``Dvv`` plus the orbital-relaxation off-diagonal blocks
-        ``D_ai = D_ia = -z_ai`` from the Z-vector solve. Dispatches on ``orbital_basis``
-        (spin-orbital or spin-adapted closed-shell RHF)."""
+        ``Doo``/``Dvv`` plus the orbital-relaxation blocks from the Z-vector solve.
+        Dispatches on ``orbital_basis``; the spin-adapted closed-shell path is frozen-core
+        aware (:meth:`_mp2_relaxed_densities`)."""
+        if self.orbital_basis != 'spinorbital':
+            D, Gam, W, hf = self._mp2_relaxed_densities()
+            return D
         o, v = self.o, self.v
         nmo = self.no + self.nv
-        if self.orbital_basis == 'spinorbital':
-            Doo, Dvv, Gam, Ip, z = self._so_mp2_zvector()
-        else:
-            Doo, Dvv, Gam, Ip, z = self._mp2_zvector()
+        Doo, Dvv, Gam, Ip, z = self._so_mp2_zvector()
         D = np.zeros((nmo, nmo))
         D[o, o] = np.asarray(Doo)
         D[v, v] = np.asarray(Dvv)
@@ -218,9 +218,11 @@ class MPwfn(Wavefunction):
         return Doo, Dvv
 
     def _mp2_cumulant(self) -> np.ndarray:
-        """Spin-adapted MP2 cumulant 2-PDM ``Gamma_ijab = 2 t2 - t2.swap`` (``oovv``/``vvoo``)."""
+        """Spin-adapted MP2 cumulant 2-PDM ``Gamma_ijab = 2 t2 - t2.swap`` (``oovv``/``vvoo``).
+        Built over the full MO space (``self.nmo``); the active ``o``/``v`` slices place the
+        amplitudes, leaving any frozen-core rows/columns zero."""
         o, v = self.o, self.v
-        nmo = self.no + self.nv
+        nmo = self.nmo
         t2 = np.asarray(self.t2)
         u = 2.0 * t2 - t2.transpose(0, 1, 3, 2)
         Gam = np.zeros((nmo, nmo, nmo, nmo))
@@ -228,52 +230,80 @@ class MPwfn(Wavefunction):
         Gam[v, v, o, o] = u.transpose(2, 3, 0, 1)
         return Gam
 
-    def _mp2_lagrangian(self, Doo, Dvv, Gam) -> np.ndarray:
-        """Spin-adapted orbital-gradient Lagrangian ``I'_pq`` -- the closed-shell analogue
-        of :meth:`_so_mp2_lagrangian`. Same structure, with the two-electron 1-PDM term
-        written with the spin-adapted ``L`` (= H.L) in place of the antisymmetrized
-        ``<rp||sq>``, and the 2-PDM term with ``<pr|st>`` (= H.ERI) and cumulant ``Gamma``."""
-        o, v = self.o, self.v
-        nmo = self.no + self.nv
+    def _mp2_lagrangian(self, D, Gam) -> np.ndarray:
+        """Spin-adapted generalized-Fock Lagrangian ``I'_pq`` (``nmo x nmo``) from a
+        full-MO 1-PDM ``D`` and cumulant 2-PDM ``Gamma`` -- the closed-shell analogue of
+        :meth:`_so_mp2_lagrangian`, with the spin-adapted ``L`` (= H.L) in the two-electron
+        1-PDM term and ``<pr|st>`` (= H.ERI) with ``Gamma`` in the 2-PDM term. The 1-PDM
+        term's column index runs over the full occupied space ``ofull`` (= core + active),
+        so the frozen-core rows/columns are built (for ``nfzc=0`` this is the whole occupied
+        space). Used both for the orbital-gradient Lagrangian (from the unrelaxed ``D``) and
+        for the energy-weighted density ``W = I'(D_relaxed)``."""
+        nmo = self.nmo
+        ofull = slice(0, self.nfzc + self.no)
         ERI = np.asarray(self.H.ERI)
         L = np.asarray(self.H.L)
         eps = np.diag(np.asarray(self.H.F))
-        D = np.zeros((nmo, nmo))
-        D[o, o] = np.asarray(Doo)
-        D[v, v] = np.asarray(Dvv)
         termA = eps[:, None] * (D + D.T)
         termB = np.zeros((nmo, nmo))
-        termB[:, o] = (np.einsum('rs,rpsq->pq', D, L[:, :, :, o])
-                       + np.einsum('rs,rqsp->pq', D, L[:, o, :, :]))
+        termB[:, ofull] = (np.einsum('rs,rpsq->pq', D, L[:, :, :, ofull])
+                           + np.einsum('rs,rqsp->pq', D, L[:, ofull, :, :]))
         termC = 4.0 * np.einsum('prst,qrst->pq', ERI, Gam)
         return -0.5 * (termA + termB + termC)
 
-    def _mp2_zvector(self):
-        """Solve the spin-adapted MP2 Z-vector. Returns ``(Doo, Dvv, Gam, Ip, z)`` as for
-        :meth:`_so_mp2_zvector`; the orbital Hessian is the closed-shell singlet CPHF
-        (``H.L``), reached through the basis-aware ``self.cphf``."""
+    def _mp2_relaxed_densities(self):
+        """Spatial MP2 relaxed 1-PDM ``D_r`` (``nmo x nmo``), cumulant ``Gamma``, and
+        energy-weighted density ``W``, with the orbital response over the full occupied
+        space (frozen-core aware). Also returns the all-electron ``HFwfn`` whose CPHF
+        carries the response (reused for the SCF gradient).
+
+        The unrelaxed correlation density (``Doo``/``Dvv``) lives on the active blocks; the
+        orbital response spans the full occupied space:
+
+          * core <-> active-occupied: non-redundant for frozen-core MP2 (these rotations
+            move the frozen/active partition) but the HF energy is invariant to any
+            occupied-occupied rotation, so their orbital Hessian is just the orbital-energy
+            difference -- a direct divide ``P_co = (I'_ci - I'_ic)/(eps_c - eps_i)``, not a
+            CPHF solve;
+          * occupied <-> virtual (incl. core-virtual): the Z-vector ``A z = X`` over the
+            full ``ndocc x nv`` space, with ``P_co`` coupled into the right-hand side, solved
+            with the all-electron ``HFwfn`` CPHF (whose occupied space is the full ``ndocc``).
+
+        ``W = I'(D_r)`` is the Lagrangian evaluated at the relaxed density; its core-active
+        contribution reproduces the ``z_kc`` energy-weighted-density term. For ``nfzc=0`` the
+        core blocks are empty and this reduces to the all-electron relaxed density."""
+        from .hfwfn import HFwfn
+        nmo, nfzc, no = self.nmo, self.nfzc, self.no
         o, v = self.o, self.v
+        co = slice(0, nfzc)
+        ofull = slice(0, nfzc + no)
+        eps = np.diag(np.asarray(self.H.F))
+        L = np.asarray(self.H.L)
+
         Doo, Dvv = self._mp2_corr_opdm()
         Gam = self._mp2_cumulant()
-        Ip = self._mp2_lagrangian(Doo, Dvv, Gam)
-        X = Ip[o, v] - Ip[v, o].T
-        z = self.cphf.solve(X).T
-        return Doo, Dvv, Gam, Ip, z
+        D = np.zeros((nmo, nmo))
+        D[o, o] = np.asarray(Doo)
+        D[v, v] = np.asarray(Dvv)
+        Ip = self._mp2_lagrangian(D, Gam)
 
-    def _energy_weighted_opdm(self, Ip, z) -> np.ndarray:
-        """Spin-adapted MP2 energy-weighted density ``I_pq`` -- the closed-shell analogue
-        of :meth:`_so_energy_weighted_opdm`, with the spin-adapted ``L`` in the oo block."""
-        o, v = self.o, self.v
-        nmo = self.no + self.nv
-        L = np.asarray(self.H.L)
-        eps = np.diag(np.asarray(self.H.F))
-        I = np.zeros((nmo, nmo))
-        I[o, o] = (Ip[o, o] + np.einsum('ak,aikj->ij', z, L[v, o, o, o])
-                   + np.einsum('ak,ajki->ij', z, L[v, o, o, o]))
-        I[v, v] = Ip[v, v]
-        I[o, v] = Ip[o, v] + (z * eps[o][None, :]).T
-        I[v, o] = Ip[o, v].T + z * eps[o][None, :]
-        return I
+        if nfzc:
+            Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
+            D[co, o] = Pco
+            D[o, co] = Pco.T
+
+        hf = HFwfn(self.ref)
+        X = Ip[ofull, v] - Ip[v, ofull].T
+        if nfzc:
+            zjc = -Pco.T                                   # z_jc, active-occupied x core
+            X = X - (np.einsum('jc,ajic->ia', zjc, L[v, o, ofull, co])
+                     + np.einsum('jc,acij->ia', zjc, L[v, co, ofull, o]))
+        z = hf.cphf.solve(X).T
+        D[v, ofull] = -z
+        D[ofull, v] = -z.T
+
+        W = self._mp2_lagrangian(D, Gam)
+        return D, Gam, W, hf
 
     # ---- MP2 nuclear gradient ----
 
@@ -285,18 +315,17 @@ class MPwfn(Wavefunction):
                          + sum_pq I_pq S^X_pq
 
         with the relaxed 1-PDM ``D``, cumulant 2-PDM ``Gamma``, and energy-weighted density
-        ``I`` (Gauss/Stanton/Bartlett). This is the spin-adapted (closed-shell RHF) path:
-        the skeleton derivative integrals come from ``self.derivatives`` in the full spatial
-        MO basis (chemist ``(pq|rs)^X``, converted to physicist here) and ``f^X = h^X +
-        sum_m L[p,m,q,m]^X`` is the closed-shell skeleton Fock derivative (the spin-summed
-        densities carry no extra prefactor). The spin-orbital path is :meth:`_so_gradient`."""
+        ``W`` (Gauss/Stanton/Bartlett). This is the spin-adapted (closed-shell RHF) path,
+        frozen-core aware: the skeleton derivative integrals come from ``self.derivatives``
+        in the full spatial MO basis (chemist ``(pq|rs)^X``, converted to physicist here),
+        ``f^X = h^X + sum_m L[p,m,q,m]^X`` is the closed-shell skeleton Fock derivative with
+        ``m`` over the full occupied space (core + active), and the relaxed density/orbital
+        response span the full occupied space (:meth:`_mp2_relaxed_densities`). The
+        spin-orbital path is :meth:`_so_gradient`."""
         if self.orbital_basis == 'spinorbital':
             return self._so_gradient()
-        from .hfwfn import HFwfn
-        o = self.o
-        Doo, Dvv, Gam, Ip, z = self._mp2_zvector()
-        D = self.mp2_relaxed_opdm()
-        I = self._energy_weighted_opdm(Ip, z)
+        ofull = slice(0, self.nfzc + self.no)
+        D, Gam, W, hf = self._mp2_relaxed_densities()
 
         d = self.derivatives
         grad = np.zeros((d.natom, 3))
@@ -307,11 +336,11 @@ class MPwfn(Wavefunction):
             for c in range(3):
                 phys = ERIx[c].transpose(0, 2, 1, 3)  # -> physicist <pq|rs>^X
                 Lx = 2.0 * phys - phys.transpose(0, 1, 3, 2)
-                fx = hx[c] + np.einsum('pmqm->pq', Lx[:, o, :, o])  # closed-shell Fock deriv
+                fx = hx[c] + np.einsum('pmqm->pq', Lx[:, ofull, :, ofull])  # Fock deriv (full occ)
                 grad[atom, c] = (np.einsum('pq,pq->', D, fx)
                                  + np.einsum('pqrs,pqrs->', Gam, phys)
-                                 + np.einsum('pq,pq->', I, Sx[c]))
-        return HFwfn(self.ref).gradient() + grad
+                                 + np.einsum('pq,pq->', W, Sx[c]))
+        return hf.gradient() + grad
 
     def _so_gradient(self) -> np.ndarray:
         """Spin-orbital MP2 gradient: the antisymmetrized ``<pq||rs>^X`` from the

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -24,14 +24,14 @@ H 1 0.96 2 104.5
 """
 
 
-def _ff_corr_dipole(geom, basis, F=0.0005):
+def _ff_corr_dipole(geom, basis, F=0.0005, freeze_core='false'):
     """Relaxed correlation mu_z by a 5-point finite field of (E_MP2 - E_SCF)."""
     def e(model, Fz):
         psi4.core.clean()
         psi4.core.clean_options()
         psi4.geometry(geom)
         opt = {'basis': basis, 'scf_type': 'pk', 'mp2_type': 'conv',
-               'freeze_core': 'false', 'e_convergence': 1e-12, 'd_convergence': 1e-12}
+               'freeze_core': freeze_core, 'e_convergence': 1e-12, 'd_convergence': 1e-12}
         if Fz:
             opt.update({'perturb_h': True, 'perturb_with': 'dipole',
                         'perturb_dipole': [0.0, 0.0, Fz]})
@@ -44,12 +44,12 @@ def _ff_corr_dipole(geom, basis, F=0.0005):
     return mu('mp2') - mu('scf')
 
 
-def _pycc_corr_dipole(geom, basis, orbital_basis='spinorbital'):
+def _pycc_corr_dipole(geom, basis, orbital_basis='spinorbital', freeze_core='false'):
     """PyCC relaxed-MP2 electronic correlation mu_z (spin-orbital or spin-adapted)."""
     psi4.core.clean()
     psi4.core.clean_options()
     psi4.geometry(geom)
-    psi4.set_options({'basis': basis, 'scf_type': 'pk',
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': freeze_core,
                       'e_convergence': 1e-12, 'd_convergence': 1e-12})
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
@@ -132,3 +132,68 @@ def test_sa_mp2_gradient_ccpvdz():
     """Spin-adapted MP2 gradient vs Psi4, H2O/cc-pVDZ (C2v: polarization + A2-irrep MOs)."""
     assert np.max(np.abs(_pycc_gradient(WATER, 'cc-pVDZ', orbital_basis='spatial')
                          - _psi4_mp2_gradient(WATER, 'cc-pVDZ'))) < 1e-8
+
+
+# ---- frozen-core spin-adapted MP2 relaxed density and gradient ----
+# The orbital response spans the full occupied space: a core<->active-occupied direct
+# divide plus the occ-virtual Z-vector (with that coupling) over the full ndocc. The
+# ground-truth oracle is the finite difference of PyCC's own frozen-core MP2 energy --
+# Psi4's analytic frozen-core MP2 gradient is itself inconsistent with its energy at ~1e-5.
+
+WATER_XYZ = [("O", 0.0, 0.0, 0.0), ("H", 0.0, 0.0, 1.814), ("H", 1.755, 0.0, -0.46)]  # bohr
+
+
+def _fc_geom(disp=None):
+    g = [list(a) for a in WATER_XYZ]
+    if disp:
+        i, c, h = disp
+        g[i][1 + c] += h
+    return ("units bohr\nnocom\nnoreorient\n"
+            + "\n".join(f"{a[0]} {a[1]} {a[2]} {a[3]}" for a in g) + "\nsymmetry c1\n")
+
+
+def _fc_mp2_total_energy(disp, basis):
+    """PyCC total frozen-core MP2 energy (E_SCF + E_corr) at a displaced geometry."""
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(_fc_geom(disp))
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': 'true',
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    escf, wfn = psi4.energy('scf', return_wfn=True)
+    mp = pycc.MPwfn(wfn, orbital_basis='spatial')
+    return escf + mp.compute_energy()
+
+
+def test_fc_mp2_relaxed_dipole_631g():
+    """Frozen-core relaxed spin-adapted MP2 dipole (mu_z) vs a 5-point finite field of
+    (E_MP2 - E_SCF), H2O/6-31G (C1) -- validates the frozen-core relaxed 1-PDM (the
+    core-active divide and the full-occ Z-vector)."""
+    geom = WATER + "symmetry c1\n"
+    assert abs(_pycc_corr_dipole(geom, '6-31G', orbital_basis='spatial', freeze_core='true')
+               - _ff_corr_dipole(geom, '6-31G', freeze_core='true')) < 1e-8
+
+
+def test_fc_mp2_gradient_vs_energy_fd_631g():
+    """Frozen-core spin-adapted MP2 nuclear gradient vs a 5-point finite difference of
+    PyCC's own frozen-core MP2 total energy, H2O/6-31G (C1). This is the ground-truth
+    oracle for the analytic gradient (Psi4's analytic frozen-core MP2 gradient disagrees
+    with its own energy at ~7e-6, so it is *not* used here)."""
+    basis = '6-31G'
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(_fc_geom())
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': 'true',
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    mp = pycc.MPwfn(wfn, orbital_basis='spatial')
+    mp.compute_energy()
+    assert mp.nfzc > 0                                   # frozen core is actually active
+    gA = mp.gradient()
+
+    h = 2.0e-3
+    gF = np.zeros((3, 3))
+    for i in range(3):
+        for c in range(3):
+            e = [_fc_mp2_total_energy((i, c, k * h), basis) for k in (-2, -1, 1, 2)]
+            gF[i, c] = (e[0] - 8 * e[1] + 8 * e[2] - e[3]) / (12 * h)
+    assert np.max(np.abs(gA - gF)) < 1e-8


### PR DESCRIPTION
  # Frozen-core spin-adapted MP2 analytic gradient

  Makes the spatial (closed-shell RHF) MP2 nuclear gradient **frozen-core aware**. The
  all-electron case is simply `nfzc=0` — no separate branch. The unrelaxed correlation
  density stays on the active blocks, but the **orbital response spans the full occupied
  space**, leveraging PyCC's full-MO Hamiltonian integrals (`H.ERI`/`H.F` are full `nmo` for
  the spatial path).

  ## Physics
  
  ```
  * core <-> active-occupied: non-redundant for frozen-core MP2 (these rotations move the
    frozen/active partition, so the MP2 energy responds) but the HF energy is invariant to
    occ-occ rotations -> orbital Hessian = orbital-energy difference -> a DIRECT DIVIDE
        P_co = (I'_ci - I'_ic) / (eps_c - eps_i)        (not a CPHF solve)

  * occupied <-> virtual (incl. core-virtual): the Z-vector over the full ndocc x nv space,
    with P_co coupled into the RHS
        X_ai -= sum_jc [ <aj||ic> + <ac||ij> ] z_jc
    solved with the all-electron HFwfn(ref).cphf (its occupied space is the full ndocc)

  * W = I'(D_r): the Lagrangian at the relaxed density supplies the core-active
    energy-weighted-density (z_kc) term automatically; f^X sums m over the full occupied space
  ```

  ## Refactor (`pycc/mpwfn.py`)
  
  - `_mp2_cumulant` / `_mp2_lagrangian` work over the full `nmo`; `_mp2_lagrangian` takes a
    full-MO `D` with the 1-PDM term's column over the full occupied space.
  - `_mp2_zvector` + `_energy_weighted_opdm` → consolidated into `_mp2_relaxed_densities`.
  - `gradient` sums `f^X` over the full occupied space and reuses the `HFwfn`.
  - Spin-orbital path **unchanged** (its Hamiltonian is active-only, so frozen-core SO stays
    deferred).

  ## Validation (`test_061`, H2O/6-31G C1)

  - frozen-core relaxed dipole vs a 5-point finite field — `< 1e-8`;
  - gradient vs a **5-point finite difference of PyCC's own frozen-core MP2 energy** — `< 1e-8`.

  The energy finite-difference is the ground-truth oracle here: **Psi4's *analytic* frozen-core
  MP2 gradient is itself inconsistent with its *own energy's* finite difference at ~7e-6**, so
  it is deliberately not used as the oracle (vs. the all-electron tests, which still check
  against `psi4.gradient('mp2')`). Full non-slow suite: **132 passed**, 3 skipped, 1 xfailed.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
