### PR TITLE
MP2 molecular (nuclear) Hessian (explicit route)   

### DIFF
--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -537,6 +537,30 @@ smaller problem.
    are PyCC's own dipole/gradient -- Psi4's frozen-core MP2 gradient is inconsistent with its own
    energy, so not used.
 
-Later: magnetic-field derivatives (AATs, for VCD) reuse the same explicit machinery with `H.m`;
-the full MP2 Hessian adds the nuclear-nuclear second-derivative skeletons and the `S^{XY}` term in
-`_xi`.
+Later: magnetic-field derivatives (AATs, for VCD) reuse the same explicit machinery with `H.m`.
+
+## MP2 molecular (nuclear) Hessian — explicit route (2026-07) — DONE
+
+**DONE (branch `feature/mp2-apt`).** `MPwfn.hessian()` (correlation, `3N x 3N`) +
+`total_hessian()`, both spatial and spin-orbital, all-electron and frozen-core. The pure
+nuclear-nuclear second derivative `H_corr[Aa,Bb] = d^2 E_corr / dX_Aa dX_Bb` -- the same
+four-term Eq. 15 assembly as the polarizability/APT, both perturbations nuclear. The
+moving-basis terms the field/APT cases zeroed now activate (Eqs. 17/18/20):
+
+- `_xi`: the **full** Eq. 18 -- `+ S^{XY} - (S^X S^Y + S^Y S^X)` beyond the U-products (the
+  `S^X S^Y` products ride nowhere else; the PI flagged them). Zero for field-field and
+  field-nuclear, so polarizability/APT are byte-unchanged.
+- `_oei2_skeleton` -> `h^{XY}` (`core2`/`so_core2`); new `_overlap2_skeleton` -> `S^{XY}`
+  (`overlap2`/`so_overlap2`); new `_d2eri_skeleton` -> `<pq||rs>^{XY}` (`eri2`/`so_eri2`,
+  physicist/antisymmetrized, bra<->ket symmetrized); `_d2eri` guard removed.
+- Efficiency: `_d2int_blocks` caches the per-atom-pair `mo_*_deriv2` integrals (shared across
+  a pair's 3x3 Cartesian blocks) -- ~7x fewer `mo_tei_deriv2` calls than recomputing per
+  coordinate pair (`test_069`: 8+ min -> ~1 min). The explicit route still solves `U^{XY}` for
+  all `3N(3N+1)/2` pairs (the `O(N^2)` the 2n+1 Z-vector interchange would avoid); acceptable
+  for a reference code.
+
+Validated (`test_069`, 6-31G): Hessian columns vs a 7-point finite difference of the analytic
+gradient ~1e-13; symmetry `H = H.T` and the translational sum rule `sum_B H = 0` ~1e-16;
+SO==spatial keystone ~1e-16. This completes the explicit second-order property path (dipole,
+gradient, polarizability, APT, Hessian). Remaining: magnetic-field derivatives (AATs/VCD) with
+`H.m`, and the deferred 2n+1 route as an efficiency pass + cross-check.

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -128,6 +128,10 @@ class CPHF(object):
         self._U2cache: dict = {}  # -> (nmo, nmo) second-order response U^{ab}
         self._dfock2: dict = {}   # -> (nmo, nmo) full second perturbed Fock deriv
         self._deri2: dict = {}    # -> (nmo^4) full second perturbed <pq||rs> deriv
+        # Nuclear-nuclear skeleton second-derivative integrals, keyed by atom pair (atom1,
+        # atom2): the expensive mo_*_deriv2 calls are shared across the 3x3 Cartesian blocks
+        # of a pair, so memoize per pair rather than recompute per coordinate pair.
+        self._d2int: dict = {}    # (a1, a2) -> {'eri','core','overlap'}: 9-block lists
 
     # ---- orbital Hessian ----
     def hessian(self, kind: str = "electric") -> np.ndarray:
@@ -409,17 +413,26 @@ class CPHF(object):
     # same index twice (that index's mixed second derivative is U^{ab}, not U^a U^b).
 
     def _xi(self, perta: "Perturbation", pertb: "Perturbation", ncore: int = 0) -> np.ndarray:
-        """Second-order orthonormality term ``xi^{ab}`` (Eq. 18), ``nmo x nmo``. For the field
-        (``S^x = S^{ab} = 0``) it reduces to ``xi^{ab}_pq = sum_r (U^a_qr U^b_pr + U^a_pr U^b_qr)
-        = U^b U^a.T + U^a U^b.T`` (symmetric).
+        """Second-order orthonormality term ``xi^{ab}`` (Eq. 18), ``nmo x nmo``::
 
-        ASSUMES A PERTURBATION-INDEPENDENT AO BASIS (electric/magnetic field). For a nuclear
-        displacement the AOs move, so ``S^a`` and ``S^{ab}`` are nonzero and Eq. 18 gains the
-        skeleton overlap terms (``-S^{ab}`` and ``S^a``-``U`` cross terms) that are dropped here.
-        Extending this route to the molecular Hessian requires restoring them."""
+            xi^{ab}_pq = S^{ab}_pq + sum_r (U^a_qr U^b_pr + U^a_pr U^b_qr
+                                            - S^a_qr S^b_pr - S^a_pr S^b_qr)
+                       = S^{ab} + (U^b U^a.T + U^a U^b.T) - (S^b S^a + S^a S^b),
+
+        the U-products (Eq. 18 has no U*S cross terms -- the S info rides in the ``-1/2 S^x``
+        oo/vv blocks of the U's) plus the mixed overlap ``S^{ab}`` minus the ``S^a S^b``
+        products. For an electric field ``S^x = 0``, and for the mixed field-nuclear case
+        ``S^F = S^{FX} = 0``, so all three skeleton-overlap terms vanish and only the
+        U-products survive (polarizability / APT). Both become active only for nuclear-nuclear
+        (the molecular Hessian). ``S^a`` is the first-order MO overlap derivative
+        (:meth:`_skeleton`); ``S^{ab}`` is :meth:`_overlap2_skeleton`."""
         Ua = self._full_U(perta, ncore)
         Ub = self._full_U(pertb, ncore)
-        return Ub @ Ua.T + Ua @ Ub.T
+        xi = Ub @ Ua.T + Ua @ Ub.T
+        _, Sa, _ = self._skeleton(perta)
+        _, Sb, _ = self._skeleton(pertb)
+        Sab = self._overlap2_skeleton(perta, pertb)
+        return xi + Sab - (Sb @ Sa + Sa @ Sb)
 
     def _cross_eri(self, Ua: np.ndarray, Ub: np.ndarray, T: np.ndarray) -> np.ndarray:
         """The cross-index (different-slot) product of two single rotations on ``T`` (Eq. 20):
@@ -445,29 +458,77 @@ class CPHF(object):
             return np.asarray((d.so_core(atom) if so else d.core(atom))[cart])
         raise NotImplementedError("one-electron skeleton wired for 'field'/'nuclear' only.")
 
+    def _d2int_blocks(self, a1: int, a2: int) -> dict:
+        """Cached nuclear-nuclear skeleton second-derivative integrals for the atom pair
+        ``(a1, a2)``: the 9 ``(cart1, cart2)`` blocks of the core Hamiltonian ``h^{XY}``, the
+        overlap ``S^{XY}``, and the two-electron ``<pq||rs>^{XY}`` (in the basis's ERI
+        convention). The ``mo_*_deriv2`` calls -- ``mo_tei_deriv2`` especially -- are shared
+        across a pair's 3x3 Cartesian blocks, so compute once per atom pair (not per coordinate
+        pair). Returns ``{'core','overlap','eri'}`` -> lists of 9 arrays (indexed ``c1*3+c2``)."""
+        key = (a1, a2)
+        if key not in self._d2int:
+            so = self.wfn.orbital_basis == 'spinorbital'
+            d = self.wfn.derivatives
+            if so:
+                core = [np.asarray(m) for m in d.so_core2(a1, a2)]
+                overlap = [np.asarray(m) for m in d.so_overlap2(a1, a2)]
+                eri = [np.asarray(m) for m in d.so_eri2(a1, a2)]     # <pq||rs>^{XY} (antisym)
+            else:
+                core = [np.asarray(m) for m in d.core2(a1, a2)]
+                overlap = [np.asarray(m) for m in d.overlap2(a1, a2)]
+                eri = []
+                for ch in d.eri2(a1, a2):                            # chemist (pq|rs)^{XY}
+                    ch = np.asarray(ch)
+                    ch = 0.5 * (ch + ch.transpose(2, 3, 0, 1))       # enforce (pq|rs)=(rs|pq)
+                    eri.append(ch.swapaxes(1, 2))                    # -> physicist <pq|rs>^{XY}
+            self._d2int[key] = {'core': core, 'overlap': overlap, 'eri': eri}
+        return self._d2int[key]
+
     def _oei2_skeleton(self, perta: "Perturbation", pertb: "Perturbation"):
         """Mixed one-electron skeleton second derivative ``h^(ab)_pq`` (fixed MO coefficients).
 
         - field-field: ``0`` (the field is linear in F).
         - field-nuclear: ``-d(mu_alpha)/dX_beta`` (dipole-derivative integrals) -- because
-          ``d_F h = -mu``, so ``d_{F X} h = -mu^X``. This is the one genuinely new integral for
-          the APT, and it is already provided (``Derivatives.dipole`` / ``so_dipole``).
-        - nuclear-nuclear: the core-Hamiltonian second derivative (``core2``) -- part of the
-          molecular Hessian, not yet built."""
+          ``d_F h = -mu``, so ``d_{F X} h = -mu^X`` (``Derivatives.dipole`` / ``so_dipole``).
+        - nuclear-nuclear: the core-Hamiltonian second derivative ``h^{XY}`` (``core2`` /
+          ``so_core2``), indexed ``cart1*3 + cart2`` for the atom pair (molecular Hessian)."""
         kinds = {perta.kind, pertb.kind}
         if kinds == {'field'}:
             return 0.0
+        so = self.wfn.orbital_basis == 'spinorbital'
+        d = self.wfn.derivatives
         if kinds == {'field', 'nuclear'}:
             fld, nuc = (perta, pertb) if perta.kind == 'field' else (pertb, perta)
             alpha = fld.comp
             atom, beta = nuc.comp
-            so = self.wfn.orbital_basis == 'spinorbital'
-            d = self.wfn.derivatives
             dip = (d.so_dipole(atom) if so else d.dipole(atom))[alpha * 3 + beta]
             return -np.asarray(dip)
-        raise NotImplementedError(
-            "mixed one-electron skeleton wired for field-field and field-nuclear (APT); "
-            "nuclear-nuclear (the molecular Hessian) needs core2.")
+        if kinds == {'nuclear'}:
+            (a1, c1), (a2, c2) = perta.comp, pertb.comp
+            return self._d2int_blocks(a1, a2)['core'][c1 * 3 + c2]
+        raise NotImplementedError("mixed one-electron skeleton wired for 'field'/'nuclear'.")
+
+    def _overlap2_skeleton(self, perta: "Perturbation", pertb: "Perturbation"):
+        """Mixed second overlap skeleton ``S^{ab}_pq`` (fixed MO coefficients), for the
+        ``xi^{ab}`` term (Eq. 18). Zero unless both perturbations are nuclear (``S^F = 0``);
+        nuclear-nuclear reads ``overlap2`` / ``so_overlap2`` (indexed ``cart1*3 + cart2``)."""
+        if not (perta.kind == 'nuclear' and pertb.kind == 'nuclear'):
+            return 0.0
+        (a1, c1), (a2, c2) = perta.comp, pertb.comp
+        return self._d2int_blocks(a1, a2)['overlap'][c1 * 3 + c2]
+
+    def _d2eri_skeleton(self, perta: "Perturbation", pertb: "Perturbation"):
+        """Mixed second two-electron skeleton ``<pq||rs>^{ab}`` (fixed MO coefficients), in the
+        basis's ERI convention (SO: antisymmetrized ``<pq||rs>``; spatial: physicist ``<pq|rs>``).
+        Zero unless both perturbations are nuclear (the field never enters the 2-e integrals) --
+        the ``d_{F X} <> = 0`` fact that made the APT need no such term. Nuclear-nuclear reads
+        ``eri2`` / ``so_eri2`` (indexed ``cart1*3 + cart2``), mirroring the first-order skeleton
+        convention in :meth:`_skeleton` (chemist -> physicist, with the bra<->ket
+        symmetrization ``so_eri2`` already applies and ``eri2`` gets here)."""
+        if not (perta.kind == 'nuclear' and pertb.kind == 'nuclear'):
+            return 0.0
+        (a1, c1), (a2, c2) = perta.comp, pertb.comp
+        return self._d2int_blocks(a1, a2)['eri'][c1 * 3 + c2]
 
     def _d2eri(self, perta, pertb, U2: np.ndarray, ncore: int = 0) -> np.ndarray:
         """Second perturbed two-electron derivative ``d_ab <pq||rs>`` (``nmo^4``) given the
@@ -479,20 +540,15 @@ class CPHF(object):
                             + <pq||rs>^(ab)
 
         where ``<pq||rs>^(x)`` is the first-order two-electron skeleton (fixed MO coefficients,
-        from :meth:`_skeleton`). For the electric field ``<pq||rs>^(x) = 0`` (the field never
+        from :meth:`_skeleton`) and ``<pq||rs>^(ab)`` the mixed second-order skeleton
+        (:meth:`_d2eri_skeleton`). For the electric field ``<pq||rs>^(x) = 0`` (the field never
         enters the two-electron integrals), so only the first three (rotation) terms survive --
-        the polarizability case. For a nuclear displacement ``<pq||rs>^(x)`` is nonzero, adding
-        the ``rotate(U^x, <>^(y))`` cross-skeleton terms; the **field-nuclear** mixed second-order
-        skeleton ``<pq||rs>^(FX) = 0`` (again, the field is absent from the 2-e integrals), so the
-        APT needs no ``<>^(ab)`` term.
+        the polarizability case. Field-nuclear adds the ``rotate(U^F, <>^X)`` cross-skeleton term
+        (``<>^(FX) = 0``, the APT case); nuclear-nuclear adds the second cross-skeleton and the
+        direct ``<pq||rs>^(XY)`` (the molecular Hessian).
 
         Takes ``U2`` as an argument so the second-order CPHF solve can call it with the ov
-        response zeroed (no recursion through :meth:`_full_U2`). NUCLEAR-NUCLEAR (the molecular
-        Hessian) additionally needs the direct ``<pq||rs>^(XY)`` second-derivative integrals --
-        not built (guarded below)."""
-        if {perta.kind, pertb.kind} == {'nuclear'}:
-            raise NotImplementedError(
-                "nuclear-nuclear second 2e skeleton <pq||rs>^(XY) not built (molecular Hessian).")
+        response zeroed (no recursion through :meth:`_full_U2`)."""
         ERI = np.asarray(self.wfn.H.ERI)
         Ua = self._full_U(perta, ncore)
         Ub = self._full_U(pertb, ncore)
@@ -504,6 +560,9 @@ class CPHF(object):
             d2e = d2e + self._rotate_eri(Ua, np.asarray(gxb))
         if np.ndim(gxa):
             d2e = d2e + self._rotate_eri(Ub, np.asarray(gxa))
+        gxab = self._d2eri_skeleton(perta, pertb)          # mixed 2e skeleton (nuclear-nuclear)
+        if np.ndim(gxab):
+            d2e = d2e + gxab
         return d2e
 
     def _d2fock(self, perta, pertb, U2: np.ndarray, ncore: int = 0) -> np.ndarray:

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -267,6 +267,12 @@ class MPwfn(Wavefunction):
         correlation APTs (:meth:`dipole_derivatives`)."""
         return self._reference_hf().dipole_derivatives() + self.dipole_derivatives()
 
+    def total_hessian(self) -> np.ndarray:
+        """Total MP2 molecular (nuclear) Hessian (a.u.), shape ``(3*natom, 3*natom)``: the SCF
+        reference Hessian (:meth:`HFwfn.hessian`, which carries the nuclear-repulsion term) plus
+        the MP2 correlation Hessian (:meth:`hessian`)."""
+        return self._reference_hf().hessian() + self.hessian()
+
     # ---- explicit-derivative property route (notes.pdf) ----
     # The first derivative of the correlation energy w.r.t. a perturbation, via the
     # full (CPHF-folded) derivatives of f and <pq||rs> from the shared CPHF engine,
@@ -517,6 +523,64 @@ class MPwfn(Wavefunction):
                           + c('pqrs,pqrs->', dGX, dFe[alpha]) + c('pqrs,pqrs->', Gam, d2e))
                     P[A, beta, alpha] = -e2
         return P
+
+    def hessian(self) -> np.ndarray:
+        """MP2 **correlation** contribution to the molecular (nuclear) Hessian (a.u.), shape
+        ``(3*natom, 3*natom)`` indexed ``(A*3+a, B*3+b)`` = ``d^2 E_corr / dX_{Aa} dX_{Bb}`` --
+        the nuclear-nuclear analog of :meth:`polarizability`/:meth:`dipole_derivatives`, via
+        the explicit route (Eq. 15)::
+
+            d_{XY} E_corr = sum_pq [ d_X gamma d_Y f + gamma d_{XY} f ]
+                          + sum_pqrs [ d_X Gamma d_Y <pq||rs> + Gamma d_{XY} <pq||rs> ]
+
+        with the nuclear density responses ``d_X gamma``/``d_X Gamma``
+        (:meth:`_perturbed_densities`), the nuclear first derivatives
+        (:meth:`CPHF.perturbed_fock`/`perturbed_eri`), and the nuclear-nuclear second
+        derivatives (:meth:`CPHF.perturbed_fock2`/`perturbed_eri2`, which carry ``U^{XY}``, the
+        ``xi^{XY}`` ``S^{XY}``/``S^X S^Y`` overlap terms, and the ``h^{XY}``/``<pq||rs>^{XY}``
+        skeletons). The reference part is separate (:meth:`HFwfn.hessian`); total is their sum
+        (:meth:`total_hessian`). Basis-aware.
+
+        The explicit route solves ``U^{XY}`` for each of the ``3N(3N+1)/2`` unique nuclear
+        pairs -- the ``O(N^2)`` cost the 2n+1 (Z-vector interchange) route would avoid; fine for
+        a reference implementation on small molecules. Validated against a finite difference of
+        the analytic gradient (``test_069``)."""
+        from .cphf import Perturbation
+        o, v, nmo = self.o, self.v, self.nmo
+        ncore = o.stop - self.no
+        if self.orbital_basis == 'spinorbital':
+            Doo, Dvv = self._so_mp2_corr_opdm()
+            Gam = self._so_mp2_cumulant()
+        else:
+            Doo, Dvv = self._mp2_corr_opdm()
+            Gam = self._mp2_cumulant()
+        gamma = np.zeros((nmo, nmo))
+        gamma[o, o] = np.asarray(Doo)
+        gamma[v, v] = np.asarray(Dvv)
+        Gam = np.asarray(Gam)
+        cphf = self._full_occ_cphf()
+        c = self.contract
+        natom = self.derivatives.natom
+        nc = 3 * natom
+        pert = [Perturbation('nuclear', (A, cart)) for A in range(natom) for cart in range(3)]
+        dXf = [np.asarray(cphf.perturbed_fock(pert[i], ncore)) for i in range(nc)]
+        dXe = [np.asarray(cphf.perturbed_eri(pert[i], ncore)) for i in range(nc)]
+        dg, dG = zip(*(self._perturbed_densities(pert[i]) for i in range(nc)))
+        dg = [np.asarray(x) for x in dg]
+        dG = [np.asarray(x) for x in dG]
+        H = np.zeros((nc, nc))
+        for i in range(nc):
+            for j in range(i, nc):                      # d_{XY} f / <> symmetric in X<->Y
+                d2f = np.asarray(cphf.perturbed_fock2(pert[i], pert[j], ncore))
+                d2e = np.asarray(cphf.perturbed_eri2(pert[i], pert[j], ncore))
+                gd2f = c('pq,pq->', gamma, d2f)
+                Gd2e = c('pqrs,pqrs->', Gam, d2e)
+                H[i, j] = (c('pq,pq->', dg[i], dXf[j]) + gd2f
+                           + c('pqrs,pqrs->', dG[i], dXe[j]) + Gd2e)
+                if j != i:
+                    H[j, i] = (c('pq,pq->', dg[j], dXf[i]) + gd2f
+                               + c('pqrs,pqrs->', dG[j], dXe[i]) + Gd2e)
+        return H
 
     # ---- spin-adapted (closed-shell RHF) MP2 relaxed-gradient densities ----
     # The closed-shell analogue of the spin-orbital densities: the spin sum is carried by

--- a/pycc/tests/test_069_mp2_hessian.py
+++ b/pycc/tests/test_069_mp2_hessian.py
@@ -1,0 +1,114 @@
+"""
+MP2 molecular (nuclear) Hessian (correlation contribution) via the explicit nuclear-nuclear
+second derivative -- H_corr[Aa,Bb] = d^2 E_corr / dX_{Aa} dX_{Bb};
+DERIVATIVES_PLAN_2026-06.md, derivints.pdf Eqs. 15/17/18/20.
+
+The nuclear-nuclear analog of the polarizability/APT, completing the second-order machinery:
+the nuclear density response d_X gamma / d_X Gamma, the nuclear first derivatives, and the
+nuclear-nuclear second derivatives (CPHF.perturbed_fock2 / perturbed_eri2). The moving-basis
+terms absent from the field/APT cases now activate -- the xi^{XY} overlap terms
+S^{XY} - S^X S^Y (Eq. 18) and the mixed skeletons h^{XY} (core2) and <pq||rs>^{XY} (eri2).
+The reference (SCF) Hessian is separate (HFwfn.hessian, carrying the nuclear-repulsion term);
+the total is their sum.
+
+Validation:
+  * primary: correlation Hessian columns vs a 7-point O(h^6) finite difference of the analytic
+    correlation gradient (H = d(gradient)/dX, a 1/h stencil ~1e-13);
+  * symmetry H = H.T and the translational sum rule sum_B H_{Aa,Bb} = 0 (E_corr is
+    translationally invariant) -- FD-free checks;
+  * keystone: spin-orbital == spin-adapted (closed-shell RHF) correlation Hessian.
+
+Geometry is Cartesian in bohr with no_com/no_reorient so displacing an atom keeps the frame
+fixed and matches the analytic (bohr) integral derivatives. Oracle is pycc's own analytic
+gradient (Psi4's frozen-core MP2 gradient bug rules out its analytic derivatives). 6-31G only
+(the shared second-order machinery is already cc-pVDZ-tested via the polarizability/APT).
+"""
+
+import psi4
+import pycc
+import numpy as np
+
+
+BASE = np.array([[0.0, 0.0, 0.0],
+                 [0.0, 0.0, 1.814137],
+                 [0.0, 1.756000, -0.454300]])
+SYM = ['O', 'H', 'H']
+
+
+def _geom(coords):
+    s = "units bohr\nsymmetry c1\nno_com\nno_reorient\n"
+    for sym, xyz in zip(SYM, coords):
+        s += f"{sym} {xyz[0]:.10f} {xyz[1]:.10f} {xyz[2]:.10f}\n"
+    return s
+
+
+def _mpwfn(coords, orbital_basis='spatial', freeze_core='false'):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(_geom(coords))
+    psi4.set_options({'basis': '6-31G', 'scf_type': 'pk', 'freeze_core': freeze_core,
+                      'e_convergence': 1e-13, 'd_convergence': 1e-13})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
+    mp.compute_energy()
+    return mp
+
+
+def _gradfd_col(orbital_basis, atom, cart, freeze_core='false', h=0.002):
+    """One Hessian column (natom, 3) via a 7-point O(h^6) FD of the analytic correlation
+    gradient over the nuclear coordinate (atom, cart)."""
+    def g(delta):
+        c = BASE.copy(); c[atom, cart] += delta
+        return np.asarray(_mpwfn(c, orbital_basis, freeze_core).gradient())
+    return (-g(-3*h) + 9*g(-2*h) - 45*g(-h)
+            + 45*g(h) - 9*g(2*h) + g(3*h)) / (60*h)
+
+
+def test_mp2_corr_hessian_symmetry_sum_rule_631g():
+    """All-electron correlation Hessian: symmetric, and translationally invariant
+    (sum over the second atom vanishes), H2O/6-31G -- FD-free checks."""
+    H = _mpwfn(BASE, 'spatial').hessian()
+    assert H.shape == (9, 9)
+    assert np.max(np.abs(H - H.T)) < 1e-10
+    assert np.max(np.abs(H.reshape(3, 3, 3, 3).sum(axis=2))) < 1e-10
+
+
+def test_mp2_corr_hessian_gradfd_631g():
+    """All-electron correlation Hessian columns vs a 7-point FD of the analytic gradient,
+    H2O/6-31G (~1e-13)."""
+    H = _mpwfn(BASE, 'spatial').hessian()
+    for (atom, cart) in [(0, 2), (2, 1)]:
+        j = atom * 3 + cart
+        assert np.max(np.abs(H[:, j] - _gradfd_col('spatial', atom, cart).reshape(-1))) < 1e-9
+
+
+def test_so_mp2_corr_hessian_vs_spatial_631g():
+    """Keystone (6-31G): closed-shell spin-orbital == spin-adapted correlation Hessian."""
+    H_so = _mpwfn(BASE, 'spinorbital').hessian()
+    H_sa = _mpwfn(BASE, 'spatial').hessian()
+    assert np.max(np.abs(H_so - H_sa)) < 1e-11
+
+
+# ---- frozen core (the nuclear-nuclear core<->active response) ----
+
+def test_fc_mp2_corr_hessian_gradfd_631g():
+    """Frozen-core correlation Hessian columns vs the 7-point gradient FD, H2O/6-31G."""
+    H = _mpwfn(BASE, 'spatial', freeze_core='true').hessian()
+    for (atom, cart) in [(0, 2), (2, 1)]:
+        j = atom * 3 + cart
+        assert np.max(np.abs(H[:, j]
+                      - _gradfd_col('spatial', atom, cart, freeze_core='true').reshape(-1))) < 1e-9
+
+
+def test_fc_mp2_corr_hessian_symmetry_sum_rule_631g():
+    """Frozen-core correlation Hessian: symmetric and translationally invariant."""
+    H = _mpwfn(BASE, 'spatial', freeze_core='true').hessian()
+    assert np.max(np.abs(H - H.T)) < 1e-10
+    assert np.max(np.abs(H.reshape(3, 3, 3, 3).sum(axis=2))) < 1e-10
+
+
+def test_fc_so_mp2_corr_hessian_vs_spatial_631g():
+    """Keystone (6-31G, frozen core): spin-orbital == spin-adapted correlation Hessian."""
+    H_so = _mpwfn(BASE, 'spinorbital', freeze_core='true').hessian()
+    H_sa = _mpwfn(BASE, 'spatial', freeze_core='true').hessian()
+    assert np.max(np.abs(H_so - H_sa)) < 1e-11


### PR DESCRIPTION
## MP2 molecular (nuclear) Hessian (explicit route)                                                                                 
                                                                                                                                      
  Adds the MP2 correlation molecular Hessian `H_corr[Aa,Bb] = ∂²E_corr/∂X_{Aa}∂X_{Bb}`                                                
  (`3N × 3N`) via the explicit nuclear-nuclear second derivative — the capstone of the                                                
  explicit second-order property path. Same four-term Eq. 15 assembly as the
  polarizability/APT, both perturbations nuclear. `MPwfn.hessian()` (correlation);
  `total_hessian()` = `HFwfn.hessian()` + correlation.

  Complete for **all-electron and frozen-core**, both the spin-orbital and spin-adapted
  (closed-shell RHF) paths. The 2n+1 (Z-vector interchange) route remains the deferred
  efficient alternative.                                            

  ### What's new — the moving-basis second-order terms              

  The field and field-nuclear (APT) cases had `S^F = S^{FX} = 0`, which zeroed several terms;
  nuclear-nuclear activates them all (`derivints.pdf` Eqs. 17/18/20):

  - **`_xi` — the full Eq. 18:** `ξ^{XY} = (UᵧUₓᵀ + UₓUᵧᵀ) + S^{XY} − (SˣSʸ + SʸSˣ)`. The `S^X S^Y`
    products (and `S^{XY}`) are new; they vanish for field-field / field-nuclear, so the
    polarizability and APT are byte-for-byte unchanged.
  - **Mixed skeletons:** `_oei2_skeleton` → `h^{XY}` (`core2`/`so_core2`); new
    `_overlap2_skeleton` → `S^{XY}` (`overlap2`/`so_overlap2`) for `ξ`; new `_d2eri_skeleton`
    → `⟨pq‖rs⟩^{XY}` (`eri2`/`so_eri2`, physicist/antisymmetrized, bra↔ket symmetrized).
    `_d2eri`'s nuclear-nuclear guard removed and the mixed 2-e skeleton added.
  - **`mpwfn.py`:** `MPwfn.hessian()` and `total_hessian()`.

  ### Efficiency                                                    

  `_d2int_blocks` caches the per-atom-pair `mo_*_deriv2` integrals (`mo_tei_deriv2` especially),
  shared across a pair's 3×3 Cartesian blocks — ~7× fewer second-derivative integral
  evaluations than recomputing per coordinate pair (`test_069`: 8+ min → ~1 min). The explicit
  route still solves `U^{XY}` for all `3N(3N+1)/2` unique pairs — the `O(N²)` the 2n+1 Z-vector
  interchange would avoid; fine for a reference code on small molecules (logged, not hidden).
                                                                    
  ### Validation (`test_069`, 6-31G)

  - **Primary:** Hessian columns vs a 7-point O(h⁶) finite difference of the analytic
    correlation gradient (`H = ∂(gradient)/∂X`, a `÷h` stencil) — ~1e-13.
  - **FD-free:** symmetry `H = Hᵀ` and the translational sum rule `Σ_B H_{Aa,Bb} = 0` (`E_corr`
    is translationally invariant) — ~1e-16.                         
  - **Keystone:** spin-orbital == spin-adapted correlation Hessian — ~1e-16.
  - All-electron and frozen-core.                                   

                                                                  
  Oracle is pycc's own analytic gradient (Psi4's frozen-core MP2 gradient bug rules out its
  analytic derivatives). 6-31G only for the Hessian (the shared second-order machinery is
  already cc-pVDZ-tested via the polarizability/APT). Polarizability (`test_067`) and APT
  (`test_068`) unregressed — 15/15.                                 

  This completes the explicit second-order property path: **dipole, gradient, polarizability,
  APT, Hessian** — all all-electron + frozen-core, both spin paths. 