### PR TITLE
Route HFwfn/MPwfn/CPHF tensor contractions through the device backend

### DIFF
--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -39,8 +39,9 @@ Lives on the Wavefunction base (lazy ``self.cphf``); it depends only on base sta
 (``o``/``v``, the Fock diagonal, the orbital-Hessian integrals) plus the dipole
 integrals, and is shared by HF, MP2, and CC orbital response.
 
-This is reference, CPU/NumPy code, consistent with the rest of the HF derivative
-engine (the explicit orbital Hessian is solved directly with ``numpy.linalg``).
+Reference code: tensor contractions route through the device-aware ``self.contract``
+(``ContractionBackend``, shared from the wavefunction), while the explicit orbital
+Hessian is solved directly with ``numpy.linalg`` (a small dense solve, left on NumPy).
 """
 
 from __future__ import annotations
@@ -70,6 +71,7 @@ class CPHF(object):
 
     def __init__(self, wfn: Any) -> None:
         self.wfn = wfn
+        self.contract = wfn.contract        # device-aware ContractionBackend (shared)
         self.o = wfn.o
         self.v = wfn.v
         self.no = wfn.no
@@ -125,8 +127,8 @@ class CPHF(object):
             raise ValueError("kind must be 'electric' or 'magnetic', got %r" % kind)
 
         # Two-electron part: G_iajb = W[a,j,i,b] + sign * W[a,b,i,j].
-        G = (np.einsum('ajib->iajb', W[v, o, o, v])
-             + sign * np.einsum('abij->iajb', W[v, v, o, o]))
+        G = (self.contract('ajib->iajb', W[v, o, o, v])
+             + sign * self.contract('abij->iajb', W[v, v, o, o]))
         G = G.reshape(no * nv, no * nv)
 
         # Orbital-energy part: + (e_a - e_i) on the (ia)=(jb) diagonal.
@@ -249,11 +251,11 @@ class CPHF(object):
         for c in range(3):
             Lx = 2.0 * gx[c] - gx[c].swapaxes(2, 3)            # derivative spin-adapted L
             # skeleton derivative Fock: F^X_pq = h^X + sum_k L[p,k,q,k]^X
-            Fx = hx[c] + np.einsum('pkqk->pq', Lx[:, o, :, o])
+            Fx = hx[c] + self.contract('pkqk->pq', Lx[:, o, :, o])
             # Pulay coupling of the overlap-determined U^X_kl = -1/2 S^X_kl into the
             # ov block:  -1/2 S^X_kl ( L[a,k,i,l] + L[a,l,i,k] ).
-            coupling = (np.einsum('akil,kl->ia', Lvooo, Sx[c][o, o])
-                        + np.einsum('alik,kl->ia', Lvooo, Sx[c][o, o]))
+            coupling = (self.contract('akil,kl->ia', Lvooo, Sx[c][o, o])
+                        + self.contract('alik,kl->ia', Lvooo, Sx[c][o, o]))
             # The CPHF RHS is minus the first-order off-diagonal ("perturbation")
             # Fock that the response drives to zero -- B = -Q (nuclear analog of the
             # field's B = -mu).
@@ -286,12 +288,12 @@ class CPHF(object):
         B, Foo, Soo = [], [], []
         for c in range(3):
             # skeleton derivative Fock F^X_pq = h^X + sum_k(occ) <pk||qk>^X
-            Fx = hx[c] + np.einsum('pkqk->pq', gx[c][:, o, :, o])
+            Fx = hx[c] + self.contract('pkqk->pq', gx[c][:, o, :, o])
             Sx = Sxa[c]
             # Pulay coupling of the overlap-determined U^X_kl = -1/2 S^X_kl into the ov
             # block: -1/2 sum_kl S^X_kl ( <ak||il> + <al||ik> ).
-            coupling = (np.einsum('akil,kl->ia', Evooo, Sx[o, o])
-                        + np.einsum('alik,kl->ia', Evooo, Sx[o, o]))
+            coupling = (self.contract('akil,kl->ia', Evooo, Sx[o, o])
+                        + self.contract('alik,kl->ia', Evooo, Sx[o, o]))
             Q = Fx[o, v] - eps_o[:, None] * Sx[o, v] - 0.5 * coupling
             B.append(-Q)
             Foo.append(Fx[o, o])

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -74,9 +74,9 @@ class HFwfn(Wavefunction):
             erix = d.eri(atom, 'o', 'o', 'o', 'o')
             for c in range(3):
                 grad[atom, c] = (2.0 * np.trace(hx[c])
-                                 + 2.0 * np.einsum('iijj->', erix[c])
-                                 - np.einsum('ijij->', erix[c])
-                                 - 2.0 * np.einsum('i,ii->', eps, Sx[c])
+                                 + 2.0 * self.contract('iijj->', erix[c])
+                                 - self.contract('ijij->', erix[c])
+                                 - 2.0 * self.contract('i,ii->', eps, Sx[c])
                                  + Vnn[atom, c])
         self.grad = grad
         return grad
@@ -130,7 +130,7 @@ class HFwfn(Wavefunction):
         alpha = np.zeros((3, 3))
         for a in range(3):
             for b in range(3):
-                alpha[a, b] = -k * np.einsum('ia,ia->', mu[a], U[b])
+                alpha[a, b] = -k * self.contract('ia,ia->', mu[a], U[b])
         self.alpha = alpha
         return self.alpha
 
@@ -168,8 +168,8 @@ class HFwfn(Wavefunction):
                 for alpha in range(3):
                     val = mol.Z(A) if alpha == beta else 0.0
                     val += 2.0 * np.trace(dip[alpha * 3 + beta])
-                    val -= 2.0 * np.einsum('ki,ki->', Sx[beta], mu[alpha][o, o])
-                    val += 4.0 * np.einsum('ia,ia->', Ux[beta], mu[alpha][o, v])
+                    val -= 2.0 * self.contract('ki,ki->', Sx[beta], mu[alpha][o, o])
+                    val += 4.0 * self.contract('ia,ia->', Ux[beta], mu[alpha][o, v])
                     dmu[A, beta, alpha] = val
         self.dipder = dmu
         return self.dipder
@@ -265,16 +265,16 @@ class HFwfn(Wavefunction):
                         Fx, Fy = Foo[A][a], Foo[Bat][b]
                         # --- skeleton (second-derivative integrals), as in the gradient ---
                         skel = (2.0 * np.trace(h2[c])
-                                + 2.0 * np.einsum('iijj->', g2[c])
-                                - np.einsum('ijij->', g2[c])
-                                - 2.0 * np.einsum('i,ii->', eps_o, S2[c])
+                                + 2.0 * self.contract('iijj->', g2[c])
+                                - self.contract('ijij->', g2[c])
+                                - 2.0 * self.contract('i,ii->', eps_o, S2[c])
                                 + Vnn2[A * 3 + a, Bat * 3 + b])
                         # --- first-order CPHF response + first-derivative cross terms ---
-                        resp = (-4.0 * np.einsum('ia,ia->', Ux, By)
-                                - 2.0 * np.einsum('ij,ij->', Sx, Fy)
-                                - 2.0 * np.einsum('ij,ij->', Sy, Fx)
-                                + 4.0 * np.einsum('i,ij,ij->', eps_o, Sx, Sy)
-                                + 2.0 * np.einsum('ij,nm,imjn->', Sx, Sy, Loooo))
+                        resp = (-4.0 * self.contract('ia,ia->', Ux, By)
+                                - 2.0 * self.contract('ij,ij->', Sx, Fy)
+                                - 2.0 * self.contract('ij,ij->', Sy, Fx)
+                                + 4.0 * self.contract('i,ij,ij->', eps_o, Sx, Sy)
+                                + 2.0 * self.contract('ij,nm,imjn->', Sx, Sy, Loooo))
                         H[A * 3 + a, Bat * 3 + b] = skel + resp
         self.hess = H
         return self.hess
@@ -366,8 +366,8 @@ class HFwfn(Wavefunction):
             for alpha in range(3):
                 for beta in range(3):
                     aat[lam, alpha, beta] = 2.0 * (
-                        np.einsum('ia,ia->', Ur[alpha], Ub[beta])
-                        + np.einsum('ia,ia->', Ub[beta], Shalf[alpha]))
+                        self.contract('ia,ia->', Ur[alpha], Ub[beta])
+                        + self.contract('ia,ia->', Ub[beta], Shalf[alpha]))
         self.aat = aat
         return self.aat
 

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -144,9 +144,9 @@ class MPwfn(Wavefunction):
         eps = np.diag(np.asarray(self.H.F))
         termA = eps[:, None] * (D + D.T)                       # f_pp (D_pq + D_qp)
         termB = np.zeros((nmo, nmo))
-        termB[:, ofull] = (np.einsum('rs,rpsq->pq', D, ERI[:, :, :, ofull])
-                           + np.einsum('rs,rqsp->pq', D, ERI[:, ofull, :, :]))
-        termC = 4.0 * np.einsum('prst,qrst->pq', ERI, Gam)
+        termB[:, ofull] = (self.contract('rs,rpsq->pq', D, ERI[:, :, :, ofull])
+                           + self.contract('rs,rqsp->pq', D, ERI[:, ofull, :, :]))
+        termC = 4.0 * self.contract('prst,qrst->pq', ERI, Gam)
         return -0.5 * (termA + termB + termC)
 
     def _so_mp2_relaxed_densities(self):
@@ -197,13 +197,13 @@ class MPwfn(Wavefunction):
         X = Ip[ofull, v] - Ip[v, ofull].T
         if nfzc:
             zjc = -Pco.T                                   # z_jc, active-occupied x core
-            X = X - (np.einsum('jc,ajic->ia', zjc, ERI[v, o, ofull, co])
-                     + np.einsum('jc,acij->ia', zjc, ERI[v, co, ofull, o]))
+            X = X - (self.contract('jc,ajic->ia', zjc, ERI[v, o, ofull, co])
+                     + self.contract('jc,acij->ia', zjc, ERI[v, co, ofull, o]))
 
         # Full-occupied spin-orbital orbital Hessian A_{ia,jb} = <aj||ib> + <ab||ij>
         # + (eps_a - eps_i) delta; solve A z = X over the full ndocc x nv space.
-        G = (np.einsum('ajib->iajb', ERI[v, ofull, ofull, v])
-             + np.einsum('abij->iajb', ERI[v, v, ofull, ofull])).reshape(nof * nv, nof * nv)
+        G = (self.contract('ajib->iajb', ERI[v, ofull, ofull, v])
+             + self.contract('abij->iajb', ERI[v, v, ofull, ofull])).reshape(nof * nv, nof * nv)
         G[np.diag_indices(nof * nv)] += (eps[v][None, :] - eps[ofull][:, None]).reshape(-1)
         z = np.linalg.solve(G, X.reshape(-1)).reshape(nof, nv).T
         D[v, ofull] = -z
@@ -269,9 +269,9 @@ class MPwfn(Wavefunction):
         eps = np.diag(np.asarray(self.H.F))
         termA = eps[:, None] * (D + D.T)
         termB = np.zeros((nmo, nmo))
-        termB[:, ofull] = (np.einsum('rs,rpsq->pq', D, L[:, :, :, ofull])
-                           + np.einsum('rs,rqsp->pq', D, L[:, ofull, :, :]))
-        termC = 4.0 * np.einsum('prst,qrst->pq', ERI, Gam)
+        termB[:, ofull] = (self.contract('rs,rpsq->pq', D, L[:, :, :, ofull])
+                           + self.contract('rs,rqsp->pq', D, L[:, ofull, :, :]))
+        termC = 4.0 * self.contract('prst,qrst->pq', ERI, Gam)
         return -0.5 * (termA + termB + termC)
 
     def _mp2_relaxed_densities(self):
@@ -319,8 +319,8 @@ class MPwfn(Wavefunction):
         X = Ip[ofull, v] - Ip[v, ofull].T
         if nfzc:
             zjc = -Pco.T                                   # z_jc, active-occupied x core
-            X = X - (np.einsum('jc,ajic->ia', zjc, L[v, o, ofull, co])
-                     + np.einsum('jc,acij->ia', zjc, L[v, co, ofull, o]))
+            X = X - (self.contract('jc,ajic->ia', zjc, L[v, o, ofull, co])
+                     + self.contract('jc,acij->ia', zjc, L[v, co, ofull, o]))
         z = hf.cphf.solve(X).T
         D[v, ofull] = -z
         D[ofull, v] = -z.T
@@ -359,10 +359,10 @@ class MPwfn(Wavefunction):
             for c in range(3):
                 phys = ERIx[c].transpose(0, 2, 1, 3)  # -> physicist <pq|rs>^X
                 Lx = 2.0 * phys - phys.transpose(0, 1, 3, 2)
-                fx = hx[c] + np.einsum('pmqm->pq', Lx[:, ofull, :, ofull])  # Fock deriv (full occ)
-                grad[atom, c] = (np.einsum('pq,pq->', D, fx)
-                                 + np.einsum('pqrs,pqrs->', Gam, phys)
-                                 + np.einsum('pq,pq->', W, Sx[c]))
+                fx = hx[c] + self.contract('pmqm->pq', Lx[:, ofull, :, ofull])  # Fock deriv (full occ)
+                grad[atom, c] = (self.contract('pq,pq->', D, fx)
+                                 + self.contract('pqrs,pqrs->', Gam, phys)
+                                 + self.contract('pq,pq->', W, Sx[c]))
         return hf.gradient() + grad
 
     def _so_gradient(self) -> np.ndarray:
@@ -381,8 +381,8 @@ class MPwfn(Wavefunction):
             Sx = d.so_overlap(atom)
             ERIx = d.so_eri(atom)
             for c in range(3):
-                fx = hx[c] + np.einsum('pmqm->pq', ERIx[c][:, ofull, :, ofull])  # Fock deriv (full occ)
-                grad[atom, c] = (np.einsum('pq,pq->', D, fx)
-                                 + np.einsum('pqrs,pqrs->', Gam, ERIx[c])
-                                 + np.einsum('pq,pq->', W, Sx[c]))
+                fx = hx[c] + self.contract('pmqm->pq', ERIx[c][:, ofull, :, ofull])  # Fock deriv (full occ)
+                grad[atom, c] = (self.contract('pq,pq->', D, fx)
+                                 + self.contract('pqrs,pqrs->', Gam, ERIx[c])
+                                 + self.contract('pq,pq->', W, Sx[c]))
         return HFwfn(self.ref).gradient() + grad


### PR DESCRIPTION
# Route HFwfn/MPwfn/CPHF tensor contractions through the device backend
  
  Converts the **44 direct `np.einsum` calls** in `HFwfn` (16), `MPwfn` (20), and `CPHF` (8)
  to `self.contract` — the device-aware `ContractionBackend` (`device.py`) already used
  throughout the CC layer. This makes the HF/MP2 derivative and spin-orbital MP2-gradient
  code GPU/precision-portable like the rest of PyCC, and closes the standing cleanup item.

  ## Changes

  - `np.einsum('...', a, b)` → `self.contract('...', a, b)` in `hfwfn.py`, `mpwfn.py`,
    `cphf.py` (densities, orbital Hessian, Lagrangian, energy-weighted density, gradient
    assembly, property tensors).
  - `CPHF.__init__` gains `self.contract = wfn.contract` (it had `self.wfn` but no direct
    backend handle); docstring updated to note contractions route through the backend.

  ## Why it's safe

  - Purely mechanical: `ContractionBackend.__call__` wraps `opt_einsum.contract` with the
    same subscript signature as `numpy.einsum`; on CPU it calls `opt_einsum.contract`
    directly (identical result), on GPU it moves operands to the device first.
  - No `optimize=` kwargs were present; all einsums are in instance methods (no
    staticmethod/module-level cases); `import numpy as np` is still needed for the many
    non-einsum `np.*` uses.
  - `np.linalg.solve` (the CPHF orbital-Hessian / Z-vector solve) is **intentionally left on
    NumPy** — a small dense solve with no device-aware analogue wired.

  ## Validation

  Full non-slow suite: **137 passed**, 3 skipped, 1 xfailed (no regressions). The HF property
  tensors (gradient/polarizability/APT/Hessian/AAT) and the MP2 gradient/density exercise all
  three converted classes.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)