### PR TITLE
MP2 first-derivative properties + explicit-derivative engine

### DIFF
--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -164,11 +164,14 @@ static (omega=0) electric-dipole correlation polarizability `alpha_corr_ab` (3x3
 computes `alpha_corr`; the reference `alpha_HF` stays in `HFwfn.polarizability()` (effectively
 free), and the total is `alpha_HF + alpha_corr`.
 
-**Approach — explicit ("simple but inefficient") energy derivatives, NOT 2n+1.** The earlier
-2n+1 / Z-vector-interchange plan was dropped in favor of the explicit-derivative formalism in
-`notes.pdf`: rather than separate the orbital response into a Z-vector + relaxed density, fold
-the CPHF coefficients `U^x` directly into the **full** derivatives of the Fock matrix and the
-antisymmetrized two-electron integrals, then contract with the **unrelaxed** densities:
+**Approach — explicit ("simple but inefficient") energy derivatives first.** We build the
+explicit-derivative formalism from `notes.pdf` before the 2n+1 / Z-vector-interchange route.
+The 2n+1 formulation is **not abandoned** — it is deferred until these simpler approaches are
+in place (it remains the efficient long-term target, and the explicit route is a stepping stone
+and a cross-check for it). The explicit route: rather than separate the orbital response into a
+Z-vector + relaxed density, fold the CPHF coefficients `U^x` directly into the **full**
+derivatives of the Fock matrix and the antisymmetrized two-electron integrals, then contract
+with the **unrelaxed** densities:
 
     d_x E_corr = sum_pq gamma_pq d_x f_pq + sum_pqrs Gamma_pqrs d_x <pq||rs>      (notes.pdf)
 

--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -197,18 +197,26 @@ the engine is purely a `U`-rotation; `nuclear`/`magnetic` add their (nonzero) sk
 into the same assembly later. `MPwfn` holds a persistent `CPHF` so the caches survive across
 property calls.
 
-**Status — first derivative DONE (field + nuclear, both bases, all-electron).**
+**Status — first derivative DONE (field + nuclear, both bases, all-electron AND frozen-core).**
 `MPwfn._corr_energy_deriv(pert)` contracts the engine with `gamma` (`Doo`/`Dvv`) and `Gamma`
 (the 2PDM); the field case gives the (negative) correlation dipole (`_corr_dipole_explicit`),
 the nuclear case the correlation gradient (`_corr_gradient_explicit`). Both the spatial
 closed-shell (default) and spin-orbital (`_so_` route) paths are implemented; the perturbed
 Fock's two-electron weight switches L (spatial) / `<pq||rs>` (SO), and `perturbed_eri` rotates
-`H.ERI` (already the right integral per basis). Validated (`test_061`): explicit ==
-relaxed-density route to ~1e-16 and the finite field to <1e-8 (6-31G C1, cc-pVDZ C2v). Both
-nuclear CPHF paths now source skeleton derivatives from one `_skeleton` cache.
+`H.ERI` (already the right integral per basis).
 
-Next: **frozen-core** versions (both bases), then the **analytic second derivative** (the
-polarizability; its term structure to be written up here before coding).
+Frozen core needs no rearrangement of the contraction: the densities stay active, and the
+engine runs over the **full** occupied space via a `CPHF` `full_occ` view on `MPwfn`
+(`_full_occ_cphf`, kept in `MPwfn`'s own ordering so SO doesn't have to borrow a differently-
+ordered all-electron SO `HFwfn`). The only extra ingredient is the non-redundant
+**core<->active block of `U`**, set by the canonical Brillouin condition `d_x f_ij = 0` (a
+direct divide; `_full_U`'s `ncore` argument), with the redundant blocks left at `-1/2 S^x`.
+
+Validated (`test_061`): explicit == relaxed-density route to ~1e-16 for all four cases
+(spatial/SO x all-electron/frozen-core), and the finite field to <1e-8 (6-31G C1, cc-pVDZ C2v).
+
+Next: the **analytic second derivative** (the polarizability; its term structure to be written
+up here before coding).
 
 Phase D (SO): `MPwfn.gradient()` assembles the MP2 analytic nuclear gradient
 

--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -197,14 +197,18 @@ the engine is purely a `U`-rotation; `nuclear`/`magnetic` add their (nonzero) sk
 into the same assembly later. `MPwfn` holds a persistent `CPHF` so the caches survive across
 property calls.
 
-**Status — first derivative DONE (field, SO).** `MPwfn._corr_energy_deriv(pert)` contracts the
-engine with `gamma` (`Doo`/`Dvv`) and `Gamma` (the 2PDM); for the field this is the (negative)
-correlation dipole, exposed as `_corr_dipole_explicit()`. Validated (`test_061`):
-`_corr_dipole_explicit` == `relaxed_dipole` (the relaxed-density route) to ~1e-16, and ==
-the finite field of `E_MP2 - E_SCF` to <1e-8 (H2O/6-31G C1 and cc-pVDZ C2v). This is the
-first-derivative foundation; the **analytic second derivative (the polarizability) is next**
-(its detailed term structure to be written up here before coding). Spatial closed-shell and
-frozen-core paths follow the SO field path.
+**Status — first derivative DONE (field + nuclear, both bases, all-electron).**
+`MPwfn._corr_energy_deriv(pert)` contracts the engine with `gamma` (`Doo`/`Dvv`) and `Gamma`
+(the 2PDM); the field case gives the (negative) correlation dipole (`_corr_dipole_explicit`),
+the nuclear case the correlation gradient (`_corr_gradient_explicit`). Both the spatial
+closed-shell (default) and spin-orbital (`_so_` route) paths are implemented; the perturbed
+Fock's two-electron weight switches L (spatial) / `<pq||rs>` (SO), and `perturbed_eri` rotates
+`H.ERI` (already the right integral per basis). Validated (`test_061`): explicit ==
+relaxed-density route to ~1e-16 and the finite field to <1e-8 (6-31G C1, cc-pVDZ C2v). Both
+nuclear CPHF paths now source skeleton derivatives from one `_skeleton` cache.
+
+Next: **frozen-core** versions (both bases), then the **analytic second derivative** (the
+polarizability; its term structure to be written up here before coding).
 
 Phase D (SO): `MPwfn.gradient()` assembles the MP2 analytic nuclear gradient
 

--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -112,7 +112,7 @@ on `MPwfn` (MP2-specific, per the decision above).
 
 ## Status / progress
 
-_Last updated 2026-06-23._
+_Last updated 2026-06-27._
 
 | Phase | Status | Landed |
 |---|---|---|
@@ -124,7 +124,7 @@ _Last updated 2026-06-23._
 | **frozen-core** spin-adapted MP2 gradient | ✅ done | merged (#158) |
 | **full-MO spin-orbital Hamiltonian** + **frozen-core SO MP2 gradient** + triples audit | ✅ done | merged (#159) |
 | `np.einsum` → `self.contract` in HFwfn/MPwfn/CPHF (device backend) | ✅ done | merged (#160) |
-| **MP2 dipole polarizability** | 📋 design locked, **code not started** | — (see next section) |
+| **MP2 dipole polarizability** | 🚧 in progress (SO path) | this branch `feature/mp2-polarizability` |
 
 ## Next up: MP2 dipole polarizability — design locked, code NOT started
 
@@ -155,6 +155,66 @@ orbital-energy denominator). Mirror the gradient phasing: **spin-orbital path fi
 spatial closed-shell; **all-electron first**, frozen core as a follow-on (reuses the
 full-occ machinery already built). When starting, write this phase up in detail here first,
 then code.
+
+### Implementation phase — detailed write-up (2026-06-27)
+
+Branch `feature/mp2-polarizability`. Deliverable: `MPwfn.polarizability()` returning the
+static (omega=0) electric-dipole polarizability `alpha_ab` (3x3, a.u.), spin-orbital path
+first, then spatial closed-shell, then frozen core. The total is reported as
+`alpha = alpha_HF + alpha_corr`, with `alpha_HF` from the existing `HFwfn.polarizability()`
+and `alpha_corr` the MP2 correlation contribution assembled here.
+
+**Reference quantity (what we differentiate).** The oracle (Psi4 `perturb_h`, and PyCC's own
+finite field) relaxes the *HF orbitals* to the field and recomputes MP2 in that field-relaxed
+basis. So the target is
+
+    alpha_corr_ab = - d^2 E_corr(F) / dF_a dF_b   evaluated at F=0,
+
+with `E_corr(F) = 1/4 <ij||ab>(F) t_ijab(F)` built from the HF orbitals `phi_p(F) =
+phi_p exp(kappa(F))` and the field-dressed Fock. The *only* explicit F-dependence of
+`E_corr` at fixed orbitals is through the denominators `D_ijab` (the field `-F.mu` shifts the
+orbital energies); the two-electron integrals `<ij||ab>` carry no explicit field (the field is
+one-electron), responding only through the orbital rotation `kappa(F)`.
+
+**First-order building blocks (all that 2n+1 needs).**
+- `U^a` = the HF electric-field CPHF response for axis `a`, `cphf.solve(cphf.rhs_field(a))`
+  — already used by `HFwfn.polarizability`. This is `kappa^a` (ov block; the oo/vv blocks
+  vanish for a field — no overlap derivative).
+- `g^a_pqrs` = the `U^a`-rotation of the antisymmetrized integrals (first-order change of
+  `<pq||rs>` under `kappa^a`): each index rotated, `g^a_pqrs = sum_t (U^a-mix on p,q,r,s)`.
+- `eps^a_p` = first-order orbital-energy change = the field-dressed first-order Fock diagonal
+  `f^a_pp` (explicit `-mu^a_pp` plus the `U^a`-rotation of the two-electron Fock), giving the
+  denominator response `D^a_ijab = eps^a_i + eps^a_j - eps^a_a - eps^a_b`.
+- `t^a_ijab = (g^a_ijab - t_ijab D^a_ijab) / D_ijab` — the **one genuinely new** building
+  block (quotient derivative of `t = g/D`). Lambda = T for MP2, so no separate `l^a`.
+
+**2n+1 assembly.** Writing `E = 1/4 g t` with `t = g/D`, the first derivative reduces (using
+`g t^a = t g^a - t^2 D^a`) to `dE/dF_a = 1/4 sum (2 t g^a - t^2 D^a)`. The second derivative is
+
+    d^2E/dF_a dF_b = (A) explicit-explicit + (B) explicit-orbital + (C) orbital-orbital
+                     + (D) orbital-gradient . second-order-response,
+
+i.e. terms in `t^a, t^b, g^a, g^b, D^a, D^b` (all first order) plus one term `(dE/dkappa).kappa^{ab}`
+that naively needs the **second-order** orbital response `kappa^{ab}`. That term is removed by
+the Handy-Schaefer interchange using the **ground-state** MP2 orbital-gradient Z-vector `z`
+(`G z = X`, the same `z` already solved in `_so_mp2_relaxed_densities`): since `kappa(F)` is the
+HF response (`G_HF kappa = -B(F)`), `(dE/dkappa).kappa^{ab} = z . (G_HF kappa^{ab}) =
+-z . (second-order field RHS)`, and the second-order field RHS is built from `U^a, U^b` only.
+**No perturbed Z-vector** (`z^a`) and **no second-order CPHF** — `z` is the unperturbed
+gradient Z-vector, consistent with the locked formulation (B). The exact per-term index
+expressions and prefactors are **pinned numerically** against the finite-field oracle (the
+documented methodology for this whole effort — Psi4's analytic response is DF/finite-field).
+
+**Validation (mirror `test_061`).** New `test_067_mp2_polarizability` (H2O):
+- `alpha_corr` (and total `alpha`) vs a high-order finite field of PyCC's own
+  `E_MP2(F) - E_SCF(F)` (5-point second-derivative stencil), `< 1e-7`;
+- HF-limit check: total `alpha == HFwfn.polarizability() + alpha_corr`;
+- keystone: spin-orbital `alpha_corr == spatial alpha_corr` on a closed shell (~1e-10);
+- C1 (6-31G) and C2v (cc-pVDZ, polarization + A2-irrep MOs).
+
+Frozen core is a follow-on (reuses the full-occ response machinery, exactly as the gradient).
+The building blocks are validated independently by finite-difference of PyCC's field-relaxed
+intermediates (`U^a`, `eps^a`, `g^a`, `t^a`) before the full contraction is assembled.
 
 Phase D (SO): `MPwfn.gradient()` assembles the MP2 analytic nuclear gradient
 

--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -156,65 +156,52 @@ spatial closed-shell; **all-electron first**, frozen core as a follow-on (reuses
 full-occ machinery already built). When starting, write this phase up in detail here first,
 then code.
 
-### Implementation phase — detailed write-up (2026-06-27)
+### Implementation phase — explicit-derivative route (2026-06-28)
 
 Branch `feature/mp2-polarizability`. Deliverable: `MPwfn.polarizability()` returning the
-static (omega=0) electric-dipole polarizability `alpha_ab` (3x3, a.u.), spin-orbital path
-first, then spatial closed-shell, then frozen core. The total is reported as
-`alpha = alpha_HF + alpha_corr`, with `alpha_HF` from the existing `HFwfn.polarizability()`
-and `alpha_corr` the MP2 correlation contribution assembled here.
+static (omega=0) electric-dipole correlation polarizability `alpha_corr_ab` (3x3, a.u.). The
+**reference (HF) and correlation contributions are kept separate** (per the PI): `MPwfn`
+computes `alpha_corr`; the reference `alpha_HF` stays in `HFwfn.polarizability()` (effectively
+free), and the total is `alpha_HF + alpha_corr`.
 
-**Reference quantity (what we differentiate).** The oracle (Psi4 `perturb_h`, and PyCC's own
-finite field) relaxes the *HF orbitals* to the field and recomputes MP2 in that field-relaxed
-basis. So the target is
+**Approach — explicit ("simple but inefficient") energy derivatives, NOT 2n+1.** The earlier
+2n+1 / Z-vector-interchange plan was dropped in favor of the explicit-derivative formalism in
+`notes.pdf`: rather than separate the orbital response into a Z-vector + relaxed density, fold
+the CPHF coefficients `U^x` directly into the **full** derivatives of the Fock matrix and the
+antisymmetrized two-electron integrals, then contract with the **unrelaxed** densities:
 
-    alpha_corr_ab = - d^2 E_corr(F) / dF_a dF_b   evaluated at F=0,
+    d_x E_corr = sum_pq gamma_pq d_x f_pq + sum_pqrs Gamma_pqrs d_x <pq||rs>      (notes.pdf)
 
-with `E_corr(F) = 1/4 <ij||ab>(F) t_ijab(F)` built from the HF orbitals `phi_p(F) =
-phi_p exp(kappa(F))` and the field-dressed Fock. The *only* explicit F-dependence of
-`E_corr` at fixed orbitals is through the denominators `D_ijab` (the field `-F.mu` shifts the
-orbital energies); the two-electron integrals `<ij||ab>` carry no explicit field (the field is
-one-electron), responding only through the orbital rotation `kappa(F)`.
+a single unrestricted sum with **all prefactors absorbed into the densities** (`gamma`, `Gamma`).
+With PyCC's existing unrelaxed densities this convention gives, at zeroth order, `E_corr =
+sum gamma f + sum Gamma <pq||rs>` (both coefficients 1, since `Tr(gamma f) = -E_corr` and
+`sum Gamma <> = +2 E_corr`); the functional is stationary in the amplitudes, so the
+density-response terms drop and the derivative keeps only `d_x f`, `d_x <pq||rs>`.
 
-**First-order building blocks (all that 2n+1 needs).**
-- `U^a` = the HF electric-field CPHF response for axis `a`, `cphf.solve(cphf.rhs_field(a))`
-  — already used by `HFwfn.polarizability`. This is `kappa^a` (ov block; the oo/vv blocks
-  vanish for a field — no overlap derivative).
-- `g^a_pqrs` = the `U^a`-rotation of the antisymmetrized integrals (first-order change of
-  `<pq||rs>` under `kappa^a`): each index rotated, `g^a_pqrs = sum_t (U^a-mix on p,q,r,s)`.
-- `eps^a_p` = first-order orbital-energy change = the field-dressed first-order Fock diagonal
-  `f^a_pp` (explicit `-mu^a_pp` plus the `U^a`-rotation of the two-electron Fock), giving the
-  denominator response `D^a_ijab = eps^a_i + eps^a_j - eps^a_a - eps^a_b`.
-- `t^a_ijab = (g^a_ijab - t_ijab D^a_ijab) / D_ijab` — the **one genuinely new** building
-  block (quotient derivative of `t = g/D`). Lambda = T for MP2, so no separate `l^a`.
+**The engine (shared, on `CPHF`).** The full derivatives are **response-dressed** (skeleton +
+`U`), so they live on `CPHF` (which owns `U` and consumes the skeleton `Derivatives`), *not*
+on `Derivatives` (kept skeleton-only) — preserving the one-directional layering
+`Derivatives <- CPHF <- HFwfn/MPwfn`. A `Perturbation('field'|'nuclear'|'magnetic', comp)`
+descriptor keys the caches so multi-property runs (e.g. IR + VCD, or an MP2 gradient +
+polarizability) never recompute the expensive (nuclear) ERI derivatives:
 
-**2n+1 assembly.** Writing `E = 1/4 g t` with `t = g/D`, the first derivative reduces (using
-`g t^a = t g^a - t^2 D^a`) to `dE/dF_a = 1/4 sum (2 t g^a - t^2 D^a)`. The second derivative is
+- `CPHF.perturbed_fock(pert)` -> `d_x f_pq` (`nmo x nmo`), cached;
+- `CPHF.perturbed_eri(pert, blocks)` -> `d_x <pq||rs>`, **block-aware with the full `nmo^4`
+  the default** (CC consumers need all blocks; MP2 can ask for `oovv`), cached.
 
-    d^2E/dF_a dF_b = (A) explicit-explicit + (B) explicit-orbital + (C) orbital-orbital
-                     + (D) orbital-gradient . second-order-response,
+For the electric field the skeleton collapses (`S^x = 0`, `<pq||rs>^(x) = 0`, `f^(x) = mu`), so
+the engine is purely a `U`-rotation; `nuclear`/`magnetic` add their (nonzero) skeleton pieces
+into the same assembly later. `MPwfn` holds a persistent `CPHF` so the caches survive across
+property calls.
 
-i.e. terms in `t^a, t^b, g^a, g^b, D^a, D^b` (all first order) plus one term `(dE/dkappa).kappa^{ab}`
-that naively needs the **second-order** orbital response `kappa^{ab}`. That term is removed by
-the Handy-Schaefer interchange using the **ground-state** MP2 orbital-gradient Z-vector `z`
-(`G z = X`, the same `z` already solved in `_so_mp2_relaxed_densities`): since `kappa(F)` is the
-HF response (`G_HF kappa = -B(F)`), `(dE/dkappa).kappa^{ab} = z . (G_HF kappa^{ab}) =
--z . (second-order field RHS)`, and the second-order field RHS is built from `U^a, U^b` only.
-**No perturbed Z-vector** (`z^a`) and **no second-order CPHF** — `z` is the unperturbed
-gradient Z-vector, consistent with the locked formulation (B). The exact per-term index
-expressions and prefactors are **pinned numerically** against the finite-field oracle (the
-documented methodology for this whole effort — Psi4's analytic response is DF/finite-field).
-
-**Validation (mirror `test_061`).** New `test_067_mp2_polarizability` (H2O):
-- `alpha_corr` (and total `alpha`) vs a high-order finite field of PyCC's own
-  `E_MP2(F) - E_SCF(F)` (5-point second-derivative stencil), `< 1e-7`;
-- HF-limit check: total `alpha == HFwfn.polarizability() + alpha_corr`;
-- keystone: spin-orbital `alpha_corr == spatial alpha_corr` on a closed shell (~1e-10);
-- C1 (6-31G) and C2v (cc-pVDZ, polarization + A2-irrep MOs).
-
-Frozen core is a follow-on (reuses the full-occ response machinery, exactly as the gradient).
-The building blocks are validated independently by finite-difference of PyCC's field-relaxed
-intermediates (`U^a`, `eps^a`, `g^a`, `t^a`) before the full contraction is assembled.
+**Status — first derivative DONE (field, SO).** `MPwfn._corr_energy_deriv(pert)` contracts the
+engine with `gamma` (`Doo`/`Dvv`) and `Gamma` (the 2PDM); for the field this is the (negative)
+correlation dipole, exposed as `_corr_dipole_explicit()`. Validated (`test_061`):
+`_corr_dipole_explicit` == `relaxed_dipole` (the relaxed-density route) to ~1e-16, and ==
+the finite field of `E_MP2 - E_SCF` to <1e-8 (H2O/6-31G C1 and cc-pVDZ C2v). This is the
+first-derivative foundation; the **analytic second derivative (the polarizability) is next**
+(its detailed term structure to be written up here before coding). Spatial closed-shell and
+frozen-core paths follow the SO field path.
 
 Phase D (SO): `MPwfn.gradient()` assembles the MP2 analytic nuclear gradient
 

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -261,7 +261,7 @@ class CPHF(object):
             return self.solve_nuclear(atom)[cart]
         raise NotImplementedError("ov response wired for 'field'/'nuclear' only.")
 
-    def _full_U(self, pert: "Perturbation") -> np.ndarray:
+    def _full_U(self, pert: "Perturbation", ncore: int = 0) -> np.ndarray:
         """The full ``nmo x nmo`` orbital-rotation matrix ``U^x_pq`` for ``pert``.
 
         The matrix element ``U_qp = <phi_q|d phi_p/dx>`` (the coefficient of orbital ``q`` in
@@ -270,18 +270,46 @@ class CPHF(object):
         derivative, ``U_ij = -1/2 S^x_ij`` and ``U_ab = -1/2 S^x_ab``; the CPHF solve gives the
         occupied response ``Uia[i,a] = <phi_a|d phi_i> = U_ai`` (so ``U[v,o] = Uia.T``), and
         orthonormality ``U_pq + U_qp = -S^x_pq`` fixes ``U[o,v] = -S^x[o,v] - Uia``. For an
-        electric field ``S^x = 0``, so the oo/vv blocks vanish and ``U[o,v] = -Uia``."""
+        electric field ``S^x = 0``, so the oo/vv blocks vanish and ``U[o,v] = -Uia``.
+
+        ``ncore > 0`` (frozen-core correlated derivatives): the lowest ``ncore`` occupied
+        orbitals are the frozen core. Core<->active-occupied rotations are non-redundant (they
+        move the frozen/active partition), so that block is *not* left at the orthonormality
+        value but determined by the canonical Brillouin condition ``d_x f_ij = 0`` -- a direct
+        divide by ``(eps_i - eps_j)``, using the already-solved ov response. The redundant
+        core-core, active-active, and vir-vir blocks stay at ``-1/2 S^x``."""
         o, v, nmo = self.o, self.v, self.wfn.nmo
-        _, Sx, _ = self._skeleton(pert)
+        fx, Sx, _ = self._skeleton(pert)
         Uia = self._ov_response(pert)                       # (no, nv): U_ai = <phi_a|d phi_i>
         U = np.zeros((nmo, nmo))
         U[o, o] = -0.5 * Sx[o, o]
         U[v, v] = -0.5 * Sx[v, v]
         U[v, o] = Uia.T
         U[o, v] = -Sx[o, v] - Uia
+        if ncore:
+            # Core <-> active-occupied block from d_x f_ij = 0 (i core, j active), with
+            # U_ji = -S^x_ij - U_ij eliminated:
+            #   U_ij = -[ f^x_ij - S^x_ij eps_j - 1/2 sum_nm S^x_nm A_injm
+            #             + sum_cm U_cm A_icjm ] / (eps_i - eps_j),
+            # A_pqrs = w[p,q,r,s] + w[p,s,r,q] with w the orbital-Hessian weight.
+            W = (np.asarray(self.wfn.H.ERI) if self.wfn.orbital_basis == 'spinorbital'
+                 else np.asarray(self.wfn.H.L))
+            eps = self.eps
+            co = slice(o.start, o.start + ncore)            # frozen core
+            ao = slice(o.start + ncore, o.stop)             # active occupied
+            Soo = Sx[o, o]
+            Uvo = U[v, o]
+            Sterm = 0.5 * (self.contract('nm,injm->ij', Soo, W[co, o, ao, o])
+                           + self.contract('nm,imjn->ij', Soo, W[co, o, ao, o]))
+            Uterm = (self.contract('cm,icjm->ij', Uvo, W[co, v, ao, o])
+                     + self.contract('cm,imjc->ij', Uvo, W[co, o, ao, v]))
+            num = fx[co, ao] - Sx[co, ao] * eps[ao][None, :] - Sterm + Uterm
+            Uca = -num / (eps[co][:, None] - eps[ao][None, :])
+            U[co, ao] = Uca
+            U[ao, co] = -(Sx[co, ao] + Uca).T
         return U
 
-    def perturbed_fock(self, pert: "Perturbation") -> np.ndarray:
+    def perturbed_fock(self, pert: "Perturbation", ncore: int = 0) -> np.ndarray:
         """Full first derivative of the MO Fock matrix ``d_x f_pq`` (``nmo x nmo``) for
         ``pert``, with the CPHF response folded in (notes.pdf)::
 
@@ -292,16 +320,18 @@ class CPHF(object):
         (``w`` = the spin-adapted ``L`` on the spatial path, the antisymmetrized ``<pq||rs>``
         on the spin-orbital path), ``n,m`` over occupied and ``c`` over virtual. The skeleton
         ``f^(x)``/``S^x`` come from :meth:`_skeleton`; for an electric field ``S^x = 0`` so the
-        ``S^x`` term drops. Cached per ``pert``."""
-        if pert in self._dfock:
-            return self._dfock[pert]
+        ``S^x`` term drops. ``ncore`` selects the frozen-core core<->active response in ``U``
+        (see :meth:`_full_U`). Cached per ``(pert, ncore)``."""
+        key = (pert, ncore)
+        if key in self._dfock:
+            return self._dfock[key]
         o, v = self.o, self.v
         eps = self.eps
         # Orbital-Hessian two-electron weight: spin-adapted L (spatial) / <pq||rs> (SO).
         W = (np.asarray(self.wfn.H.ERI) if self.wfn.orbital_basis == 'spinorbital'
              else np.asarray(self.wfn.H.L))
         fx, Sx, _ = self._skeleton(pert)
-        U = self._full_U(pert)
+        U = self._full_U(pert, ncore)
         df = fx + U * eps[:, None] + U.T * eps[None, :]     # f^(x) + U_pq f_pp + U_qp f_qq
         # - 1/2 sum_nm(occ) S^x_nm ( w[p,n,q,m] + w[p,m,q,n] )
         Soo = Sx[o, o]
@@ -311,10 +341,10 @@ class CPHF(object):
         Uvo = U[v, o]
         df = df + (self.contract('cm,pcqm->pq', Uvo, W[:, v, :, o])
                    + self.contract('cm,pmqc->pq', Uvo, W[:, o, :, v]))
-        self._dfock[pert] = df
+        self._dfock[key] = df
         return df
 
-    def perturbed_eri(self, pert: "Perturbation", blocks=None) -> np.ndarray:
+    def perturbed_eri(self, pert: "Perturbation", ncore: int = 0, blocks=None) -> np.ndarray:
         """Full first derivative of the MO two-electron integrals ``d_x <pq|rs>`` for ``pert``
         (notes.pdf)::
 
@@ -325,21 +355,24 @@ class CPHF(object):
         in the basis's integral convention: the plain physicist ``<pq|rs>`` (= ``H.ERI``) on
         the spatial path, the antisymmetrized ``<pq||rs>`` (= ``H.ERI``) on the spin-orbital
         path -- so the same rotation of ``H.ERI`` serves both. The skeleton ``<pq|rs>^(x)``
-        comes from :meth:`_skeleton` (zero for an electric field). The full ``nmo^4`` tensor is
-        built and cached per ``pert`` (geometry-bound, shared across properties). ``blocks`` is
-        an optional 4-tuple of block labels ('o'/'v'/'all'), e.g. ``('o','o','v','v')`` for the
-        MP2 2PDM; the **default returns the full tensor** (CC consumers need the other blocks)."""
-        full = self._deri.get(pert)
+        comes from :meth:`_skeleton` (zero for an electric field). ``ncore`` selects the
+        frozen-core core<->active response in ``U`` (see :meth:`_full_U`). The full ``nmo^4``
+        tensor is built and cached per ``(pert, ncore)`` (geometry-bound, shared across
+        properties). ``blocks`` is an optional 4-tuple of block labels ('o'/'v'/'all'), e.g.
+        ``('o','o','v','v')`` for the MP2 2PDM; the **default returns the full tensor** (CC
+        consumers need the other blocks)."""
+        key = (pert, ncore)
+        full = self._deri.get(key)
         if full is None:
             ERI = np.asarray(self.wfn.H.ERI)
             _, _, gx = self._skeleton(pert)
-            U = self._full_U(pert)
+            U = self._full_U(pert, ncore)
             full = (gx
                     + self.contract('tp,tqrs->pqrs', U, ERI)
                     + self.contract('tq,ptrs->pqrs', U, ERI)
                     + self.contract('tr,pqts->pqrs', U, ERI)
                     + self.contract('ts,pqrt->pqrs', U, ERI))
-            self._deri[pert] = full
+            self._deri[key] = full
         if blocks is None:
             return full
         sl = tuple({'o': self.o, 'v': self.v}.get(b, slice(None)) for b in blocks)

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -404,37 +404,30 @@ class CPHF(object):
         provider; the unperturbed L is H.L. Validated to ~1e-8 via the dipole-
         derivative / APT-transpose check against finite difference of the SCF dipole.
 
-        The spin-orbital path dispatches to :meth:`_so_build_nuclear`.
+        The skeleton derivatives (including the dominant ``nmo^4`` ERI derivative) come from
+        the unified :meth:`_skeleton` cache, computed once per atom/cart and reused by the
+        explicit perturbed-integral engine. The spin-orbital path dispatches to
+        :meth:`_so_build_nuclear`.
         """
         if self.wfn.orbital_basis == 'spinorbital':
             return self._so_build_nuclear(atom)
-        o, v, no, nv = self.o, self.v, self.no, self.nv
+        o, v = self.o, self.v
         eps_o = self.eps[o]
-        L = np.asarray(self.wfn.H.L)  # spin-adapted, physicist, unperturbed
-
-        d = self.wfn.derivatives
-        Sx = d.overlap(atom)                                   # 3 x (nmo,nmo)
-        hx = d.core(atom)                                      # 3 x (nmo,nmo)
-        gx = [g.swapaxes(1, 2) for g in                        # chemist -> physicist
-              d.eri(atom)]                                     # 3 x (nmo^4) <pq|rs>^X
-
-        Lvooo = L[v, o, o, o]
+        Lvooo = np.asarray(self.wfn.H.L)[v, o, o, o]   # spin-adapted, unperturbed
         B, Foo, Soo = [], [], []
         for c in range(3):
-            Lx = 2.0 * gx[c] - gx[c].swapaxes(2, 3)            # derivative spin-adapted L
-            # skeleton derivative Fock: F^X_pq = h^X + sum_k L[p,k,q,k]^X
-            Fx = hx[c] + self.contract('pkqk->pq', Lx[:, o, :, o])
+            Fx, Sx, _ = self._skeleton(Perturbation('nuclear', (atom, c)))
             # Pulay coupling of the overlap-determined U^X_kl = -1/2 S^X_kl into the
             # ov block:  -1/2 S^X_kl ( L[a,k,i,l] + L[a,l,i,k] ).
-            coupling = (self.contract('akil,kl->ia', Lvooo, Sx[c][o, o])
-                        + self.contract('alik,kl->ia', Lvooo, Sx[c][o, o]))
+            coupling = (self.contract('akil,kl->ia', Lvooo, Sx[o, o])
+                        + self.contract('alik,kl->ia', Lvooo, Sx[o, o]))
             # The CPHF RHS is minus the first-order off-diagonal ("perturbation")
             # Fock that the response drives to zero -- B = -Q (nuclear analog of the
             # field's B = -mu).
-            Q = Fx[o, v] - eps_o[:, None] * Sx[c][o, v] - 0.5 * coupling
+            Q = Fx[o, v] - eps_o[:, None] * Sx[o, v] - 0.5 * coupling
             B.append(-Q)
             Foo.append(Fx[o, o])
-            Soo.append(Sx[c][o, o])
+            Soo.append(Sx[o, o])
         return B, Foo, Soo
 
     def _so_build_nuclear(self, atom: int):

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -182,15 +182,13 @@ class CPHF(object):
         return np.asarray(self.wfn.H.mu[axis])[self.o, self.v]
 
     def rhs_field(self, axis: int) -> np.ndarray:
-        """Electric-field CPHF RHS for ``axis`` (0/1/2), i.e. ``B = -mu``.
+        """Electric-field CPHF right-hand side for ``axis`` (0/1/2): ``B = +mu``.
 
-        The field enters the Hamiltonian as ``H' = -mu . E`` -- the field-interaction
-        sign is distinct from the electron-charge sign already carried by the dipole
-        integrals (``H.mu`` = -e r) -- so ``dH'/dE = -mu`` and the response RHS is the
-        negated dipole. (For the polarizability the two sign conventions cancel, but
-        the response ``U`` is reused by other properties where they do not.)
+        The field enters as ``H' = -mu . E`` (``H.mu`` is the dipole operator ``-e r``), so the
+        skeleton Fock derivative is ``f^(a) = -mu`` and the CPHF RHS is ``B = -f^(a) = +mu``
+        (no overlap/Pulay term -- the field does not move the basis functions).
         """
-        return -self._mu_ov(axis)
+        return self._mu_ov(axis)
 
     def solve_field(self, axis: int) -> np.ndarray:
         """Electric-field CPHF response ``U^a`` for ``axis`` (0/1/2), ``(no, nv)``, solved
@@ -215,8 +213,7 @@ class CPHF(object):
         derivative ``<pq||rs>^(x)`` (``nmo^4``), cached per ``pert``.
 
         - **field**: the basis functions do not move, so ``S^x = 0`` and ``<pq||rs>^(x) = 0``;
-          the skeleton Fock derivative is the explicit one-electron operator ``f^(x) = mu``
-          (sign consistent with ``rhs_field``'s ``B = -mu``).
+          the skeleton Fock derivative is ``f^(a) = -mu`` (``H' = -mu.E``).
         - **nuclear** (``comp = (atom, cart)``): the skeleton derivative integrals come from
           the (spin-orbital) ``Derivatives`` provider; the skeleton Fock derivative is
           ``f^(x)_pq = h^(x)_pq + sum_k(occ) <pk||qk>^(x)``."""
@@ -224,7 +221,7 @@ class CPHF(object):
             return self._skel[pert]
         nmo, o = self.wfn.nmo, self.o
         if pert.kind == 'field':
-            fx = np.asarray(self.wfn.H.mu[pert.comp])
+            fx = -np.asarray(self.wfn.H.mu[pert.comp])       # f^(a) = -mu  (H' = -mu.E)
             Sx = np.zeros((nmo, nmo))
             gx = 0.0                                         # no skeleton 2e deriv (field)
         elif pert.kind == 'nuclear':

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -112,6 +112,7 @@ class CPHF(object):
         # inefficient" explicit form), persisting for the life of this CPHF object so that
         # multiple property calculations on one wavefunction share them.
         self._U_field: dict = {}  # axis -> (no, nv) electric-field response U^a
+        self._skel: dict = {}     # Perturbation -> (fx, Sx, gx) skeleton derivatives
         self._dfock: dict = {}    # Perturbation -> (nmo, nmo) full perturbed Fock deriv
         self._deri: dict = {}     # Perturbation -> (nmo^4) full perturbed <pq||rs> deriv
 
@@ -203,28 +204,72 @@ class CPHF(object):
     # response into a Z-vector + relaxed density, fold the CPHF coefficients ``U^x``
     # directly into the full derivatives of the Fock matrix and the antisymmetrized
     # two-electron integrals, then contract with the (unrelaxed) densities. These are the
-    # building blocks of the correlated field properties (dipole now; polarizability next)
-    # and, later, of the nuclear gradient/Hessian. Spin-orbital path first.
+    # building blocks of the correlated properties -- the field dipole/polarizability and
+    # the nuclear gradient. Spin-orbital path first. Each perturbation differs only in its
+    # *skeleton* derivatives and its ov CPHF response; the assembly below is shared.
+
+    def _skeleton(self, pert: "Perturbation"):
+        """Skeleton (fixed-MO-coefficient) derivatives for ``pert``: a triple
+        ``(fx, Sx, gx)`` of the skeleton Fock derivative ``f^(x)_pq`` (``nmo x nmo``), the
+        overlap derivative ``S^x_pq`` (``nmo x nmo``), and the antisymmetrized two-electron
+        derivative ``<pq||rs>^(x)`` (``nmo^4``), cached per ``pert``.
+
+        - **field**: the basis functions do not move, so ``S^x = 0`` and ``<pq||rs>^(x) = 0``;
+          the skeleton Fock derivative is the explicit one-electron operator ``f^(x) = mu``
+          (sign consistent with ``rhs_field``'s ``B = -mu``).
+        - **nuclear** (``comp = (atom, cart)``): the skeleton derivative integrals come from
+          the (spin-orbital) ``Derivatives`` provider; the skeleton Fock derivative is
+          ``f^(x)_pq = h^(x)_pq + sum_k(occ) <pk||qk>^(x)``."""
+        if pert in self._skel:
+            return self._skel[pert]
+        nmo, o = self.wfn.nmo, self.o
+        if pert.kind == 'field':
+            fx = np.asarray(self.wfn.H.mu[pert.comp])
+            Sx = np.zeros((nmo, nmo))
+            gx = 0.0                                         # no skeleton 2e deriv (field)
+        elif pert.kind == 'nuclear':
+            atom, cart = pert.comp
+            d = self.wfn.derivatives
+            hx = np.asarray(d.so_core(atom)[cart])
+            Sx = np.asarray(d.so_overlap(atom)[cart])
+            gx = np.asarray(d.so_eri(atom)[cart])           # antisymmetrized <pq||rs>^(x)
+            fx = hx + self.contract('pkqk->pq', gx[:, o, :, o])  # skeleton Fock derivative
+        else:
+            raise NotImplementedError(
+                "explicit perturbed derivatives are wired for 'field' and 'nuclear' only; "
+                "'magnetic' uses the same machinery but is not yet built.")
+        self._skel[pert] = (fx, Sx, gx)
+        return self._skel[pert]
+
+    def _ov_response(self, pert: "Perturbation") -> np.ndarray:
+        """The independent ov CPHF response ``U_ai`` (``(no, nv)``, indexed ``[i, a]``) for
+        ``pert`` -- ``solve_field`` for the electric field, the cached ``solve_nuclear`` for
+        a nuclear displacement."""
+        if pert.kind == 'field':
+            return self.solve_field(pert.comp)
+        if pert.kind == 'nuclear':
+            atom, cart = pert.comp
+            return self.solve_nuclear(atom)[cart]
+        raise NotImplementedError("ov response wired for 'field'/'nuclear' only.")
 
     def _full_U(self, pert: "Perturbation") -> np.ndarray:
         """The full ``nmo x nmo`` orbital-rotation matrix ``U^x_pq`` for ``pert``.
 
-        The matrix element ``U_qp = <phi_q|d phi_p/dx>`` (the coefficient of orbital ``q``
-        in the first-order change of orbital ``p``, as it enters the integral derivatives).
-        The CPHF solve returns the occupied response ``Uia[i,a] = <phi_a|d phi_i> = U_ai``,
-        so the virtual-occupied block is ``U[v,o] = Uia.T``. For an electric field the basis
-        functions do not move (``S^x = 0``): the occupied-occupied and virtual-virtual blocks
-        vanish (``U_ij = U_ab = -1/2 S^x = 0``) and the ov/vo blocks are antisymmetric
-        (``U_ia = -U_ai``), so ``U[o,v] = -Uia``."""
-        if pert.kind != 'field':
-            raise NotImplementedError(
-                "full perturbed derivatives are wired for 'field' only so far; "
-                "'nuclear'/'magnetic' use the same machinery but are not yet built.")
-        nmo = self.wfn.nmo
-        Uia = self.solve_field(pert.comp)                  # (no, nv): U_ai = <phi_a|d phi_i>
+        The matrix element ``U_qp = <phi_q|d phi_p/dx>`` (the coefficient of orbital ``q`` in
+        the first-order change of orbital ``p``, as it enters the integral derivatives). The
+        non-canonical perturbed-orbital conditions fix the diagonal blocks from the overlap
+        derivative, ``U_ij = -1/2 S^x_ij`` and ``U_ab = -1/2 S^x_ab``; the CPHF solve gives the
+        occupied response ``Uia[i,a] = <phi_a|d phi_i> = U_ai`` (so ``U[v,o] = Uia.T``), and
+        orthonormality ``U_pq + U_qp = -S^x_pq`` fixes ``U[o,v] = -S^x[o,v] - Uia``. For an
+        electric field ``S^x = 0``, so the oo/vv blocks vanish and ``U[o,v] = -Uia``."""
+        o, v, nmo = self.o, self.v, self.wfn.nmo
+        _, Sx, _ = self._skeleton(pert)
+        Uia = self._ov_response(pert)                       # (no, nv): U_ai = <phi_a|d phi_i>
         U = np.zeros((nmo, nmo))
-        U[self.o, self.v] = -Uia
-        U[self.v, self.o] = Uia.T
+        U[o, o] = -0.5 * Sx[o, o]
+        U[v, v] = -0.5 * Sx[v, v]
+        U[v, o] = Uia.T
+        U[o, v] = -Sx[o, v] - Uia
         return U
 
     def perturbed_fock(self, pert: "Perturbation") -> np.ndarray:
@@ -234,10 +279,10 @@ class CPHF(object):
             d_x f_pq = f^(x)_pq + U^x_pq f_pp + U^x_qp f_qq
                        - 1/2 sum_nm S^x_nm A_pnqm + sum_cm U^x_cm A_pcqm
 
-        with ``A_pqrs = <pq||rs> + <ps||qr>`` (the orbital-Hessian two-electron weight).
-        For an electric field ``S^x = 0`` and the skeleton Fock derivative ``f^(x) = mu``
-        (the MO dipole integral, sign consistent with ``rhs_field``'s ``B = -mu``), so the
-        ``S^x`` term drops. Cached per ``pert``. Spin-orbital path only for now."""
+        with ``A_pqrs = <pq||rs> + <ps||qr>`` (the orbital-Hessian two-electron weight),
+        ``n,m`` over occupied and ``c`` over virtual. The skeleton ``f^(x)``/``S^x`` come from
+        :meth:`_skeleton`; for an electric field ``S^x = 0`` so the ``S^x`` term drops. Cached
+        per ``pert``. Spin-orbital path only for now."""
         if self.wfn.orbital_basis != 'spinorbital':
             raise NotImplementedError(
                 "perturbed_fock is implemented for the spin-orbital path only so far.")
@@ -246,9 +291,13 @@ class CPHF(object):
         o, v = self.o, self.v
         eps = self.eps
         ERI = np.asarray(self.wfn.H.ERI)
+        fx, Sx, _ = self._skeleton(pert)
         U = self._full_U(pert)
-        fx = np.asarray(self.wfn.H.mu[pert.comp])          # skeleton field Fock deriv = mu
         df = fx + U * eps[:, None] + U.T * eps[None, :]     # f^(x) + U_pq f_pp + U_qp f_qq
+        # - 1/2 sum_nm(occ) S^x_nm ( <pn||qm> + <pm||qn> )
+        Soo = Sx[o, o]
+        df = df - 0.5 * (self.contract('nm,pnqm->pq', Soo, ERI[:, o, :, o])
+                         + self.contract('nm,pmqn->pq', Soo, ERI[:, o, :, o]))
         # + sum_cm U_cm ( <pc||qm> + <pm||qc> ),  c in vir, m in occ
         Uvo = U[v, o]
         df = df + (self.contract('cm,pcqm->pq', Uvo, ERI[:, v, :, o])
@@ -264,20 +313,22 @@ class CPHF(object):
                            + sum_t ( U^x_tp <tq||rs> + U^x_tq <pt||rs>
                                      + U^x_tr <pq||ts> + U^x_ts <pq||rt> )
 
-        For an electric field the skeleton derivative ``<pq||rs>^(x) = 0``, leaving the
-        ``U``-rotation. The full ``nmo^4`` tensor is built and cached per ``pert`` (memory
-        is geometry-bound, shared across properties). ``blocks`` is an optional 4-tuple of
-        block labels ('o'/'v'/'all'), e.g. ``('o','o','v','v')`` for the MP2 2PDM; the
-        **default returns the full tensor** (CC consumers need the other blocks). Spin-orbital
-        path only for now."""
+        The skeleton ``<pq||rs>^(x)`` comes from :meth:`_skeleton` (zero for an electric
+        field). The full ``nmo^4`` tensor is built and cached per ``pert`` (memory is
+        geometry-bound, shared across properties). ``blocks`` is an optional 4-tuple of block
+        labels ('o'/'v'/'all'), e.g. ``('o','o','v','v')`` for the MP2 2PDM; the **default
+        returns the full tensor** (CC consumers need the other blocks). Spin-orbital path
+        only for now."""
         if self.wfn.orbital_basis != 'spinorbital':
             raise NotImplementedError(
                 "perturbed_eri is implemented for the spin-orbital path only so far.")
         full = self._deri.get(pert)
         if full is None:
             ERI = np.asarray(self.wfn.H.ERI)
-            U = self._full_U(pert)                          # skeleton <pq||rs>^(x) = 0 (field)
-            full = (self.contract('tp,tqrs->pqrs', U, ERI)
+            _, _, gx = self._skeleton(pert)
+            U = self._full_U(pert)
+            full = (gx
+                    + self.contract('tp,tqrs->pqrs', U, ERI)
                     + self.contract('tq,ptrs->pqrs', U, ERI)
                     + self.contract('tr,pqts->pqrs', U, ERI)
                     + self.contract('ts,pqrt->pqrs', U, ERI))
@@ -389,21 +440,21 @@ class CPHF(object):
             B^X_ia = -[ F^X_ia - eps_i S^X_ia
                         - 1/2 sum_kl S^X_kl ( <ak||il> + <al||ik> ) ]
 
-        Returns ``(B, Foo, Soo)`` as for the spatial path."""
+        Returns ``(B, Foo, Soo)`` as for the spatial path.
+
+        The skeleton derivative integrals (including the dominant ``nmo^4`` ``so_eri``
+        derivative) come from the unified :meth:`_skeleton` cache, so they are computed once
+        per atom/cart and reused by the explicit perturbed-integral engine
+        (:meth:`perturbed_fock` / :meth:`perturbed_eri`) and by any second-derivative
+        consumer; ``Foo``/``Soo`` are then just the ``oo`` slices of the cached
+        ``f^(x)``/``S^x``."""
         o, v = self.o, self.v
         eps_o = self.eps[o]
         ERI = np.asarray(self.wfn.H.ERI)         # antisymmetrized, unperturbed
-        d = self.wfn.derivatives
-        hx = d.so_core(atom)                     # 3 x (nmo,nmo)
-        Sxa = d.so_overlap(atom)                 # 3 x (nmo,nmo)
-        gx = d.so_eri(atom)                      # 3 x (nmo^4), antisymmetrized <pq||rs>^X
-
         Evooo = ERI[v, o, o, o]
         B, Foo, Soo = [], [], []
         for c in range(3):
-            # skeleton derivative Fock F^X_pq = h^X + sum_k(occ) <pk||qk>^X
-            Fx = hx[c] + self.contract('pkqk->pq', gx[c][:, o, :, o])
-            Sx = Sxa[c]
+            Fx, Sx, _ = self._skeleton(Perturbation('nuclear', (atom, c)))
             # Pulay coupling of the overlap-determined U^X_kl = -1/2 S^X_kl into the ov
             # block: -1/2 sum_kl S^X_kl ( <ak||il> + <al||ik> ).
             coupling = (self.contract('akil,kl->ia', Evooo, Sx[o, o])

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -80,12 +80,21 @@ class CPHF(object):
     ('electric' / 'magnetic') and cached, then reused across all perturbations.
     """
 
-    def __init__(self, wfn: Any) -> None:
+    def __init__(self, wfn: Any, full_occ: bool = False) -> None:
         self.wfn = wfn
         self.contract = wfn.contract        # device-aware ContractionBackend (shared)
-        self.o = wfn.o
+        # ``full_occ`` spans the full occupied space (frozen core + active) in the wfn's own
+        # MO ordering, for frozen-core correlated derivatives whose orbital response (incl.
+        # core<->active and core-virtual) the active-space CPHF can't supply. The core block
+        # is the first ``o.stop - no`` orbitals (the frozen core leads ``o`` in both the
+        # spatial and spin-orbital orderings). For ``nfzc=0`` it coincides with the default.
+        if full_occ:
+            self.o = slice(0, wfn.o.stop)
+            self.no = wfn.o.stop
+        else:
+            self.o = wfn.o
+            self.no = wfn.no
         self.v = wfn.v
-        self.no = wfn.no
         self.nv = wfn.nv
         # Orbital energies from the Fock diagonal (energy-ordered, all-electron --
         # HFwfn builds the full MO space).

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -203,23 +203,28 @@ class CPHF(object):
     # directly into the full derivatives of the Fock matrix and the antisymmetrized
     # two-electron integrals, then contract with the (unrelaxed) densities. These are the
     # building blocks of the correlated properties -- the field dipole/polarizability and
-    # the nuclear gradient. Spin-orbital path first. Each perturbation differs only in its
-    # *skeleton* derivatives and its ov CPHF response; the assembly below is shared.
+    # the nuclear gradient. Each perturbation differs only in its *skeleton* derivatives and
+    # its ov CPHF response; the assembly below is shared, and basis-aware (spatial closed-shell
+    # default, spin-orbital via the same ``orbital_basis`` switch as the rest of the code).
 
     def _skeleton(self, pert: "Perturbation"):
         """Skeleton (fixed-MO-coefficient) derivatives for ``pert``: a triple
         ``(fx, Sx, gx)`` of the skeleton Fock derivative ``f^(x)_pq`` (``nmo x nmo``), the
-        overlap derivative ``S^x_pq`` (``nmo x nmo``), and the antisymmetrized two-electron
-        derivative ``<pq||rs>^(x)`` (``nmo^4``), cached per ``pert``.
+        overlap derivative ``S^x_pq`` (``nmo x nmo``), and the two-electron derivative
+        ``gx`` (``nmo^4``, in the basis's integral convention -- spin-adapted ``<pq|rs>^(x)``
+        on the spatial path, antisymmetrized ``<pq||rs>^(x)`` on the spin-orbital path),
+        cached per ``pert``.
 
-        - **field**: the basis functions do not move, so ``S^x = 0`` and ``<pq||rs>^(x) = 0``;
-          the skeleton Fock derivative is ``f^(a) = -mu`` (``H' = -mu.E``).
+        - **field**: the basis functions do not move, so ``S^x = 0`` and ``gx = 0``; the
+          skeleton Fock derivative is ``f^(a) = -mu`` (``H' = -mu.E``).
         - **nuclear** (``comp = (atom, cart)``): the skeleton derivative integrals come from
-          the (spin-orbital) ``Derivatives`` provider; the skeleton Fock derivative is
-          ``f^(x)_pq = h^(x)_pq + sum_k(occ) <pk||qk>^(x)``."""
+          the ``Derivatives`` provider; the skeleton Fock derivative is ``f^(x)_pq = h^(x)_pq
+          + sum_m(occ) w[p,m,q,m]^(x)`` with ``w`` the spin-adapted ``L`` (spatial) or
+          antisymmetrized ``<pq||rs>`` (spin-orbital)."""
         if pert in self._skel:
             return self._skel[pert]
         nmo, o = self.wfn.nmo, self.o
+        so = self.wfn.orbital_basis == 'spinorbital'
         if pert.kind == 'field':
             fx = -np.asarray(self.wfn.H.mu[pert.comp])       # f^(a) = -mu  (H' = -mu.E)
             Sx = np.zeros((nmo, nmo))
@@ -227,10 +232,17 @@ class CPHF(object):
         elif pert.kind == 'nuclear':
             atom, cart = pert.comp
             d = self.wfn.derivatives
-            hx = np.asarray(d.so_core(atom)[cart])
-            Sx = np.asarray(d.so_overlap(atom)[cart])
-            gx = np.asarray(d.so_eri(atom)[cart])           # antisymmetrized <pq||rs>^(x)
-            fx = hx + self.contract('pkqk->pq', gx[:, o, :, o])  # skeleton Fock derivative
+            if so:
+                hx = np.asarray(d.so_core(atom)[cart])
+                Sx = np.asarray(d.so_overlap(atom)[cart])
+                gx = np.asarray(d.so_eri(atom)[cart])        # <pq||rs>^(x)
+                w = gx                                        # Fock 2e weight = <pq||rs>^(x)
+            else:
+                hx = np.asarray(d.core(atom)[cart])
+                Sx = np.asarray(d.overlap(atom)[cart])
+                gx = np.asarray(d.eri(atom)[cart]).swapaxes(1, 2)  # chemist -> physicist <pq|rs>^(x)
+                w = 2.0 * gx - gx.swapaxes(2, 3)              # spin-adapted L^(x)
+            fx = hx + self.contract('pmqm->pq', w[:, o, :, o])   # skeleton Fock derivative
         else:
             raise NotImplementedError(
                 "explicit perturbed derivatives are wired for 'field' and 'nuclear' only; "
@@ -276,49 +288,47 @@ class CPHF(object):
             d_x f_pq = f^(x)_pq + U^x_pq f_pp + U^x_qp f_qq
                        - 1/2 sum_nm S^x_nm A_pnqm + sum_cm U^x_cm A_pcqm
 
-        with ``A_pqrs = <pq||rs> + <ps||qr>`` (the orbital-Hessian two-electron weight),
-        ``n,m`` over occupied and ``c`` over virtual. The skeleton ``f^(x)``/``S^x`` come from
-        :meth:`_skeleton`; for an electric field ``S^x = 0`` so the ``S^x`` term drops. Cached
-        per ``pert``. Spin-orbital path only for now."""
-        if self.wfn.orbital_basis != 'spinorbital':
-            raise NotImplementedError(
-                "perturbed_fock is implemented for the spin-orbital path only so far.")
+        with ``A_pqrs = w[p,q,r,s] + w[p,s,r,q]`` the orbital-Hessian two-electron weight
+        (``w`` = the spin-adapted ``L`` on the spatial path, the antisymmetrized ``<pq||rs>``
+        on the spin-orbital path), ``n,m`` over occupied and ``c`` over virtual. The skeleton
+        ``f^(x)``/``S^x`` come from :meth:`_skeleton`; for an electric field ``S^x = 0`` so the
+        ``S^x`` term drops. Cached per ``pert``."""
         if pert in self._dfock:
             return self._dfock[pert]
         o, v = self.o, self.v
         eps = self.eps
-        ERI = np.asarray(self.wfn.H.ERI)
+        # Orbital-Hessian two-electron weight: spin-adapted L (spatial) / <pq||rs> (SO).
+        W = (np.asarray(self.wfn.H.ERI) if self.wfn.orbital_basis == 'spinorbital'
+             else np.asarray(self.wfn.H.L))
         fx, Sx, _ = self._skeleton(pert)
         U = self._full_U(pert)
         df = fx + U * eps[:, None] + U.T * eps[None, :]     # f^(x) + U_pq f_pp + U_qp f_qq
-        # - 1/2 sum_nm(occ) S^x_nm ( <pn||qm> + <pm||qn> )
+        # - 1/2 sum_nm(occ) S^x_nm ( w[p,n,q,m] + w[p,m,q,n] )
         Soo = Sx[o, o]
-        df = df - 0.5 * (self.contract('nm,pnqm->pq', Soo, ERI[:, o, :, o])
-                         + self.contract('nm,pmqn->pq', Soo, ERI[:, o, :, o]))
-        # + sum_cm U_cm ( <pc||qm> + <pm||qc> ),  c in vir, m in occ
+        df = df - 0.5 * (self.contract('nm,pnqm->pq', Soo, W[:, o, :, o])
+                         + self.contract('nm,pmqn->pq', Soo, W[:, o, :, o]))
+        # + sum_cm U_cm ( w[p,c,q,m] + w[p,m,q,c] ),  c in vir, m in occ
         Uvo = U[v, o]
-        df = df + (self.contract('cm,pcqm->pq', Uvo, ERI[:, v, :, o])
-                   + self.contract('cm,pmqc->pq', Uvo, ERI[:, o, :, v]))
+        df = df + (self.contract('cm,pcqm->pq', Uvo, W[:, v, :, o])
+                   + self.contract('cm,pmqc->pq', Uvo, W[:, o, :, v]))
         self._dfock[pert] = df
         return df
 
     def perturbed_eri(self, pert: "Perturbation", blocks=None) -> np.ndarray:
-        """Full first derivative of the antisymmetrized two-electron integrals
-        ``d_x <pq||rs>`` for ``pert`` (notes.pdf)::
+        """Full first derivative of the MO two-electron integrals ``d_x <pq|rs>`` for ``pert``
+        (notes.pdf)::
 
-            d_x <pq||rs> = <pq||rs>^(x)
-                           + sum_t ( U^x_tp <tq||rs> + U^x_tq <pt||rs>
-                                     + U^x_tr <pq||ts> + U^x_ts <pq||rt> )
+            d_x <pq|rs> = <pq|rs>^(x)
+                          + sum_t ( U^x_tp <tq|rs> + U^x_tq <pt|rs>
+                                    + U^x_tr <pq|ts> + U^x_ts <pq|rt> )
 
-        The skeleton ``<pq||rs>^(x)`` comes from :meth:`_skeleton` (zero for an electric
-        field). The full ``nmo^4`` tensor is built and cached per ``pert`` (memory is
-        geometry-bound, shared across properties). ``blocks`` is an optional 4-tuple of block
-        labels ('o'/'v'/'all'), e.g. ``('o','o','v','v')`` for the MP2 2PDM; the **default
-        returns the full tensor** (CC consumers need the other blocks). Spin-orbital path
-        only for now."""
-        if self.wfn.orbital_basis != 'spinorbital':
-            raise NotImplementedError(
-                "perturbed_eri is implemented for the spin-orbital path only so far.")
+        in the basis's integral convention: the plain physicist ``<pq|rs>`` (= ``H.ERI``) on
+        the spatial path, the antisymmetrized ``<pq||rs>`` (= ``H.ERI``) on the spin-orbital
+        path -- so the same rotation of ``H.ERI`` serves both. The skeleton ``<pq|rs>^(x)``
+        comes from :meth:`_skeleton` (zero for an electric field). The full ``nmo^4`` tensor is
+        built and cached per ``pert`` (geometry-bound, shared across properties). ``blocks`` is
+        an optional 4-tuple of block labels ('o'/'v'/'all'), e.g. ``('o','o','v','v')`` for the
+        MP2 2PDM; the **default returns the full tensor** (CC consumers need the other blocks)."""
         full = self._deri.get(pert)
         if full is None:
             ERI = np.asarray(self.wfn.H.ERI)

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -46,11 +46,22 @@ Hessian is solved directly with ``numpy.linalg`` (a small dense solve, left on N
 
 from __future__ import annotations
 
+from collections import namedtuple
 from typing import Any, List
 
 import numpy as np
 
 from .utils import diag
+
+
+# A perturbation descriptor used to key the response and full-derivative caches.
+# ``kind`` is 'field' (electric dipole, axis ``comp`` in 0/1/2), 'nuclear' (atomic
+# displacement, ``comp`` = (atom, cart)), or 'magnetic' (axis ``comp``). It is the
+# shared identity under which CPHF memoizes ``U^x`` and the full (CPHF-folded) first
+# derivatives ``d_x f`` and ``d_x <pq||rs>`` so multi-property workflows (e.g. IR + VCD,
+# or an MP2 gradient + polarizability) never recompute them. Only 'field' is wired so
+# far; 'nuclear'/'magnetic' slot into the same machinery later.
+Perturbation = namedtuple('Perturbation', ['kind', 'comp'])
 
 
 class CPHF(object):
@@ -96,6 +107,13 @@ class CPHF(object):
         self._F_nuc: dict = {}  # atom -> list of 3 (no, no) skeleton deriv Fock F^X_ij
         self._S_nuc: dict = {}  # atom -> list of 3 (no, no) overlap deriv S^X_ij
         self._U_mag: dict = {}  # axis -> (no, nv) magnetic-field response U^B (real)
+        # Full (CPHF-folded) first-derivative caches, keyed by Perturbation. These hold
+        # the response-dressed derivatives d_x f and d_x <pq||rs> (notes: the "simple but
+        # inefficient" explicit form), persisting for the life of this CPHF object so that
+        # multiple property calculations on one wavefunction share them.
+        self._U_field: dict = {}  # axis -> (no, nv) electric-field response U^a
+        self._dfock: dict = {}    # Perturbation -> (nmo, nmo) full perturbed Fock deriv
+        self._deri: dict = {}     # Perturbation -> (nmo^4) full perturbed <pq||rs> deriv
 
     # ---- orbital Hessian ----
     def hessian(self, kind: str = "electric") -> np.ndarray:
@@ -172,6 +190,102 @@ class CPHF(object):
         the response ``U`` is reused by other properties where they do not.)
         """
         return -self._mu_ov(axis)
+
+    def solve_field(self, axis: int) -> np.ndarray:
+        """Electric-field CPHF response ``U^a`` for ``axis`` (0/1/2), ``(no, nv)``, solved
+        once and cached (shared by the polarizability and the correlated field properties)."""
+        if axis not in self._U_field:
+            self._U_field[axis] = self.solve(self.rhs_field(axis), kind="electric")
+        return self._U_field[axis]
+
+    # ---- explicit (CPHF-folded) full first derivatives of f and <pq||rs> ----
+    # The "simple but inefficient" form (notes.pdf): rather than separate the orbital
+    # response into a Z-vector + relaxed density, fold the CPHF coefficients ``U^x``
+    # directly into the full derivatives of the Fock matrix and the antisymmetrized
+    # two-electron integrals, then contract with the (unrelaxed) densities. These are the
+    # building blocks of the correlated field properties (dipole now; polarizability next)
+    # and, later, of the nuclear gradient/Hessian. Spin-orbital path first.
+
+    def _full_U(self, pert: "Perturbation") -> np.ndarray:
+        """The full ``nmo x nmo`` orbital-rotation matrix ``U^x_pq`` for ``pert``.
+
+        The matrix element ``U_qp = <phi_q|d phi_p/dx>`` (the coefficient of orbital ``q``
+        in the first-order change of orbital ``p``, as it enters the integral derivatives).
+        The CPHF solve returns the occupied response ``Uia[i,a] = <phi_a|d phi_i> = U_ai``,
+        so the virtual-occupied block is ``U[v,o] = Uia.T``. For an electric field the basis
+        functions do not move (``S^x = 0``): the occupied-occupied and virtual-virtual blocks
+        vanish (``U_ij = U_ab = -1/2 S^x = 0``) and the ov/vo blocks are antisymmetric
+        (``U_ia = -U_ai``), so ``U[o,v] = -Uia``."""
+        if pert.kind != 'field':
+            raise NotImplementedError(
+                "full perturbed derivatives are wired for 'field' only so far; "
+                "'nuclear'/'magnetic' use the same machinery but are not yet built.")
+        nmo = self.wfn.nmo
+        Uia = self.solve_field(pert.comp)                  # (no, nv): U_ai = <phi_a|d phi_i>
+        U = np.zeros((nmo, nmo))
+        U[self.o, self.v] = -Uia
+        U[self.v, self.o] = Uia.T
+        return U
+
+    def perturbed_fock(self, pert: "Perturbation") -> np.ndarray:
+        """Full first derivative of the MO Fock matrix ``d_x f_pq`` (``nmo x nmo``) for
+        ``pert``, with the CPHF response folded in (notes.pdf)::
+
+            d_x f_pq = f^(x)_pq + U^x_pq f_pp + U^x_qp f_qq
+                       - 1/2 sum_nm S^x_nm A_pnqm + sum_cm U^x_cm A_pcqm
+
+        with ``A_pqrs = <pq||rs> + <ps||qr>`` (the orbital-Hessian two-electron weight).
+        For an electric field ``S^x = 0`` and the skeleton Fock derivative ``f^(x) = mu``
+        (the MO dipole integral, sign consistent with ``rhs_field``'s ``B = -mu``), so the
+        ``S^x`` term drops. Cached per ``pert``. Spin-orbital path only for now."""
+        if self.wfn.orbital_basis != 'spinorbital':
+            raise NotImplementedError(
+                "perturbed_fock is implemented for the spin-orbital path only so far.")
+        if pert in self._dfock:
+            return self._dfock[pert]
+        o, v = self.o, self.v
+        eps = self.eps
+        ERI = np.asarray(self.wfn.H.ERI)
+        U = self._full_U(pert)
+        fx = np.asarray(self.wfn.H.mu[pert.comp])          # skeleton field Fock deriv = mu
+        df = fx + U * eps[:, None] + U.T * eps[None, :]     # f^(x) + U_pq f_pp + U_qp f_qq
+        # + sum_cm U_cm ( <pc||qm> + <pm||qc> ),  c in vir, m in occ
+        Uvo = U[v, o]
+        df = df + (self.contract('cm,pcqm->pq', Uvo, ERI[:, v, :, o])
+                   + self.contract('cm,pmqc->pq', Uvo, ERI[:, o, :, v]))
+        self._dfock[pert] = df
+        return df
+
+    def perturbed_eri(self, pert: "Perturbation", blocks=None) -> np.ndarray:
+        """Full first derivative of the antisymmetrized two-electron integrals
+        ``d_x <pq||rs>`` for ``pert`` (notes.pdf)::
+
+            d_x <pq||rs> = <pq||rs>^(x)
+                           + sum_t ( U^x_tp <tq||rs> + U^x_tq <pt||rs>
+                                     + U^x_tr <pq||ts> + U^x_ts <pq||rt> )
+
+        For an electric field the skeleton derivative ``<pq||rs>^(x) = 0``, leaving the
+        ``U``-rotation. The full ``nmo^4`` tensor is built and cached per ``pert`` (memory
+        is geometry-bound, shared across properties). ``blocks`` is an optional 4-tuple of
+        block labels ('o'/'v'/'all'), e.g. ``('o','o','v','v')`` for the MP2 2PDM; the
+        **default returns the full tensor** (CC consumers need the other blocks). Spin-orbital
+        path only for now."""
+        if self.wfn.orbital_basis != 'spinorbital':
+            raise NotImplementedError(
+                "perturbed_eri is implemented for the spin-orbital path only so far.")
+        full = self._deri.get(pert)
+        if full is None:
+            ERI = np.asarray(self.wfn.H.ERI)
+            U = self._full_U(pert)                          # skeleton <pq||rs>^(x) = 0 (field)
+            full = (self.contract('tp,tqrs->pqrs', U, ERI)
+                    + self.contract('tq,ptrs->pqrs', U, ERI)
+                    + self.contract('tr,pqts->pqrs', U, ERI)
+                    + self.contract('ts,pqrt->pqrs', U, ERI))
+            self._deri[pert] = full
+        if blocks is None:
+            return full
+        sl = tuple({'o': self.o, 'v': self.v}.get(b, slice(None)) for b in blocks)
+        return full[sl]
 
     # ---- magnetic-field perturbation (imaginary; for AATs) ----
     def _m_ov(self, axis: int) -> np.ndarray:

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -109,19 +109,36 @@ class HFwfn(Wavefunction):
         self.grad = grad
         return grad
 
+    def dipole(self) -> np.ndarray:
+        """Total SCF electric-dipole moment (a.u.), shape ``(3,)``: the nuclear term plus
+        the electronic term, in the molecule's frame (gauge-independent for a neutral system).
+
+        ``mu_a = sum_A Z_A R_Aa  +  k sum_i (mu_a)_ii``, the electronic part being the occupied
+        trace of the MO dipole integrals (``H.mu`` = ``-e r``; same ``Tr(D mu)`` convention as
+        :meth:`MPwfn.relaxed_dipole`, with the SCF density's occupied block). The prefactor is
+        the orbital occupancy: ``k = 2`` on the spatial closed-shell path, ``k = 1`` for singly
+        occupied spin orbitals. Kept separate from the correlation dipole so the total MP2
+        dipole is ``HFwfn.dipole() + MPwfn.relaxed_dipole()`` (mirroring the gradient split).
+        Basis-aware."""
+        o = self.o
+        k = 1.0 if self.orbital_basis == 'spinorbital' else 2.0
+        mol = self.ref.molecule()
+        geom = np.asarray(mol.geometry())                      # (natom, 3), bohr
+        Z = np.array([mol.Z(A) for A in range(mol.natom())])
+        nuc = np.einsum('a,ax->x', Z, geom)
+        elec = np.array([k * np.trace(np.asarray(self.H.mu[a])[o, o]) for a in range(3)])
+        self.mu_scf = nuc + elec
+        return self.mu_scf
+
     def polarizability(self) -> np.ndarray:
         """Static electric-dipole polarizability tensor (a.u.), shape ``(3, 3)``.
 
-        The field perturbation does not move the basis functions, so the response has
-        no overlap/Pulay contribution: solve the electric-field CPHF response for each
-        Cartesian axis (:class:`CPHF`) and contract with the MO dipole integrals,
-        ``alpha_ab = -k sum_ia mu^a_ia U^b_ia``, where ``U^b`` solves ``G U^b = -mu^b``
-        in the ov block. The prefactor counts the ``ov``+``vo`` response (factor 2) and,
-        on the spatial closed-shell path, the double occupancy (another factor 2 ->
-        ``k = 4``); the spin-orbital path has singly occupied spin orbitals, so ``k = 2``
-        and the orbital Hessian carries the spin structure. (The two minus signs -- the
-        ``-mu`` RHS and the ``-k`` contraction -- make alpha positive definite and
-        cancel.) Basis-aware.
+        The field does not move the basis functions, so there is no overlap/Pulay term:
+        solve the electric-field CPHF response per Cartesian axis (:class:`CPHF`) and contract
+        with the MO dipole integrals, ``alpha_ab = k sum_ia mu^a_ia U^b_ia``, where ``U^b``
+        solves ``G U^b = mu^b`` in the ov block. The prefactor counts the ``ov``+``vo``
+        response (factor 2) and the orbital occupancy: ``k = 4`` on the spatial closed-shell
+        path (double occupancy), ``k = 2`` for singly occupied spin orbitals. Basis-aware.
         """
         o, v = self.o, self.v
         k = 2.0 if self.orbital_basis == 'spinorbital' else 4.0
@@ -130,7 +147,7 @@ class HFwfn(Wavefunction):
         alpha = np.zeros((3, 3))
         for a in range(3):
             for b in range(3):
-                alpha[a, b] = -k * self.contract('ia,ia->', mu[a], U[b])
+                alpha[a, b] = k * self.contract('ia,ia->', mu[a], U[b])
         self.alpha = alpha
         return self.alpha
 

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -228,16 +228,14 @@ class MPwfn(Wavefunction):
         ``(3,)`` (x, y, z).
 
         The relaxed (orbital-response) correlation one-particle density contracted with
-        the MO dipole integrals, ``mu_a^corr = - sum_pq D_pq (mu_a)_pq`` (:meth:`mp2_relaxed_opdm`,
-        ``H.mu``). This is the *correlation* dipole only: the reference (SCF) electronic
-        dipole and the nuclear term are kept separate (and are trivially cheap) -- the total
-        MP2 dipole is the SCF dipole plus this. Basis-aware (the relaxed density dispatches
-        on the orbital basis) and frozen-core aware.
+        the MO dipole integrals, ``mu_a^corr = sum_pq D_pq (mu_a)_pq`` (:meth:`mp2_relaxed_opdm`,
+        ``H.mu`` = ``-e r``). This is the *correlation* dipole only: the reference (SCF) dipole
+        is kept separate (:meth:`HFwfn.dipole`) -- the total MP2 dipole is their sum.
+        Basis-aware (the relaxed density dispatches on the orbital basis) and frozen-core aware.
 
-        The field analog of :meth:`HFwfn.polarizability`'s response; validated against a
-        finite field of (E_MP2 - E_SCF)."""
+        Validated against a finite field of (E_MP2 - E_SCF)."""
         D = self.mp2_relaxed_opdm()
-        return np.array([-self.contract('pq,pq->', D, np.asarray(self.H.mu[a]))
+        return np.array([self.contract('pq,pq->', D, np.asarray(self.H.mu[a]))
                          for a in range(3)])
 
     # ---- explicit-derivative property route (notes.pdf) ----
@@ -289,8 +287,8 @@ class MPwfn(Wavefunction):
         :meth:`_corr_energy_deriv` for each nuclear perturbation. The "simple but
         inefficient" form -- one nuclear CPHF solve per perturbation (``3*natom``) and a full
         perturbed-integral build, instead of the single Z-vector of :meth:`gradient`. An
-        independent cross-check of the relaxed-density correlation gradient
-        (``gradient() - HFwfn(ref).gradient()``). Spin-orbital, all-electron path."""
+        independent cross-check of the relaxed-density correlation gradient (:meth:`gradient`,
+        which is now correlation-only). Spin-orbital, all-electron path."""
         from .cphf import Perturbation
         natom = self.derivatives.natom
         g = np.zeros((natom, 3))
@@ -407,24 +405,25 @@ class MPwfn(Wavefunction):
     # ---- MP2 nuclear gradient ----
 
     def gradient(self) -> np.ndarray:
-        """MP2 analytic nuclear energy gradient (a.u.), shape (natom, 3): the SCF
-        (``HFwfn``) gradient plus the correlation contribution
+        """MP2 **correlation** contribution to the analytic nuclear energy gradient (a.u.),
+        shape (natom, 3)
 
             dE_corr/dX = sum_pq D_pq f^X_pq + sum_pqrs Gamma_pqrs <pq|rs>^X
                          + sum_pq I_pq S^X_pq
 
         with the relaxed 1-PDM ``D``, cumulant 2-PDM ``Gamma``, and energy-weighted density
-        ``W`` (Gauss/Stanton/Bartlett). This is the spin-adapted (closed-shell RHF) path,
-        frozen-core aware: the skeleton derivative integrals come from ``self.derivatives``
-        in the full spatial MO basis (chemist ``(pq|rs)^X``, converted to physicist here),
-        ``f^X = h^X + sum_m L[p,m,q,m]^X`` is the closed-shell skeleton Fock derivative with
-        ``m`` over the full occupied space (core + active), and the relaxed density/orbital
-        response span the full occupied space (:meth:`_mp2_relaxed_densities`). The
-        spin-orbital path is :meth:`_so_gradient`."""
+        ``W`` (Gauss/Stanton/Bartlett). The **reference (SCF) gradient is kept separate** (as
+        for :meth:`relaxed_dipole`): the total MP2 gradient is ``HFwfn(ref).gradient()`` plus
+        this. This is the spin-adapted (closed-shell RHF) path, frozen-core aware: the skeleton
+        derivative integrals come from ``self.derivatives`` in the full spatial MO basis
+        (chemist ``(pq|rs)^X``, converted to physicist here), ``f^X = h^X + sum_m L[p,m,q,m]^X``
+        is the closed-shell skeleton Fock derivative with ``m`` over the full occupied space
+        (core + active), and the relaxed density/orbital response span the full occupied space
+        (:meth:`_mp2_relaxed_densities`). The spin-orbital path is :meth:`_so_gradient`."""
         if self.orbital_basis == 'spinorbital':
             return self._so_gradient()
         ofull = slice(0, self.nfzc + self.no)
-        D, Gam, W, hf = self._mp2_relaxed_densities()
+        D, Gam, W, _ = self._mp2_relaxed_densities()
 
         d = self.derivatives
         grad = np.zeros((d.natom, 3))
@@ -439,14 +438,13 @@ class MPwfn(Wavefunction):
                 grad[atom, c] = (self.contract('pq,pq->', D, fx)
                                  + self.contract('pqrs,pqrs->', Gam, phys)
                                  + self.contract('pq,pq->', W, Sx[c]))
-        return hf.gradient() + grad
+        return grad
 
     def _so_gradient(self) -> np.ndarray:
-        """Spin-orbital MP2 gradient: the antisymmetrized ``<pq||rs>^X`` from the
-        spin-orbital ``self.derivatives.so_*`` (semicanonical gauge), ``f^X = h^X +
-        sum_m <pm||qm>^X`` with ``m`` over the full occupied space (frozen-core aware;
-        :meth:`_so_mp2_relaxed_densities`)."""
-        from .hfwfn import HFwfn
+        """Spin-orbital MP2 **correlation** gradient (the reference gradient kept separate;
+        see :meth:`gradient`): the antisymmetrized ``<pq||rs>^X`` from the spin-orbital
+        ``self.derivatives.so_*`` (semicanonical gauge), ``f^X = h^X + sum_m <pm||qm>^X`` with
+        ``m`` over the full occupied space (frozen-core aware; :meth:`_so_mp2_relaxed_densities`)."""
         ofull = slice(0, self.o.stop)
         D, Gam, W = self._so_mp2_relaxed_densities()
 
@@ -461,4 +459,4 @@ class MPwfn(Wavefunction):
                 grad[atom, c] = (self.contract('pq,pq->', D, fx)
                                  + self.contract('pqrs,pqrs->', Gam, ERIx[c])
                                  + self.contract('pq,pq->', W, Sx[c]))
-        return HFwfn(self.ref).gradient() + grad
+        return grad

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -279,7 +279,13 @@ class MPwfn(Wavefunction):
         with the unrelaxed correlation 1-PDM ``gamma`` (``Doo``/``Dvv``) and the 2PDM
         ``Gamma`` (``oovv``/``vvoo``), and the explicit derivatives from
         :meth:`CPHF.perturbed_fock` / :meth:`CPHF.perturbed_eri`. Spin-adapted (closed-shell
-        RHF) here; the spin-orbital path is :meth:`_so_corr_energy_deriv`."""
+        RHF) here; the spin-orbital path is :meth:`_so_corr_energy_deriv`.
+
+        Frozen-core aware with no rearrangement: the densities stay in the active space
+        (``Doo``/``Dvv``/``Gamma`` placed at the active ``o``/``v`` blocks of full-MO arrays),
+        while the perturbed derivatives are built over the **full occupied space** by the
+        all-electron reference CPHF (:meth:`_reference_hf`). The final contraction against the
+        full ``f``/``<pq|rs>`` derivatives then carries the core response automatically."""
         if self.orbital_basis == 'spinorbital':
             return self._so_corr_energy_deriv(pert)
         nmo, o, v = self.nmo, self.o, self.v
@@ -288,8 +294,9 @@ class MPwfn(Wavefunction):
         gamma[o, o] = np.asarray(Doo)
         gamma[v, v] = np.asarray(Dvv)
         Gam = self._mp2_cumulant()
-        df = self.cphf.perturbed_fock(pert)
-        deri = self.cphf.perturbed_eri(pert)
+        cphf = self._reference_hf().cphf            # full-occupied (all-electron) CPHF
+        df = cphf.perturbed_fock(pert, self.nfzc)
+        deri = cphf.perturbed_eri(pert, self.nfzc)
         return (self.contract('pq,pq->', gamma, df)
                 + self.contract('pqrs,pqrs->', Gam, deri))
 

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -267,21 +267,36 @@ class MPwfn(Wavefunction):
     # inside d_x f / d_x <pq||rs>, not in a relaxed density). This is the building block of
     # the analytic MP2 polarizability (the second derivative); for an electric-field
     # perturbation the first derivative is the (negative) correlation dipole, which must
-    # reproduce :meth:`relaxed_dipole`. Spin-orbital path first.
+    # reproduce :meth:`relaxed_dipole`. Spatial closed-shell default; spin-orbital via the
+    # ``_so_`` route (the convention used throughout HFwfn/MPwfn). All-electron.
 
     def _corr_energy_deriv(self, pert) -> float:
         """First derivative of the MP2 correlation energy along ``pert`` (a
         :class:`~pycc.cphf.Perturbation`)::
 
-            dE_corr/dx = sum_pq gamma_pq d_x f_pq + sum_pqrs Gamma_pqrs d_x <pq||rs>
+            dE_corr/dx = sum_pq gamma_pq d_x f_pq + sum_pqrs Gamma_pqrs d_x <pq|rs>
 
         with the unrelaxed correlation 1-PDM ``gamma`` (``Doo``/``Dvv``) and the 2PDM
         ``Gamma`` (``oovv``/``vvoo``), and the explicit derivatives from
-        :meth:`CPHF.perturbed_fock` / :meth:`CPHF.perturbed_eri`. Spin-orbital path only."""
-        if self.orbital_basis != 'spinorbital':
-            raise NotImplementedError(
-                "the explicit-derivative correlation gradient is implemented for the "
-                "spin-orbital path only so far.")
+        :meth:`CPHF.perturbed_fock` / :meth:`CPHF.perturbed_eri`. Spin-adapted (closed-shell
+        RHF) here; the spin-orbital path is :meth:`_so_corr_energy_deriv`."""
+        if self.orbital_basis == 'spinorbital':
+            return self._so_corr_energy_deriv(pert)
+        nmo, o, v = self.nmo, self.o, self.v
+        Doo, Dvv = self._mp2_corr_opdm()
+        gamma = np.zeros((nmo, nmo))
+        gamma[o, o] = np.asarray(Doo)
+        gamma[v, v] = np.asarray(Dvv)
+        Gam = self._mp2_cumulant()
+        df = self.cphf.perturbed_fock(pert)
+        deri = self.cphf.perturbed_eri(pert)
+        return (self.contract('pq,pq->', gamma, df)
+                + self.contract('pqrs,pqrs->', Gam, deri))
+
+    def _so_corr_energy_deriv(self, pert) -> float:
+        """Spin-orbital first derivative of the MP2 correlation energy along ``pert`` --
+        the antisymmetrized-integral form of :meth:`_corr_energy_deriv` (unrelaxed
+        ``gamma`` and 2PDM ``Gamma``, with the spin-orbital perturbed derivatives)."""
         nmo, o, v = self.nmo, self.o, self.v
         Doo, Dvv = self._so_mp2_corr_opdm()
         gamma = np.zeros((nmo, nmo))
@@ -298,7 +313,8 @@ class MPwfn(Wavefunction):
         explicit-derivative route -- ``mu_a = -dE_corr/dF_a`` from :meth:`_corr_energy_deriv`
         for the three electric-field perturbations. An independent cross-check of
         :meth:`relaxed_dipole` (same number, computed without the relaxed density / Z-vector)
-        and the validation that the CPHF perturbed-derivative engine is correct."""
+        and the validation that the CPHF perturbed-derivative engine is correct. Basis-aware,
+        all-electron."""
         from .cphf import Perturbation
         return np.array([-self._corr_energy_deriv(Perturbation('field', a))
                          for a in range(3)])
@@ -309,8 +325,8 @@ class MPwfn(Wavefunction):
         :meth:`_corr_energy_deriv` for each nuclear perturbation. The "simple but
         inefficient" form -- one nuclear CPHF solve per perturbation (``3*natom``) and a full
         perturbed-integral build, instead of the single Z-vector of :meth:`gradient`. An
-        independent cross-check of the relaxed-density correlation gradient (:meth:`gradient`,
-        which is now correlation-only). Spin-orbital, all-electron path."""
+        independent cross-check of the relaxed-density correlation gradient (:meth:`gradient`).
+        Basis-aware, all-electron."""
         from .cphf import Perturbation
         natom = self.derivatives.natom
         g = np.zeros((natom, 3))

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -238,6 +238,28 @@ class MPwfn(Wavefunction):
         return np.array([self.contract('pq,pq->', D, np.asarray(self.H.mu[a]))
                          for a in range(3)])
 
+    # ---- total (reference + correlation) properties ----
+    # MPwfn.gradient/relaxed_dipole are the correlation contributions only; these add the
+    # all-electron SCF reference (HFwfn, frozen_core=False) for the full molecular property.
+
+    def _reference_hf(self):
+        """The all-electron :class:`HFwfn` for the SCF reference (cached), supplying the
+        reference dipole and gradient for the total MP2 properties."""
+        if getattr(self, '_ref_hf', None) is None:
+            from .hfwfn import HFwfn
+            self._ref_hf = HFwfn(self.ref, orbital_basis=self.orbital_basis)
+        return self._ref_hf
+
+    def total_dipole(self) -> np.ndarray:
+        """Total MP2 electric-dipole moment (a.u.), shape ``(3,)``: the SCF reference dipole
+        (:meth:`HFwfn.dipole`) plus the MP2 correlation dipole (:meth:`relaxed_dipole`)."""
+        return self._reference_hf().dipole() + self.relaxed_dipole()
+
+    def total_gradient(self) -> np.ndarray:
+        """Total MP2 analytic nuclear gradient (a.u.), shape ``(natom, 3)``: the SCF reference
+        gradient (:meth:`HFwfn.gradient`) plus the MP2 correlation gradient (:meth:`gradient`)."""
+        return self._reference_hf().gradient() + self.gradient()
+
     # ---- explicit-derivative property route (notes.pdf) ----
     # The first derivative of the correlation energy w.r.t. a perturbation, via the
     # full (CPHF-folded) derivatives of f and <pq||rs> from the shared CPHF engine,

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -240,6 +240,49 @@ class MPwfn(Wavefunction):
         return np.array([-self.contract('pq,pq->', D, np.asarray(self.H.mu[a]))
                          for a in range(3)])
 
+    # ---- explicit-derivative property route (notes.pdf) ----
+    # The first derivative of the correlation energy w.r.t. a perturbation, via the
+    # full (CPHF-folded) derivatives of f and <pq||rs> from the shared CPHF engine,
+    # contracted with the *unrelaxed* correlation densities (the orbital relaxation rides
+    # inside d_x f / d_x <pq||rs>, not in a relaxed density). This is the building block of
+    # the analytic MP2 polarizability (the second derivative); for an electric-field
+    # perturbation the first derivative is the (negative) correlation dipole, which must
+    # reproduce :meth:`relaxed_dipole`. Spin-orbital path first.
+
+    def _corr_energy_deriv(self, pert) -> float:
+        """First derivative of the MP2 correlation energy along ``pert`` (a
+        :class:`~pycc.cphf.Perturbation`)::
+
+            dE_corr/dx = sum_pq gamma_pq d_x f_pq + sum_pqrs Gamma_pqrs d_x <pq||rs>
+
+        with the unrelaxed correlation 1-PDM ``gamma`` (``Doo``/``Dvv``) and the 2PDM
+        ``Gamma`` (``oovv``/``vvoo``), and the explicit derivatives from
+        :meth:`CPHF.perturbed_fock` / :meth:`CPHF.perturbed_eri`. Spin-orbital path only."""
+        if self.orbital_basis != 'spinorbital':
+            raise NotImplementedError(
+                "the explicit-derivative correlation gradient is implemented for the "
+                "spin-orbital path only so far.")
+        nmo, o, v = self.nmo, self.o, self.v
+        Doo, Dvv = self._so_mp2_corr_opdm()
+        gamma = np.zeros((nmo, nmo))
+        gamma[o, o] = np.asarray(Doo)
+        gamma[v, v] = np.asarray(Dvv)
+        Gam = self._so_mp2_cumulant()
+        df = self.cphf.perturbed_fock(pert)
+        deri = self.cphf.perturbed_eri(pert)
+        return (self.contract('pq,pq->', gamma, df)
+                + self.contract('pqrs,pqrs->', Gam, deri))
+
+    def _corr_dipole_explicit(self) -> np.ndarray:
+        """MP2 correlation electronic dipole (a.u.), shape ``(3,)``, via the
+        explicit-derivative route -- ``mu_a = -dE_corr/dF_a`` from :meth:`_corr_energy_deriv`
+        for the three electric-field perturbations. An independent cross-check of
+        :meth:`relaxed_dipole` (same number, computed without the relaxed density / Z-vector)
+        and the validation that the CPHF perturbed-derivative engine is correct."""
+        from .cphf import Perturbation
+        return np.array([-self._corr_energy_deriv(Perturbation('field', a))
+                         for a in range(3)])
+
     # ---- spin-adapted (closed-shell RHF) MP2 relaxed-gradient densities ----
     # The closed-shell analogue of the spin-orbital densities: the spin sum is carried by
     # the spin-adapted lambda ``l2 = 2(2 t2 - t2.swap)`` and the spin-adapted ``L`` (= H.L,

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -283,6 +283,22 @@ class MPwfn(Wavefunction):
         return np.array([-self._corr_energy_deriv(Perturbation('field', a))
                          for a in range(3)])
 
+    def _corr_gradient_explicit(self) -> np.ndarray:
+        """MP2 correlation contribution to the nuclear gradient (a.u.), shape
+        ``(natom, 3)``, via the explicit-derivative route: ``dE_corr/dX_Ac`` from
+        :meth:`_corr_energy_deriv` for each nuclear perturbation. The "simple but
+        inefficient" form -- one nuclear CPHF solve per perturbation (``3*natom``) and a full
+        perturbed-integral build, instead of the single Z-vector of :meth:`gradient`. An
+        independent cross-check of the relaxed-density correlation gradient
+        (``gradient() - HFwfn(ref).gradient()``). Spin-orbital, all-electron path."""
+        from .cphf import Perturbation
+        natom = self.derivatives.natom
+        g = np.zeros((natom, 3))
+        for atom in range(natom):
+            for c in range(3):
+                g[atom, c] = self._corr_energy_deriv(Perturbation('nuclear', (atom, c)))
+        return g
+
     # ---- spin-adapted (closed-shell RHF) MP2 relaxed-gradient densities ----
     # The closed-shell analogue of the spin-orbital densities: the spin sum is carried by
     # the spin-adapted lambda ``l2 = 2(2 t2 - t2.swap)`` and the spin-adapted ``L`` (= H.L,

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -268,7 +268,19 @@ class MPwfn(Wavefunction):
     # the analytic MP2 polarizability (the second derivative); for an electric-field
     # perturbation the first derivative is the (negative) correlation dipole, which must
     # reproduce :meth:`relaxed_dipole`. Spatial closed-shell default; spin-orbital via the
-    # ``_so_`` route (the convention used throughout HFwfn/MPwfn). All-electron.
+    # ``_so_`` route (the convention used throughout HFwfn/MPwfn).
+
+    def _full_occ_cphf(self):
+        """A CPHF over the **full** occupied space (frozen core + active) in this wavefunction's
+        own MO ordering (cached). The explicit-derivative engine needs the orbital response over
+        the full occupied space (core<->active and core-virtual), which ``self.cphf`` (active
+        only) can't supply; building it here -- rather than borrowing an all-electron ``HFwfn``
+        -- keeps the spin-orbital ordering consistent with the densities (the all-electron SO
+        ``HFwfn`` orders the spins differently). For ``nfzc=0`` it coincides with ``self.cphf``."""
+        if getattr(self, '_focphf', None) is None:
+            from .cphf import CPHF
+            self._focphf = CPHF(self, full_occ=True)
+        return self._focphf
 
     def _corr_energy_deriv(self, pert) -> float:
         """First derivative of the MP2 correlation energy along ``pert`` (a
@@ -283,9 +295,9 @@ class MPwfn(Wavefunction):
 
         Frozen-core aware with no rearrangement: the densities stay in the active space
         (``Doo``/``Dvv``/``Gamma`` placed at the active ``o``/``v`` blocks of full-MO arrays),
-        while the perturbed derivatives are built over the **full occupied space** by the
-        all-electron reference CPHF (:meth:`_reference_hf`). The final contraction against the
-        full ``f``/``<pq|rs>`` derivatives then carries the core response automatically."""
+        while the perturbed derivatives are built over the **full occupied space**
+        (:meth:`_full_occ_cphf`) with the core<->active block of ``U`` from ``ncore``. The
+        contraction against the full ``f``/``<pq|rs>`` derivatives carries the core response."""
         if self.orbital_basis == 'spinorbital':
             return self._so_corr_energy_deriv(pert)
         nmo, o, v = self.nmo, self.o, self.v
@@ -294,24 +306,28 @@ class MPwfn(Wavefunction):
         gamma[o, o] = np.asarray(Doo)
         gamma[v, v] = np.asarray(Dvv)
         Gam = self._mp2_cumulant()
-        cphf = self._reference_hf().cphf            # full-occupied (all-electron) CPHF
-        df = cphf.perturbed_fock(pert, self.nfzc)
-        deri = cphf.perturbed_eri(pert, self.nfzc)
+        ncore = o.stop - self.no                    # frozen-core orbitals at the front of o
+        cphf = self._full_occ_cphf()
+        df = cphf.perturbed_fock(pert, ncore)
+        deri = cphf.perturbed_eri(pert, ncore)
         return (self.contract('pq,pq->', gamma, df)
                 + self.contract('pqrs,pqrs->', Gam, deri))
 
     def _so_corr_energy_deriv(self, pert) -> float:
         """Spin-orbital first derivative of the MP2 correlation energy along ``pert`` --
         the antisymmetrized-integral form of :meth:`_corr_energy_deriv` (unrelaxed
-        ``gamma`` and 2PDM ``Gamma``, with the spin-orbital perturbed derivatives)."""
+        ``gamma`` and 2PDM ``Gamma``, with the spin-orbital perturbed derivatives over the
+        full occupied space; ``ncore`` = the frozen spin orbitals at the front of ``o``)."""
         nmo, o, v = self.nmo, self.o, self.v
         Doo, Dvv = self._so_mp2_corr_opdm()
         gamma = np.zeros((nmo, nmo))
         gamma[o, o] = np.asarray(Doo)
         gamma[v, v] = np.asarray(Dvv)
         Gam = self._so_mp2_cumulant()
-        df = self.cphf.perturbed_fock(pert)
-        deri = self.cphf.perturbed_eri(pert)
+        ncore = o.stop - self.no                    # frozen-core spin orbitals at the front of o
+        cphf = self._full_occ_cphf()
+        df = cphf.perturbed_fock(pert, ncore)
+        deri = cphf.perturbed_eri(pert, ncore)
         return (self.contract('pq,pq->', gamma, df)
                 + self.contract('pqrs,pqrs->', Gam, deri))
 

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -223,6 +223,23 @@ class MPwfn(Wavefunction):
             D, Gam, W, hf = self._mp2_relaxed_densities()
         return D
 
+    def relaxed_dipole(self) -> np.ndarray:
+        """MP2 correlation contribution to the electronic dipole moment (a.u.), shape
+        ``(3,)`` (x, y, z).
+
+        The relaxed (orbital-response) correlation one-particle density contracted with
+        the MO dipole integrals, ``mu_a^corr = - sum_pq D_pq (mu_a)_pq`` (:meth:`mp2_relaxed_opdm`,
+        ``H.mu``). This is the *correlation* dipole only: the reference (SCF) electronic
+        dipole and the nuclear term are kept separate (and are trivially cheap) -- the total
+        MP2 dipole is the SCF dipole plus this. Basis-aware (the relaxed density dispatches
+        on the orbital basis) and frozen-core aware.
+
+        The field analog of :meth:`HFwfn.polarizability`'s response; validated against a
+        finite field of (E_MP2 - E_SCF)."""
+        D = self.mp2_relaxed_opdm()
+        return np.array([-self.contract('pq,pq->', D, np.asarray(self.H.mu[a]))
+                         for a in range(3)])
+
     # ---- spin-adapted (closed-shell RHF) MP2 relaxed-gradient densities ----
     # The closed-shell analogue of the spin-orbital densities: the spin sum is carried by
     # the spin-adapted lambda ``l2 = 2(2 t2 - t2.swap)`` and the spin-adapted ``L`` (= H.L,

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -132,13 +132,14 @@ def test_mp2_explicit_corr_dipole_ccpvdz():
                - _ff_corr_dipole(WATER, 'cc-pVDZ')) < 1e-8
 
 
-def _pycc_corr_gradient_explicit_and_relaxed(geom, basis, orbital_basis='spinorbital'):
+def _pycc_corr_gradient_explicit_and_relaxed(geom, basis, orbital_basis='spinorbital',
+                                             freeze_core='false'):
     """MP2 correlation nuclear gradient two ways: the explicit-derivative route
     (`_corr_gradient_explicit`) and the relaxed-density route (`gradient`, correlation-only)."""
     psi4.core.clean()
     psi4.core.clean_options()
     psi4.geometry(geom)
-    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': 'false',
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': freeze_core,
                       'e_convergence': 1e-12, 'd_convergence': 1e-12})
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
@@ -170,6 +171,24 @@ def test_mp2_explicit_corr_gradient_ccpvdz():
     assert np.max(np.abs(g_so_e - g_so_r)) < 1e-9
     g_sa_e, g_sa_r = _pycc_corr_gradient_explicit_and_relaxed(WATER, 'cc-pVDZ', 'spatial')
     assert np.max(np.abs(g_sa_e - g_sa_r)) < 1e-9
+
+
+def test_fc_sa_mp2_explicit_corr_dipole_631g():
+    """Frozen-core spin-adapted (spatial) explicit-derivative MP2 correlation dipole vs the
+    finite field of (E_MP2 - E_SCF), H2O/6-31G (C1) -- the core<->active orbital response (the
+    canonical d_x f_ij = 0 block of U) is what the explicit route needs for frozen core."""
+    geom = WATER + "symmetry c1\n"
+    assert abs(_pycc_corr_dipole_explicit(geom, '6-31G', orbital_basis='spatial', freeze_core='true')
+               - _ff_corr_dipole(geom, '6-31G', freeze_core='true')) < 1e-8
+
+
+def test_fc_sa_mp2_explicit_corr_gradient_631g():
+    """Keystone: frozen-core spin-adapted explicit-derivative MP2 correlation gradient ==
+    relaxed-density route, H2O/6-31G (C1)."""
+    geom = WATER + "symmetry c1\n"
+    g_explicit, g_relaxed = _pycc_corr_gradient_explicit_and_relaxed(
+        geom, '6-31G', orbital_basis='spatial', freeze_core='true')
+    assert np.max(np.abs(g_explicit - g_relaxed)) < 1e-9
 
 
 def _pycc_gradient(geom, basis, orbital_basis='spinorbital', freeze_core='false'):

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -162,9 +162,7 @@ def _pycc_gradient(geom, basis, orbital_basis='spinorbital', freeze_core='false'
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
-    # MPwfn.gradient() is the correlation contribution only; the total MP2 gradient adds
-    # the (separately computed) SCF gradient, mirroring the dipole split.
-    return pycc.HFwfn(wfn).gradient() + mp.gradient()
+    return mp.total_gradient()
 
 
 def _psi4_mp2_gradient(geom, basis):
@@ -264,7 +262,7 @@ def test_fc_mp2_gradient_vs_energy_fd_631g():
     mp = pycc.MPwfn(wfn, orbital_basis='spatial')
     mp.compute_energy()
     assert mp.nfzc > 0                                   # frozen core is actually active
-    gA = pycc.HFwfn(wfn).gradient() + mp.gradient()      # total = SCF + correlation
+    gA = mp.total_gradient()                             # total = SCF + correlation
 
     h = 2.0e-3
     gF = np.zeros((3, 3))
@@ -334,7 +332,7 @@ def test_mp2_total_dipole_631g():
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis='spinorbital')
     mp.compute_energy()
-    total = pycc.HFwfn(wfn).dipole() + mp.relaxed_dipole()
+    total = mp.total_dipole()
     assert abs(total[2] - _ff_total_dipole(geom, '6-31G', 'mp2')) < 1e-8
 
 

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -39,8 +39,8 @@ def _ff_corr_dipole(geom, basis, F=0.0005, freeze_core='false'):
         return psi4.energy(model)
 
     def mu(model):
-        return -(-e(model, 2 * F) + 8 * e(model, F)
-                 - 8 * e(model, -F) + e(model, -2 * F)) / (12 * F)
+        return (-e(model, 2 * F) + 8 * e(model, F)
+                - 8 * e(model, -F) + e(model, -2 * F)) / (12 * F)
     return mu('mp2') - mu('scf')
 
 
@@ -122,7 +122,8 @@ def test_mp2_explicit_corr_dipole_ccpvdz():
 
 def _pycc_corr_gradient_explicit_and_relaxed(geom, basis):
     """SO MP2 correlation nuclear gradient two ways: the explicit-derivative route
-    (`_corr_gradient_explicit`) and the relaxed-density route (`gradient` - HF gradient)."""
+    (`_corr_gradient_explicit`) and the relaxed-density route (`gradient`, which is now
+    correlation-only)."""
     psi4.core.clean()
     psi4.core.clean_options()
     psi4.geometry(geom)
@@ -132,7 +133,7 @@ def _pycc_corr_gradient_explicit_and_relaxed(geom, basis):
     mp = pycc.MPwfn(wfn, orbital_basis='spinorbital')
     mp.compute_energy()
     g_explicit = mp._corr_gradient_explicit()
-    g_relaxed = mp.gradient() - pycc.HFwfn(wfn).gradient()
+    g_relaxed = mp.gradient()
     return g_explicit, g_relaxed
 
 
@@ -161,7 +162,9 @@ def _pycc_gradient(geom, basis, orbital_basis='spinorbital', freeze_core='false'
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
-    return mp.gradient()
+    # MPwfn.gradient() is the correlation contribution only; the total MP2 gradient adds
+    # the (separately computed) SCF gradient, mirroring the dipole split.
+    return pycc.HFwfn(wfn).gradient() + mp.gradient()
 
 
 def _psi4_mp2_gradient(geom, basis):
@@ -261,7 +264,7 @@ def test_fc_mp2_gradient_vs_energy_fd_631g():
     mp = pycc.MPwfn(wfn, orbital_basis='spatial')
     mp.compute_energy()
     assert mp.nfzc > 0                                   # frozen core is actually active
-    gA = mp.gradient()
+    gA = pycc.HFwfn(wfn).gradient() + mp.gradient()      # total = SCF + correlation
 
     h = 2.0e-3
     gF = np.zeros((3, 3))
@@ -270,6 +273,69 @@ def test_fc_mp2_gradient_vs_energy_fd_631g():
             e = [_fc_mp2_total_energy((i, c, k * h), basis) for k in (-2, -1, 1, 2)]
             gF[i, c] = (e[0] - 8 * e[1] + 8 * e[2] - e[3]) / (12 * h)
     assert np.max(np.abs(gA - gF)) < 1e-8
+
+
+# ---- SCF dipole (HFwfn.dipole) and the total MP2 dipole ----
+# The reference dipole is kept separate from the correlation dipole (as for the gradient):
+# the total MP2 dipole is HFwfn.dipole() + MPwfn.relaxed_dipole().
+
+def _scf_dipole(geom, basis):
+    """PyCC HFwfn.dipole() (spatial + spin-orbital) and Psi4's analytic SCF dipole."""
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk',
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    ref = np.asarray(psi4.variable('SCF DIPOLE'))
+    return (pycc.HFwfn(wfn).dipole(),
+            pycc.HFwfn(wfn, orbital_basis='spinorbital').dipole(), ref)
+
+
+def test_hf_dipole_631g():
+    """HFwfn.dipole() (spatial and spin-orbital) vs Psi4's analytic SCF dipole, H2O/6-31G."""
+    d_spatial, d_so, ref = _scf_dipole(WATER + "symmetry c1\n", '6-31G')
+    assert np.max(np.abs(d_spatial - ref)) < 1e-9
+    assert np.max(np.abs(d_so - ref)) < 1e-9
+
+
+def test_hf_dipole_ccpvdz():
+    """HFwfn.dipole() vs Psi4's analytic SCF dipole, H2O/cc-pVDZ (C2v)."""
+    d_spatial, d_so, ref = _scf_dipole(WATER, 'cc-pVDZ')
+    assert np.max(np.abs(d_spatial - ref)) < 1e-9
+    assert np.max(np.abs(d_so - ref)) < 1e-9
+
+
+def _ff_total_dipole(geom, basis, model, F=0.0005):
+    """z-component of the total ``model`` dipole via a 5-point finite field of its energy."""
+    def e(Fz):
+        psi4.core.clean()
+        psi4.core.clean_options()
+        psi4.geometry(geom)
+        opt = {'basis': basis, 'scf_type': 'pk', 'mp2_type': 'conv',
+               'freeze_core': 'false', 'e_convergence': 1e-12, 'd_convergence': 1e-12}
+        if Fz:
+            opt.update({'perturb_h': True, 'perturb_with': 'dipole',
+                        'perturb_dipole': [0.0, 0.0, Fz]})
+        psi4.set_options(opt)
+        return psi4.energy(model)
+    return (-e(2 * F) + 8 * e(F) - 8 * e(-F) + e(-2 * F)) / (12 * F)
+
+
+def test_mp2_total_dipole_631g():
+    """Total MP2 dipole = HFwfn.dipole() + MPwfn.relaxed_dipole() vs a finite field of the
+    total MP2 energy, H2O/6-31G (C1) -- validates the reference/correlation dipole split."""
+    geom = WATER + "symmetry c1\n"
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'basis': '6-31G', 'scf_type': 'pk', 'freeze_core': 'false',
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    mp = pycc.MPwfn(wfn, orbital_basis='spinorbital')
+    mp.compute_energy()
+    total = pycc.HFwfn(wfn).dipole() + mp.relaxed_dipole()
+    assert abs(total[2] - _ff_total_dipole(geom, '6-31G', 'mp2')) < 1e-8
 
 
 def test_fc_so_mp2_relaxed_dipole_631g():

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -120,6 +120,38 @@ def test_mp2_explicit_corr_dipole_ccpvdz():
                - _ff_corr_dipole(WATER, 'cc-pVDZ')) < 1e-8
 
 
+def _pycc_corr_gradient_explicit_and_relaxed(geom, basis):
+    """SO MP2 correlation nuclear gradient two ways: the explicit-derivative route
+    (`_corr_gradient_explicit`) and the relaxed-density route (`gradient` - HF gradient)."""
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': 'false',
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    mp = pycc.MPwfn(wfn, orbital_basis='spinorbital')
+    mp.compute_energy()
+    g_explicit = mp._corr_gradient_explicit()
+    g_relaxed = mp.gradient() - pycc.HFwfn(wfn).gradient()
+    return g_explicit, g_relaxed
+
+
+def test_mp2_explicit_corr_gradient_631g():
+    """Keystone: the explicit-derivative SO MP2 correlation nuclear gradient equals the
+    relaxed-density route (`MPwfn.gradient` minus the HF gradient), H2O/6-31G (C1) -- the
+    nuclear analog of the field engine, exercising the full skeleton + CPHF response."""
+    geom = WATER + "symmetry c1\n"
+    g_explicit, g_relaxed = _pycc_corr_gradient_explicit_and_relaxed(geom, '6-31G')
+    assert np.max(np.abs(g_explicit - g_relaxed)) < 1e-9
+
+
+def test_mp2_explicit_corr_gradient_ccpvdz():
+    """Explicit-derivative SO MP2 correlation gradient == relaxed-density route, H2O/cc-pVDZ
+    (C2v: polarization functions and A2-irrep MOs)."""
+    g_explicit, g_relaxed = _pycc_corr_gradient_explicit_and_relaxed(WATER, 'cc-pVDZ')
+    assert np.max(np.abs(g_explicit - g_relaxed)) < 1e-9
+
+
 def _pycc_gradient(geom, basis, orbital_basis='spinorbital', freeze_core='false'):
     psi4.core.clean()
     psi4.core.clean_options()

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -85,7 +85,7 @@ def test_mp2_relaxed_dipole_ccpvdz():
 # correlation dipole, and the validation of the perturbed-derivative engine that the
 # analytic MP2 polarizability will build on. Spin-orbital path.
 
-def _pycc_corr_dipole_explicit(geom, basis, freeze_core='false'):
+def _pycc_corr_dipole_explicit(geom, basis, orbital_basis='spinorbital', freeze_core='false'):
     """PyCC relaxed-MP2 correlation mu_z via :meth:`MPwfn._corr_dipole_explicit`."""
     psi4.core.clean()
     psi4.core.clean_options()
@@ -93,7 +93,7 @@ def _pycc_corr_dipole_explicit(geom, basis, freeze_core='false'):
     psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': freeze_core,
                       'e_convergence': 1e-12, 'd_convergence': 1e-12})
     _, wfn = psi4.energy('scf', return_wfn=True)
-    mp = pycc.MPwfn(wfn, orbital_basis='spinorbital')
+    mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
     return mp._corr_dipole_explicit()[2]
 
@@ -105,52 +105,71 @@ def test_mp2_explicit_corr_dipole_631g():
                - _ff_corr_dipole(geom, '6-31G')) < 1e-8
 
 
+def test_sa_mp2_explicit_corr_dipole_631g():
+    """Explicit-derivative spin-adapted (spatial) MP2 correlation dipole vs the finite
+    field, H2O/6-31G (C1)."""
+    geom = WATER + "symmetry c1\n"
+    assert abs(_pycc_corr_dipole_explicit(geom, '6-31G', orbital_basis='spatial')
+               - _ff_corr_dipole(geom, '6-31G')) < 1e-8
+
+
 def test_mp2_explicit_equals_relaxed_631g():
     """Keystone: the explicit-derivative correlation dipole equals the relaxed-density
-    route (same number, computed without the Z-vector / relaxed density), H2O/6-31G."""
+    route (same number, computed without the Z-vector / relaxed density), both bases, H2O/6-31G."""
     geom = WATER + "symmetry c1\n"
     assert abs(_pycc_corr_dipole_explicit(geom, '6-31G')
                - _pycc_corr_dipole(geom, '6-31G')) < 1e-10
+    assert abs(_pycc_corr_dipole_explicit(geom, '6-31G', orbital_basis='spatial')
+               - _pycc_corr_dipole(geom, '6-31G', orbital_basis='spatial')) < 1e-10
 
 
 def test_mp2_explicit_corr_dipole_ccpvdz():
-    """Explicit-derivative SO MP2 correlation dipole vs finite field, H2O/cc-pVDZ (C2v:
-    polarization functions and A2-irrep MOs)."""
+    """Explicit-derivative MP2 correlation dipole vs finite field, H2O/cc-pVDZ (C2v:
+    polarization functions and A2-irrep MOs), both bases."""
     assert abs(_pycc_corr_dipole_explicit(WATER, 'cc-pVDZ')
+               - _ff_corr_dipole(WATER, 'cc-pVDZ')) < 1e-8
+    assert abs(_pycc_corr_dipole_explicit(WATER, 'cc-pVDZ', orbital_basis='spatial')
                - _ff_corr_dipole(WATER, 'cc-pVDZ')) < 1e-8
 
 
-def _pycc_corr_gradient_explicit_and_relaxed(geom, basis):
-    """SO MP2 correlation nuclear gradient two ways: the explicit-derivative route
-    (`_corr_gradient_explicit`) and the relaxed-density route (`gradient`, which is now
-    correlation-only)."""
+def _pycc_corr_gradient_explicit_and_relaxed(geom, basis, orbital_basis='spinorbital'):
+    """MP2 correlation nuclear gradient two ways: the explicit-derivative route
+    (`_corr_gradient_explicit`) and the relaxed-density route (`gradient`, correlation-only)."""
     psi4.core.clean()
     psi4.core.clean_options()
     psi4.geometry(geom)
     psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': 'false',
                       'e_convergence': 1e-12, 'd_convergence': 1e-12})
     _, wfn = psi4.energy('scf', return_wfn=True)
-    mp = pycc.MPwfn(wfn, orbital_basis='spinorbital')
+    mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
-    g_explicit = mp._corr_gradient_explicit()
-    g_relaxed = mp.gradient()
-    return g_explicit, g_relaxed
+    return mp._corr_gradient_explicit(), mp.gradient()
 
 
 def test_mp2_explicit_corr_gradient_631g():
     """Keystone: the explicit-derivative SO MP2 correlation nuclear gradient equals the
-    relaxed-density route (`MPwfn.gradient` minus the HF gradient), H2O/6-31G (C1) -- the
-    nuclear analog of the field engine, exercising the full skeleton + CPHF response."""
+    relaxed-density route, H2O/6-31G (C1) -- the nuclear analog of the field engine,
+    exercising the full skeleton + CPHF response."""
     geom = WATER + "symmetry c1\n"
     g_explicit, g_relaxed = _pycc_corr_gradient_explicit_and_relaxed(geom, '6-31G')
     assert np.max(np.abs(g_explicit - g_relaxed)) < 1e-9
 
 
-def test_mp2_explicit_corr_gradient_ccpvdz():
-    """Explicit-derivative SO MP2 correlation gradient == relaxed-density route, H2O/cc-pVDZ
-    (C2v: polarization functions and A2-irrep MOs)."""
-    g_explicit, g_relaxed = _pycc_corr_gradient_explicit_and_relaxed(WATER, 'cc-pVDZ')
+def test_sa_mp2_explicit_corr_gradient_631g():
+    """Keystone: the explicit-derivative spin-adapted (spatial) MP2 correlation gradient
+    equals the relaxed-density route, H2O/6-31G (C1)."""
+    geom = WATER + "symmetry c1\n"
+    g_explicit, g_relaxed = _pycc_corr_gradient_explicit_and_relaxed(geom, '6-31G', 'spatial')
     assert np.max(np.abs(g_explicit - g_relaxed)) < 1e-9
+
+
+def test_mp2_explicit_corr_gradient_ccpvdz():
+    """Explicit-derivative MP2 correlation gradient == relaxed-density route, H2O/cc-pVDZ
+    (C2v: polarization functions and A2-irrep MOs), both bases."""
+    g_so_e, g_so_r = _pycc_corr_gradient_explicit_and_relaxed(WATER, 'cc-pVDZ')
+    assert np.max(np.abs(g_so_e - g_so_r)) < 1e-9
+    g_sa_e, g_sa_r = _pycc_corr_gradient_explicit_and_relaxed(WATER, 'cc-pVDZ', 'spatial')
+    assert np.max(np.abs(g_sa_e - g_sa_r)) < 1e-9
 
 
 def _pycc_gradient(geom, basis, orbital_basis='spinorbital', freeze_core='false'):

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -79,6 +79,47 @@ def test_mp2_relaxed_dipole_ccpvdz():
                - _ff_corr_dipole(WATER, 'cc-pVDZ')) < 1e-8
 
 
+# ---- explicit-derivative route (notes.pdf): correlation dipole from the full
+# CPHF-folded derivatives of f and <pq||rs> (CPHF.perturbed_fock / perturbed_eri),
+# contracted with the *unrelaxed* densities -- an independent computation of the same
+# correlation dipole, and the validation of the perturbed-derivative engine that the
+# analytic MP2 polarizability will build on. Spin-orbital path.
+
+def _pycc_corr_dipole_explicit(geom, basis, freeze_core='false'):
+    """PyCC relaxed-MP2 correlation mu_z via :meth:`MPwfn._corr_dipole_explicit`."""
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': freeze_core,
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    mp = pycc.MPwfn(wfn, orbital_basis='spinorbital')
+    mp.compute_energy()
+    return mp._corr_dipole_explicit()[2]
+
+
+def test_mp2_explicit_corr_dipole_631g():
+    """Explicit-derivative SO MP2 correlation dipole vs the finite field, H2O/6-31G (C1)."""
+    geom = WATER + "symmetry c1\n"
+    assert abs(_pycc_corr_dipole_explicit(geom, '6-31G')
+               - _ff_corr_dipole(geom, '6-31G')) < 1e-8
+
+
+def test_mp2_explicit_equals_relaxed_631g():
+    """Keystone: the explicit-derivative correlation dipole equals the relaxed-density
+    route (same number, computed without the Z-vector / relaxed density), H2O/6-31G."""
+    geom = WATER + "symmetry c1\n"
+    assert abs(_pycc_corr_dipole_explicit(geom, '6-31G')
+               - _pycc_corr_dipole(geom, '6-31G')) < 1e-10
+
+
+def test_mp2_explicit_corr_dipole_ccpvdz():
+    """Explicit-derivative SO MP2 correlation dipole vs finite field, H2O/cc-pVDZ (C2v:
+    polarization functions and A2-irrep MOs)."""
+    assert abs(_pycc_corr_dipole_explicit(WATER, 'cc-pVDZ')
+               - _ff_corr_dipole(WATER, 'cc-pVDZ')) < 1e-8
+
+
 def _pycc_gradient(geom, basis, orbital_basis='spinorbital', freeze_core='false'):
     psi4.core.clean()
     psi4.core.clean_options()

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -45,7 +45,8 @@ def _ff_corr_dipole(geom, basis, F=0.0005, freeze_core='false'):
 
 
 def _pycc_corr_dipole(geom, basis, orbital_basis='spinorbital', freeze_core='false'):
-    """PyCC relaxed-MP2 electronic correlation mu_z (spin-orbital or spin-adapted)."""
+    """PyCC relaxed-MP2 electronic correlation mu_z (spin-orbital or spin-adapted),
+    via the user-API :meth:`MPwfn.relaxed_dipole`."""
     psi4.core.clean()
     psi4.core.clean_options()
     psi4.geometry(geom)
@@ -54,8 +55,7 @@ def _pycc_corr_dipole(geom, basis, orbital_basis='spinorbital', freeze_core='fal
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
-    D = mp.mp2_relaxed_opdm()
-    return -np.einsum('pq,pq->', D, np.asarray(mp.H.mu[2]))
+    return mp.relaxed_dipole()[2]
 
 
 def test_mp2_relaxed_dipole_631g():

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -191,6 +191,24 @@ def test_fc_sa_mp2_explicit_corr_gradient_631g():
     assert np.max(np.abs(g_explicit - g_relaxed)) < 1e-9
 
 
+def test_fc_so_mp2_explicit_corr_dipole_631g():
+    """Frozen-core spin-orbital explicit-derivative MP2 correlation dipole vs the finite field
+    of (E_MP2 - E_SCF), H2O/6-31G (C1). The core<->active response is built over MPwfn's own
+    full-occupied SO space (no all-electron SO HFwfn to borrow -- different spin ordering)."""
+    geom = WATER + "symmetry c1\n"
+    assert abs(_pycc_corr_dipole_explicit(geom, '6-31G', orbital_basis='spinorbital', freeze_core='true')
+               - _ff_corr_dipole(geom, '6-31G', freeze_core='true')) < 1e-8
+
+
+def test_fc_so_mp2_explicit_corr_gradient_631g():
+    """Keystone: frozen-core spin-orbital explicit-derivative MP2 correlation gradient ==
+    relaxed-density route, H2O/6-31G (C1)."""
+    geom = WATER + "symmetry c1\n"
+    g_explicit, g_relaxed = _pycc_corr_gradient_explicit_and_relaxed(
+        geom, '6-31G', orbital_basis='spinorbital', freeze_core='true')
+    assert np.max(np.abs(g_explicit - g_relaxed)) < 1e-9
+
+
 def _pycc_gradient(geom, basis, orbital_basis='spinorbital', freeze_core='false'):
     psi4.core.clean()
     psi4.core.clean_options()


### PR DESCRIPTION
  ## MP2 first-derivative properties + explicit-derivative engine                                                            
                                                                                                                             
  Builds out the MP2 analytic first-derivative property layer and the explicit ("simple but inefficient") perturbed-integral 
  engine that will underpin the MP2 polarizability — on the spin-adapted (spatial RHF) **and** spin-orbital paths,           
  all-electron **and** frozen-core.                                                                                          
                                                                                                                             
  ### Public API (`MPwfn`)                                                                                                   
  - `relaxed_dipole()` — MP2 correlation electronic dipole                                                                   
  - `gradient()` — now **correlation-only** (parallels `relaxed_dipole`)                                                     
  - `total_dipole()` / `total_gradient()` — totals = reference + correlation                                                 
  - `HFwfn.dipole()` — total SCF dipole                                                                                      
                                                                                                                             
  ### Physical field sign convention                                                                                         
  `H' = −μ·E` ⟹ `f^(a) = −μ`, CPHF RHS `B = −f^(a) = +μ`. Adopted throughout (replacing two compensating sign flips), so     
  every dipole matches Psi4: `HFwfn.dipole()` = SCF dipole, `relaxed_dipole()` = correlation dipole, and their sum is the MP2
  dipole.                                                                                                                    
                                                                                                                             
  ### Explicit-derivative engine (`CPHF`, from `notes.pdf`)                                                                  
  Folds the CPHF response directly into the full derivatives of `f` and `⟨pq‖rs⟩` and contracts with the *unrelaxed*         
  densities (`dE_corr/dx = Σ γ ∂f + Σ Γ ∂⟨pq‖rs⟩`):                                                                          
  - `Perturbation` descriptor keys all caches; `perturbed_fock` / `perturbed_eri` build the full CPHF-folded derivatives     
  (block-aware, full `nmo⁴` default for CC consumers), cached for multi-property reuse.                                      
  - A single `_skeleton` cache feeds both the nuclear CPHF RHS and the engine (no double ERI-derivative computation).        
  - **Frozen core**: a `full_occ` CPHF view runs the engine over the full occupied space in the wfn's own ordering; the      
  non-redundant core↔active block of `U` comes from the canonical `∂_x f_ij = 0` divide (`ncore`), redundant blocks stay at  
  `−½Sˣ`. No rearrangement of the contraction.                                                                               
                                                                                                                             
  The explicit routes (`_corr_dipole_explicit`, `_corr_gradient_explicit`) are intentionally private — an independent        
  cross-check of the relaxed-density route and the foundation for the analytic polarizability.                               
                                                                                                                             
  ### Validation (`test_061`)                                                                                                
  Explicit == relaxed-density route to ~1e-16 and == finite field of `E_MP2(F)` to <1e-8, across all four cases (spatial/SO ×
  all-electron/frozen-core), H2O/6-31G (C1) and cc-pVDZ (C2v). HF derivative properties (`047–050`, `057`, `062–066`)        
  unaffected.                                                                                                                
                                                                                                                             
  Design notes in `docs/DERIVATIVES_PLAN_2026-06.md`. Next: the analytic second derivative (MP2 polarizability).  