### PR TITLE
MP2 atomic polar tensors (nuclear dipole derivatives / APTs)

### DIFF
--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -462,7 +462,22 @@ correlated (MP2) gradient, frozen core, then CC gradients / the MP2 property pat
 Once the SO HF gradient is in, `MPwfn.gradient()` can use an SO `HFwfn` for the SCF term,
 lifting the closed-shell-only restriction on the spin-orbital MP2 gradient.
 
-## Next up: MP2 APT (atomic polar tensors / dipole derivatives) — explicit route (2026-07)
+## MP2 APT (atomic polar tensors / dipole derivatives) — explicit route (2026-07) — DONE
+
+**DONE (branch `feature/mp2-apt`).** `MPwfn.dipole_derivatives()` (correlation APT,
+`3 x 3N`) + `total_dipole_derivatives()`, both spatial and spin-orbital, all-electron and
+frozen-core. Both predictions of the plan held: (1) the nuclear T2 density response works
+through the generic `_perturbed_densities` with no change (validated via the gauge-invariant
+`Tr(gamma^2)`/`||Gamma||^2` scalars); (2) the only new machinery was the skeleton
+generalization of `_d2fock`/`_d2eri` (`_oei_skeleton`, `_oei2_skeleton` giving `-mu^X`, and
+the `rotate(U^F, <>^X)` cross-skeleton) -- `_xi` needed no change (`S^F = S^{FX} = 0`), and
+frozen core needed no APT-specific fix (the ov `xi`-seed and core<->active divide carried over
+from the polarizability). Validated (`test_068`): APT vs a 7-point FD of the analytic dipole
+over nuclear displacement ~1e-12; SO==spatial keystone ~1e-15; the acoustic (translational)
+sum rule `sum_A P = 0` (total and correlation) ~1e-15; nuclear T2 response ~1e-9. Field-field
+polarizability unregressed. The 2n+1 route remains the deferred efficient alternative.
+
+The original planning notes follow.
 
 Branch (planned): `feature/mp2-apt`. Deliverable: the MP2 **correlation** atomic polar tensor
 `P_corr_{a,Xb} = d(mu_a)/d(X_b) = -d^2 E_corr / dF_a dX_b` (the IR-intensity tensor, `3 x 3N`),

--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -267,6 +267,23 @@ derivative of PyCC's own `E_MP2(F)`. Build up incrementally:
 4. full `alpha_corr` vs the finite field of `E_MP2`, plus the `alpha = alpha_HF + alpha_corr`
    HF-limit check and the **SO == spatial** keystone; both bases, all-electron then frozen core.
 
+**MP2 dipole polarizability — DONE (PR #163, on `main`).** All-electron and frozen-core, both
+bases, both spin paths. Second-order block on `CPHF` (`_xi`, `_cross_eri`, `_d2eri`, `_d2fock`
+via the `h` + occupied-mean-field decomposition, `_full_U2`, `perturbed_fock2`/`perturbed_eri2`);
+`MPwfn.polarizability()` assembles Eq. 15. Eq. 17 verified against the independent `_d2fock` to
+~3e-15 (with the Eq. 3 typo corrected, `A_pqrs = <pq||rs> + <ps||rq>`). **Frozen-core subtlety
+found & fixed:** the second-order ov CPHF solve reused the first-order Hessian `G`, which maps
+only the *antisymmetric* ov rotation, but the core<->active oo block makes `xi_ov != 0`, so
+`U^{ab}_ov = -xi_ov - Uai` is not antisymmetric; seeding `U^{ab}_ov = -xi_ov` before the RHS
+restores second-order Brillouin `d_ab f_ai = 0` (all-electron `xi_ov = 0`, so a no-op there). It
+hid because first-order Brillouin *did* hold for frozen core but the validated dipole never
+touches the `[v,o]` block. Validated (`test_067`) via a **7-point O(h^6) finite difference of the
+analytic dipole** (`alpha = d mu / dF`, a `1/h` stencil ~3 orders tighter than an energy `1/h^2`
+second difference) to ~1e-12, with an external energy-FD guard and the SO==spatial keystone. The
+whole second-order block assumes a perturbation-independent AO basis (electric field only);
+docstrings on `_xi`/`_d2eri`/`_d2fock`/`_full_U2`/`perturbed_*2` flag the skeleton
+derivative-integral terms a nuclear (molecular-Hessian) extension requires.
+
 Phase D (SO): `MPwfn.gradient()` assembles the MP2 analytic nuclear gradient
 
     dE/dX = E_SCF gradient (HFwfn) + sum_pq D_pq f^X_pq + sum_pqrs Gamma_pqrs <pq||rs>^X
@@ -444,3 +461,67 @@ correlated (MP2) gradient, frozen core, then CC gradients / the MP2 property pat
 
 Once the SO HF gradient is in, `MPwfn.gradient()` can use an SO `HFwfn` for the SCF term,
 lifting the closed-shell-only restriction on the spin-orbital MP2 gradient.
+
+## Next up: MP2 APT (atomic polar tensors / dipole derivatives) — explicit route (2026-07)
+
+Branch (planned): `feature/mp2-apt`. Deliverable: the MP2 **correlation** atomic polar tensor
+`P_corr_{a,Xb} = d(mu_a)/d(X_b) = -d^2 E_corr / dF_a dX_b` (the IR-intensity tensor, `3 x 3N`),
+with the reference part from `HFwfn.dipole_derivatives()` (total `P = P_HF + P_corr`). Explicit
+route, consistent with the polarizability; the 2n+1 (Z-vector interchange) route remains the
+deferred efficient alternative. **Spin-orbital first, all-electron first** (then spatial, then
+frozen core), mirroring the gradient/polarizability phasing.
+
+**Assembly (mixed field `F_a` / nuclear `X_b`, Eq. 15 with one field + one nuclear perturbation):**
+
+    d_{F_a X_b} E_corr = sum_pq   [ d_{X_b}(gamma_pq) d_{F_a} f_pq + gamma_pq d_{F_a X_b} f_pq ]
+                       + sum_pqrs [ d_{X_b}(Gamma)    d_{F_a} <pq||rs> + Gamma d_{F_a X_b} <pq||rs> ]
+
+(equivalently `d_{F_a}` of the gradient integrand -- the two are equal.)
+
+**What we already have.** First-order field derivatives `d_F f`/`d_F <>` and nuclear derivatives
+`d_X f`/`d_X <>` (`perturbed_fock`/`perturbed_eri`, both kinds -- nuclear validated for the
+gradient); the field density response `d_F gamma/Gamma`; the **dipole-derivative integrals**
+`mu^X` (`Derivatives.dipole`/`so_dipole`, already used by the HF APT); `HFwfn.dipole_derivatives()`
+(reference APT); `_xi` (Eq. 18 -- products of the first-order `U`'s, the `S^x` info riding in via
+their `-1/2 S^x` oo/vv blocks, no explicit `U*S` cross terms), the ov `xi`-seed, and the
+core<->active canonical divide (all from the polarizability).
+
+**Genuinely new -- two pieces:**
+
+1. **Nuclear density response `d_X gamma`, `d_X Gamma`** via `d_X t2`. `_perturbed_t2` /
+   `_perturbed_densities` are generic in the perturbation and already call the nuclear
+   `perturbed_fock/eri`, so they should work as-is (same closed form; the non-canonical `d_X f`
+   oo/vv blocks fold in). Task: **validate** `d_X t2`/`d_X gamma` vs a finite nuclear displacement.
+
+2. **Skeleton generalization of `_d2fock` / `_d2eri`** -- the one real piece of new machinery.
+   Today they hardcode the field skeleton (`f^(a) = -mu`, `<>^(a) = 0`). Generalize to use each
+   perturbation's own first-order skeleton from `_skeleton`, add the cross-rotations
+   `rotate(U^a, skel_b) + rotate(U^b, skel_a)`, and the mixed second-order skeleton. For F/X:
+     - Fock: `d_{F X} f_skel = -mu^X` (existing `Derivatives.dipole`), plus
+       `rotate(U^F, f^X) + rotate(U^X, -mu)`.
+     - ERI: mixed 2-e skeleton `= 0` (the field never touches the two-electron integrals), but
+       `rotate(U^F, <>^X)` is new.
+   Because the field does not move the basis, `S^F = 0` and `S^{FX} = 0`, so **`_xi` needs no
+   change** (Eq. 18 with the nuclear `U^X` carrying `-1/2 S^X` in its oo/vv blocks) and there is
+   no mixed overlap second derivative. `_full_U2(field, nuclear)` then follows: the ov `xi`-seed
+   and the core<->active divide carry over unchanged.
+
+**Why APT before the Hessian.** The mixed F/X second derivative exercises all of the moving-basis
+second-order machinery (nuclear skeletons in `_d2fock`/`_d2eri`, `S^X` via the first-order `U^X`)
+*without* the pure nuclear-nuclear skeletons (`h^{XY}`, `<>^{XY}`, `S^{XY}` -- the geometric-Hessian
+integrals) or the `S^{XY}` term in `_xi`. So it de-risks most of the Hessian generalization on a
+smaller problem.
+
+**Validation (new `test_068`).** Build up incrementally:
+1. `d_X t2` / `d_X gamma` vs a finite nuclear displacement (pins the nuclear T2 response);
+2. `d_{F X} f` vs a finite difference of `d_F f(X)` (the mixed second-order integral / `U^{FX}`);
+3. full `P_corr` vs a **7-point O(h^6) finite difference of the analytic dipole over nuclear
+   displacement** (`P = d mu / dX`, a `1/h` stencil ~1e-11), plus the **SO == spatial** keystone,
+   the `P = P_HF + P_corr` split, and the **acoustic (translational) sum rule** `sum_atoms P = 0`
+   (electronic part). External guard: a mixed `1/h^2` finite difference of `E_MP2(F, X)`. Oracles
+   are PyCC's own dipole/gradient -- Psi4's frozen-core MP2 gradient is inconsistent with its own
+   energy, so not used.
+
+Later: magnetic-field derivatives (AATs, for VCD) reuse the same explicit machinery with `H.m`;
+the full MP2 Hessian adds the nuclear-nuclear second-derivative skeletons and the `S^{XY}` term in
+`_xi`.

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -431,24 +431,80 @@ class CPHF(object):
                 + c('tp,us,tqru->pqrs', Ua, Ub, T) + c('tq,ur,ptus->pqrs', Ua, Ub, T)
                 + c('tq,us,ptru->pqrs', Ua, Ub, T) + c('tr,us,pqtu->pqrs', Ua, Ub, T))
 
+    def _oei_skeleton(self, pert: "Perturbation") -> np.ndarray:
+        """First-order one-electron (core-Hamiltonian) skeleton derivative ``h^(x)_pq``
+        (``nmo x nmo``, MO basis, fixed MO coefficients) -- the piece of the skeleton Fock
+        derivative *without* the occupied mean field. Field: ``h^(F) = -mu`` (``H' = -mu.E``).
+        Nuclear: the core-Hamiltonian derivative from the ``Derivatives`` provider."""
+        so = self.wfn.orbital_basis == 'spinorbital'
+        if pert.kind == 'field':
+            return -np.asarray(self.wfn.H.mu[pert.comp])
+        if pert.kind == 'nuclear':
+            atom, cart = pert.comp
+            d = self.wfn.derivatives
+            return np.asarray((d.so_core(atom) if so else d.core(atom))[cart])
+        raise NotImplementedError("one-electron skeleton wired for 'field'/'nuclear' only.")
+
+    def _oei2_skeleton(self, perta: "Perturbation", pertb: "Perturbation"):
+        """Mixed one-electron skeleton second derivative ``h^(ab)_pq`` (fixed MO coefficients).
+
+        - field-field: ``0`` (the field is linear in F).
+        - field-nuclear: ``-d(mu_alpha)/dX_beta`` (dipole-derivative integrals) -- because
+          ``d_F h = -mu``, so ``d_{F X} h = -mu^X``. This is the one genuinely new integral for
+          the APT, and it is already provided (``Derivatives.dipole`` / ``so_dipole``).
+        - nuclear-nuclear: the core-Hamiltonian second derivative (``core2``) -- part of the
+          molecular Hessian, not yet built."""
+        kinds = {perta.kind, pertb.kind}
+        if kinds == {'field'}:
+            return 0.0
+        if kinds == {'field', 'nuclear'}:
+            fld, nuc = (perta, pertb) if perta.kind == 'field' else (pertb, perta)
+            alpha = fld.comp
+            atom, beta = nuc.comp
+            so = self.wfn.orbital_basis == 'spinorbital'
+            d = self.wfn.derivatives
+            dip = (d.so_dipole(atom) if so else d.dipole(atom))[alpha * 3 + beta]
+            return -np.asarray(dip)
+        raise NotImplementedError(
+            "mixed one-electron skeleton wired for field-field and field-nuclear (APT); "
+            "nuclear-nuclear (the molecular Hessian) needs core2.")
+
     def _d2eri(self, perta, pertb, U2: np.ndarray, ncore: int = 0) -> np.ndarray:
         """Second perturbed two-electron derivative ``d_ab <pq||rs>`` (``nmo^4``) given the
-        second-order rotation ``U2`` = ``U^{ab}`` (Eq. 20; field skeleton zero)::
+        second-order rotation ``U2`` = ``U^{ab}`` (Eq. 20)::
 
             d_ab <pq||rs> = rotate(U^{ab}, <pq||rs>)
-                            + cross(U^a, U^b, <pq||rs>) + cross(U^b, U^a, <pq||rs>).
+                            + cross(U^a, U^b, <pq||rs>) + cross(U^b, U^a, <pq||rs>)
+                            + rotate(U^a, <pq||rs>^(b)) + rotate(U^b, <pq||rs>^(a))
+                            + <pq||rs>^(ab)
+
+        where ``<pq||rs>^(x)`` is the first-order two-electron skeleton (fixed MO coefficients,
+        from :meth:`_skeleton`). For the electric field ``<pq||rs>^(x) = 0`` (the field never
+        enters the two-electron integrals), so only the first three (rotation) terms survive --
+        the polarizability case. For a nuclear displacement ``<pq||rs>^(x)`` is nonzero, adding
+        the ``rotate(U^x, <>^(y))`` cross-skeleton terms; the **field-nuclear** mixed second-order
+        skeleton ``<pq||rs>^(FX) = 0`` (again, the field is absent from the 2-e integrals), so the
+        APT needs no ``<>^(ab)`` term.
 
         Takes ``U2`` as an argument so the second-order CPHF solve can call it with the ov
-        response zeroed (no recursion through :meth:`_full_U2`).
-
-        ASSUMES A PERTURBATION-INDEPENDENT AO BASIS (field only): there is no skeleton
-        (direct AO) second-derivative term ``<pq||rs>^{ab}``, which vanishes for a field but
-        not for a nuclear displacement. The molecular Hessian would add it here."""
+        response zeroed (no recursion through :meth:`_full_U2`). NUCLEAR-NUCLEAR (the molecular
+        Hessian) additionally needs the direct ``<pq||rs>^(XY)`` second-derivative integrals --
+        not built (guarded below)."""
+        if {perta.kind, pertb.kind} == {'nuclear'}:
+            raise NotImplementedError(
+                "nuclear-nuclear second 2e skeleton <pq||rs>^(XY) not built (molecular Hessian).")
         ERI = np.asarray(self.wfn.H.ERI)
         Ua = self._full_U(perta, ncore)
         Ub = self._full_U(pertb, ncore)
-        return (self._rotate_eri(U2, ERI)
-                + self._cross_eri(Ua, Ub, ERI) + self._cross_eri(Ub, Ua, ERI))
+        _, _, gxa = self._skeleton(perta)
+        _, _, gxb = self._skeleton(pertb)
+        d2e = (self._rotate_eri(U2, ERI)
+               + self._cross_eri(Ua, Ub, ERI) + self._cross_eri(Ub, Ua, ERI))
+        if np.ndim(gxb):                                    # gxb is an array (nuclear), not 0.0 (field)
+            d2e = d2e + self._rotate_eri(Ua, np.asarray(gxb))
+        if np.ndim(gxa):
+            d2e = d2e + self._rotate_eri(Ub, np.asarray(gxa))
+        return d2e
 
     def _d2fock(self, perta, pertb, U2: np.ndarray, ncore: int = 0) -> np.ndarray:
         """Second perturbed Fock derivative ``d_ab f_pq`` (``nmo x nmo``) given ``U2`` = ``U^{ab}``.
@@ -458,32 +514,37 @@ class CPHF(object):
         with the correct multilinear rule (rotation + cross-index products, *no* same-index
         terms)::
 
-            d_ab h = rotate2(U^{ab}, h) + cross2(U^a, U^b, h)          [+ cross2(U^b,U^a,h)]
-                     + rotate2(U^a, -mu_b) + rotate2(U^b, -mu_a)       (field skeleton f^(x)=-mu)
-            d_ab G_pq = sum_m d_ab w[p,m,q,m]                          (from d_ab <pq||rs>)
+            d_ab h = rotate2(U^{ab}, h) + cross2(U^a, U^b, h) + cross2(U^b, U^a, h)
+                     + rotate2(U^a, h^(b)) + rotate2(U^b, h^(a))   (first-order oei skeletons)
+                     + h^(ab)                                      (mixed oei skeleton)
+            d_ab G_pq = sum_m d_ab w[p,m,q,m]                      (from d_ab <pq||rs>)
 
-        with ``rotate2(U, M) = U.T M + M U`` and ``cross2(U^a,U^b,M) = U^a.T M U^b``. Takes
-        ``U2`` as an argument (no recursion through :meth:`_full_U2`).
+        with ``rotate2(U, M) = U.T M + M U`` and ``cross2(U^a,U^b,M) = U^a.T M U^b``. The
+        one-electron skeletons come from :meth:`_oei_skeleton` (field ``h^(F) = -mu``, nuclear
+        the core-Hamiltonian derivative) and :meth:`_oei2_skeleton` (field-field ``0``,
+        field-nuclear ``-mu^X``). ``d_ab G`` inherits the (now perturbation-general) second
+        two-electron derivative from :meth:`_d2eri`. Takes ``U2`` as an argument (no recursion
+        through :meth:`_full_U2`).
 
-        ASSUMES A PERTURBATION-INDEPENDENT AO BASIS (field only). The one-electron skeleton is
-        just ``f^(x) = -mu`` with no ``h^{ab}``, and ``d_ab G`` inherits the field-only
-        ``d_ab <pq||rs>`` from :meth:`_d2eri`. A nuclear displacement would add the direct AO
-        second derivatives ``h^{ab}`` and ``<pq||rs>^{ab}`` (and the ``S``-dependent terms via
-        ``U2``); this routine does not."""
+        Handles field-field (polarizability) and field-nuclear (APT). NUCLEAR-NUCLEAR (the
+        molecular Hessian) additionally needs ``h^(XY)`` (``core2``) and ``<pq||rs>^(XY)``
+        (guarded in :meth:`_d2eri`), and the ``S^{XY}`` term in :meth:`_xi`."""
         o = self.o
         c = self.contract
         f = np.asarray(self.wfn.H.F)
         so = self.wfn.orbital_basis == 'spinorbital'
         W = np.asarray(self.wfn.H.ERI) if so else np.asarray(self.wfn.H.L)
         h = f - c('pmqm->pq', W[:, o, :, o])                 # bare one-electron MO Fock
-        mua = np.asarray(self.wfn.H.mu[perta.comp])
-        mub = np.asarray(self.wfn.H.mu[pertb.comp])
         Ua = self._full_U(perta, ncore)
         Ub = self._full_U(pertb, ncore)
+        hxa = self._oei_skeleton(perta)                      # first-order oei skeletons
+        hxb = self._oei_skeleton(pertb)
+        hxab = self._oei2_skeleton(perta, pertb)             # mixed oei skeleton (0 for field-field)
         d2h = (c('rp,rq->pq', U2, h) + c('pr,rq->pq', h, U2)             # rotate2(U^{ab}, h)
                + c('rp,rs,sq->pq', Ua, h, Ub) + c('rp,rs,sq->pq', Ub, h, Ua)  # cross2
-               - c('rp,rq->pq', Ua, mub) - c('pr,rq->pq', mub, Ua)      # rotate2(U^a, -mu_b)
-               - c('rp,rq->pq', Ub, mua) - c('pr,rq->pq', mua, Ub))     # rotate2(U^b, -mu_a)
+               + c('rp,rq->pq', Ua, hxb) + c('pr,rq->pq', hxb, Ua)      # rotate2(U^a, h^(b))
+               + c('rp,rq->pq', Ub, hxa) + c('pr,rq->pq', hxa, Ub)      # rotate2(U^b, h^(a))
+               + hxab)                                                   # mixed oei skeleton
         d2e = self._d2eri(perta, pertb, U2, ncore)
         d2W = d2e if so else (2.0 * d2e - d2e.swapaxes(2, 3))
         d2G = c('pmqm->pq', d2W[:, o, :, o])                 # sum_m d_ab w[p,m,q,m]

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -260,6 +260,13 @@ class MPwfn(Wavefunction):
         gradient (:meth:`HFwfn.gradient`) plus the MP2 correlation gradient (:meth:`gradient`)."""
         return self._reference_hf().gradient() + self.gradient()
 
+    def total_dipole_derivatives(self) -> np.ndarray:
+        """Total MP2 atomic polar tensors (nuclear dipole derivatives, a.u.), shape
+        ``(natom, 3, 3)`` indexed ``[A, beta, alpha]``: the SCF reference APTs
+        (:meth:`HFwfn.dipole_derivatives`, which carry the ``Z_A`` nuclear term) plus the MP2
+        correlation APTs (:meth:`dipole_derivatives`)."""
+        return self._reference_hf().dipole_derivatives() + self.dipole_derivatives()
+
     # ---- explicit-derivative property route (notes.pdf) ----
     # The first derivative of the correlation energy w.r.t. a perturbation, via the
     # full (CPHF-folded) derivatives of f and <pq||rs> from the shared CPHF engine,
@@ -459,6 +466,57 @@ class MPwfn(Wavefunction):
                       + c('pqrs,pqrs->', dGam[a], dbe) + c('pqrs,pqrs->', Gam, d2e))
                 alpha[a, b] = -e2
         return alpha
+
+    def dipole_derivatives(self) -> np.ndarray:
+        """MP2 **correlation** contribution to the atomic polar tensors (nuclear dipole
+        derivatives, a.u.), shape ``(natom, 3, 3)`` indexed ``[A, beta, alpha]`` =
+        ``d(mu_alpha)/d(X_{A,beta}) = -d^2 E_corr / dF_alpha dX_{A,beta}`` -- the mixed
+        field/nuclear analog of :meth:`polarizability`, via the explicit route (Eq. 15)::
+
+            d_{F X} E_corr = sum_pq [ d_X gamma_pq d_F f_pq + gamma_pq d_{F X} f_pq ]
+                           + sum_pqrs [ d_X Gamma d_F <pq||rs> + Gamma d_{F X} <pq||rs> ]
+
+        with the unrelaxed densities ``gamma``/``Gamma``, the **nuclear** density responses
+        ``d_X gamma``/``d_X Gamma`` (:meth:`_perturbed_densities`), the field first derivatives
+        (:meth:`CPHF.perturbed_fock`/`perturbed_eri`), and the mixed second derivatives
+        (:meth:`CPHF.perturbed_fock2`/`perturbed_eri2`, which carry the second-order response
+        ``U^{FX}`` and the ``-mu^X`` mixed skeleton). Electronic only; the nuclear ``Z_A`` term
+        is in the reference (:meth:`HFwfn.dipole_derivatives`), so the total is their sum
+        (:meth:`total_dipole_derivatives`). Basis-aware. Validated against a finite nuclear
+        displacement of the analytic dipole (``test_068``)."""
+        from .cphf import Perturbation
+        o, v, nmo = self.o, self.v, self.nmo
+        ncore = o.stop - self.no
+        if self.orbital_basis == 'spinorbital':
+            Doo, Dvv = self._so_mp2_corr_opdm()
+            Gam = self._so_mp2_cumulant()
+        else:
+            Doo, Dvv = self._mp2_corr_opdm()
+            Gam = self._mp2_cumulant()
+        gamma = np.zeros((nmo, nmo))
+        gamma[o, o] = np.asarray(Doo)
+        gamma[v, v] = np.asarray(Dvv)
+        Gam = np.asarray(Gam)
+        cphf = self._full_occ_cphf()
+        c = self.contract
+        natom = self.derivatives.natom
+        field = [Perturbation('field', a) for a in range(3)]
+        dFf = [np.asarray(cphf.perturbed_fock(field[a], ncore)) for a in range(3)]
+        dFe = [np.asarray(cphf.perturbed_eri(field[a], ncore)) for a in range(3)]
+        P = np.zeros((natom, 3, 3))
+        for A in range(natom):
+            for beta in range(3):
+                pX = Perturbation('nuclear', (A, beta))
+                dgX, dGX = self._perturbed_densities(pX)
+                dgX = np.asarray(dgX)
+                dGX = np.asarray(dGX)
+                for alpha in range(3):
+                    d2f = np.asarray(cphf.perturbed_fock2(field[alpha], pX, ncore))
+                    d2e = np.asarray(cphf.perturbed_eri2(field[alpha], pX, ncore))
+                    e2 = (c('pq,pq->', dgX, dFf[alpha]) + c('pq,pq->', gamma, d2f)
+                          + c('pqrs,pqrs->', dGX, dFe[alpha]) + c('pqrs,pqrs->', Gam, d2e))
+                    P[A, beta, alpha] = -e2
+        return P
 
     # ---- spin-adapted (closed-shell RHF) MP2 relaxed-gradient densities ----
     # The closed-shell analogue of the spin-orbital densities: the spin sum is carried by

--- a/pycc/tests/test_068_mp2_apt.py
+++ b/pycc/tests/test_068_mp2_apt.py
@@ -44,11 +44,11 @@ def _geom(coords):
     return s
 
 
-def _mpwfn(coords, basis, orbital_basis='spatial'):
+def _mpwfn(coords, basis, orbital_basis='spatial', freeze_core='false'):
     psi4.core.clean()
     psi4.core.clean_options()
     psi4.geometry(_geom(coords))
-    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': 'false',
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': freeze_core,
                       'e_convergence': 1e-13, 'd_convergence': 1e-13})
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
@@ -67,12 +67,12 @@ def _dens_invariants(mp):
     return np.sum(g * g), np.sum(Gam * Gam)
 
 
-def _corr_dipfd(basis, orbital_basis, alpha, atom, cart, h=0.002):
-    """|P_corr[A,cart,alpha]| via a 7-point O(h^6) FD of the analytic correlation dipole
+def _corr_dipfd(basis, orbital_basis, alpha, atom, cart, freeze_core='false', h=0.002):
+    """P_corr[A,cart,alpha] via a 7-point O(h^6) FD of the analytic correlation dipole
     component `alpha` over the nuclear coordinate (atom, cart)."""
     def mu(delta):
         c = BASE.copy(); c[atom, cart] += delta
-        return _mpwfn(c, basis, orbital_basis)._corr_dipole_explicit()[alpha]
+        return _mpwfn(c, basis, orbital_basis, freeze_core)._corr_dipole_explicit()[alpha]
     return (-mu(-3*h) + 9*mu(-2*h) - 45*mu(-h)
             + 45*mu(h) - 9*mu(2*h) + mu(3*h)) / (60*h)
 
@@ -132,3 +132,34 @@ def test_mp2_apt_translational_sum_rule_631g():
     P_tot = mp0.total_dipole_derivatives()
     assert np.max(np.abs(np.sum(P_corr, axis=0))) < 1e-10
     assert np.max(np.abs(np.sum(P_tot, axis=0))) < 1e-10
+
+
+# ---- frozen core (the mixed field/nuclear core<->active response) ----
+
+def test_fc_mp2_corr_apt_dipfd_631g():
+    """Frozen-core spatial correlation APT vs the 7-point dipole-over-nuclear FD, H2O/6-31G.
+
+    Exercises the mixed field/nuclear core<->active response: the frozen-core U^{FX} (with the
+    core<->active canonical divide and the ov xi-seed) and the nuclear density response over
+    the active space. Works with no APT-specific code change -- the ncore machinery carries
+    over from the gradient/polarizability."""
+    P = _mpwfn(BASE, '6-31G', 'spatial', freeze_core='true').dipole_derivatives()
+    for (alpha, atom, cart) in [(2, 0, 2), (1, 2, 1), (2, 1, 1)]:
+        assert abs(P[atom, cart, alpha]
+                   - _corr_dipfd('6-31G', 'spatial', alpha, atom, cart,
+                                 freeze_core='true')) < 1e-10
+
+
+def test_fc_so_mp2_corr_apt_vs_spatial_631g():
+    """Keystone (6-31G, frozen core): spin-orbital == spin-adapted correlation APT."""
+    P_so = _mpwfn(BASE, '6-31G', 'spinorbital', freeze_core='true').dipole_derivatives()
+    P_sa = _mpwfn(BASE, '6-31G', 'spatial', freeze_core='true').dipole_derivatives()
+    assert np.max(np.abs(P_so - P_sa)) < 1e-11
+
+
+def test_fc_mp2_apt_translational_sum_rule_631g():
+    """Frozen-core acoustic sum rule: sum over atoms of the total (and correlation) APT
+    vanishes for neutral water."""
+    mp0 = _mpwfn(BASE, '6-31G', 'spatial', freeze_core='true')
+    assert np.max(np.abs(np.sum(mp0.dipole_derivatives(), axis=0))) < 1e-10
+    assert np.max(np.abs(np.sum(mp0.total_dipole_derivatives(), axis=0))) < 1e-10

--- a/pycc/tests/test_068_mp2_apt.py
+++ b/pycc/tests/test_068_mp2_apt.py
@@ -1,0 +1,134 @@
+"""
+MP2 atomic polar tensors / nuclear dipole derivatives (correlation contribution) via the
+explicit mixed field-nuclear second derivative -- P_corr_{A,beta,alpha} = d(mu_alpha)/dX_{A,beta}
+= -d^2 E_corr / dF_alpha dX_{A,beta} (the IR-intensity tensor); DERIVATIVES_PLAN_2026-06.md.
+
+Reuses the polarizability infrastructure: the field first derivatives d_F f / d_F <pq||rs>,
+the *nuclear* density response d_X gamma / d_X Gamma (the generic MPwfn._perturbed_densities
+driven by the nuclear perturbed integrals), and the mixed second derivatives d_{F X} f /
+d_{F X} <pq||rs> (CPHF.perturbed_fock2 / perturbed_eri2, with the generalized skeletons: the
+first-order nuclear two-electron skeleton and the -mu^X mixed one-electron skeleton). The
+reference (SCF) APTs are separate (HFwfn.dipole_derivatives, carrying the Z_A term); the total
+is their sum.
+
+Validation:
+  * nuclear T2 density response: gauge-invariant scalars Tr(gamma^2), ||Gamma||^2 vs a finite
+    nuclear displacement (a nuclear displacement genuinely rotates pycc's -1/2 S^X gauge vs the
+    canonical MOs, so these orthogonal invariants -- not the raw amplitudes -- are compared);
+  * primary: correlation APT vs a 7-point O(h^6) finite difference of the analytic dipole over
+    nuclear displacement (P = d mu / dX, a 1/h stencil ~1e-12);
+  * keystone: spin-orbital == spin-adapted (closed-shell RHF) correlation APT;
+  * translational (acoustic) sum rule: sum over atoms of the total (and correlation) APT is zero
+    for a neutral molecule -- an FD-free physics check.
+
+Geometry is Cartesian in bohr with no_com/no_reorient so displacing an atom keeps the frame
+fixed and matches the analytic (bohr) integral derivatives. Oracles are pycc's own dipole
+(Psi4's frozen-core MP2 gradient bug rules out its analytic derivatives).
+"""
+
+import psi4
+import pycc
+import numpy as np
+
+
+BASE = np.array([[0.0, 0.0, 0.0],
+                 [0.0, 0.0, 1.814137],
+                 [0.0, 1.756000, -0.454300]])
+SYM = ['O', 'H', 'H']
+
+
+def _geom(coords):
+    s = "units bohr\nsymmetry c1\nno_com\nno_reorient\n"
+    for sym, xyz in zip(SYM, coords):
+        s += f"{sym} {xyz[0]:.10f} {xyz[1]:.10f} {xyz[2]:.10f}\n"
+    return s
+
+
+def _mpwfn(coords, basis, orbital_basis='spatial'):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(_geom(coords))
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': 'false',
+                      'e_convergence': 1e-13, 'd_convergence': 1e-13})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
+    mp.compute_energy()
+    return mp
+
+
+def _dens_invariants(mp):
+    """Gauge-invariant Tr(gamma^2), ||Gamma||^2 (orthogonal orbital rotations preserve both)."""
+    o, v, nmo = mp.o, mp.v, mp.nmo
+    if mp.orbital_basis == 'spinorbital':
+        Doo, Dvv = mp._so_mp2_corr_opdm(); Gam = np.asarray(mp._so_mp2_cumulant())
+    else:
+        Doo, Dvv = mp._mp2_corr_opdm(); Gam = np.asarray(mp._mp2_cumulant())
+    g = np.zeros((nmo, nmo)); g[o, o] = np.asarray(Doo); g[v, v] = np.asarray(Dvv)
+    return np.sum(g * g), np.sum(Gam * Gam)
+
+
+def _corr_dipfd(basis, orbital_basis, alpha, atom, cart, h=0.002):
+    """|P_corr[A,cart,alpha]| via a 7-point O(h^6) FD of the analytic correlation dipole
+    component `alpha` over the nuclear coordinate (atom, cart)."""
+    def mu(delta):
+        c = BASE.copy(); c[atom, cart] += delta
+        return _mpwfn(c, basis, orbital_basis)._corr_dipole_explicit()[alpha]
+    return (-mu(-3*h) + 9*mu(-2*h) - 45*mu(-h)
+            + 45*mu(h) - 9*mu(2*h) + mu(3*h)) / (60*h)
+
+
+def test_mp2_nuclear_t2_response_631g():
+    """Nuclear T2 density response d_X gamma / d_X Gamma vs a finite nuclear displacement,
+    via the gauge-invariant scalars d Tr(gamma^2), d ||Gamma||^2 (spatial, H2O/6-31G)."""
+    from pycc.cphf import Perturbation
+    mp0 = _mpwfn(BASE, '6-31G', 'spatial')
+    o, v, nmo = mp0.o, mp0.v, mp0.nmo
+    Doo, Dvv = mp0._mp2_corr_opdm(); Gam = np.asarray(mp0._mp2_cumulant())
+    g = np.zeros((nmo, nmo)); g[o, o] = np.asarray(Doo); g[v, v] = np.asarray(Dvv)
+    for (atom, cart) in [(0, 2), (2, 1)]:
+        dgX, dGX = mp0._perturbed_densities(Perturbation('nuclear', (atom, cart)))
+        dTrg2 = 2.0 * np.sum(g * np.asarray(dgX))
+        dGam2 = 2.0 * np.sum(Gam * np.asarray(dGX))
+        h = 0.005
+
+        def inv(delta):
+            c = BASE.copy(); c[atom, cart] += delta
+            return _dens_invariants(_mpwfn(c, '6-31G', 'spatial'))
+        v2, v1, vm1, vm2 = inv(2*h), inv(h), inv(-h), inv(-2*h)
+        fd_g = (-v2[0] + 8*v1[0] - 8*vm1[0] + vm2[0]) / (12*h)
+        fd_G = (-v2[1] + 8*v1[1] - 8*vm1[1] + vm2[1]) / (12*h)
+        assert abs(dTrg2 - fd_g) < 1e-8
+        assert abs(dGam2 - fd_G) < 1e-8
+
+
+def test_mp2_corr_apt_dipfd_631g():
+    """Spatial correlation APT vs a 7-point FD of the analytic dipole over nuclear
+    displacement, representative components, H2O/6-31G (~1e-12)."""
+    P = _mpwfn(BASE, '6-31G', 'spatial').dipole_derivatives()
+    for (alpha, atom, cart) in [(2, 0, 2), (1, 2, 1), (0, 1, 2), (2, 1, 1)]:
+        assert abs(P[atom, cart, alpha]
+                   - _corr_dipfd('6-31G', 'spatial', alpha, atom, cart)) < 1e-10
+
+
+def test_so_mp2_corr_apt_vs_spatial_631g():
+    """Keystone (6-31G): closed-shell spin-orbital == spin-adapted correlation APT."""
+    P_so = _mpwfn(BASE, '6-31G', 'spinorbital').dipole_derivatives()
+    P_sa = _mpwfn(BASE, '6-31G', 'spatial').dipole_derivatives()
+    assert np.max(np.abs(P_so - P_sa)) < 1e-11
+
+
+def test_so_mp2_corr_apt_vs_spatial_ccpvdz():
+    """Keystone (cc-pVDZ): spin-orbital == spin-adapted correlation APT."""
+    P_so = _mpwfn(BASE, 'cc-pVDZ', 'spinorbital').dipole_derivatives()
+    P_sa = _mpwfn(BASE, 'cc-pVDZ', 'spatial').dipole_derivatives()
+    assert np.max(np.abs(P_so - P_sa)) < 1e-11
+
+
+def test_mp2_apt_translational_sum_rule_631g():
+    """Acoustic (translational) sum rule: for a neutral molecule the sum over atoms of the
+    total APT vanishes (the correlation APT sums to zero on its own -- Tr(gamma_corr) = 0)."""
+    mp0 = _mpwfn(BASE, '6-31G', 'spatial')
+    P_corr = mp0.dipole_derivatives()
+    P_tot = mp0.total_dipole_derivatives()
+    assert np.max(np.abs(np.sum(P_corr, axis=0))) < 1e-10
+    assert np.max(np.abs(np.sum(P_tot, axis=0))) < 1e-10


### PR DESCRIPTION
  ## MP2 atomic polar tensors (nuclear dipole derivatives / APTs)                                                                     
                                                                                                                                      
  Adds the MP2 correlation atomic polar tensor `P_corr[A,β,α] = d(μ_α)/dX_{A,β} =                                                     
  -∂²E_corr/∂F_α∂X_{A,β}` (the IR-intensity tensor) via the explicit mixed field/nuclear                                              
  second derivative — the field/nuclear analog of the polarizability. Correlation and                                                 
  reference (SCF) parts stay separate; total = `HFwfn.dipole_derivatives()` +                                                         
  `MPwfn.dipole_derivatives()`.                                                                                                       
                                                                                                                                      
  Complete for **all-electron and frozen-core**, both bases, and both the spin-orbital and                                            
  spin-adapted (closed-shell RHF) paths. The 2n+1 (Z-vector interchange) route remains the                                            
  deferred efficient alternative.                                                                                                     
                                                                                                                                      
  ### Assembly (Eq. 15, one field + one nuclear perturbation)                                                                         
                                                                                                                                      
      d_{F_α X_β} E_corr = Σ_pq   [ d_X γ_pq · d_F f_pq  + γ_pq · d_{FX} f_pq ]                                                       
                         + Σ_pqrs [ d_X Γ    · d_F <pq||rs> + Γ · d_{FX} <pq||rs> ]                                                   
                                                                                                                                      
  ### What's new                                                                                                                      
                                                                                                                                      
  **`cphf.py` — second-order CPHF skeletons generalized field-only → field-nuclear**                                                  
  (field-field / polarizability preserved byte-for-byte):                                                                             
  - `_oei_skeleton(pert)` — first-order one-electron skeleton (`-μ` field / core-Hamiltonian                                          
    derivative nuclear).                                                                                                              
  - `_oei2_skeleton(a,b)` — mixed one-electron skeleton (`0` field-field, `-μ^X`                                                      
    field-nuclear, from the existing `Derivatives.dipole`/`so_dipole` — `∂_F h = -μ` ⇒                                                
    `∂_{FX} h = -μ^X`).                                                                                                               
  - `_d2eri` — adds the first-order 2-e skeleton cross-rotations `rotate(U^a, ⟨⟩^(b))` (the                                           
    field-nuclear mixed 2-e skeleton is 0); `_d2fock` uses the per-perturbation one-electron                                          
    skeletons + the mixed one.                                                                                                        
  - Nuclear-nuclear (the molecular Hessian) is guarded (`NotImplementedError`): still needs                                           
    `⟨⟩^{XY}`, `core2`, and the `S^{XY}` term in `_xi`.                                                                               
                                                                                                                                      
  `_xi` needed **no** change for the mixed case (`S^F = S^{FX} = 0`; the nuclear `U^X` carries                                        
  `-½S^X` in its oo/vv blocks), and frozen core needed **no** APT-specific fix (the ov                                                
  `ξ`-seed and core↔active canonical divide carry over from the polarizability). The nuclear                                          
  T2 density response works through the generic `_perturbed_densities` unchanged.                                                     
                                                                                                                                      
  **`mpwfn.py`**                                                                                                                      
  - `MPwfn.dipole_derivatives()` — correlation APT (`natom × 3 × 3`, indexed `[A,β,α]`),                                              
    basis-aware.                                                                                                                      
  - `total_dipole_derivatives()` — reference (with the `Z_A` term) + correlation.                                                     

  ### Validation (`test_068`, 8 tests)                                                                                                
                                                                                                                                      
  - **Primary** — correlation APT vs a 7-point O(h⁶) FD of the analytic dipole over nuclear                                           
    displacement (`P = ∂μ/∂X`, a `÷h` stencil): **~1e-12** (all-electron + frozen-core).                                              
  - **Nuclear T2 response** — `∂_X γ`/`∂_X Γ` vs a finite nuclear displacement, via the                                               
    gauge-invariant `Tr(γ²)`/`‖Γ‖²` scalars (~1e-9): a nuclear displacement genuinely rotates                                         
    pycc's `-½S^X` gauge vs the canonical MOs, so orthogonal invariants — not raw amplitudes —                                        
    are compared.                                                                                                                     
  - **Keystone** — spin-orbital == spin-adapted APT (6-31G and cc-pVDZ, all-electron + frozen                                         
    core) ~1e-15.                                                   
  - **Acoustic sum rule** — `Σ_A P = 0` (total and correlation) for neutral water ~1e-15, an
    FD-free physics check.                                          

  Oracles are pycc's own dipole (Psi4's frozen-core MP2 gradient bug rules out its analytic
  derivatives). Field-field polarizability (`test_067`) unregressed.
