### PR TITLE
Full-MO spin-orbital Hamiltonian + frozen-core spin-orbital MP2 gradient

### DIFF
--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -112,7 +112,7 @@ on `MPwfn` (MP2-specific, per the decision above).
 
 ## Status / progress
 
-_Last updated 2026-06-22._
+_Last updated 2026-06-23._
 
 | Phase | Status | Landed |
 |---|---|---|
@@ -121,7 +121,8 @@ _Last updated 2026-06-22._
 | C — **spin-orbital** relaxed density (GSB Lagrangian + Z-vector) | ✅ done | this branch |
 | D — **spin-orbital** gradient assembly (keystone) | ✅ done | this branch |
 | **spin-adapted** (closed-shell RHF) MP2 gradient | ✅ done | merged |
-| **frozen-core** spin-adapted MP2 gradient | ✅ done | `feature/mp2-frozen-core-gradient` |
+| **frozen-core** spin-adapted MP2 gradient | ✅ done | merged (#158) |
+| **full-MO spin-orbital Hamiltonian** + **frozen-core SO MP2 gradient** + triples audit | ✅ done | `feature/spinorbital-fc-gradient` |
 
 Phase D (SO): `MPwfn.gradient()` assembles the MP2 analytic nuclear gradient
 
@@ -178,10 +179,29 @@ gradient vs a **5-point finite difference of PyCC's own frozen-core MP2 energy**
 (the ground-truth oracle -- Psi4's *analytic* frozen-core MP2 gradient is itself inconsistent
 with its *own energy's* finite difference at ~7e-6, so it is not used as the oracle).
 
+**Frozen-core spin-orbital MP2 gradient + full-MO Hamiltonian consistency -- DONE.** The
+spin-orbital Hamiltonian is now built over the **full MO space** (frozen core included),
+mirroring the spatial path: `_init_spinorbital` orders the spin orbitals
+`[a-core, b-core, a-occ, b-occ, a-vir, b-vir]` with `co`/`o`/`v` slices skipping the core
+(`nfzc=0` is byte-identical to before). This gives the spin-orbital gradient its
+core-virtual/core-active response integrals; the recipe (core-active divide, full-occ
+Z-vector with the `z_jc` coupling, `W = I'(D_r)`) then applies **literally** in the
+spin-orbital basis (no spin-adaptation), with the full-occupied orbital Hessian built
+inline. Validated (`test_061`): keystone **SO == spatial** frozen-core gradient to ~1e-16,
+plus the SO relaxed dipole.
+
+The full-MO spin-orbital Hamiltonian exposed a latent **`occ-starts-at-0`** assumption in
+the correlated triples kernels (they indexed the Hamiltonian/perturbation with loop
+variables, e.g. `ERI[j,k,v,v]`, `pert[k,v]`, valid only when the active occupied began at
+index 0). Audited and fixed across the (T), CC3 T-residual/Λ/response, and the `pertbar`
+`[A,T3]` term -- each made relative to the `o`/`v` slices (behavior-preserving for
+`nfzc=0`). Validated: frozen-core UCCSD(T) (`test_005`), frozen-core CC3 energy + Λ
+keystones vs Psi4 (`test_031`), and frozen-core CC3 polarizability vs a finite field of the
+CC3 energy (`test_059`).
+
 Next: the MP2 property path (APT / Hessian) or CC gradients (swap the densities; the
 Z-vector + assembly carry over). Frozen-core CC gradients reuse the same full-occ response
-machinery. The spin-orbital frozen-core gradient remains deferred (its Hamiltonian is
-active-only, so it lacks the core integrals the response needs).
+machinery, now available on both the spatial and spin-orbital paths.
 
 The original spatial Phases A (`MPwfn.cphf` access to the CPHF Z-vector solver) and B (the
 spatial MP2 `Doo`/`Dvv` and `oovv` 2-PDM in the `l2 = 2u` convention) were committed while

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -294,8 +294,8 @@ class cclambda(object):
                 for j in range(no):
                     for k in range(no):
                         t3 = t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
-                        Zijal[i,j] -= 0.5 * contract('abc,lbc->al', t3, ERI[o,k,v,v])
-                        Ziabd[i] -= 0.5 * contract('abc,dc->abd', t3, ERI[j,k,v,v])
+                        Zijal[i,j] -= 0.5 * contract('abc,lbc->al', t3, ERI[o,o,v,v][:,k])
+                        Ziabd[i] -= 0.5 * contract('abc,dc->abd', t3, ERI[o,o,v,v][j,k])
 
         return {'Fov': Fov, 'Woooo': Woooo, 'Wovoo': Wovoo, 'Wooov': Wooov,
                 'Wvovv': Wvovv, 'Wvvvo': Wvvvo, 'Wvvvv': Wvvvv, 'Wovvo': Wovvo,
@@ -345,7 +345,7 @@ class cclambda(object):
 
                     # <0|L3 [[H~,T2],nu1]|0> -> L1
                     Ziabe[i] += 0.5 * contract('abc,ec->abe', l3, t2[j,k])
-                    Zijam[i,j] += 0.5 * contract('abc,mbc->am', l3, t2[o,k])
+                    Zijam[i,j] += 0.5 * contract('abc,mbc->am', l3, t2[:,k])
 
                     # <0|L3 [H~,nu2]|0> -> L2
                     Y2[i,j] += 0.5 * contract('abc,bcd->ad', l3, Wvvvo[:,:,:,k])
@@ -482,10 +482,10 @@ class cclambda(object):
                     if real_time is True:
                         V = F - clone(self.ccwfn.H.F)
                         t3_lmn -= t3_pert_ijk(o, v, l, m, n, t2, V, F, contract)
-                    Zmndi[m,n] += contract('def,ief->di', t3_lmn, ERI[o,l,v,v])
-                    Zmndi[m,n] -= contract('fed,ief->di', t3_lmn, L[o,l,v,v])
-                    Zmdfa[m] += contract('def,ea->dfa', t3_lmn, ERI[n,l,v,v])
-                    Zmdfa[m] -= contract('dfe,ea->dfa', t3_lmn, L[n,l,v,v])
+                    Zmndi[m,n] += contract('def,ief->di', t3_lmn, ERI[o,o,v,v][:,l])
+                    Zmndi[m,n] -= contract('fed,ief->di', t3_lmn, L[o,o,v,v][:,l])
+                    Zmdfa[m] += contract('def,ea->dfa', t3_lmn, ERI[o,o,v,v][n,l])
+                    Zmdfa[m] -= contract('dfe,ea->dfa', t3_lmn, L[o,o,v,v][n,l])
 
         return {'Fov': Fov, 'Woooo': Woooo, 'Wovoo': Wovoo, 'Wooov': Wooov,
                 'Wvovv': Wvovv, 'Wvvvo': Wvvvo, 'Wovov': Wovov, 'Wovvo': Wovvo,
@@ -562,7 +562,7 @@ class cclambda(object):
                     Znf[n] += contract('de,def->f', l2[l,m], (t3_lmn - t3_lmn.swapaxes(0,2)))
         for m in range(no):
             Y1 += contract('idf,dfa->ia', l2[:,m], Zmdfa[m])
-            Y1 += contract('iaf,f->ia', L[o,m,v,v], Znf[m])
+            Y1 += contract('iaf,f->ia', L[o,o,v,v][:,m], Znf[m])
             for n in range(no):
                 Y1 += contract('ad,di->ia', l2[m,n], Zmndi[m,n,:,:])
         # end of t3l1

--- a/pycc/ccresponse.py
+++ b/pycc/ccresponse.py
@@ -406,8 +406,8 @@ class ccresponse(object):
             for j in range(no):
                 for k in range(no):
                     t3 = t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
-                    Yoovo[i,j] -= 0.5 * contract('abc,lbc->al', t3, ERI[o,k,v,v])
-                    Yovvv[i] -= 0.5 * contract('abc,dc->abd', t3, ERI[j,k,v,v])
+                    Yoovo[i,j] -= 0.5 * contract('abc,lbc->al', t3, ERI[o,o,v,v][:,k])
+                    Yovvv[i] -= 0.5 * contract('abc,dc->abd', t3, ERI[o,o,v,v][j,k])
         Zovoo = 0.5 * contract('ld,jkdc->lcjk', pertbar.Aov, t2)
         Zvvvo = -0.5 * contract('ld,lkbc->bcdk', pertbar.Aov, t2)
 
@@ -470,7 +470,7 @@ class ccresponse(object):
                     x3 += t3c_ijk_so(o, v, i, j, k, t2, Zvvvo+Zbcdk, Zovoo+Zlcjk, F, contract, omega)
                     x3 += t3c_ijk_so(o, v, i, j, k, X2, Wvvvo, Wovoo, F, contract, omega)
 
-                    z1[i] += 0.25 * contract('abc,bc->a', x3, ERI[j,k,v,v])
+                    z1[i] += 0.25 * contract('abc,bc->a', x3, ERI[o,o,v,v][j,k])
                     z2[i,j] += contract('abc,c->ab', x3, hbar.Hov[k])
                     tmp = 0.5 * contract('abc,dbc->ad', x3, hbar.Hvovv[:,k,:,:])
                     z2[i,j] += tmp - tmp.swapaxes(0,1)
@@ -492,7 +492,7 @@ class ccresponse(object):
                              - (vir[a] + vir[b] + vir[c]))
                     x3 = x3/denom
 
-                    y1[a] += 0.25 * contract('ijk,jk->i', x3, ERI[o,o,b+no,c+no])
+                    y1[a] += 0.25 * contract('ijk,jk->i', x3, ERI[o,o,v,v][:,:,b,c])
                     y2[a,b] += contract('ijk,k->ij', x3, hbar.Hov[:,c])
                     tmp = -0.5 * contract('ijk,jkl->il', x3, hbar.Hooov[:,:,:,c])
                     y2[a,b] += tmp - tmp.swapaxes(0,1)
@@ -1863,7 +1863,7 @@ class pertbar(object):
                     for j in range(no):
                         for k in range(no):
                             t3 = t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
-                            self.Avvoo[i,j] += contract('c,abc->ab', pert[k,v], t3)
+                            self.Avvoo[i,j] += contract('c,abc->ab', pert[o,v][k], t3)
             return
 
         self.Aov = pert[o,v].copy()

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -782,19 +782,27 @@ def t_vikings_so(o, v, t1, t2, F, ERI, contract):
     no = t1.shape[0]
     Wvvvo = ERI[v,v,v,o]
     Wovoo = ERI[o,v,o,o]
+    # Pre-slice the integrals to the active occupied space, so the (i,j,k,l) loop indices
+    # are relative to it. The spin-orbital Hamiltonian is full-MO (frozen core included);
+    # under frozen core the active occupied does not start at index 0, so the loop indices
+    # must not be used as absolute Hamiltonian indices.
+    Woovv = ERI[o,o,v,v]
+    Wvovv = ERI[v,o,v,v]
+    Wooov = ERI[o,o,o,v]
+    Fov = F[o,v]
 
     for i in range(no):
         for j in range(no):
             for k in range(no):
                 t3 = t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
-                x1[i] += 0.25 * contract('bc,abc->a', ERI[j,k,v,v], t3)
+                x1[i] += 0.25 * contract('bc,abc->a', Woovv[j,k], t3)
                 # Occ-vir Fock term (cf. the CC3 Fme[k] term): nonzero only for a
                 # non-canonical (semicanonical ROHF) reference, where f_kc != 0.
-                x2[i,j] += contract('c,abc->ab', F[k,v], t3)
-                tmp = 0.5 * contract('dbc,abc->ad', ERI[v,k,v,v], t3)
+                x2[i,j] += contract('c,abc->ab', Fov[k], t3)
+                tmp = 0.5 * contract('dbc,abc->ad', Wvovv[:,k], t3)
                 x2[i,j] += tmp - tmp.swapaxes(0,1)
                 for l in range(no):
-                    tmp = 0.5 * contract('c,abc->ab', ERI[j,k,l,v], t3)
+                    tmp = 0.5 * contract('c,abc->ab', Wooov[j,k,l], t3)
                     x2[i,l] -= tmp
                     x2[l,i] += tmp
 

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -398,7 +398,7 @@ class CCwfn(Wavefunction):
                         V = F - clone(self.H.F)
                         t3 -= t3_pert_ijk(o, v, i, j, k, t2, V, F, contract)
 
-                    X1[i] += contract('abc,bc->a', t3 - t3.swapaxes(0,2), L[j,k,v,v])
+                    X1[i] += contract('abc,bc->a', t3 - t3.swapaxes(0,2), L[o,o,v,v][j,k])
 
                     X2[i,j] += contract('abc,dbc->ad', 2 * t3 - t3.swapaxes(1,2) - t3.swapaxes(0,2), Wamef_cc3.swapaxes(0,1)[k])
                     X2[i] -= contract('lc,abc->lab', Wmnie_cc3[j,k], (2 * t3 - t3.swapaxes(1,2) - t3.swapaxes(0,2)))
@@ -1195,7 +1195,7 @@ class CCwfn(Wavefunction):
             for j in range(no):
                 for k in range(no):
                     t3 = t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
-                    x1[i] += 0.25 * contract('bc,abc->a', ERI[j,k,v,v], t3)
+                    x1[i] += 0.25 * contract('bc,abc->a', ERI[o,o,v,v][j,k], t3)
                     x2[i,j] += contract('c,abc->ab', Fme[k], t3)
                     tmp = 0.5 * contract('dbc,abc->ad', Wvovv[:,k,:,:], t3)
                     x2[i,j] += tmp - tmp.swapaxes(0,1)
@@ -1302,9 +1302,9 @@ class CCwfn(Wavefunction):
                     Y3 = 8*N3 - 4*N3.swapaxes(0,1) - 4*N3.swapaxes(1,2) - 4*N3.swapaxes(0,2) + 2*np.moveaxis(N3, 0, 2) + 2*np.moveaxis(N3, 2, 0)
 
                     # Doubles contribution (T) correction (Viking's formulation)
-                    X2[i,j] += contract('abc,c->ab',(M3 - M3.swapaxes(0,2)), F[k,v])
-                    X2[i,j] += contract('abc,dbc->ad', (2*M3 - M3.swapaxes(1,2) - M3.swapaxes(0,2)),ERI[v,k,v,v])
-                    X2[i] -= contract('abc,lc->lab', (2*M3 - M3.swapaxes(1,2) - M3.swapaxes(0,2)),ERI[j,k,o,v])
+                    X2[i,j] += contract('abc,c->ab',(M3 - M3.swapaxes(0,2)), F[o,v][k])
+                    X2[i,j] += contract('abc,dbc->ad', (2*M3 - M3.swapaxes(1,2) - M3.swapaxes(0,2)),ERI[v,o,v,v][:,k])
+                    X2[i] -= contract('abc,lc->lab', (2*M3 - M3.swapaxes(1,2) - M3.swapaxes(0,2)),ERI[o,o,o,v][j,k])
 
                     # (T) contribution to vir-vir block of one-electron density
                     Dvv += 0.5 * contract('acd,bcd->ab', M3, (X3 + Y3))
@@ -1319,10 +1319,10 @@ class CCwfn(Wavefunction):
                     Gvvvo[:,:,:,j] += contract('abc,cd->abd', (2*X3 + Y3), t2[k,i,:,:])
 
                     # (T) contribution to Lambda_1 residual
-                    S1[i] += contract('abc,bc->a', 2*(M3 - M3.swapaxes(0,1)), L[j,k,v,v])
+                    S1[i] += contract('abc,bc->a', 2*(M3 - M3.swapaxes(0,1)), L[o,o,v,v][j,k])
                     # (T) contribution to Lambda_2 residual
-                    S2[i] -= contract('abc,lc->lab', (2*X3 + Y3), ERI[j,k,o,v])
-                    S2[i,j] += contract('abc,dcb->ad', (2*X3 + Y3), ERI[k,v,v,v])
+                    S2[i] -= contract('abc,lc->lab', (2*X3 + Y3), ERI[o,o,o,v][j,k])
+                    S2[i,j] += contract('abc,dcb->ad', (2*X3 + Y3), ERI[o,v,v,v][k])
 
         S2 = S2 + S2.swapaxes(0,1).swapaxes(2,3)
 

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -116,89 +116,112 @@ class MPwfn(Wavefunction):
     def _so_mp2_cumulant(self) -> np.ndarray:
         """Spin-orbital MP2 cumulant 2-PDM ``Gamma_ijab = 1/4 t2`` in the ``oovv``/``vvoo``
         blocks -- the only blocks that contribute (determined from the MP2 energy
-        Lagrangian, in which Lambda and T2 enter linearly)."""
+        Lagrangian, in which Lambda and T2 enter linearly). Built over the full MO space
+        (``self.nmo``); the active ``o``/``v`` slices place the amplitudes."""
         o, v = self.o, self.v
-        nmo = self.no + self.nv
+        nmo = self.nmo
         t2 = np.asarray(self.t2)
         Gam = np.zeros((nmo, nmo, nmo, nmo))
         Gam[o, o, v, v] = 0.25 * t2
         Gam[v, v, o, o] = 0.25 * t2.transpose(2, 3, 0, 1)
         return Gam
 
-    def _so_mp2_lagrangian(self, Doo, Dvv, Gam) -> np.ndarray:
-        """Spin-orbital orbital-gradient Lagrangian matrix ``I'_pq`` (``nmo x nmo``)
+    def _so_mp2_lagrangian(self, D, Gam) -> np.ndarray:
+        """Spin-orbital generalized-Fock Lagrangian ``I'_pq`` (``nmo x nmo``) from a full-MO
+        1-PDM ``D`` and cumulant 2-PDM ``Gamma``
 
             I'_pq = -1/2 [ f_pp (D_pq + D_qp)
-                           + delta_{q,occ} sum_rs D_rs (<rp||sq> + <rq||sp>)
+                           + delta_{q in ofull} sum_rs D_rs (<rp||sq> + <rq||sp>)
                            + 4 sum_rst <pr||st> Gamma_qrst ]
 
-        from the correlation 1-PDM ``D`` (Doo/Dvv) and cumulant 2-PDM ``Gamma``. Its
-        occupied-virtual antisymmetric part ``X_ai = I'_ia - I'_ai`` is the Z-vector RHS."""
-        o, v = self.o, self.v
-        nmo = self.no + self.nv
+        The 1-PDM term's column index runs over the full occupied space ``ofull`` (= core +
+        active), so the frozen-core rows/columns are built (for ``nfzc=0`` this is the whole
+        occupied space). Its occupied-virtual antisymmetric part ``X_ai = I'_ia - I'_ai`` is
+        the Z-vector RHS; evaluated at the relaxed ``D`` it is the energy-weighted density."""
+        nmo = self.nmo
+        ofull = slice(0, self.o.stop)
         ERI = np.asarray(self.H.ERI)
         eps = np.diag(np.asarray(self.H.F))
-        D = np.zeros((nmo, nmo))
-        D[o, o] = np.asarray(Doo)
-        D[v, v] = np.asarray(Dvv)
         termA = eps[:, None] * (D + D.T)                       # f_pp (D_pq + D_qp)
-        termB = np.zeros((nmo, nmo))                           # only q in occ
-        termB[:, o] = (np.einsum('rs,rpsq->pq', D, ERI[:, :, :, o])
-                       + np.einsum('rs,rqsp->pq', D, ERI[:, o, :, :]))
+        termB = np.zeros((nmo, nmo))
+        termB[:, ofull] = (np.einsum('rs,rpsq->pq', D, ERI[:, :, :, ofull])
+                           + np.einsum('rs,rqsp->pq', D, ERI[:, ofull, :, :]))
         termC = 4.0 * np.einsum('prst,qrst->pq', ERI, Gam)
         return -0.5 * (termA + termB + termC)
 
-    def _so_mp2_zvector(self):
-        """Solve the spin-orbital MP2 Z-vector. Returns ``(Doo, Dvv, Gam, Ip, z)``: the
-        correlation densities, the cumulant 2-PDM, the Lagrangian ``I'_pq``, and the
-        orbital relaxation ``z_ai`` (``A z = X``, ``X_ai = I'_ia - I'_ai``, via the
-        basis-aware CPHF orbital Hessian on ``self.cphf``)."""
+    def _so_mp2_relaxed_densities(self):
+        """Spin-orbital MP2 relaxed 1-PDM ``D_r`` (``nmo x nmo``), cumulant ``Gamma``, and
+        energy-weighted density ``W``, with the orbital response over the full occupied space
+        (frozen-core aware) -- the spin-orbital analog of :meth:`_mp2_relaxed_densities`.
+        With the antisymmetrized ``<pq||rs>`` the frozen-core recipe applies directly (no
+        spin-adaptation):
+
+          * core <-> active-occupied: a direct divide ``P_co = (I'_ci - I'_ic)/(eps_c -
+            eps_i)`` (the HF energy is invariant to occupied-occupied rotations, so the
+            orbital Hessian is the orbital-energy difference);
+          * occupied <-> virtual (incl. core-virtual): the Z-vector ``A z = X`` over the full
+            ``ndocc x nv`` space, with ``P_co`` coupled into the RHS
+            (``X_ai -= sum_jc[<aj||ic> + <ac||ij>] z_jc``).
+
+        The Z-vector uses the full-occupied spin-orbital orbital Hessian, built here (the
+        active-space CPHF is ``self.cphf``; there is no all-electron spin-orbital HFwfn to
+        borrow it from, as the spatial path does). ``W = I'(D_r)``. For ``nfzc=0`` the core
+        blocks are empty and this reduces to the all-electron relaxed density."""
         if self.orbital_basis != 'spinorbital':
             raise NotImplementedError(
-                "The MP2 relaxed gradient is implemented for the spin-orbital path.")
-        o, v = self.o, self.v
+                "The spin-orbital MP2 relaxed gradient requires the spin-orbital path.")
+        if self.cphf.is_rohf:
+            raise NotImplementedError(
+                "The spin-orbital MP2 gradient is not implemented for ROHF references "
+                "(the semicanonical response does not reproduce the restricted ROHF "
+                "response). RHF and UHF are supported.")
+        nmo, nfzc, nv = self.nmo, self.nfzc, self.nv
+        o, v, co = self.o, self.v, self.co
+        ofull = slice(0, o.stop)
+        nof = o.stop
+        eps = np.diag(np.asarray(self.H.F))
+        ERI = np.asarray(self.H.ERI)
+
         Doo, Dvv = self._so_mp2_corr_opdm()
         Gam = self._so_mp2_cumulant()
-        Ip = self._so_mp2_lagrangian(Doo, Dvv, Gam)
-        X = Ip[o, v] - Ip[v, o].T              # (no, nv), X[i,a] = I'_ia - I'_ai
-        z = self.cphf.solve(X).T               # (nv, no), z_ai
-        return Doo, Dvv, Gam, Ip, z
-
-    def mp2_relaxed_opdm(self) -> np.ndarray:
-        """Relaxed MP2 one-particle correlation density (``nmo x nmo``): the unrelaxed
-        ``Doo``/``Dvv`` plus the orbital-relaxation blocks from the Z-vector solve.
-        Dispatches on ``orbital_basis``; the spin-adapted closed-shell path is frozen-core
-        aware (:meth:`_mp2_relaxed_densities`)."""
-        if self.orbital_basis != 'spinorbital':
-            D, Gam, W, hf = self._mp2_relaxed_densities()
-            return D
-        o, v = self.o, self.v
-        nmo = self.no + self.nv
-        Doo, Dvv, Gam, Ip, z = self._so_mp2_zvector()
         D = np.zeros((nmo, nmo))
         D[o, o] = np.asarray(Doo)
         D[v, v] = np.asarray(Dvv)
-        D[v, o] = -z
-        D[o, v] = -z.T
+        Ip = self._so_mp2_lagrangian(D, Gam)
+
+        if nfzc:
+            Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
+            D[co, o] = Pco
+            D[o, co] = Pco.T
+
+        X = Ip[ofull, v] - Ip[v, ofull].T
+        if nfzc:
+            zjc = -Pco.T                                   # z_jc, active-occupied x core
+            X = X - (np.einsum('jc,ajic->ia', zjc, ERI[v, o, ofull, co])
+                     + np.einsum('jc,acij->ia', zjc, ERI[v, co, ofull, o]))
+
+        # Full-occupied spin-orbital orbital Hessian A_{ia,jb} = <aj||ib> + <ab||ij>
+        # + (eps_a - eps_i) delta; solve A z = X over the full ndocc x nv space.
+        G = (np.einsum('ajib->iajb', ERI[v, ofull, ofull, v])
+             + np.einsum('abij->iajb', ERI[v, v, ofull, ofull])).reshape(nof * nv, nof * nv)
+        G[np.diag_indices(nof * nv)] += (eps[v][None, :] - eps[ofull][:, None]).reshape(-1)
+        z = np.linalg.solve(G, X.reshape(-1)).reshape(nof, nv).T
+        D[v, ofull] = -z
+        D[ofull, v] = -z.T
+
+        W = self._so_mp2_lagrangian(D, Gam)
+        return D, Gam, W
+
+    def mp2_relaxed_opdm(self) -> np.ndarray:
+        """Relaxed MP2 one-particle correlation density (``nmo x nmo``): the unrelaxed
+        ``Doo``/``Dvv`` plus the orbital-relaxation blocks from the Z-vector solve. Both the
+        spin-orbital and spin-adapted closed-shell paths are frozen-core aware
+        (:meth:`_so_mp2_relaxed_densities` / :meth:`_mp2_relaxed_densities`)."""
+        if self.orbital_basis == 'spinorbital':
+            D, Gam, W = self._so_mp2_relaxed_densities()
+        else:
+            D, Gam, W, hf = self._mp2_relaxed_densities()
         return D
-
-    def _so_energy_weighted_opdm(self, Ip, z) -> np.ndarray:
-        """Spin-orbital MP2 energy-weighted density ``I_pq`` (the gradient's overlap-
-        derivative weight), from the Lagrangian ``I'`` and the Z-vector (GSB notes):
-
-            I_ij = I'_ij + sum_ak z_ak (<ai||kj> + <aj||ki>),   I_ab = I'_ab,
-            I_ia = I_ai = I'_ia + z_ai eps_i."""
-        o, v = self.o, self.v
-        nmo = self.no + self.nv
-        ERI = np.asarray(self.H.ERI)
-        eps = np.diag(np.asarray(self.H.F))
-        I = np.zeros((nmo, nmo))
-        I[o, o] = (Ip[o, o] + np.einsum('ak,aikj->ij', z, ERI[v, o, o, o])
-                   + np.einsum('ak,ajki->ij', z, ERI[v, o, o, o]))
-        I[v, v] = Ip[v, v]
-        I[o, v] = Ip[o, v] + (z * eps[o][None, :]).T
-        I[v, o] = Ip[o, v].T + z * eps[o][None, :]
-        return I
 
     # ---- spin-adapted (closed-shell RHF) MP2 relaxed-gradient densities ----
     # The closed-shell analogue of the spin-orbital densities: the spin sum is carried by
@@ -345,12 +368,11 @@ class MPwfn(Wavefunction):
     def _so_gradient(self) -> np.ndarray:
         """Spin-orbital MP2 gradient: the antisymmetrized ``<pq||rs>^X`` from the
         spin-orbital ``self.derivatives.so_*`` (semicanonical gauge), ``f^X = h^X +
-        sum_m <pm||qm>^X``."""
+        sum_m <pm||qm>^X`` with ``m`` over the full occupied space (frozen-core aware;
+        :meth:`_so_mp2_relaxed_densities`)."""
         from .hfwfn import HFwfn
-        o = self.o
-        Doo, Dvv, Gam, Ip, z = self._so_mp2_zvector()
-        D = self.mp2_relaxed_opdm()
-        I = self._so_energy_weighted_opdm(Ip, z)
+        ofull = slice(0, self.o.stop)
+        D, Gam, W = self._so_mp2_relaxed_densities()
 
         d = self.derivatives
         grad = np.zeros((d.natom, 3))
@@ -359,8 +381,8 @@ class MPwfn(Wavefunction):
             Sx = d.so_overlap(atom)
             ERIx = d.so_eri(atom)
             for c in range(3):
-                fx = hx[c] + np.einsum('pmqm->pq', ERIx[c][:, o, :, o])  # skeleton Fock deriv
+                fx = hx[c] + np.einsum('pmqm->pq', ERIx[c][:, ofull, :, ofull])  # Fock deriv (full occ)
                 grad[atom, c] = (np.einsum('pq,pq->', D, fx)
                                  + np.einsum('pqrs,pqrs->', Gam, ERIx[c])
-                                 + np.einsum('pq,pq->', I, Sx[c]))
+                                 + np.einsum('pq,pq->', W, Sx[c]))
         return HFwfn(self.ref).gradient() + grad

--- a/pycc/tests/test_031_cc3.py
+++ b/pycc/tests/test_031_cc3.py
@@ -89,6 +89,42 @@ def test_so_cc3_lambda_equals_spatial_rhf(rhf_wfn):
     assert abs(l_so - l_spatial) < 1e-10
 
 
+def test_so_cc3_equals_spatial_rhf_frzc(rhf_wfn):
+    """Frozen-core CC3 (closed shell): spin-orbital reproduces spin-adapted spatial, and
+    both match Psi4's CC3. Validates the frozen-core triples indexing -- the spin-orbital
+    Hamiltonian is now full-MO (the active occupied no longer starts at index 0), so the
+    triples kernels must slice the Hamiltonian (``ERI[o,o,v,v][j,k]``) rather than index it
+    with loop variables (``ERI[j,k,v,v]``)."""
+    wfn = rhf_wfn("H2O", "STO-3G", freeze_core="true",
+                  e_convergence=1e-12, d_convergence=1e-12)
+
+    e_spatial = pycc.CCwfn(wfn, model="CC3").solve_cc(e_conv=1e-11, r_conv=1e-11)
+
+    so = pycc.CCwfn(wfn, model="CC3", orbital_basis="spinorbital")
+    assert so.orbital_basis == "spinorbital" and so.nfzc > 0
+    e_so = so.solve_cc(e_conv=1e-11, r_conv=1e-11)
+
+    assert abs(e_so - e_spatial) < 1e-10
+    psi4.energy('cc3')
+    assert abs(e_spatial - psi4.variable('CC3 CORRELATION ENERGY')) < 1e-10
+
+
+def test_so_cc3_lambda_equals_spatial_rhf_frzc(rhf_wfn):
+    """Frozen-core CC3 Lambda (closed shell): spin-orbital reproduces spin-adapted spatial
+    -- keystone for the frozen-core CC3 Lambda triples indexing."""
+    wfn = rhf_wfn("H2O", "STO-3G", freeze_core="true",
+                  e_convergence=1e-12, d_convergence=1e-12)
+
+    def _lcc(basis):
+        cc = pycc.CCwfn(wfn, model="CC3", orbital_basis=basis)
+        cc.solve_cc(e_conv=1e-11, r_conv=1e-11)
+        hbar = pycc.cchbar(cc)
+        lam = pycc.cclambda(cc, hbar)
+        return lam.solve_lambda(e_conv=1e-11, r_conv=1e-11)
+
+    assert abs(_lcc("spinorbital") - _lcc("spatial")) < 1e-10
+
+
 def test_ucc3_oh(uhf_wfn):
     """Open-shell .OH 6-31G, all-electron UCC3 vs Psi4's UCC3."""
     wfn = uhf_wfn(OH, "6-31G", freeze_core="false",
@@ -102,8 +138,11 @@ def test_ucc3_oh(uhf_wfn):
     ref = psi4.variable('CC3 CORRELATION ENERGY')
 
     assert abs(ecc3 - ref) < 1e-10
-    # Frozen-core UCC3 is intentionally not retested here: the spin-orbital
-    # frozen-core active space is already validated by the MP2/CCSD/CCSD(T)
-    # frozen-core tests (CC3 reuses the same o/v slicing), and the iterative CC3
-    # solve is the costliest in the suite.
+    # Frozen-core CC3 is validated on a closed shell by
+    # test_so_cc3_equals_spatial_rhf_frzc / _lambda_frzc (energy and Lambda, vs Psi4 and
+    # the spin-orbital==spatial keystone). The full-MO spin-orbital Hamiltonian means the
+    # active occupied no longer starts at index 0, so the triples kernels slice the
+    # Hamiltonian rather than indexing it with loop variables. Open-shell frozen-core UCC3
+    # is not separately retested (same triples indexing; the iterative CC3 solve is the
+    # costliest in the suite), and frozen-core UCCSD(T) is covered by test_005.
 

--- a/pycc/tests/test_059_cc3_response.py
+++ b/pycc/tests/test_059_cc3_response.py
@@ -84,6 +84,46 @@ def test_cc3_polarizability_zz():
     assert abs(alpha_zz - DALTON_POLAR[2, 2]) < 1e-6
 
 
+def test_cc3_polarizability_zz_frzc():
+    """Frozen-core CC3 static polarizability alpha_zz vs a 5-point finite field of the
+    frozen-core CC3 energy. Validates the frozen-core CC3 *response* triples: with the
+    full-MO spin-orbital Hamiltonian the perturbation operator must be sliced to the active
+    space (``pert[o,v][k]``) before being indexed by occupied loop variables -- otherwise
+    the [A,T3] contribution to Avvoo hits the frozen core. The finite-field oracle is sound
+    here because the field's [V,T3] coupling (T3 solve, store_triples) slices V the same way."""
+    psi4.core.clean()
+    psi4.core.be_quiet()
+    psi4.geometry(H2O)
+    psi4.set_options({'basis': 'STO-3G', 'scf_type': 'pk', 'mp2_type': 'conv',
+                      'freeze_core': 'true', 'reference': 'rhf',
+                      'e_convergence': 1e-13, 'd_convergence': 1e-13, 'r_convergence': 1e-13})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+
+    # analytic static (omega=0) alpha_zz
+    cc = pycc.CCwfn(wfn, model='CC3', orbital_basis='spinorbital', store_triples=True)
+    assert cc.nfzc > 0
+    cc.solve_cc(e_conv=1e-13, r_conv=1e-13)
+    hbar = pycc.cchbar(cc)
+    lam = pycc.cclambda(cc, hbar); lam.solve_lambda(e_conv=1e-13, r_conv=1e-13)
+    dens = pycc.ccdensity(cc, lam, onlyone=True)
+    resp = pycc.ccresponse(dens)
+    A = resp.pertbar["MU_Z"]
+    X0, _ = resp.solve_right(A, 0.0)
+    alpha_analytic = -resp.linresp_sym(A, X0, A, X0)
+
+    # finite-field oracle: alpha_zz = -d^2 E_CC3 / dF^2 (store_triples -> [V,T3] coupling)
+    def E(s):
+        kw = dict(model='CC3', orbital_basis='spinorbital', store_triples=True)
+        if s:
+            kw.update(field=True, field_strength=s, field_axis='Z')
+        return pycc.CCwfn(wfn, **kw).solve_cc(e_conv=1e-13, r_conv=1e-13)
+    F = 2e-3
+    e0, ep, e2p, em, e2m = E(0.0), E(F), E(2 * F), E(-F), E(-2 * F)
+    alpha_ff = -(-e2p + 16 * ep - 30 * e0 + 16 * em - e2m) / (12 * F * F)
+
+    assert abs(alpha_analytic - alpha_ff) < 1e-6
+
+
 @pytest.mark.slow
 def test_cc3_polarizability():
     """Spin-orbital CC3 dynamic polarizability (omega=0.1).

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -79,11 +79,11 @@ def test_mp2_relaxed_dipole_ccpvdz():
                - _ff_corr_dipole(WATER, 'cc-pVDZ')) < 1e-8
 
 
-def _pycc_gradient(geom, basis, orbital_basis='spinorbital'):
+def _pycc_gradient(geom, basis, orbital_basis='spinorbital', freeze_core='false'):
     psi4.core.clean()
     psi4.core.clean_options()
     psi4.geometry(geom)
-    psi4.set_options({'basis': basis, 'scf_type': 'pk',
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': freeze_core,
                       'e_convergence': 1e-12, 'd_convergence': 1e-12})
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
@@ -197,3 +197,23 @@ def test_fc_mp2_gradient_vs_energy_fd_631g():
             e = [_fc_mp2_total_energy((i, c, k * h), basis) for k in (-2, -1, 1, 2)]
             gF[i, c] = (e[0] - 8 * e[1] + 8 * e[2] - e[3]) / (12 * h)
     assert np.max(np.abs(gA - gF)) < 1e-8
+
+
+def test_fc_so_mp2_relaxed_dipole_631g():
+    """Frozen-core relaxed spin-orbital MP2 dipole (mu_z) vs a 5-point finite field of
+    (E_MP2 - E_SCF), H2O/6-31G (C1). Exercises the full-MO spin-orbital Hamiltonian (the
+    frozen core is now kept in H) and the spin-orbital frozen-core relaxed 1-PDM."""
+    geom = WATER + "symmetry c1\n"
+    assert abs(_pycc_corr_dipole(geom, '6-31G', orbital_basis='spinorbital', freeze_core='true')
+               - _ff_corr_dipole(geom, '6-31G', freeze_core='true')) < 1e-8
+
+
+def test_fc_mp2_gradient_spatial_vs_so_631g():
+    """Keystone: the frozen-core spin-orbital and spin-adapted MP2 gradients agree on a
+    closed shell (H2O/6-31G, C1). Both are the exact derivative of the MP2(fc) energy, so
+    they must match to machine precision -- the cleanest frozen-core validation, and a check
+    that the full-MO spin-orbital Hamiltonian carries the same core response as the spatial
+    path."""
+    geom = WATER + "symmetry c1\n"
+    assert np.max(np.abs(_pycc_gradient(geom, '6-31G', orbital_basis='spatial', freeze_core='true')
+                         - _pycc_gradient(geom, '6-31G', orbital_basis='spinorbital', freeze_core='true'))) < 1e-10

--- a/pycc/wavefunction.py
+++ b/pycc/wavefunction.py
@@ -264,11 +264,16 @@ class Wavefunction(object):
         """Build the spin-orbital (UHF/ROHF) orbital spaces, coefficients, and
         Hamiltonian.
 
-        Works on the ACTIVE orbital subset (frozen core already excluded), so the
-        active occupied/virtual slices are contiguous and 0-based. Spin orbitals are
-        ordered ``[alpha-occ, beta-occ, alpha-vir, beta-vir]``; the per-spin-orbital
-        ``spin`` (0=alpha, 1=beta) and ``spat`` (index into that spin's spatial
-        active space) maps drive the integral build.
+        Built over the FULL spin-orbital MO space (frozen core included), mirroring the
+        spatial path (``_init_spatial``): the Hamiltonian integrals span all MOs and the
+        active occupied/virtual slices skip the frozen core. Spin orbitals are ordered
+        ``[alpha-core, beta-core, alpha-occ, beta-occ, alpha-vir, beta-vir]`` (the frozen
+        core first), so ``co``/``o``/``v`` are contiguous; for ``nfzc=0`` this reduces to
+        the ``[alpha-occ, beta-occ, alpha-vir, beta-vir]`` ordering. The per-spin-orbital
+        ``spin`` (0=alpha, 1=beta) and ``spat`` (index into that spin's full spatial space)
+        maps drive the integral build. Keeping the core in the Hamiltonian gives the
+        frozen-core gradient its core-virtual/core-active response integrals (the spatial
+        path already relies on this).
         """
         ref = self.ref
         self.nfzc = ref.nfrzc() if frozen_core else 0
@@ -311,37 +316,48 @@ class Wavefunction(object):
             print(f"  {i:>4}   {a_lab[i]:>5} {aocc:>1} {a_eps[i]:>16.10f}"
                   f"    {b_lab[i]:>5} {bocc:>1} {b_eps[i]:>16.10f}")
 
-        self.o = slice(0, self.no)
-        self.v = slice(self.no, self.nact)
+        # Full spin-orbital MO space, ordered [a-core, b-core, a-occ, b-occ, a-vir, b-vir]
+        # with the frozen core first (mirrors _init_spatial); the active slices skip it.
+        # For nfzc=0 the core blocks are empty and this is the previous active ordering.
+        nc = self.nfzc                       # frozen core per spin (alpha = beta = nfzc)
+        self.co = slice(0, 2 * nc)
+        self.o = slice(2 * nc, 2 * nc + self.no)
+        self.v = slice(2 * nc + self.no, self.nmo)
 
-        # Spin-orbital subspaces (ordered alpha-occ, beta-occ, alpha-vir, beta-vir)
-        # and the spin / spatial-index maps the Hamiltonian build needs.
-        ao = slice(0, nao)
-        bo = slice(nao, self.no)
-        av = slice(self.no, self.no + nav)
-        bv = slice(self.no + nav, self.nact)
-        spin = np.zeros(self.nact, dtype=int)
+        aco = slice(0, nc)
+        bco = slice(nc, 2 * nc)
+        ao = slice(2 * nc, 2 * nc + nao)
+        bo = slice(2 * nc + nao, 2 * nc + self.no)
+        av = slice(2 * nc + self.no, 2 * nc + self.no + nav)
+        bv = slice(2 * nc + self.no + nav, self.nmo)
+        spin = np.zeros(self.nmo, dtype=int)
+        spin[bco] = 1
         spin[bo] = 1
         spin[bv] = 1
-        spat = np.zeros(self.nact, dtype=int)
-        spat[ao] = np.arange(nao)
-        spat[bo] = np.arange(nbo)
-        spat[av] = np.arange(nao, nao + nav)
-        spat[bv] = np.arange(nbo, nbo + nbv)
+        spat = np.zeros(self.nmo, dtype=int)
+        spat[aco] = np.arange(nc)                       # alpha core: spatial 0..nc-1
+        spat[bco] = np.arange(nc)                       # beta core
+        spat[ao] = np.arange(nc, nc + nao)              # alpha active occ: spatial nc..na-1
+        spat[bo] = np.arange(nc, nc + nbo)
+        spat[av] = np.arange(nc + nao, nc + nao + nav)  # alpha virtual
+        spat[bv] = np.arange(nc + nbo, nc + nbo + nbv)
         self.spin = spin
         self.spat = spat
 
-        self.Ca = ref.Ca_subset("AO", "ACTIVE")
-        self.Cb = ref.Cb_subset("AO", "ACTIVE")
+        self.Ca = ref.Ca_subset("AO", "ALL")
+        self.Cb = ref.Cb_subset("AO", "ALL")
         # Optional static external field (finite-field CC properties); only CCwfn sets
         # these attributes, so default to no field for the other method classes.
         field_strength, field_axis = 0.0, 2
         if getattr(self, 'field', False):
             field_strength = getattr(self, 'field_strength', 0.0)
             field_axis = {'X': 0, 'Y': 1, 'Z': 2}[str(getattr(self, 'field_axis', 'Z')).upper()]
-        # nao/nbo are the per-spin active occupied counts: the Hamiltonian needs them to
-        # split each spin's MO set into occ/vir for the semicanonical rotation.
-        self.H = SpinOrbitalHamiltonian(ref, self.Ca, self.Cb, spin, spat, nao, nbo,
+        # The Hamiltonian splits each spin's full MO set into occ/vir for the semicanonical
+        # rotation; pass the full per-spin occupied counts (core + active = nalpha/nbeta).
+        # The rotation is a no-op for canonical RHF/UHF, so the frozen core is not mixed
+        # into the active occupied (ROHF frozen-core response is deferred regardless).
+        self.H = SpinOrbitalHamiltonian(ref, self.Ca, self.Cb, spin, spat,
+                                        nc + nao, nc + nbo,
                                         field_strength=field_strength, field_axis=field_axis)
 
     @property


### PR DESCRIPTION
  # Full-MO spin-orbital Hamiltonian + frozen-core spin-orbital MP2 gradient

  Builds the spin-orbital Hamiltonian over the **full MO space** (frozen core included),
  bringing it into consistency with the spatial path, and adds the spin-orbital frozen-core
  MP2 analytic gradient on top.

  ## Hamiltonian consistency (`wavefunction.py`)

  `_init_spinorbital` now uses the full (`"ALL"`) MO coefficients and orders the spin orbitals
  `[a-core, b-core, a-occ, b-occ, a-vir, b-vir]` with `co`/`o`/`v` slices that skip the core.
  **`nfzc=0` is byte-identical** to the previous active-only build, so all-electron is
  unaffected. Keeping the core in `H` gives the gradient its core-virtual/core-active response
  integrals — exactly what the spatial path already relies on.

  ## SO frozen-core MP2 gradient (`mpwfn.py`)

  The frozen-core recipe applies **literally** in the spin-orbital basis (no spin-adaptation):
  core-active direct divide `P_co`, full-occupied Z-vector (with the `z_jc` coupling) over the
  spin-orbital orbital Hessian built inline, `W = I'(D_r)`. `_so_mp2_zvector` +
  `_so_energy_weighted_opdm` are consolidated into `_so_mp2_relaxed_densities`.

  ## Triples audit (the consistency change's blast radius)

  The full-MO SO Hamiltonian exposed a latent **`occ-starts-at-0`** assumption in the
  correlated **triples** kernels — they indexed the full-MO Hamiltonian/perturbation with loop
  variables, or sliced active-sized amplitudes with the now-offset slices:

  ```
  ERI[j,k,v,v]  ->  ERI[o,o,v,v][j,k]      pert[k,v]  ->  pert[o,v][k]
  F[k,v]        ->  F[o,v][k]              t2[o,k]    ->  t2[:,k]
  ERI[o,o,b+no,c+no] -> ERI[o,o,v,v][:,:,b,c]
  ```

  Fixed across the `(T)` (`cctriples`, `ccwfn`), CC3 T-residual/Λ/response (`ccwfn`,
  `cclambda`, `ccresponse`), and the `pertbar` `[A,T3]` term. All behavior-preserving for
  `nfzc=0` (the all-electron suite is the regression gate). The CCSD/MP2 code was already clean.

  ## Validation
  
  ```
  keystone SO == spatial frozen-core MP2 gradient  ~1e-16   (test_061)
  SO frozen-core relaxed dipole vs finite field             (test_061)
  frozen-core UCCSD(T) OH                                    (test_005)
  frozen-core CC3 energy + Lambda: SO == spatial == Psi4    (test_031)
  frozen-core CC3 polarizability == finite-field of E_CC3   (test_059)
  ```

  Ground-truth oracle throughout is the **finite difference of PyCC's own energy** — Psi4's
  *analytic* frozen-core gradients are themselves slightly inconsistent. Full non-slow suite:
  **137 passed**.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
