### PR TITLE
MP2 atomic axial tensors (VCD): gauge-invariant, frozen-core, both spin paths

### DIFF
--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -117,6 +117,7 @@ class CPHF(object):
         self._S_nuc: dict = {}  # atom -> list of 3 (no, no) overlap deriv S^X_ij
         self._U_mag: dict = {}  # axis -> (no, nv) magnetic-field response U^B (real)
         self._U_mom: dict = {}  # axis -> (no, nv) linear-momentum response U^A (real)
+        self._mag_int: dict = {}  # axis -> (U^H, dF^H, dERI^H) magnetic engine (for MP2 AATs)
         # Full (CPHF-folded) first-derivative caches, keyed by Perturbation. These hold
         # the response-dressed derivatives d_x f and d_x <pq||rs> (notes: the "simple but
         # inefficient" explicit form), persisting for the life of this CPHF object so that
@@ -747,6 +748,80 @@ class CPHF(object):
         if axis not in self._U_mom:
             self._U_mom[axis] = self.solve(self.rhs_momentum(axis), kind="magnetic")
         return self._U_mom[axis]
+
+    def magnetic_ints(self, axis: int, ncore: int = 0, gauge: str = 'non-canonical'):
+        """Magnetic-field-perturbed MO integrals for ``axis`` (0/1/2): returns the tuple
+        ``(U^H, dF^H, dERI^H)`` used by the MP2 atomic axial tensors
+        (:meth:`MPwfn.atomic_axial_tensors`). Cached per ``(axis, ncore, gauge)``.
+
+        The magnetic perturbation ``H' = -m.H`` (``m = -1/2 L``, the real antisymmetric
+        magnetic-dipole matrix, stripped of the ``i`` carried in ``H.m``) is imaginary, so the
+        orbital response is antisymmetric and uses the ``kind='magnetic'`` orbital Hessian.
+
+        ``U^H`` is the **full** ``nmo x nmo`` response: the ov block from the magnetic CPHF solve,
+        the vo block as its (symmetric) transpose, and the oo/vv blocks set by ``gauge``:
+
+        * ``'non-canonical'`` (default): the redundant within-space rotations (core-core,
+          active-active, virtual-virtual) are left at zero -- the ``-1/2 S^H = 0`` common-origin
+          choice.  Only the **non-redundant** core<->active-occupied block (present when
+          ``ncore > 0``, frozen core) is filled from the canonical condition.  This avoids the
+          near-degenerate divides of the fully canonical choice (e.g. close-lying core orbitals)
+          and is numerically preferred.  The AAT total is invariant to this choice.
+        * ``'canonical'``: every oo/vv block from ``d_H f_pq = 0`` (divide by the orbital-energy
+          difference), degeneracy-guarded.
+
+        ``dF^H``/``dERI^H`` are the perturbed Fock / two-electron integrals with the antisymmetric
+        (ket ``+``, bra ``-``) rotation.  ``W`` is the antisymmetrized ``<pq||rs>`` (spin-orbital)
+        or the spin-adapted ``L`` (spatial), matching the rest of the CPHF engine."""
+        key = (axis, ncore, gauge)
+        if key in self._mag_int:
+            return self._mag_int[key]
+        o, v, nmo = self.o, self.v, self.wfn.nmo
+        no, nv = self.no, self.nv
+        t = slice(0, nmo)
+        eps = self.eps
+        c = self.contract
+        ERI = np.asarray(self.wfn.H.ERI)
+        W = ERI if self.wfn.orbital_basis == 'spinorbital' else np.asarray(self.wfn.H.L)
+        core = -W + W.swapaxes(1, 3)                # antisymmetric mean-field weight
+        Gm = (np.einsum('ab,ij->aibj', np.eye(nv), np.eye(no))
+              * (eps[v].reshape(nv, 1, 1, 1) - eps[o].reshape(1, no, 1, 1))
+              + core.swapaxes(1, 2)[v, o, v, o]).reshape(nv * no, nv * no)
+        hmag = np.asarray(-1.0j * self.wfn.H.m[axis]).real
+
+        def _safe_div(num, e):
+            # canonical oo/vv rotation num_pq / (eps_q - eps_p), degeneracy-guarded: where two
+            # orbitals are (near-)degenerate the spin-diagonal magnetic numerator also vanishes,
+            # so set 0/0 (and the diagonal) to zero rather than divide.
+            gap = e[None, :] - e[:, None]
+            out = np.zeros_like(num)
+            m = np.abs(gap) > 1e-7
+            out[m] = num[m] / gap[m]
+            return out
+
+        U = np.zeros((nmo, nmo))
+        U[v, o] = np.linalg.solve(Gm, hmag[v, o].reshape(nv * no)).reshape(nv, no)
+        U[o, v] = U[v, o].T
+        if gauge == 'canonical':
+            U[o, o] = _safe_div(-hmag[o, o] + c('em,iejm->ij', U[v, o], core[o, v, o, o]), eps[o])
+            U[v, v] = _safe_div(-hmag[v, v] + c('em,aebm->ab', U[v, o], core[v, v, v, o]), eps[v])
+        elif ncore:
+            # non-canonical: only the non-redundant core<->active-occupied block is canonical
+            Uoo = _safe_div(-hmag[o, o] + c('em,iejm->ij', U[v, o], core[o, v, o, o]), eps[o])
+            keep = np.zeros((no, no), dtype=bool)
+            keep[:ncore, ncore:] = True
+            keep[ncore:, :ncore] = True
+            U[o, o] = Uoo * keep
+        np.fill_diagonal(U, 0.0)
+        dF = np.zeros((nmo, nmo))
+        dF[o, o] = (-hmag[o, o] + (U[o, o] * eps[o].reshape(-1, 1) - U[o, o].T * eps[o])
+                    + c('em,iejm->ij', U[v, o], core[o, v, o, o]))
+        dF[v, v] = (-hmag[v, v] + (U[v, v] * eps[v].reshape(-1, 1) - U[v, v].T * eps[v])
+                    + c('em,aebm->ab', U[v, o], core[v, v, v, o]))
+        dERI = (c('tr,pqts->pqrs', U[:, t], ERI[t, t, :, t]) + c('ts,pqrt->pqrs', U[:, t], ERI[t, t, t, :])
+                - c('tp,tqrs->pqrs', U[:, t], ERI[:, t, t, t]) - c('tq,ptrs->pqrs', U[:, t], ERI[t, :, t, t]))
+        self._mag_int[key] = (U, dF, dERI)
+        return self._mag_int[key]
 
     def _build_nuclear(self, atom: int):
         """One heavy pass over the derivative integrals for ``atom``; returns three

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -262,6 +262,22 @@ class MPwfn(Wavefunction):
             D, Gam, W, hf = self._mp2_relaxed_densities()
         return D
 
+    def _mp2_normalization(self) -> float:
+        """MP2 intermediate normalization ``N = 1/sqrt(1 + <T2|2T2 - T2~>)`` (spin-adapted),
+        for the wave-function-overlap AAT (:meth:`atomic_axial_tensors`). The normalized
+        doubles are ``c2 = N t2`` and the reference coefficient is ``c0 = N``."""
+        t2 = np.asarray(self.t2)
+        norm2 = self.contract('ijab,ijab->', t2, 2.0 * t2 - t2.swapaxes(2, 3))
+        return 1.0 / np.sqrt(1.0 + norm2)
+
+    def _so_mp2_normalization(self) -> float:
+        """Spin-orbital MP2 normalization ``N = 1/sqrt(1 + (1/4)<T2|T2>)`` -- the spin-orbital
+        analogue of :meth:`_mp2_normalization` (the ``1/4`` for the antisymmetric double sum).
+        Equal to the spin-adapted value on a closed shell."""
+        t2 = np.asarray(self.t2)
+        norm2 = 0.25 * self.contract('ijab,ijab->', t2, t2)
+        return 1.0 / np.sqrt(1.0 + norm2)
+
     # ---- correlation dipole ----
 
     def relaxed_dipole(self) -> np.ndarray:
@@ -1149,6 +1165,188 @@ class MPwfn(Wavefunction):
                              + c('pq,pq->', dW[iy] + Wtil[iy], SX[ix]) + c('pq,pq->', W, ov2)
                              + float(np.sum(U[iy][:, ofull] * JX[ix])))
         return H
+
+    # ---- atomic axial tensors (VCD, magnetic/nuclear mixed derivative) ----
+
+    def atomic_axial_tensors(self, gauge: str = 'non-canonical') -> np.ndarray:
+        """MP2 **electronic** atomic axial tensors ``I^A_{alpha,beta}`` (a.u.), shape
+        ``(natom, 3, 3)`` indexed ``[A, alpha, beta]`` -- the nuclear(``alpha``)/magnetic-field
+        (``beta``) mixed derivative of the wave function, as an overlap of its perturbed
+        derivatives.  This is the full (reference + correlation) **electronic** contribution
+        ``<d_R Psi | d_H Psi>``; the trivial nuclear term (nuclear charge x position) is added
+        separately when forming the total AAT / VCD rotational strengths.  The electron-density formulation follows the diagonal Born-Oppenheimer
+        correction of Gauss, Tajti, Kallay, Stanton & Szalay, J. Chem. Phys. 125, 144111 (2006)
+        [Eqs. (16), (18), (19)], generalized to the mixed nuclear/magnetic derivative (Krishnan,
+        Shumberger & Crawford, in prep.)::
+
+            I = sum_I dc^R_I dc^H_I                    (coefficient overlap,            Icc)
+              + sum_pq g^R_pq <phi_p|d_H phi_q>        (left derivative density x U^H,  Icphi)
+              + sum_pq g^H_pq <phi_p|d_R phi_q>        (right derivative density x U^R, Iphic)
+              + sum_pq gamma_pq <d_R phi_p|d_H phi_q>  (density x both MO derivatives,  Ipp)
+
+        ``g^R``/``g^H`` are derivatives of the unrelaxed correlation 1-PDM: ``g^R`` the
+        **symmetric** derivative (real nuclear perturbation) and ``g^H`` the **antisymmetric** one
+        (imaginary magnetic perturbation -- the anti-Hermitian derivative of a Hermitian density).
+        With that symmetry the folded density expression is **orbital-gauge invariant**.  ``gamma``
+        is the unrelaxed correlation 1-PDM; the orbital relaxation lives entirely in the
+        MO-derivative overlaps, so the cumulant 2-PDM does not contribute (it cancels by the
+        magnetic antisymmetry).
+
+        ``gauge`` selects the redundant magnetic oo/vv orbital response:
+
+        * ``'non-canonical'`` (default): the redundant blocks are zero (numerically preferred --
+          it avoids near-degenerate canonical divides such as close-lying core orbitals); only the
+          non-redundant core<->active block is canonical (frozen core).
+        * ``'canonical'``: all oo/vv blocks canonical.
+
+        The total is invariant to this choice (:meth:`CPHF.magnetic_ints`).  The nuclear MO
+        responses use pycc's ``-1/2 S`` gauge (:meth:`_perturbed_t2` / :meth:`CPHF._full_U`).
+        Magnetic quantities are stripped of their ``i`` (as in the HF AAT); the VCD rotatory
+        strength takes ``Im`` of the APT*AAT product.
+
+        Frozen-core aware (the correlation densities/amplitudes stay in the active space while the
+        orbital responses and reference density span the full occupied space; no Z-vector is
+        needed because the densities are unrelaxed).  Both spin paths (the spin-orbital form is
+        :meth:`_so_atomic_axial_tensors`).  Validated all-electron and frozen-core, both spins,
+        both gauges, against the independent apyib MP2-VCD implementation."""
+        if self.orbital_basis == 'spinorbital':
+            return self._so_atomic_axial_tensors(gauge)
+        from .cphf import Perturbation
+        o, v, nmo = self.o, self.v, self.nmo
+        no = o.stop
+        ncore = o.stop - self.no
+        c = self.contract
+        cphf = self._full_occ_cphf()
+        d = self.derivatives
+        natom = d.natom
+        t2 = np.asarray(self.t2)
+        Dijab = np.asarray(self.Dijab)
+        tau = 2.0 * t2 - t2.swapaxes(2, 3)
+        N = self._mp2_normalization()
+        c0, c2 = N, N * t2
+        # unrelaxed, normalized 1-PDM  gamma = 2 delta_ij + correlation
+        gamma = np.zeros((nmo, nmo))
+        gamma[o, o] = -2.0 * N**2 * c('ikab,jkab->ij', tau, t2)
+        gamma[v, v] = +2.0 * N**2 * c('ijac,ijbc->ab', tau, t2)
+        gamma[np.arange(no), np.arange(no)] += 2.0
+
+        def dt2_from(dF, dERI):
+            # magnetic (imaginary) perturbed T2: dERI enters via the vvoo block (antisymmetric)
+            return ((dERI.swapaxes(0, 2).swapaxes(1, 3)[o, o, v, v]
+                     + c('ac,ijcb->ijab', dF[v, v], t2) + c('bc,ijac->ijab', dF[v, v], t2)
+                     - c('ki,kjab->ijab', dF[o, o], t2) - c('kj,ikab->ijab', dF[o, o], t2)) / Dijab)
+
+        # magnetic side (3): U^H, magnetic derivative density gamma^H.  gamma^H tilde's the
+        # *perturbed* amplitude (imaginary perturbation -> antisymmetric density derivative),
+        # mirroring gamma^R; this is what makes the folded form orbital-gauge invariant.
+        UH, gH = [], []
+        for b in range(3):
+            U, dF, dERI = cphf.magnetic_ints(b, ncore, gauge)
+            dc2H = c0 * dt2_from(dF, dERI)
+            tauH = 2.0 * dc2H - dc2H.swapaxes(2, 3)
+            UH.append(U)
+            R = np.zeros((nmo, nmo))
+            R[o, o] = -2.0 * c('ikab,jkab->ij', tauH, c2)
+            R[v, v] = +2.0 * c('ijac,ijbc->ab', tauH, c2)
+            gH.append((R, dc2H))
+
+        P = np.zeros((natom, 3, 3))
+        for A in range(natom):
+            hs = d.overlap_half(A)                             # 3 x (nmo, nmo), full
+            for cart in range(3):
+                pX = Perturbation('nuclear', (A, cart))
+                dt2R = np.asarray(self._perturbed_t2(pX))      # -1/2 S gauge
+                dc0R = -c0**3 * c('ijab,ijab->', tau, dt2R)
+                dc2R = dc0R * t2 + c0 * dt2R
+                tauR = 2.0 * dc2R - dc2R.swapaxes(2, 3)
+                UReff = np.asarray(cphf._full_U(pX, ncore)) + np.asarray(hs[cart]).T
+                gR = np.zeros((nmo, nmo))
+                gR[o, o] = -2.0 * c('ikab,jkab->ij', tauR, c2)
+                gR[v, v] = +2.0 * c('ijac,ijbc->ab', tauR, c2)
+                gR[np.arange(no), np.arange(no)] += 2.0 * c0 * dc0R
+                for b in range(3):
+                    RH, dc2H = gH[b]
+                    Icc = c('ijab,ijab->', tauR, dc2H)
+                    Icphi = c('ij,ij->', gR[o, o], UH[b][o, o]) + c('ab,ab->', gR[v, v], UH[b][v, v])
+                    Iphic = c('ij,ji->', RH[o, o], UReff[o, o]) + c('ab,ab->', RH[v, v], UReff[v, v])
+                    Ipp = c('pq,pq->', gamma, UH[b].T @ UReff)
+                    P[A, cart, b] = Icc + Icphi + Iphic + Ipp
+        self.aat = P
+        return P
+
+    def _so_atomic_axial_tensors(self, gauge: str = 'non-canonical') -> np.ndarray:
+        """Spin-orbital MP2 electronic AATs (``(natom, 3, 3)``) -- the spin-orbital form of
+        :meth:`atomic_axial_tensors` (see there for the theory), in the bare (already-
+        antisymmetrized) spin-orbital amplitudes.  The derivative densities carry the same
+        symmetry as in the spin-adapted path: ``gamma^R`` is the **symmetric** part of
+        ``-1/2 <d c2, c2>`` (real perturbation) and ``gamma^H`` the **antisymmetric** part of
+        ``+1/2 <d c2, c2>`` (imaginary perturbation).  With those, the folded form is
+        orbital-gauge invariant.  Verified equal to the spin-adapted path to machine precision."""
+        from .cphf import Perturbation
+        o, v, nmo = self.o, self.v, self.nmo
+        no = o.stop
+        ncore = o.stop - self.no
+        c = self.contract
+        cphf = self._full_occ_cphf()
+        d = self.derivatives
+        natom = d.natom
+        t2 = np.asarray(self.t2)
+        Dijab = np.asarray(self.Dijab)
+        N = self._so_mp2_normalization()
+        c0, c2 = N, N * t2
+        Doo, Dvv = self._so_mp2_corr_opdm()
+        gamma = np.zeros((nmo, nmo))                    # unrelaxed 1-PDM: delta_ij + correlation
+        gamma[o, o] = N**2 * np.asarray(Doo)
+        gamma[v, v] = N**2 * np.asarray(Dvv)
+        gamma[np.arange(no), np.arange(no)] += 1.0
+
+        def dt2_from(dF, dERI):
+            # magnetic (imaginary) perturbed T2: dERI enters via the vvoo block (antisymmetric)
+            return ((dERI.swapaxes(0, 2).swapaxes(1, 3)[o, o, v, v]
+                     + c('ac,ijcb->ijab', dF[v, v], t2) + c('bc,ijac->ijab', dF[v, v], t2)
+                     - c('ki,kjab->ijab', dF[o, o], t2) - c('kj,ikab->ijab', dF[o, o], t2)) / Dijab)
+
+        def gdens(dc2, imaginary):
+            """Derivative density from ``A = <d c2, c2>``: the symmetric part (real perturbation,
+            gamma^R) or the antisymmetric part (imaginary perturbation, gamma^H).  The oo and vv
+            blocks carry opposite signs (the Doo/Dvv sign), and gamma^R vs gamma^H flip together."""
+            Aoo = c('imef,jmef->ij', dc2, c2)
+            Avv = c('mnbe,mnae->ab', dc2, c2)
+            R = np.zeros((nmo, nmo))
+            if imaginary:                                  # gamma^H: antisymmetric
+                R[o, o] = +0.25 * (Aoo - Aoo.T)
+                R[v, v] = -0.25 * (Avv - Avv.T)
+            else:                                          # gamma^R: symmetric
+                R[o, o] = -0.25 * (Aoo + Aoo.T)
+                R[v, v] = +0.25 * (Avv + Avv.T)
+            return R
+
+        UH, gH, dc2Hs = [], [], []
+        for b in range(3):
+            U, dF, dERI = cphf.magnetic_ints(b, ncore, gauge)
+            dc2H = c0 * dt2_from(dF, dERI)
+            UH.append(U)
+            dc2Hs.append(dc2H)
+            gH.append(gdens(dc2H, imaginary=True))        # antisymmetric
+
+        P = np.zeros((natom, 3, 3))
+        for A in range(natom):
+            hs = d.so_overlap_half(A)
+            for cart in range(3):
+                pX = Perturbation('nuclear', (A, cart))
+                dt2R = np.asarray(self._perturbed_t2(pX))
+                dc0R = -0.25 * c0**3 * c('ijab,ijab->', t2, dt2R)
+                dc2R = dc0R * t2 + c0 * dt2R
+                UReff = np.asarray(cphf._full_U(pX, ncore)) + np.asarray(hs[cart]).T
+                gR = gdens(dc2R, imaginary=False)          # symmetric
+                for b in range(3):
+                    Icc = 0.25 * c('ijab,ijab->', dc2R, dc2Hs[b])
+                    Icphi = c('ij,ij->', gR[o, o], UH[b][o, o]) + c('ab,ab->', gR[v, v], UH[b][v, v])
+                    Iphic = c('ij,ij->', gH[b][o, o], UReff[o, o]) + c('ab,ab->', gH[b][v, v], UReff[v, v])
+                    Ipp = c('pq,pq->', gamma, UH[b].T @ UReff)
+                    P[A, cart, b] = Icc + Icphi + Iphic + Ipp
+        self.aat = P
+        return P
 
     # ---- total (reference + correlation) properties ----
     # The correlation methods above are the correlation contribution only; these add the

--- a/pycc/tests/test_072_mp2_aat.py
+++ b/pycc/tests/test_072_mp2_aat.py
@@ -1,0 +1,90 @@
+"""
+MP2 atomic axial tensors (AATs) -- MPwfn.atomic_axial_tensors(), the density/wave-function-
+overlap formulation (Krishnan, Shumberger & Crawford, in prep.), built on the diagonal
+Born-Oppenheimer correction of Gauss, Tajti, Kallay, Stanton & Szalay, J. Chem. Phys. 125,
+144111 (2006) [Eqs. (16), (18), (19)].
+
+Reference: the independent analytic MP2-VCD implementation apyib
+(https://github.com/bshumberger/apyib; Shumberger, Krishnan & Crawford), for (P)-hydrogen
+peroxide / STO-3G at the manuscript geometry below (a.u.).  All-electron AND frozen-core,
+both spin paths.
+"""
+
+import psi4
+import pycc
+import numpy as np
+
+
+# (P)-hydrogen peroxide, manuscript geometry (a.u.); atom order H,H,O,O.
+H2O2 = """
+H -1.780954530308296   1.411647335546379   0.872055376436941
+H  1.780954530308296  -1.411647335546379   0.872055376436941
+O -1.371214332646589  -0.115525249760340  -0.054947416764017
+O  1.371214332646589   0.115525249760340  -0.054947416764017
+no_com
+no_reorient
+symmetry c1
+units bohr
+"""
+
+# apyib reference AATs (electronic), indexed [3*atom + cart, beta].
+AAT_REF = {
+    'false': {(0, 0): -0.00452027, (0, 2): 0.02808062, (1, 1): -0.11644060,
+              (2, 0): -0.16918159, (6, 2): -0.17323102, (7, 1): -0.18817788, (8, 0): 0.14146044},
+    'true':  {(0, 0): -0.00452025, (0, 2): 0.02808068, (1, 1): -0.11644088,
+              (2, 0): -0.16918189, (6, 2): -0.17326318, (7, 1): -0.18819783, (8, 0): 0.14143838},
+}
+
+
+def _mpwfn(orbital_basis='spatial', freeze_core='false'):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(H2O2)
+    psi4.set_options({'basis': 'STO-3G', 'scf_type': 'pk', 'freeze_core': freeze_core,
+                      'e_convergence': 1e-11, 'd_convergence': 1e-11})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
+    mp.compute_energy()
+    return mp
+
+
+def test_mp2_aat_all_electron():
+    """All-electron spatial MP2 AAT reproduces the apyib reference for (P)-H2O2/STO-3G."""
+    P = np.asarray(_mpwfn().atomic_axial_tensors()).reshape(-1, 3)
+    for (row, col), ref in AAT_REF['false'].items():
+        assert abs(P[row, col] - ref) < 1e-6, (row, col, P[row, col], ref)
+
+
+def test_mp2_aat_frozen_core():
+    """Frozen-core spatial MP2 AAT reproduces the independent apyib frozen-core reference."""
+    P = np.asarray(_mpwfn(freeze_core='true').atomic_axial_tensors()).reshape(-1, 3)
+    for (row, col), ref in AAT_REF['true'].items():
+        assert abs(P[row, col] - ref) < 1e-6, (row, col, P[row, col], ref)
+
+
+def test_mp2_aat_so_equals_spatial():
+    """Spin-orbital MP2 AAT == spin-adapted (the keystone), all-electron and frozen-core."""
+    for fc in ('false', 'true'):
+        P = np.asarray(_mpwfn(freeze_core=fc).atomic_axial_tensors()).reshape(-1, 3)
+        P_so = np.asarray(_mpwfn('spinorbital', fc).atomic_axial_tensors()).reshape(-1, 3)
+        assert np.max(np.abs(P_so - P)) < 1e-9, (fc, np.max(np.abs(P_so - P)))
+        for (row, col), ref in AAT_REF[fc].items():
+            assert abs(P_so[row, col] - ref) < 1e-6, (fc, row, col, P_so[row, col], ref)
+
+
+def test_mp2_aat_gauge_invariance():
+    """The AAT total is invariant to the orbital gauge of the redundant magnetic oo/vv response
+    (non-canonical default vs canonical), all-electron and frozen-core, both spin paths."""
+    for fc in ('false', 'true'):
+        for ob in ('spatial', 'spinorbital'):
+            mp = _mpwfn(ob, fc)
+            nc = np.asarray(mp.atomic_axial_tensors(gauge='non-canonical'))
+            ca = np.asarray(mp.atomic_axial_tensors(gauge='canonical'))
+            assert np.max(np.abs(nc - ca)) < 1e-9, (fc, ob, np.max(np.abs(nc - ca)))
+
+
+def test_mp2_aat_normalization():
+    """MP2 normalization N < 1 and (closed shell) spin-orbital == spin-adapted."""
+    N = _mpwfn()._mp2_normalization()
+    assert 0.9 < N < 1.0
+    assert abs(N - _mpwfn('spinorbital')._so_mp2_normalization()) < 1e-10


### PR DESCRIPTION
# MP2 atomic axial tensors (VCD): gauge-invariant, frozen-core, both spin paths

Branch: `feature/mp2-aat-vcd` (pushed)

## Summary

Adds `MPwfn.atomic_axial_tensors()` (+ spin-orbital `_so_atomic_axial_tensors()`), the
**electronic** MP2 atomic axial tensors `I^A_{αβ} = ⟨∂_RΨ|∂_HΨ⟩` for VCD — the nuclear(α) /
magnetic-field(β) mixed derivative — via the compact **density (DBOC) formulation**
[Gauss, Tajti, Kállay, Stanton & Szalay, *J. Chem. Phys.* **125**, 144111 (2006), Eqs. (16)/(18)/(19);
generalized to the mixed nuclear/magnetic derivative, Krishnan/Shumberger/Crawford, in prep.].

## Highlights

- **Orbital-gauge invariant** folded density form: `γ^R` is the *symmetric* derivative of the
  unrelaxed 1-PDM (real nuclear perturbation), `γ^H` the *antisymmetric* one (imaginary magnetic
  perturbation — the anti-Hermitian derivative of a Hermitian density). The total is invariant to
  the redundant magnetic oo/vv orbital gauge.
- **Non-canonical gauge by default** (`CPHF.magnetic_ints(axis, ncore, gauge)`): the redundant
  oo/vv blocks are zeroed — numerically preferred, avoiding the near-degenerate canonical divides
  (e.g. close-lying core orbitals) — while the non-redundant core↔active block stays canonical for
  frozen core. `gauge='canonical'` selectable.
- **Frozen-core aware**, both **spatial and spin-orbital** paths. No Z-vector needed (unrelaxed
  densities).
- Electronic contribution only (reference + correlation); the trivial nuclear term (nuclear charge
  × position) is added separately when forming total AATs / rotational strengths.

## Validation (`test_072`, 5 tests)

Against the independent **apyib** analytic MP2-VCD implementation
(https://github.com/bshumberger/apyib) on (P)-H₂O₂/STO-3G:

- all-electron vs apyib, **frozen-core vs apyib**, SO==spatial (both), **gauge-invariance
  (canonical == non-canonical)**, normalization — all ~6e-13.

Full regression clean: MP2 derivative suite incl. frozen core (54), HF AAT / HF velocity APT /
MP2 AAT neighbors (10), MP2 energy (4).

## Files

- `pycc/cphf.py` — `magnetic_ints` gauge modes (`ncore`, `gauge`; non-canonical default).
- `pycc/mpwfn.py` — `atomic_axial_tensors` / `_so_`, `_mp2_normalization` / `_so_`.
- `pycc/tests/test_072_mp2_aat.py` (new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
