### PR TITLE
HF velocity-gauge atomic polar tensors

### DIFF
--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -116,6 +116,7 @@ class CPHF(object):
         self._F_nuc: dict = {}  # atom -> list of 3 (no, no) skeleton deriv Fock F^X_ij
         self._S_nuc: dict = {}  # atom -> list of 3 (no, no) overlap deriv S^X_ij
         self._U_mag: dict = {}  # axis -> (no, nv) magnetic-field response U^B (real)
+        self._U_mom: dict = {}  # axis -> (no, nv) linear-momentum response U^A (real)
         # Full (CPHF-folded) first-derivative caches, keyed by Perturbation. These hold
         # the response-dressed derivatives d_x f and d_x <pq||rs> (notes: the "simple but
         # inefficient" explicit form), persisting for the life of this CPHF object so that
@@ -718,6 +719,34 @@ class CPHF(object):
         if axis not in self._U_mag:
             self._U_mag[axis] = self.solve(self.rhs_magnetic(axis), kind="magnetic")
         return self._U_mag[axis]
+
+    def _p_ov(self, axis: int) -> np.ndarray:
+        """ov block of the (real) MO linear-momentum integral for ``axis`` (0/1/2).
+
+        ``H.p`` is ``i * <mu|Del|nu>`` in the MO basis (the pure-imaginary linear-momentum
+        operator, carrying the same ``i`` convention as ``H.m``); this strips the ``i`` by
+        multiplying by ``-i`` so the momentum CPHF is a real problem, exactly as
+        :meth:`_m_ov` does for the magnetic dipole."""
+        return np.asarray(-1.0j * self.wfn.H.p[axis])[self.o, self.v].real
+
+    def rhs_momentum(self, axis: int) -> np.ndarray:
+        """Linear-momentum (magnetic vector-potential) CPHF RHS for ``axis`` (0/1/2), real.
+
+        The vector potential enters the Hamiltonian as ``H'(A) = A . pi`` (Amos, Jalkanen &
+        Stephens, JPC 92, 5571 (1988), Eq. 10), so ``dH'/dA = +pi`` -- the (positive) real
+        momentum ov integral (contrast the magnetic ``B = -m``). Like the field/magnetic
+        perturbations, ``A`` does not move the basis functions, so there is no overlap/Pulay
+        term. The momentum perturbation is imaginary, so this uses the antisymmetric
+        (``kind='magnetic'``) orbital Hessian -- the same Hessian as the magnetic response."""
+        return self._p_ov(axis)
+
+    def solve_momentum(self, axis: int) -> np.ndarray:
+        """Linear-momentum CPHF response ``U^A`` for ``axis`` (0/1/2), ``(no, nv)``, solved
+        once and cached. Real. This is the ket derivative ``dPsi/dA`` in the velocity-gauge
+        APT (:meth:`HFwfn.velocity_dipole_derivatives`)."""
+        if axis not in self._U_mom:
+            self._U_mom[axis] = self.solve(self.rhs_momentum(axis), kind="magnetic")
+        return self._U_mom[axis]
 
     def _build_nuclear(self, atom: int):
         """One heavy pass over the derivative integrals for ``atom``; returns three

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -417,3 +417,73 @@ class HFwfn(Wavefunction):
                         + self.contract('ia,ia->', Ub[beta], Shalf[alpha]))
         self.aat = aat
         return self.aat
+
+    def velocity_dipole_derivatives(self) -> np.ndarray:
+        """Velocity-gauge (VG) atomic polar tensors ``[P^A_{beta,alpha}]^VG`` (a.u.), shape
+        ``(natom, 3, 3)`` indexed ``[A, beta, alpha]`` = ``d(mu_alpha)/d(X_A,beta)`` -- the
+        momentum-form APT, an alternative to the length-gauge :meth:`dipole_derivatives`.
+
+        Formulated (Amos, Jalkanen & Stephens, JPC 92, 5571 (1988), Eq. 14; Shumberger et al.,
+        LG(OI) VCD, Eq. 15) as an overlap of wave-function derivatives -- the nuclear derivative
+        of the bra with the magnetic-vector-potential derivative of the ket::
+
+            [P^A_{beta,alpha}]^VG = -4 sum_ia (U^R_{ia,beta} + <phi^R_i|phi_a>) U^A_{ia,alpha}
+                                    + Z_A delta_{alpha,beta}
+
+        the same overlap structure as the AAT (:meth:`atomic_axial_tensors`) with the linear-
+        momentum response ``U^A`` (:meth:`CPHF.solve_momentum`, ``dPsi/dA``) in place of the
+        magnetic response ``U^B``, and the length-gauge ``Z_A delta`` nuclear term in place of
+        the AAT's Levi-Civita term. ``U^R`` is the nuclear CPHF response; ``<phi^R_i|phi_a>`` the
+        nuclear half-derivative overlap (the vector potential does not move the basis, so this
+        rides on the R side only). The ``-4`` prefactor is the closed-shell value (real-wf
+        doubling x double occupancy; the two imaginary units of ``-2i`` x ``H.p`` fix the sign)
+        -- pinned to the Amos et al. NH3 ``P(pi)`` values.
+
+        Unlike the length-gauge APT, the VG APT differs from it in a finite basis and converges
+        to it only toward the basis-set limit; both are origin-independent. The spin-orbital path
+        dispatches to :meth:`_so_velocity_dipole_derivatives`."""
+        if self.orbital_basis == 'spinorbital':
+            return self._so_velocity_dipole_derivatives()
+        d = self.derivatives
+        mol = self.ref.molecule()
+        natom = mol.natom()
+        Ua = [self.cphf.solve_momentum(alpha) for alpha in range(3)]   # 3 x (no,nv)
+        P = np.zeros((natom, 3, 3))
+        for A in range(natom):
+            Ur = self.cphf.solve_nuclear(A)                            # 3 x (no,nv)
+            Sh = d.overlap_half(A, 'o', 'v', side="LEFT")              # 3 x (no,nv)
+            for beta in range(3):
+                for alpha in range(3):
+                    val = mol.Z(A) if alpha == beta else 0.0
+                    val += -4.0 * self.contract('ia,ia->', Ur[beta] + Sh[beta], Ua[alpha])
+                    P[A, beta, alpha] = val
+        self.vgapt = P
+        return self.vgapt
+
+    def _so_velocity_dipole_derivatives(self) -> np.ndarray:
+        """Spin-orbital velocity-gauge APTs, shape ``(natom, 3, 3)``. The spin-orbital form of
+        :meth:`velocity_dipole_derivatives`: singly occupied spin orbitals halve the closed-shell
+        prefactor (``-4 -> -2``), with the spin-orbital nuclear/momentum responses
+        (:meth:`CPHF.solve_nuclear`/:meth:`CPHF.solve_momentum`) and half-derivative overlaps
+        (:meth:`Derivatives.so_overlap_half`)::
+
+            [P^A_{beta,alpha}]^VG = -2 sum_ia (U^R_{ia,beta} + <phi^R_i|phi_a>) U^A_{ia,alpha}
+                                    + Z_A delta_{alpha,beta}
+
+        Valid for UHF as well as a closed-shell RHF forced to spin orbitals; ROHF raises (via
+        :meth:`CPHF.solve`)."""
+        d = self.derivatives
+        mol = self.ref.molecule()
+        natom = mol.natom()
+        Ua = [self.cphf.solve_momentum(alpha) for alpha in range(3)]
+        P = np.zeros((natom, 3, 3))
+        for A in range(natom):
+            Ur = self.cphf.solve_nuclear(A)
+            Sh = d.so_overlap_half(A, 'o', 'v', side="LEFT")
+            for beta in range(3):
+                for alpha in range(3):
+                    val = mol.Z(A) if alpha == beta else 0.0
+                    val += -2.0 * self.contract('ia,ia->', Ur[beta] + Sh[beta], Ua[alpha])
+                    P[A, beta, alpha] = val
+        self.vgapt = P
+        return self.vgapt

--- a/pycc/tests/test_071_hf_velocity_apt.py
+++ b/pycc/tests/test_071_hf_velocity_apt.py
@@ -1,0 +1,100 @@
+"""
+HF velocity-gauge (VG) atomic polar tensors -- HFwfn.velocity_dipole_derivatives().
+
+The momentum-form APT P^lambda_{beta,alpha} = d(mu_alpha)/dX_{A,beta}, formulated (Amos,
+Jalkanen & Stephens, J. Phys. Chem. 92, 5571 (1988), Eq. 14; Shumberger, Cheeseman, Caricato
+& Crawford, LG(OI) VCD, Eq. 15) as an overlap of wave-function derivatives,
+
+    [P^A_{beta,alpha}]^VG = -4 sum_ia (U^R_{ia,beta} + <phi^R_i|phi_a>) U^A_{ia,alpha}
+                            + Z_A delta_{alpha,beta}   (closed-shell; -2 spin-orbital),
+
+with the linear-momentum (magnetic-vector-potential) response U^A (CPHF.solve_momentum, dPsi/dA)
+in place of the AAT's magnetic response U^B. Unlike the length-gauge APT (dipole_derivatives),
+the VG APT differs from it in a finite basis (converging only toward the basis-set limit) but is
+likewise origin-independent.
+
+Oracle: the Amos et al. NH3 P(pi) values (their Table I), reproduced to the paper's 3-digit
+precision. Geometry is their Table I geometry (bohr, no_com/no_reorient). Also: the SO == spatial
+keystone, and origin invariance (an FD-free physics check).
+
+TODO(precision): the Amos et al. numbers are only 3 significant figures, so the oracle tolerance
+here is a loose ~2e-3. The PI will provide higher-precision reference VG APTs; tighten
+`test_hf_vgapt_vs_amos` accordingly once available. (The SO==spatial keystone and origin-
+invariance checks are already at ~1e-11/1e-9 and are the tight internal anchors in the meantime.)
+"""
+
+import psi4
+import pycc
+import numpy as np
+
+
+# Amos et al., Table I geometry (atomic units); atom 0 = N, atom 3 = H3.
+NH3 = """
+units bohr
+symmetry c1
+no_com
+no_reorient
+N  0.0000  0.0000  0.1278
+H -0.8855  1.5337 -0.5920
+H -0.8855 -1.5337 -0.5920
+H  1.7710  0.0000 -0.5920
+"""
+
+# Amos Table I P(pi) (velocity gauge), keyed [atom, nuc_cart, dip_dir].
+AMOS_PI = {
+    '6-31G*':  {(0, 0, 0): 2.791, (0, 2, 2): 3.355, (3, 0, 0): 0.127, (3, 0, 2): 0.284,
+                (3, 1, 1): 0.618, (3, 2, 0): 0.356, (3, 2, 2): 0.582},
+    '6-31G**': {(0, 0, 0): 2.484, (0, 2, 2): 3.005, (3, 0, 0): 0.065, (3, 0, 2): 0.235,
+                (3, 1, 1): 0.451, (3, 2, 0): 0.307, (3, 2, 2): 0.424},
+}
+
+
+def _hfwfn(basis, orbital_basis='spatial', geom=NH3):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk',
+                      'e_convergence': 1e-11, 'd_convergence': 1e-11})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    return pycc.HFwfn(wfn, orbital_basis=orbital_basis)
+
+
+def test_hf_vgapt_vs_amos():
+    """Spatial VG APT reproduces the Amos et al. NH3 P(pi) values (Table I) to ~3 digits,
+    for both 6-31G* and 6-31G**."""
+    for basis, ref in AMOS_PI.items():
+        P = np.asarray(_hfwfn(basis).velocity_dipole_derivatives())
+        for (A, nc, dp), val in ref.items():
+            assert abs(P[A, nc, dp] - val) < 2e-3, (basis, A, nc, dp, P[A, nc, dp], val)
+
+
+def test_hf_vgapt_so_vs_spatial():
+    """Keystone: closed-shell spin-orbital == spin-adapted VG APT (both bases)."""
+    for basis in ('6-31G*', '6-31G**'):
+        Psa = np.asarray(_hfwfn(basis, 'spatial').velocity_dipole_derivatives())
+        Pso = np.asarray(_hfwfn(basis, 'spinorbital').velocity_dipole_derivatives())
+        assert np.max(np.abs(Pso - Psa)) < 1e-11
+
+
+def test_hf_vgapt_origin_invariant():
+    """The VG APT is origin-independent (Amos et al.): a rigid translation of the molecule (and
+    thus the gauge origin) leaves it unchanged -- an FD-free physics check, and the whole point
+    of the velocity gauge for VCD."""
+    shifted = NH3.replace('N  0.0000  0.0000  0.1278',
+                          'N  5.0000 -3.0000  4.1278').replace(
+                          'H -0.8855  1.5337 -0.5920', 'H  4.1145 -1.4663  3.4080').replace(
+                          'H -0.8855 -1.5337 -0.5920', 'H  4.1145 -4.5337  3.4080').replace(
+                          'H  1.7710  0.0000 -0.5920', 'H  6.7710 -3.0000  3.4080')
+    P0 = np.asarray(_hfwfn('6-31G*').velocity_dipole_derivatives())
+    P1 = np.asarray(_hfwfn('6-31G*', geom=shifted).velocity_dipole_derivatives())
+    assert np.max(np.abs(P0 - P1)) < 1e-9
+
+
+def test_hf_vgapt_differs_from_lg_finite_basis():
+    """Sanity: VG and LG APTs are genuinely different in a finite basis (they agree only toward
+    the basis-set limit), and they share the same Z_A delta nuclear term, so their difference is
+    purely electronic and nonzero here."""
+    hf = _hfwfn('6-31G*')
+    Pvg = np.asarray(hf.velocity_dipole_derivatives())
+    Plg = np.asarray(hf.dipole_derivatives())
+    assert np.max(np.abs(Pvg - Plg)) > 1.0        # N diagonal differs by ~3 in 6-31G*


### PR DESCRIPTION
## HF velocity-gauge atomic polar tensors

Adds `HFwfn.velocity_dipole_derivatives()` — the momentum-form (velocity-gauge, VG) APT for HF, both spin paths (RHF/UHF; ROHF raises via `CPHF.solve`). This is the electric-dipole ingredient the LG(OI)/VG VCD formulations need, and the HF prerequisite for the eventual MP2 velocity-gauge APT.

### Formulation
The VG APT is an **overlap of wave-function derivatives** (Amos, Jalkanen & Stephens, JPC 92, 5571 (1988), Eq. 14; Shumberger, Cheeseman, Caricato & Crawford, LG(OI) VCD, Eq. 15):

```
[P^A_{beta,alpha}]^VG = -4 sum_ia (U^R_{ia,beta} + <phi^R_i|phi_a>) U^A_{ia,alpha}
                        + Z_A delta_{alpha,beta}          (closed-shell; -2 spin-orbital)
```

— the AAT's overlap-of-derivatives structure with two swaps: the ket derivative is w.r.t. the magnetic **vector potential** `A` (linear-momentum response `U^A = dPsi/dA`) instead of the magnetic **field** `H` (angular-momentum response `U^B`), and the nuclear term is the length-gauge `Z_A delta` instead of the AAT's Levi-Civita term. The VG APT is origin-invariant and differs from the length-gauge APT in a finite basis, converging to it only toward the basis-set limit.

### Changes
- **`cphf.py`**: `solve_momentum` / `rhs_momentum` / `_p_ov` — mirror the magnetic trio using the existing linear-momentum integrals `H.p` (`i*Del`, stripped of its `i`). The momentum perturbation is imaginary, so it reuses the antisymmetric (`kind='magnetic'`) orbital Hessian. Purely additive.
- **`hfwfn.py`**: `velocity_dipole_derivatives()` + `_so_velocity_dipole_derivatives()` — a deliberately distinct interface from the length-gauge `dipole_derivatives()`, so a knowledgeable user reads "velocity gauge / momentum / overlap-of-derivatives" immediately (per PI request).

The closed-shell prefactor `-4` (spin-orbital `-2`) was pinned against the oracle (the double-occupancy factor of 2 is easy to under-count; the signed Amos values fixed it unambiguously).

### Validation (`test_071`)
- Reproduces the Amos et al. NH3 `P(pi)` values (their Table I) for **6-31G\*** and **6-31G\*\*** to the paper's 3-digit precision, **both spin paths**.
- SO == spatial keystone (~1e-15); origin invariance (FD-free); VG != LG at finite basis.
- (The length-gauge `dipole_derivatives()` also reproduces the Amos `P(mu)` column, confirming the geometry/basis/convention setup.)

### Note — validation precision
The Amos oracle is only **3 significant figures**, so the vs-Amos tolerance is a loose ~2e-3. **Higher-precision reference VG APTs are pending (to be provided by the PI)** to tighten `test_hf_vgapt_vs_amos`; a `TODO(precision)` marks this in `test_071`. The SO==spatial keystone and origin-invariance checks are the tight internal anchors in the meantime.

### Scope / next
HF only. The MP2 velocity-gauge APT waits on the MP2 AATs (theory beyond the current published formulations, to be provided by the PI).
