### PR TITLE
Uniform property facade: `pycc.PropertyComponents` + `pycc.aat/apt/dipole/gradient/polarizability/hessian`

### DIFF
--- a/pycc/__init__.py
+++ b/pycc/__init__.py
@@ -17,9 +17,9 @@ from .ccresponse import ccresponse
 from .ccresponse import pertbar
 from pycc.rt.rtcc import rtcc
 from .cceom import cceom
-from .properties import PropertyComponents, aat
+from .properties import PropertyComponents, aat, apt, dipole, gradient, hessian, polarizability
 
-__all__ = ['CCwfn', 'ccwfn', 'MPwfn', 'HFwfn', 'CIwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom', 'PropertyComponents', 'aat']
+__all__ = ['CCwfn', 'ccwfn', 'MPwfn', 'HFwfn', 'CIwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom', 'PropertyComponents', 'aat', 'apt', 'dipole', 'gradient', 'hessian', 'polarizability']
 
 # Handle versioneer
 from ._version import get_versions

--- a/pycc/__init__.py
+++ b/pycc/__init__.py
@@ -17,8 +17,9 @@ from .ccresponse import ccresponse
 from .ccresponse import pertbar
 from pycc.rt.rtcc import rtcc
 from .cceom import cceom
+from .properties import PropertyComponents, aat
 
-__all__ = ['CCwfn', 'ccwfn', 'MPwfn', 'HFwfn', 'CIwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom']
+__all__ = ['CCwfn', 'ccwfn', 'MPwfn', 'HFwfn', 'CIwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom', 'PropertyComponents', 'aat']
 
 # Handle versioneer
 from ._version import get_versions

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -58,16 +58,25 @@ class HFwfn(Wavefunction):
         space, so a frozen core on the reference does not affect the gradient.
 
         The spin-orbital path (open-shell UHF/ROHF, or a closed shell forced to spin
-        orbitals) dispatches to :meth:`_so_gradient`.
+        orbitals) is handled by :meth:`_so_gradient_electronic`.  The electronic and
+        nuclear-repulsion pieces are computed separately (:meth:`_gradient_electronic` /
+        :meth:`Derivatives.nuclear_repulsion`) and summed here; the :func:`pycc.gradient`
+        facade exposes them as :class:`pycc.PropertyComponents`.
         """
+        grad = self._gradient_electronic() + self.derivatives.nuclear_repulsion()
+        self.grad = grad
+        return grad
+
+    def _gradient_electronic(self) -> np.ndarray:
+        """Electronic (CPHF-free) part of the RHF gradient, shape (natom, 3) -- the public
+        :meth:`gradient` adds the nuclear-repulsion derivative ``dV_NN/dX``.  Dispatches the
+        spin-orbital path to :meth:`_so_gradient_electronic`."""
         if self.orbital_basis == 'spinorbital':
-            return self._so_gradient()
+            return self._so_gradient_electronic()
         o = self.o
         eps = np.asarray(diag(self.H.F))[o]
-
         d = self.derivatives
         grad = np.zeros((d.natom, 3))
-        Vnn = d.nuclear_repulsion()
         for atom in range(d.natom):
             Sx = d.overlap(atom, 'o', 'o')
             hx = d.core(atom, 'o', 'o')
@@ -76,27 +85,17 @@ class HFwfn(Wavefunction):
                 grad[atom, c] = (2.0 * np.trace(hx[c])
                                  + 2.0 * self.contract('iijj->', erix[c])
                                  - self.contract('ijij->', erix[c])
-                                 - 2.0 * self.contract('i,ii->', eps, Sx[c])
-                                 + Vnn[atom, c])
-        self.grad = grad
+                                 - 2.0 * self.contract('i,ii->', eps, Sx[c]))
         return grad
 
-    def _so_gradient(self) -> np.ndarray:
-        """Spin-orbital Hartree-Fock analytic energy gradient (a.u.), shape (natom, 3).
-
-        The spin-orbital form of the CPHF-free HF gradient (i, j over occupied spin
-        orbitals; ``<ij||ij>`` antisymmetrized), valid for UHF/ROHF as well as a
-        closed-shell RHF reference forced to spin orbitals::
-
-            dE/dX = sum_i h^x_ii + 1/2 sum_ij <ij||ij>^x - sum_i eps_i S^x_ii + dV_NN/dX
-
-        The skeleton spin-orbital derivative integrals come from ``self.derivatives``
-        (built in the semicanonical MO gauge). For a closed shell this equals the
-        spatial RHF gradient term-for-term."""
+    def _so_gradient_electronic(self) -> np.ndarray:
+        """Electronic part of the spin-orbital HF gradient (i, j over occupied spin orbitals;
+        ``<ij||ij>`` antisymmetrized), valid for UHF/ROHF and a closed shell forced to spin
+        orbitals.  For a closed shell this equals the spatial electronic gradient term-for-term;
+        :meth:`gradient` adds ``dV_NN/dX``."""
         eps = np.asarray(diag(self.H.F))[self.o]
         d = self.derivatives
         grad = np.zeros((d.natom, 3))
-        Vnn = d.nuclear_repulsion()
         for atom in range(d.natom):
             hx = d.so_core(atom, 'o', 'o')
             Sx = d.so_overlap(atom, 'o', 'o')
@@ -104,9 +103,7 @@ class HFwfn(Wavefunction):
             for c in range(3):
                 grad[atom, c] = (self.contract('ii->', hx[c])
                                  + 0.5 * self.contract('ijij->', erix[c])
-                                 - self.contract('i,ii->', eps, Sx[c])
-                                 + Vnn[atom, c])
-        self.grad = grad
+                                 - self.contract('i,ii->', eps, Sx[c]))
         return grad
 
     def dipole(self) -> np.ndarray:
@@ -119,16 +116,22 @@ class HFwfn(Wavefunction):
         the orbital occupancy: ``k = 2`` on the spatial closed-shell path, ``k = 1`` for singly
         occupied spin orbitals. Kept separate from the correlation dipole so the total MP2
         dipole is ``HFwfn.dipole() + MPwfn.relaxed_dipole()`` (mirroring the gradient split).
-        Basis-aware."""
-        o = self.o
-        k = 1.0 if self.orbital_basis == 'spinorbital' else 2.0
+        Basis-aware. The :func:`pycc.dipole` facade exposes the nuclear/reference/correlation
+        pieces as :class:`pycc.PropertyComponents`."""
         mol = self.ref.molecule()
         geom = np.asarray(mol.geometry())                      # (natom, 3), bohr
         Z = np.array([mol.Z(A) for A in range(mol.natom())])
         nuc = np.einsum('a,ax->x', Z, geom)
-        elec = np.array([k * np.trace(np.asarray(self.H.mu[a])[o, o]) for a in range(3)])
-        self.mu_scf = nuc + elec
+        self.mu_scf = nuc + self._dipole_electronic()
         return self.mu_scf
+
+    def _dipole_electronic(self) -> np.ndarray:
+        """Electronic part of the SCF dipole (a.u.), shape (3,): ``k sum_i (mu_a)_ii`` (the
+        occupied trace of the MO dipole integrals; ``k = 2`` spatial, ``1`` spin-orbital).
+        :meth:`dipole` adds the nuclear term ``sum_A Z_A R_A``."""
+        o = self.o
+        k = 1.0 if self.orbital_basis == 'spinorbital' else 2.0
+        return np.array([k * np.trace(np.asarray(self.H.mu[a])[o, o]) for a in range(3)])
 
     def polarizability(self) -> np.ndarray:
         """Static electric-dipole polarizability tensor (a.u.), shape ``(3, 3)``.
@@ -166,16 +169,29 @@ class HFwfn(Wavefunction):
                             - 2 sum_ik S^X_ki (mu_a)_ik            (oo / Pulay response)
                             + 4 sum_ia U^X_ia (mu_a)_ia            (ov / CPHF response)
 
-        The spin-orbital path dispatches to :meth:`_so_dipole_derivatives`.
+        The spin-orbital path is handled by :meth:`_so_dipole_derivatives_electronic`; the
+        nuclear ``Z_A delta`` term is added here and the electronic part comes from
+        :meth:`_dipole_derivatives_electronic`.  The :func:`pycc.apt` facade exposes the pieces
+        as :class:`pycc.PropertyComponents`.
         """
+        dmu = self._dipole_derivatives_electronic()
+        mol = self.ref.molecule()
+        for A in range(mol.natom()):
+            for a in range(3):
+                dmu[A, a, a] += mol.Z(A)             # nuclear Z_A delta_{alpha,beta}
+        self.dipder = dmu
+        return self.dipder
+
+    def _dipole_derivatives_electronic(self) -> np.ndarray:
+        """Electronic part of the APT (a.u.), shape ``(natom, 3, 3)`` -- the explicit + Pulay +
+        CPHF-response terms without the nuclear ``Z_A delta`` (added by
+        :meth:`dipole_derivatives`).  Dispatches to :meth:`_so_dipole_derivatives_electronic`."""
         if self.orbital_basis == 'spinorbital':
-            return self._so_dipole_derivatives()
+            return self._so_dipole_derivatives_electronic()
         o, v = self.o, self.v
         mu = [np.asarray(self.H.mu[a]) for a in range(3)]
         d = self.derivatives
-        mol = self.ref.molecule()
-        natom = mol.natom()
-
+        natom = self.ref.molecule().natom()
         dmu = np.zeros((natom, 3, 3))
         for A in range(natom):
             Ux = self.cphf.solve_nuclear(A)      # cached; shared with the Hessian
@@ -183,33 +199,22 @@ class HFwfn(Wavefunction):
             dip = d.dipole(A, 'o', 'o')          # 9 x (no,no): index alpha*3 + beta
             for beta in range(3):
                 for alpha in range(3):
-                    val = mol.Z(A) if alpha == beta else 0.0
-                    val += 2.0 * np.trace(dip[alpha * 3 + beta])
+                    val = 2.0 * np.trace(dip[alpha * 3 + beta])
                     val -= 2.0 * self.contract('ki,ki->', Sx[beta], mu[alpha][o, o])
                     val += 4.0 * self.contract('ia,ia->', Ux[beta], mu[alpha][o, v])
                     dmu[A, beta, alpha] = val
-        self.dipder = dmu
-        return self.dipder
+        return dmu
 
-    def _so_dipole_derivatives(self) -> np.ndarray:
-        """Spin-orbital nuclear dipole derivatives (APTs), shape ``(natom, 3, 3)`` indexed
-        ``[A, beta, alpha]``. The spin-orbital form of :meth:`dipole_derivatives`: singly
-        occupied spin orbitals (the one-electron traces carry factor 1, the ov response
-        factor 2, vs 2 and 4 closed-shell), with the spin-orbital nuclear CPHF response
-        (:meth:`CPHF.solve_nuclear`) and spin-orbital dipole derivatives
-        (:meth:`Derivatives.so_dipole`)::
-
-            d mu_a / d X_Ab = Z_A delta_ab + sum_i (d mu_a / d X_Ab)_ii
-                            - sum_ik S^X_ki (mu_a)_ik + 2 sum_ia U^X_ia (mu_a)_ia
-
-        Valid for UHF as well as a closed-shell RHF reference forced to spin orbitals;
-        ROHF raises (the nuclear response goes through :meth:`CPHF.solve`)."""
+    def _so_dipole_derivatives_electronic(self) -> np.ndarray:
+        """Electronic part of the spin-orbital APT (singly occupied spin orbitals: one-electron
+        traces carry factor 1 and the ov response factor 2, vs 2 and 4 closed-shell), with the
+        spin-orbital nuclear CPHF response and dipole derivatives.  :meth:`dipole_derivatives`
+        adds ``Z_A delta``.  Valid for UHF and a closed shell forced to spin orbitals; ROHF
+        raises (via :meth:`CPHF.solve`)."""
         o, v = self.o, self.v
         mu = [np.asarray(self.H.mu[a]) for a in range(3)]
         d = self.derivatives
-        mol = self.ref.molecule()
-        natom = mol.natom()
-
+        natom = self.ref.molecule().natom()
         dmu = np.zeros((natom, 3, 3))
         for A in range(natom):
             Ux = self.cphf.solve_nuclear(A)      # 3 x (no,nv), spin-orbital response
@@ -217,13 +222,11 @@ class HFwfn(Wavefunction):
             dip = d.so_dipole(A, 'o', 'o')       # 9 x (no,no): index alpha*3 + beta
             for beta in range(3):
                 for alpha in range(3):
-                    val = mol.Z(A) if alpha == beta else 0.0
-                    val += self.contract('ii->', dip[alpha * 3 + beta])
+                    val = self.contract('ii->', dip[alpha * 3 + beta])
                     val -= self.contract('ki,ki->', Sx[beta], mu[alpha][o, o])
                     val += 2.0 * self.contract('ia,ia->', Ux[beta], mu[alpha][o, v])
                     dmu[A, beta, alpha] = val
-        self.dipder = dmu
-        return self.dipder
+        return dmu
 
     def hessian(self) -> np.ndarray:
         """RHF nuclear (molecular) Hessian ``d^2 E / dX_Aa dX_Bb`` (a.u.), shape
@@ -248,18 +251,28 @@ class HFwfn(Wavefunction):
         where ``U^x``/``B^x`` are the cached nuclear response/RHS and ``F^x_ij``/``S^x_ij``
         the skeleton derivative Fock/overlap oo blocks (cached by :meth:`CPHF.solve_nuclear`).
 
-        The spin-orbital path dispatches to :meth:`_so_hessian`.
+        The spin-orbital path is handled by :meth:`_so_hessian_electronic`; the electronic terms
+        (:meth:`_hessian_electronic`) and the nuclear-repulsion second derivative are computed
+        separately and summed.  The :func:`pycc.hessian` facade exposes the pieces as
+        :class:`pycc.PropertyComponents`.
         """
+        H = self._hessian_electronic() + self.derivatives.nuclear_repulsion2()
+        self.hess = H
+        return self.hess
+
+    def _hessian_electronic(self) -> np.ndarray:
+        """Electronic part of the RHF molecular Hessian, shape ``(3*natom, 3*natom)`` -- the
+        skeleton (second-derivative integral) and CPHF-response terms, without the nuclear-
+        repulsion second derivative ``V_NN^{ab}`` (added by :meth:`hessian`).  Dispatches to
+        :meth:`_so_hessian_electronic`."""
         if self.orbital_basis == 'spinorbital':
-            return self._so_hessian()
+            return self._so_hessian_electronic()
         o, v = self.o, self.v
         eps_o = np.asarray(diag(self.H.F))[o]
         d = self.derivatives
-        mol = self.ref.molecule()
-        natom = mol.natom()
+        natom = self.ref.molecule().natom()
 
         Loooo = np.asarray(self.H.L)[o, o, o, o]       # i,m,j,n (spin-adapted)
-        Vnn2 = d.nuclear_repulsion2()                  # (3*natom, 3*natom)
         # Pre-solve & cache the nuclear response for every atom (shared with the APTs);
         # all four come from a single heavy per-atom pass (CPHF.solve_nuclear).
         U = [self.cphf.solve_nuclear(A) for A in range(natom)]            # U[A][a]->(no,nv)
@@ -284,8 +297,7 @@ class HFwfn(Wavefunction):
                         skel = (2.0 * np.trace(h2[c])
                                 + 2.0 * self.contract('iijj->', g2[c])
                                 - self.contract('ijij->', g2[c])
-                                - 2.0 * self.contract('i,ii->', eps_o, S2[c])
-                                + Vnn2[A * 3 + a, Bat * 3 + b])
+                                - 2.0 * self.contract('i,ii->', eps_o, S2[c]))
                         # --- first-order CPHF response + first-derivative cross terms ---
                         resp = (-4.0 * self.contract('ia,ia->', Ux, By)
                                 - 2.0 * self.contract('ij,ij->', Sx, Fy)
@@ -293,18 +305,17 @@ class HFwfn(Wavefunction):
                                 + 4.0 * self.contract('i,ij,ij->', eps_o, Sx, Sy)
                                 + 2.0 * self.contract('ij,nm,imjn->', Sx, Sy, Loooo))
                         H[A * 3 + a, Bat * 3 + b] = skel + resp
-        self.hess = H
-        return self.hess
+        return H
 
-    def _so_hessian(self) -> np.ndarray:
-        """Spin-orbital RHF/UHF molecular Hessian, shape ``(3*natom, 3*natom)``. The
-        spin-orbital form of :meth:`hessian`: singly occupied spin orbitals (the
-        closed-shell prefactors halve) with the antisymmetrized ``<ij||kl>``, the
-        spin-orbital second-derivative integrals (:meth:`Derivatives.so_core2` /
-        ``so_eri2`` / ``so_overlap2``, occupied block), and the spin-orbital nuclear CPHF
-        response/cache (:meth:`CPHF.solve_nuclear`)::
+    def _so_hessian_electronic(self) -> np.ndarray:
+        """Electronic part of the spin-orbital molecular Hessian, shape ``(3*natom, 3*natom)``.
+        The spin-orbital form of :meth:`_hessian_electronic`: singly occupied spin orbitals (the
+        closed-shell prefactors halve) with the antisymmetrized ``<ij||kl>`` and the spin-orbital
+        second-derivative integrals (:meth:`Derivatives.so_core2` / ``so_eri2`` / ``so_overlap2``,
+        occupied block); the nuclear-repulsion second derivative ``V_NN^{ab}`` is added by
+        :meth:`hessian`::
 
-            skeleton:  h^{ab}_ii + 1/2 <ij||ij>^{ab} - eps_i S^{ab}_ii + V_NN^{ab}
+            skeleton:  h^{ab}_ii + 1/2 <ij||ij>^{ab} - eps_i S^{ab}_ii
             response:  -2 U^x_ai B^y_ai - S^x_ij F^y_ij - S^y_ij F^x_ij
                        + 2 eps_i S^x_ij S^y_ij + S^x_ij S^y_nm <im||jn>
 
@@ -314,10 +325,8 @@ class HFwfn(Wavefunction):
         eps_o = np.asarray(diag(self.H.F))[o]
         ERIoooo = np.asarray(self.H.ERI)[o, o, o, o]   # i,m,j,n (antisymmetrized)
         d = self.derivatives
-        mol = self.ref.molecule()
-        natom = mol.natom()
+        natom = self.ref.molecule().natom()
 
-        Vnn2 = d.nuclear_repulsion2()
         U = [self.cphf.solve_nuclear(A) for A in range(natom)]            # U[A][a]->(no,nv)
         B = [self.cphf.rhs_nuclear_cached(A) for A in range(natom)]       # B[A][a]->(no,nv)
         Foo = [self.cphf.fock_nuclear_cached(A) for A in range(natom)]    # F^X_ij->(no,no)
@@ -339,8 +348,7 @@ class HFwfn(Wavefunction):
                         # --- skeleton (second-derivative integrals), as in the gradient ---
                         skel = (self.contract('ii->', h2[c])
                                 + 0.5 * self.contract('ijij->', g2[c])
-                                - self.contract('i,ii->', eps_o, S2[c])
-                                + Vnn2[A * 3 + a, Bat * 3 + b])
+                                - self.contract('i,ii->', eps_o, S2[c]))
                         # --- first-order CPHF response + first-derivative cross terms ---
                         resp = (-2.0 * self.contract('ia,ia->', Ux, By)
                                 - self.contract('ij,ij->', Sx, Fy)
@@ -348,8 +356,7 @@ class HFwfn(Wavefunction):
                                 + 2.0 * self.contract('i,ij,ij->', eps_o, Sx, Sy)
                                 + self.contract('ij,nm,imjn->', Sx, Sy, ERIoooo))
                         H[A * 3 + a, Bat * 3 + b] = skel + resp
-        self.hess = H
-        return self.hess
+        return H
 
     def atomic_axial_tensors(self) -> np.ndarray:
         """RHF atomic axial tensors (AATs) ``I^lambda_{alpha,beta}`` (a.u.), shape
@@ -441,12 +448,26 @@ class HFwfn(Wavefunction):
 
         Unlike the length-gauge APT, the VG APT differs from it in a finite basis and converges
         to it only toward the basis-set limit; both are origin-independent. The spin-orbital path
-        dispatches to :meth:`_so_velocity_dipole_derivatives`."""
-        if self.orbital_basis == 'spinorbital':
-            return self._so_velocity_dipole_derivatives()
-        d = self.derivatives
+        is handled by :meth:`_so_velocity_dipole_derivatives_electronic`; the nuclear ``Z_A delta``
+        term is added here.  The :func:`pycc.apt` (``gauge='velocity'``) facade exposes the pieces
+        as :class:`pycc.PropertyComponents`."""
+        P = self._velocity_dipole_derivatives_electronic()
         mol = self.ref.molecule()
-        natom = mol.natom()
+        for A in range(mol.natom()):
+            for a in range(3):
+                P[A, a, a] += mol.Z(A)              # nuclear Z_A delta_{alpha,beta}
+        self.vgapt = P
+        return self.vgapt
+
+    def _velocity_dipole_derivatives_electronic(self) -> np.ndarray:
+        """Electronic part of the VG APT (a.u.), shape ``(natom, 3, 3)`` -- the wave-function-
+        overlap term ``-4 sum_ia (U^R + <phi^R|phi>) U^A`` without the nuclear ``Z_A delta``
+        (added by :meth:`velocity_dipole_derivatives`).  Dispatches to
+        :meth:`_so_velocity_dipole_derivatives_electronic`."""
+        if self.orbital_basis == 'spinorbital':
+            return self._so_velocity_dipole_derivatives_electronic()
+        d = self.derivatives
+        natom = self.ref.molecule().natom()
         Ua = [self.cphf.solve_momentum(alpha) for alpha in range(3)]   # 3 x (no,nv)
         P = np.zeros((natom, 3, 3))
         for A in range(natom):
@@ -454,27 +475,18 @@ class HFwfn(Wavefunction):
             Sh = d.overlap_half(A, 'o', 'v', side="LEFT")              # 3 x (no,nv)
             for beta in range(3):
                 for alpha in range(3):
-                    val = mol.Z(A) if alpha == beta else 0.0
-                    val += -4.0 * self.contract('ia,ia->', Ur[beta] + Sh[beta], Ua[alpha])
-                    P[A, beta, alpha] = val
-        self.vgapt = P
-        return self.vgapt
+                    P[A, beta, alpha] = -4.0 * self.contract('ia,ia->', Ur[beta] + Sh[beta], Ua[alpha])
+        return P
 
-    def _so_velocity_dipole_derivatives(self) -> np.ndarray:
-        """Spin-orbital velocity-gauge APTs, shape ``(natom, 3, 3)``. The spin-orbital form of
-        :meth:`velocity_dipole_derivatives`: singly occupied spin orbitals halve the closed-shell
-        prefactor (``-4 -> -2``), with the spin-orbital nuclear/momentum responses
+    def _so_velocity_dipole_derivatives_electronic(self) -> np.ndarray:
+        """Electronic part of the spin-orbital VG APT: singly occupied spin orbitals halve the
+        closed-shell prefactor (``-4 -> -2``), with the spin-orbital nuclear/momentum responses
         (:meth:`CPHF.solve_nuclear`/:meth:`CPHF.solve_momentum`) and half-derivative overlaps
-        (:meth:`Derivatives.so_overlap_half`)::
-
-            [P^A_{beta,alpha}]^VG = -2 sum_ia (U^R_{ia,beta} + <phi^R_i|phi_a>) U^A_{ia,alpha}
-                                    + Z_A delta_{alpha,beta}
-
-        Valid for UHF as well as a closed-shell RHF forced to spin orbitals; ROHF raises (via
-        :meth:`CPHF.solve`)."""
+        (:meth:`Derivatives.so_overlap_half`); :meth:`velocity_dipole_derivatives` adds
+        ``Z_A delta``.  Valid for UHF and a closed shell forced to spin orbitals; ROHF raises
+        (via :meth:`CPHF.solve`)."""
         d = self.derivatives
-        mol = self.ref.molecule()
-        natom = mol.natom()
+        natom = self.ref.molecule().natom()
         Ua = [self.cphf.solve_momentum(alpha) for alpha in range(3)]
         P = np.zeros((natom, 3, 3))
         for A in range(natom):
@@ -482,8 +494,5 @@ class HFwfn(Wavefunction):
             Sh = d.so_overlap_half(A, 'o', 'v', side="LEFT")
             for beta in range(3):
                 for alpha in range(3):
-                    val = mol.Z(A) if alpha == beta else 0.0
-                    val += -2.0 * self.contract('ia,ia->', Ur[beta] + Sh[beta], Ua[alpha])
-                    P[A, beta, alpha] = val
-        self.vgapt = P
-        return self.vgapt
+                    P[A, beta, alpha] = -2.0 * self.contract('ia,ia->', Ur[beta] + Sh[beta], Ua[alpha])
+        return P

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -873,10 +873,9 @@ class MPwfn(Wavefunction):
         skeletons). Both are of interest for the IR/VCD path (which stores the field and nuclear
         responses anyway).
 
-        Electronic only; the nuclear ``Z_A`` term is in the reference
-        (:meth:`HFwfn.dipole_derivatives`), so the total is their sum
-        (:meth:`total_dipole_derivatives`). Basis-aware. Validated against a finite nuclear
-        displacement of the analytic dipole (``test_068``)."""
+        Correlation only; the nuclear ``Z_A`` and SCF reference terms are separate, and the total
+        (nuclear + reference + correlation) is assembled by :func:`pycc.apt`. Basis-aware.
+        Validated against a finite nuclear displacement of the analytic dipole (``test_068``)."""
         if route in ('2n+1-nuclear', '2n+1-field'):
             return self._dipole_derivatives_2n1(route)
         if route != 'explicit':
@@ -1034,9 +1033,9 @@ class MPwfn(Wavefunction):
         ``f^{XY}``/``<pq||rs>^{XY}``/``S^{XY}`` (all nonzero here). Reproduces the explicit route
         to ~machine precision.
 
-        The reference part is separate (:meth:`HFwfn.hessian`); total is their sum
-        (:meth:`total_hessian`). Basis-aware. Validated against a finite difference of the
-        analytic gradient (``test_069``)."""
+        The reference and nuclear parts are separate; the total (nuclear + reference +
+        correlation) is assembled by :func:`pycc.hessian`. Basis-aware. Validated against a finite
+        difference of the analytic gradient (``test_069``)."""
         if route == '2n+1':
             return self._hessian_2n1()
         if route != 'explicit':
@@ -1356,20 +1355,20 @@ class MPwfn(Wavefunction):
     def velocity_dipole_derivatives(self, gauge: str = 'non-canonical') -> np.ndarray:
         """MP2 velocity-gauge (VG) atomic polar tensors ``[P^A_{beta,alpha}]^VG`` (a.u.), shape
         ``(natom, 3, 3)`` indexed ``[A, beta, alpha]`` = ``d(mu_alpha)/d(X_A,beta)`` -- the
-        momentum-form APT.  This is the atomic-axial-tensor machinery
-        (:meth:`atomic_axial_tensors`) with the magnetic-dipole operator replaced by the linear
-        momentum ``p = -i nabla`` (:meth:`CPHF.momentum_ints`) and the AAT's Levi-Civita nuclear
-        term replaced by the length-gauge ``Z_A delta_{alpha,beta}``::
+        momentum-form APT.  This is the **correlation** contribution only; the SCF reference VG
+        APT (:meth:`HFwfn.velocity_dipole_derivatives`) and the nuclear ``Z_A delta_{alpha,beta}``
+        term are kept separate and summed by the :func:`pycc.apt` (``gauge='velocity'``) facade.
+        Built on the atomic-axial-tensor machinery (:meth:`atomic_axial_tensors`) with the
+        magnetic-dipole operator replaced by the linear momentum ``p = -i nabla``
+        (:meth:`CPHF.momentum_ints`)::
 
-            [P^A_{beta,alpha}]^VG = 2 <d_R Psi | d_A Psi>  +  Z_A delta_{alpha,beta}
+            correlation = 2 <d_R Psi | d_A Psi>_correlation
 
-        the full (reference + correlation) electronic overlap plus the nuclear charge term.  Like
-        the AAT, the folded density overlap is orbital-gauge invariant (``gauge`` selects the
-        redundant momentum oo/vv response, default ``'non-canonical'``); frozen-core aware; both
-        spin paths (spin-orbital: :meth:`_so_velocity_dipole_derivatives`).  The ``+2`` prefactor
-        is the closed-shell value; it reduces to the HF VG APT
-        (:meth:`HFwfn.velocity_dipole_derivatives`, Amos, Jalkanen & Stephens, JPC 92, 5571 (1988))
-        as the correlation vanishes.
+        As for the AAT, the correlation is computed directly (the reference density block never
+        enters) and is orbital-gauge invariant on its own (``gauge`` selects the redundant momentum
+        oo/vv response, default ``'non-canonical'``); frozen-core aware; both spin paths
+        (spin-orbital: :meth:`_so_velocity_dipole_derivatives`).  The ``+2`` prefactor is the
+        closed-shell value.
 
         Unlike the length-gauge APT (:meth:`dipole_derivatives`) the VG APT differs from it in a
         finite basis, converging to it toward the basis-set limit; both are origin-independent."""
@@ -1383,16 +1382,14 @@ class MPwfn(Wavefunction):
         cphf = self._full_occ_cphf()
         d = self.derivatives
         natom = d.natom
-        mol = self.ref.molecule()
         t2 = np.asarray(self.t2)
         Dijab = np.asarray(self.Dijab)
         tau = 2.0 * t2 - t2.swapaxes(2, 3)
         N = self._mp2_normalization()
         c0, c2 = N, N * t2
-        gamma = np.zeros((nmo, nmo))
+        gamma = np.zeros((nmo, nmo))                    # correlation 1-PDM only (no 2 delta ref)
         gamma[o, o] = -2.0 * N**2 * c('ikab,jkab->ij', tau, t2)
         gamma[v, v] = +2.0 * N**2 * c('ijac,ijbc->ab', tau, t2)
-        gamma[np.arange(no), np.arange(no)] += 2.0
 
         def dt2_from(dF, dERI):
             # momentum (imaginary) perturbed T2: dERI enters via the vvoo block (antisymmetric)
@@ -1432,18 +1429,16 @@ class MPwfn(Wavefunction):
                     Iphic = c('ij,ji->', RA[o, o], UReff[o, o]) + c('ab,ab->', RA[v, v], UReff[v, v])
                     Ipp = c('pq,pq->', gamma, UA[alpha].T @ UReff)
                     P[A, beta, alpha] = 2.0 * (Icc + Icphi + Iphic + Ipp)
-                    if alpha == beta:
-                        P[A, beta, alpha] += mol.Z(A)
         self.vgapt = P
         return P
 
     def _so_velocity_dipole_derivatives(self, gauge: str = 'non-canonical') -> np.ndarray:
-        """Spin-orbital MP2 velocity-gauge APTs (``(natom, 3, 3)``) -- the spin-orbital form of
-        :meth:`velocity_dipole_derivatives` (see there for the theory), sharing the spin-orbital
-        AAT densities (:meth:`_so_atomic_axial_tensors`) with the linear-momentum response
-        (:meth:`CPHF.momentum_ints`) and the ``Z_A delta`` nuclear term.  The ``+2`` prefactor is
-        the same as the spin-adapted path (the spin-orbital overlap equals the spin-adapted overlap
-        by construction); verified equal to the spin-adapted path to machine precision."""
+        """Spin-orbital MP2 velocity-gauge APTs (``(natom, 3, 3)``) -- the correlation-only
+        spin-orbital form of :meth:`velocity_dipole_derivatives` (see there for the theory),
+        sharing the spin-orbital AAT densities (:meth:`_so_atomic_axial_tensors`) with the
+        linear-momentum response (:meth:`CPHF.momentum_ints`).  The ``+2`` prefactor is the same as
+        the spin-adapted path (the spin-orbital overlap equals the spin-adapted overlap by
+        construction); verified equal to the spin-adapted path to machine precision."""
         from .cphf import Perturbation
         o, v, nmo = self.o, self.v, self.nmo
         no = o.stop
@@ -1452,16 +1447,14 @@ class MPwfn(Wavefunction):
         cphf = self._full_occ_cphf()
         d = self.derivatives
         natom = d.natom
-        mol = self.ref.molecule()
         t2 = np.asarray(self.t2)
         Dijab = np.asarray(self.Dijab)
         N = self._so_mp2_normalization()
         c0, c2 = N, N * t2
         Doo, Dvv = self._so_mp2_corr_opdm()
-        gamma = np.zeros((nmo, nmo))
+        gamma = np.zeros((nmo, nmo))                    # correlation 1-PDM only (no delta ref)
         gamma[o, o] = N**2 * np.asarray(Doo)
         gamma[v, v] = N**2 * np.asarray(Dvv)
-        gamma[np.arange(no), np.arange(no)] += 1.0
 
         def dt2_from(dF, dERI):
             return ((dERI.swapaxes(0, 2).swapaxes(1, 3)[o, o, v, v]
@@ -1504,42 +1497,19 @@ class MPwfn(Wavefunction):
                     Iphic = c('ij,ij->', gA[alpha][o, o], UReff[o, o]) + c('ab,ab->', gA[alpha][v, v], UReff[v, v])
                     Ipp = c('pq,pq->', gamma, UA[alpha].T @ UReff)
                     P[A, beta, alpha] = 2.0 * (Icc + Icphi + Iphic + Ipp)
-                    if alpha == beta:
-                        P[A, beta, alpha] += mol.Z(A)
         self.vgapt = P
         return P
 
-    # ---- total (reference + correlation) properties ----
-    # The correlation methods above are the correlation contribution only; these add the
-    # all-electron SCF reference (HFwfn, frozen_core=False) for the full molecular property.
+    # ---- reference for the total (reference + correlation) properties ----
+    # The property methods above are the correlation contribution only.  The full molecular
+    # property (nuclear + SCF reference + correlation) is assembled by the pycc property facade
+    # (pycc.dipole/gradient/polarizability/hessian/apt/aat), which pairs each correlation method
+    # with the SCF reference below and the separate nuclear term.
 
     def _reference_hf(self):
-        """The all-electron :class:`HFwfn` for the SCF reference (cached), supplying the
-        reference dipole and gradient for the total MP2 properties."""
+        """The all-electron :class:`HFwfn` for the SCF reference (cached), supplying the reference
+        (electronic) contribution to the total MP2 properties via the pycc property facade."""
         if getattr(self, '_ref_hf', None) is None:
             from .hfwfn import HFwfn
             self._ref_hf = HFwfn(self.ref, orbital_basis=self.orbital_basis)
         return self._ref_hf
-
-    def total_dipole(self) -> np.ndarray:
-        """Total MP2 electric-dipole moment (a.u.), shape ``(3,)``: the SCF reference dipole
-        (:meth:`HFwfn.dipole`) plus the MP2 correlation dipole (:meth:`relaxed_dipole`)."""
-        return self._reference_hf().dipole() + self.relaxed_dipole()
-
-    def total_gradient(self) -> np.ndarray:
-        """Total MP2 analytic nuclear gradient (a.u.), shape ``(natom, 3)``: the SCF reference
-        gradient (:meth:`HFwfn.gradient`) plus the MP2 correlation gradient (:meth:`gradient`)."""
-        return self._reference_hf().gradient() + self.gradient()
-
-    def total_dipole_derivatives(self) -> np.ndarray:
-        """Total MP2 atomic polar tensors (nuclear dipole derivatives, a.u.), shape
-        ``(natom, 3, 3)`` indexed ``[A, beta, alpha]``: the SCF reference APTs
-        (:meth:`HFwfn.dipole_derivatives`, which carry the ``Z_A`` nuclear term) plus the MP2
-        correlation APTs (:meth:`dipole_derivatives`)."""
-        return self._reference_hf().dipole_derivatives() + self.dipole_derivatives()
-
-    def total_hessian(self) -> np.ndarray:
-        """Total MP2 molecular (nuclear) Hessian (a.u.), shape ``(3*natom, 3*natom)``: the SCF
-        reference Hessian (:meth:`HFwfn.hessian`, which carries the nuclear-repulsion term) plus
-        the MP2 correlation Hessian (:meth:`hessian`)."""
-        return self._reference_hf().hessian() + self.hessian()

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -1169,12 +1169,17 @@ class MPwfn(Wavefunction):
     # ---- atomic axial tensors (VCD, magnetic/nuclear mixed derivative) ----
 
     def atomic_axial_tensors(self, gauge: str = 'non-canonical') -> np.ndarray:
-        """MP2 **electronic** atomic axial tensors ``I^A_{alpha,beta}`` (a.u.), shape
+        """MP2 **correlation** atomic axial tensors ``I^A_{alpha,beta}`` (a.u.), shape
         ``(natom, 3, 3)`` indexed ``[A, alpha, beta]`` -- the nuclear(``alpha``)/magnetic-field
         (``beta``) mixed derivative of the wave function, as an overlap of its perturbed
-        derivatives.  This is the full (reference + correlation) **electronic** contribution
-        ``<d_R Psi | d_H Psi>``; the trivial nuclear term (nuclear charge x position) is added
-        separately when forming the total AAT / VCD rotational strengths.  The electron-density formulation follows the diagonal Born-Oppenheimer
+        derivatives.  This is the **correlation** contribution only; the SCF reference AAT
+        (:meth:`HFwfn.atomic_axial_tensors`) and the nuclear (charge x position) term are kept
+        separate and summed by the :func:`pycc.aat` facade.  The correlation is computed directly
+        from the correlation 1-PDM/amplitude derivatives (the reference ``2 delta_ij`` density
+        block never enters), so the pieces are separated in fact, not by subtraction.  Dropping
+        the reference density leaves the result orbital-gauge invariant on its own: the reference
+        block it removes is itself gauge invariant (the antisymmetric magnetic oo/vv response
+        contracts to zero against the symmetric nuclear response).  The electron-density formulation follows the diagonal Born-Oppenheimer
         correction of Gauss, Tajti, Kallay, Stanton & Szalay, J. Chem. Phys. 125, 144111 (2006)
         [Eqs. (16), (18), (19)], generalized to the mixed nuclear/magnetic derivative (Krishnan,
         Shumberger & Crawford, in prep.)::
@@ -1224,11 +1229,12 @@ class MPwfn(Wavefunction):
         tau = 2.0 * t2 - t2.swapaxes(2, 3)
         N = self._mp2_normalization()
         c0, c2 = N, N * t2
-        # unrelaxed, normalized 1-PDM  gamma = 2 delta_ij + correlation
+        # correlation part of the unrelaxed, normalized 1-PDM (the 2 delta_ij reference block is
+        # excluded: it contributes the SCF reference AAT via Ipp, kept separate -- see the method
+        # docstring).  This makes the return the correlation contribution only.
         gamma = np.zeros((nmo, nmo))
         gamma[o, o] = -2.0 * N**2 * c('ikab,jkab->ij', tau, t2)
         gamma[v, v] = +2.0 * N**2 * c('ijac,ijbc->ab', tau, t2)
-        gamma[np.arange(no), np.arange(no)] += 2.0
 
         def dt2_from(dF, dERI):
             # magnetic (imaginary) perturbed T2: dERI enters via the vvoo block (antisymmetric)
@@ -1295,10 +1301,9 @@ class MPwfn(Wavefunction):
         N = self._so_mp2_normalization()
         c0, c2 = N, N * t2
         Doo, Dvv = self._so_mp2_corr_opdm()
-        gamma = np.zeros((nmo, nmo))                    # unrelaxed 1-PDM: delta_ij + correlation
-        gamma[o, o] = N**2 * np.asarray(Doo)
-        gamma[v, v] = N**2 * np.asarray(Dvv)
-        gamma[np.arange(no), np.arange(no)] += 1.0
+        gamma = np.zeros((nmo, nmo))                    # correlation part of the 1-PDM (no delta_ij
+        gamma[o, o] = N**2 * np.asarray(Doo)            # reference: it rides in the SCF AAT, kept
+        gamma[v, v] = N**2 * np.asarray(Dvv)            # separate -- return is correlation only)
 
         def dt2_from(dF, dERI):
             # magnetic (imaginary) perturbed T2: dERI enters via the vvoo block (antisymmetric)

--- a/pycc/properties.py
+++ b/pycc/properties.py
@@ -63,6 +63,90 @@ for _a, _b, _g in ((0, 1, 2), (1, 2, 0), (2, 0, 1)):
     _LEVI_CIVITA[_a, _g, _b] = -1.0
 
 
+def _nuclear_dipole(mol) -> np.ndarray:
+    """Nuclear contribution to the electric dipole (a.u.), shape ``(3,)``: ``sum_A Z_A R_A``."""
+    geom = np.asarray(mol.geometry().np)
+    Z = np.array([mol.Z(A) for A in range(mol.natom())])
+    return np.einsum('a,ax->x', Z, geom)
+
+
+def _nuclear_apt(mol) -> np.ndarray:
+    """Nuclear contribution to the APT (length or velocity gauge), shape ``(natom, 3, 3)``
+    indexed ``[A, beta, alpha]``: ``Z_A delta_{alpha,beta}``."""
+    natom = mol.natom()
+    nuc = np.zeros((natom, 3, 3))
+    for A in range(natom):
+        for a in range(3):
+            nuc[A, a, a] = mol.Z(A)
+    return nuc
+
+
+def _dispatch(wfn, hf_method, mp_method):
+    """Reference (SCF electronic) and correlation blocks of a property, computed apart.  For an
+    ``MPwfn`` the reference is the all-electron SCF value (``_reference_hf()``) and the correlation
+    is the MP2 correlation-only method; for an ``HFwfn`` the reference is the SCF value and the
+    correlation is an all-zeros array of the same shape."""
+    from .hfwfn import HFwfn
+    from .mpwfn import MPwfn
+    if isinstance(wfn, MPwfn):
+        reference = np.asarray(getattr(wfn._reference_hf(), hf_method)())
+        correlation = np.asarray(getattr(wfn, mp_method)())
+    elif isinstance(wfn, HFwfn):
+        reference = np.asarray(getattr(wfn, hf_method)())
+        correlation = np.zeros_like(reference)
+    else:
+        raise TypeError(f"unsupported wavefunction type {type(wfn).__name__!r}")
+    return reference, correlation
+
+
+def dipole(wfn) -> PropertyComponents:
+    """Electric-dipole moment as a :class:`PropertyComponents` (``nuclear + reference +
+    correlation``, shape ``(3,)`` each) for any supported wavefunction type."""
+    reference, correlation = _dispatch(wfn, '_dipole_electronic', 'relaxed_dipole')
+    return PropertyComponents(_nuclear_dipole(wfn.ref.molecule()), reference, correlation)
+
+
+def gradient(wfn) -> PropertyComponents:
+    """Analytic energy gradient as a :class:`PropertyComponents` (``nuclear + reference +
+    correlation``, shape ``(natom, 3)`` each).  The nuclear block is the nuclear-repulsion
+    derivative ``dV_NN/dX``."""
+    reference, correlation = _dispatch(wfn, '_gradient_electronic', 'gradient')
+    nuclear = np.asarray(wfn.derivatives.nuclear_repulsion())
+    return PropertyComponents(nuclear, reference, correlation)
+
+
+def polarizability(wfn) -> PropertyComponents:
+    """Static electric-dipole polarizability as a :class:`PropertyComponents`, shape ``(3, 3)``
+    each.  A pure electronic response property: the nuclear block is zero."""
+    reference, correlation = _dispatch(wfn, 'polarizability', 'polarizability')
+    return PropertyComponents(np.zeros((3, 3)), reference, correlation)
+
+
+def hessian(wfn) -> PropertyComponents:
+    """Molecular (nuclear) Hessian as a :class:`PropertyComponents` (``nuclear + reference +
+    correlation``, shape ``(3*natom, 3*natom)`` each).  The nuclear block is the nuclear-
+    repulsion second derivative ``d^2 V_NN/dX dY``."""
+    reference, correlation = _dispatch(wfn, '_hessian_electronic', 'hessian')
+    nuclear = np.asarray(wfn.derivatives.nuclear_repulsion2())
+    return PropertyComponents(nuclear, reference, correlation)
+
+
+def apt(wfn, gauge='length') -> PropertyComponents:
+    """Atomic polar tensors (nuclear dipole derivatives) as a :class:`PropertyComponents`
+    (``nuclear + reference + correlation``, shape ``(natom, 3, 3)`` each), indexed
+    ``[A, beta, alpha]``.  ``gauge='length'`` (default) is the length-gauge APT
+    (:meth:`dipole_derivatives`); ``gauge='velocity'`` is the velocity-gauge APT
+    (:meth:`velocity_dipole_derivatives`).  The nuclear block is ``Z_A delta_{alpha,beta}``."""
+    if gauge == 'length':
+        reference, correlation = _dispatch(wfn, '_dipole_derivatives_electronic', 'dipole_derivatives')
+    elif gauge == 'velocity':
+        reference, correlation = _dispatch(wfn, '_velocity_dipole_derivatives_electronic',
+                                           'velocity_dipole_derivatives')
+    else:
+        raise ValueError(f"apt: gauge must be 'length' or 'velocity', got {gauge!r}")
+    return PropertyComponents(_nuclear_apt(wfn.ref.molecule()), reference, correlation)
+
+
 def _nuclear_aat(mol, origin) -> np.ndarray:
     """Nuclear contribution to the AAT (a.u.), shape ``(natom, 3, 3)``::
 

--- a/pycc/properties.py
+++ b/pycc/properties.py
@@ -1,0 +1,109 @@
+"""Molecular-property facade: uniform, wavefunction-type-agnostic access to the analytic
+derivative properties, each returned as its additive physical decomposition
+
+    total = nuclear + reference + correlation
+
+The same call works for any supported wavefunction (``HFwfn``, ``MPwfn``, ...): the correlation
+block is simply zero for an SCF wavefunction.  The pieces are genuinely computed apart -- the
+correlation contribution is built from correlation quantities only, never as (total - reference).
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class PropertyComponents:
+    """Additive decomposition of a molecular-property tensor::
+
+        total = nuclear + reference + correlation
+
+    all the same shape.  ``reference`` is the SCF electronic contribution, ``correlation`` the
+    post-SCF (e.g. MP2) correction -- an all-zeros array for an SCF wavefunction.  ``origin``
+    records the coordinate/gauge origin used by origin-dependent properties (the AAT), else
+    ``None``.
+
+    Access is by name (never by position): ``.total`` and ``.electronic`` are derived so they
+    can never drift out of sync with the stored pieces; ``.scf`` and ``.hf`` are aliases of
+    ``.reference``.
+    """
+
+    nuclear: np.ndarray
+    reference: np.ndarray
+    correlation: np.ndarray
+    origin: Optional[Tuple[float, float, float]] = None
+
+    @property
+    def total(self) -> np.ndarray:
+        """nuclear + reference + correlation."""
+        return self.nuclear + self.reference + self.correlation
+
+    @property
+    def electronic(self) -> np.ndarray:
+        """reference + correlation (the full electronic contribution)."""
+        return self.reference + self.correlation
+
+    @property
+    def scf(self) -> np.ndarray:
+        """Alias of :attr:`reference`."""
+        return self.reference
+
+    @property
+    def hf(self) -> np.ndarray:
+        """Alias of :attr:`reference`."""
+        return self.reference
+
+
+# Levi-Civita symbol eps_{alpha,beta,gamma}
+_LEVI_CIVITA = np.zeros((3, 3, 3))
+for _a, _b, _g in ((0, 1, 2), (1, 2, 0), (2, 0, 1)):
+    _LEVI_CIVITA[_a, _b, _g] = 1.0
+    _LEVI_CIVITA[_a, _g, _b] = -1.0
+
+
+def _nuclear_aat(mol, origin) -> np.ndarray:
+    """Nuclear contribution to the AAT (a.u.), shape ``(natom, 3, 3)``::
+
+        I^A_{alpha,beta} = (Z_A / 4) sum_gamma eps_{alpha,beta,gamma} (R_{A,gamma} - O_gamma)
+
+    ``origin`` O (in the molecule's frame, bohr); ``None`` -> the coordinate origin (0, 0, 0)."""
+    natom = mol.natom()
+    R = np.asarray(mol.geometry().np)                    # (natom, 3), bohr, input frame
+    O = np.zeros(3) if origin is None else np.asarray(origin, dtype=float)
+    Z = np.array([mol.Z(A) for A in range(natom)])
+    return 0.25 * Z[:, None, None] * np.einsum('abg,Ag->Aab', _LEVI_CIVITA, R - O)
+
+
+def aat(wfn, origin=None) -> PropertyComponents:
+    """Atomic axial tensors (AATs, for VCD) as a :class:`PropertyComponents`
+    (``nuclear + reference + correlation``), shape ``(natom, 3, 3)`` each, for any supported
+    wavefunction type.
+
+    The correlation block is the genuine correlation contribution
+    (:meth:`MPwfn.atomic_axial_tensors`, which excludes the reference density), the reference
+    block is the independent SCF AAT (:meth:`HFwfn.atomic_axial_tensors`), and the nuclear block
+    is ``(Z_A/4) eps R``.  Each block is orbital-gauge invariant, so the decomposition is well
+    defined independent of the magnetic oo/vv gauge.
+
+    ``origin`` is the coordinate origin for the nuclear term; ``None`` (default) uses the current
+    coordinate origin ``(0, 0, 0)`` in the molecule's input frame (honoring ``no_com`` /
+    ``no_reorient``).  The electronic AAT's common gauge origin is psi4's (the input-frame
+    origin), which matches the default; a non-default ``origin`` shifts only the nuclear term (the
+    matching electronic-gauge shift is a planned follow-up)."""
+    from .hfwfn import HFwfn
+    from .mpwfn import MPwfn
+
+    mol = wfn.ref.molecule()
+    nuclear = _nuclear_aat(mol, origin)
+    if isinstance(wfn, MPwfn):
+        reference = np.asarray(wfn._reference_hf().atomic_axial_tensors())
+        correlation = np.asarray(wfn.atomic_axial_tensors())
+    elif isinstance(wfn, HFwfn):
+        reference = np.asarray(wfn.atomic_axial_tensors())
+        correlation = np.zeros_like(reference)
+    else:
+        raise TypeError(f"pycc.aat: unsupported wavefunction type {type(wfn).__name__!r}")
+    o = (0.0, 0.0, 0.0) if origin is None else tuple(float(x) for x in origin)
+    return PropertyComponents(nuclear=nuclear, reference=reference, correlation=correlation, origin=o)

--- a/pycc/properties.py
+++ b/pycc/properties.py
@@ -56,6 +56,12 @@ class PropertyComponents:
         return self.reference
 
 
+# ------------------------------------------------------------------------------------------------
+# Nuclear-only contributions (geometry + charge; no wavefunction).  One helper per property whose
+# total carries a nuclear term (the gradient/Hessian nuclear terms are the nuclear-repulsion
+# derivatives, taken from Derivatives; polarizability has no nuclear term).
+# ------------------------------------------------------------------------------------------------
+
 # Levi-Civita symbol eps_{alpha,beta,gamma}
 _LEVI_CIVITA = np.zeros((3, 3, 3))
 for _a, _b, _g in ((0, 1, 2), (1, 2, 0), (2, 0, 1)):
@@ -81,16 +87,35 @@ def _nuclear_apt(mol) -> np.ndarray:
     return nuc
 
 
-def _dispatch(wfn, hf_method, mp_method):
+def _nuclear_aat(mol, origin) -> np.ndarray:
+    """Nuclear contribution to the AAT (a.u.), shape ``(natom, 3, 3)``::
+
+        I^A_{alpha,beta} = (Z_A / 4) sum_gamma eps_{alpha,beta,gamma} (R_{A,gamma} - O_gamma)
+
+    ``origin`` O (in the molecule's frame, bohr); ``None`` -> the coordinate origin (0, 0, 0)."""
+    natom = mol.natom()
+    R = np.asarray(mol.geometry().np)                    # (natom, 3), bohr, input frame
+    O = np.zeros(3) if origin is None else np.asarray(origin, dtype=float)
+    Z = np.array([mol.Z(A) for A in range(natom)])
+    return 0.25 * Z[:, None, None] * np.einsum('abg,Ag->Aab', _LEVI_CIVITA, R - O)
+
+
+# ------------------------------------------------------------------------------------------------
+# Property facade: dispatch on wavefunction type, assemble the PropertyComponents decomposition.
+# ------------------------------------------------------------------------------------------------
+
+def _dispatch(wfn, hf_method, mp_method, mp_kwargs=None):
     """Reference (SCF electronic) and correlation blocks of a property, computed apart.  For an
     ``MPwfn`` the reference is the all-electron SCF value (``_reference_hf()``) and the correlation
-    is the MP2 correlation-only method; for an ``HFwfn`` the reference is the SCF value and the
-    correlation is an all-zeros array of the same shape."""
+    is the MP2 correlation-only method (called with ``mp_kwargs`` -- ``route``/``gauge`` are
+    MP2-only knobs the SCF reference does not take); for an ``HFwfn`` the reference is the SCF
+    value and the correlation is an all-zeros array of the same shape (``mp_kwargs`` do not
+    apply -- there is no correlation)."""
     from .hfwfn import HFwfn
     from .mpwfn import MPwfn
     if isinstance(wfn, MPwfn):
         reference = np.asarray(getattr(wfn._reference_hf(), hf_method)())
-        correlation = np.asarray(getattr(wfn, mp_method)())
+        correlation = np.asarray(getattr(wfn, mp_method)(**(mp_kwargs or {})))
     elif isinstance(wfn, HFwfn):
         reference = np.asarray(getattr(wfn, hf_method)())
         correlation = np.zeros_like(reference)
@@ -115,52 +140,55 @@ def gradient(wfn) -> PropertyComponents:
     return PropertyComponents(nuclear, reference, correlation)
 
 
-def polarizability(wfn) -> PropertyComponents:
+def polarizability(wfn, route='explicit') -> PropertyComponents:
     """Static electric-dipole polarizability as a :class:`PropertyComponents`, shape ``(3, 3)``
-    each.  A pure electronic response property: the nuclear block is zero."""
-    reference, correlation = _dispatch(wfn, 'polarizability', 'polarizability')
+    each.  A pure electronic response property: the nuclear block is zero.
+
+    ``route`` selects the MP2 correlation algorithm, ``'explicit'`` (default) or ``'2n+1'`` (the
+    O(N)-cheaper 2n+1 route); both give the same tensor and it is ignored for an ``HFwfn``."""
+    reference, correlation = _dispatch(wfn, 'polarizability', 'polarizability', {'route': route})
     return PropertyComponents(np.zeros((3, 3)), reference, correlation)
 
 
-def hessian(wfn) -> PropertyComponents:
+def hessian(wfn, route='explicit') -> PropertyComponents:
     """Molecular (nuclear) Hessian as a :class:`PropertyComponents` (``nuclear + reference +
     correlation``, shape ``(3*natom, 3*natom)`` each).  The nuclear block is the nuclear-
-    repulsion second derivative ``d^2 V_NN/dX dY``."""
-    reference, correlation = _dispatch(wfn, '_hessian_electronic', 'hessian')
+    repulsion second derivative ``d^2 V_NN/dX dY``.
+
+    ``route`` selects the MP2 correlation algorithm, ``'explicit'`` (default) or ``'2n+1'`` (the
+    O(N)-cheaper 2n+1 route); both give the same matrix and it is ignored for an ``HFwfn``."""
+    reference, correlation = _dispatch(wfn, '_hessian_electronic', 'hessian', {'route': route})
     nuclear = np.asarray(wfn.derivatives.nuclear_repulsion2())
     return PropertyComponents(nuclear, reference, correlation)
 
 
-def apt(wfn, gauge='length') -> PropertyComponents:
+def apt(wfn, gauge='length', route='explicit', orbital_gauge='non-canonical') -> PropertyComponents:
     """Atomic polar tensors (nuclear dipole derivatives) as a :class:`PropertyComponents`
     (``nuclear + reference + correlation``, shape ``(natom, 3, 3)`` each), indexed
-    ``[A, beta, alpha]``.  ``gauge='length'`` (default) is the length-gauge APT
-    (:meth:`dipole_derivatives`); ``gauge='velocity'`` is the velocity-gauge APT
-    (:meth:`velocity_dipole_derivatives`).  The nuclear block is ``Z_A delta_{alpha,beta}``."""
+    ``[A, beta, alpha]``.  The nuclear block is ``Z_A delta_{alpha,beta}``.
+
+    ``gauge='length'`` (default) is the length-gauge APT (:meth:`dipole_derivatives`);
+    ``gauge='velocity'`` is the velocity-gauge APT (:meth:`velocity_dipole_derivatives`).
+
+    ``route`` (length gauge only) selects the MP2 correlation algorithm -- ``'explicit'``
+    (default), ``'2n+1-nuclear'`` or ``'2n+1-field'``; all give the same tensor.
+
+    ``orbital_gauge`` (velocity gauge only; **expert only**) selects the redundant momentum
+    orbital-rotation gauge, ``'non-canonical'`` (default, numerically stable) or ``'canonical'``.
+    The velocity APT is invariant to this choice, so it exists only for verification/debugging.
+    Both extra knobs are ignored for an ``HFwfn`` (no correlation)."""
     if gauge == 'length':
-        reference, correlation = _dispatch(wfn, '_dipole_derivatives_electronic', 'dipole_derivatives')
+        reference, correlation = _dispatch(wfn, '_dipole_derivatives_electronic',
+                                           'dipole_derivatives', {'route': route})
     elif gauge == 'velocity':
         reference, correlation = _dispatch(wfn, '_velocity_dipole_derivatives_electronic',
-                                           'velocity_dipole_derivatives')
+                                           'velocity_dipole_derivatives', {'gauge': orbital_gauge})
     else:
         raise ValueError(f"apt: gauge must be 'length' or 'velocity', got {gauge!r}")
     return PropertyComponents(_nuclear_apt(wfn.ref.molecule()), reference, correlation)
 
 
-def _nuclear_aat(mol, origin) -> np.ndarray:
-    """Nuclear contribution to the AAT (a.u.), shape ``(natom, 3, 3)``::
-
-        I^A_{alpha,beta} = (Z_A / 4) sum_gamma eps_{alpha,beta,gamma} (R_{A,gamma} - O_gamma)
-
-    ``origin`` O (in the molecule's frame, bohr); ``None`` -> the coordinate origin (0, 0, 0)."""
-    natom = mol.natom()
-    R = np.asarray(mol.geometry().np)                    # (natom, 3), bohr, input frame
-    O = np.zeros(3) if origin is None else np.asarray(origin, dtype=float)
-    Z = np.array([mol.Z(A) for A in range(natom)])
-    return 0.25 * Z[:, None, None] * np.einsum('abg,Ag->Aab', _LEVI_CIVITA, R - O)
-
-
-def aat(wfn, origin=None) -> PropertyComponents:
+def aat(wfn, origin=None, orbital_gauge='non-canonical') -> PropertyComponents:
     """Atomic axial tensors (AATs, for VCD) as a :class:`PropertyComponents`
     (``nuclear + reference + correlation``), shape ``(natom, 3, 3)`` each, for any supported
     wavefunction type.
@@ -175,7 +203,12 @@ def aat(wfn, origin=None) -> PropertyComponents:
     coordinate origin ``(0, 0, 0)`` in the molecule's input frame (honoring ``no_com`` /
     ``no_reorient``).  The electronic AAT's common gauge origin is psi4's (the input-frame
     origin), which matches the default; a non-default ``origin`` shifts only the nuclear term (the
-    matching electronic-gauge shift is a planned follow-up)."""
+    matching electronic-gauge shift is a planned follow-up).
+
+    ``orbital_gauge`` (**expert only**) selects the redundant magnetic orbital-rotation gauge of
+    the MP2 correlation AAT, ``'non-canonical'`` (default, numerically stable) or ``'canonical'``.
+    The AAT is invariant to this choice, so it exists only for verification/debugging; it is
+    ignored for an ``HFwfn`` (no correlation)."""
     from .hfwfn import HFwfn
     from .mpwfn import MPwfn
 
@@ -183,7 +216,7 @@ def aat(wfn, origin=None) -> PropertyComponents:
     nuclear = _nuclear_aat(mol, origin)
     if isinstance(wfn, MPwfn):
         reference = np.asarray(wfn._reference_hf().atomic_axial_tensors())
-        correlation = np.asarray(wfn.atomic_axial_tensors())
+        correlation = np.asarray(wfn.atomic_axial_tensors(gauge=orbital_gauge))
     elif isinstance(wfn, HFwfn):
         reference = np.asarray(wfn.atomic_axial_tensors())
         correlation = np.zeros_like(reference)

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -218,7 +218,7 @@ def _pycc_gradient(geom, basis, orbital_basis='spinorbital', freeze_core='false'
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
-    return mp.total_gradient()
+    return np.asarray(pycc.gradient(mp).total)
 
 
 def _psi4_mp2_gradient(geom, basis):
@@ -318,7 +318,7 @@ def test_fc_mp2_gradient_vs_energy_fd_631g():
     mp = pycc.MPwfn(wfn, orbital_basis='spatial')
     mp.compute_energy()
     assert mp.nfzc > 0                                   # frozen core is actually active
-    gA = mp.total_gradient()                             # total = SCF + correlation
+    gA = np.asarray(pycc.gradient(mp).total)             # total = SCF + correlation
 
     h = 2.0e-3
     gF = np.zeros((3, 3))
@@ -388,7 +388,7 @@ def test_mp2_total_dipole_631g():
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis='spinorbital')
     mp.compute_energy()
-    total = mp.total_dipole()
+    total = np.asarray(pycc.dipole(mp).total)
     assert abs(total[2] - _ff_total_dipole(geom, '6-31G', 'mp2')) < 1e-8
 
 

--- a/pycc/tests/test_068_mp2_apt.py
+++ b/pycc/tests/test_068_mp2_apt.py
@@ -129,7 +129,7 @@ def test_mp2_apt_translational_sum_rule_631g():
     total APT vanishes (the correlation APT sums to zero on its own -- Tr(gamma_corr) = 0)."""
     mp0 = _mpwfn(BASE, '6-31G', 'spatial')
     P_corr = mp0.dipole_derivatives()
-    P_tot = mp0.total_dipole_derivatives()
+    P_tot = np.asarray(pycc.apt(mp0).total)
     assert np.max(np.abs(np.sum(P_corr, axis=0))) < 1e-10
     assert np.max(np.abs(np.sum(P_tot, axis=0))) < 1e-10
 
@@ -162,7 +162,7 @@ def test_fc_mp2_apt_translational_sum_rule_631g():
     vanishes for neutral water."""
     mp0 = _mpwfn(BASE, '6-31G', 'spatial', freeze_core='true')
     assert np.max(np.abs(np.sum(mp0.dipole_derivatives(), axis=0))) < 1e-10
-    assert np.max(np.abs(np.sum(mp0.total_dipole_derivatives(), axis=0))) < 1e-10
+    assert np.max(np.abs(np.sum(np.asarray(pycc.apt(mp0).total), axis=0))) < 1e-10
 
 
 # ---- 2n+1 routes (Phase C): both reproduce the explicit APT to ~machine precision ----

--- a/pycc/tests/test_072_mp2_aat.py
+++ b/pycc/tests/test_072_mp2_aat.py
@@ -49,32 +49,37 @@ def _mpwfn(orbital_basis='spatial', freeze_core='false'):
 
 
 def test_mp2_aat_all_electron():
-    """All-electron spatial MP2 AAT reproduces the apyib reference for (P)-H2O2/STO-3G."""
-    P = np.asarray(_mpwfn().atomic_axial_tensors()).reshape(-1, 3)
+    """All-electron spatial MP2 electronic AAT (SCF reference + correlation, via the pycc.aat
+    facade) reproduces the apyib reference for (P)-H2O2/STO-3G."""
+    P = np.asarray(pycc.aat(_mpwfn()).electronic).reshape(-1, 3)
     for (row, col), ref in AAT_REF['false'].items():
         assert abs(P[row, col] - ref) < 1e-6, (row, col, P[row, col], ref)
 
 
 def test_mp2_aat_frozen_core():
-    """Frozen-core spatial MP2 AAT reproduces the independent apyib frozen-core reference."""
-    P = np.asarray(_mpwfn(freeze_core='true').atomic_axial_tensors()).reshape(-1, 3)
+    """Frozen-core spatial MP2 electronic AAT reproduces the independent apyib frozen-core
+    reference (all-electron SCF reference + frozen-core correlation)."""
+    P = np.asarray(pycc.aat(_mpwfn(freeze_core='true')).electronic).reshape(-1, 3)
     for (row, col), ref in AAT_REF['true'].items():
         assert abs(P[row, col] - ref) < 1e-6, (row, col, P[row, col], ref)
 
 
 def test_mp2_aat_so_equals_spatial():
-    """Spin-orbital MP2 AAT == spin-adapted (the keystone), all-electron and frozen-core."""
+    """Spin-orbital MP2 correlation AAT == spin-adapted (the keystone), all-electron and
+    frozen-core; the electronic total also matches the apyib reference."""
     for fc in ('false', 'true'):
         P = np.asarray(_mpwfn(freeze_core=fc).atomic_axial_tensors()).reshape(-1, 3)
         P_so = np.asarray(_mpwfn('spinorbital', fc).atomic_axial_tensors()).reshape(-1, 3)
         assert np.max(np.abs(P_so - P)) < 1e-9, (fc, np.max(np.abs(P_so - P)))
+        E_so = np.asarray(pycc.aat(_mpwfn('spinorbital', fc)).electronic).reshape(-1, 3)
         for (row, col), ref in AAT_REF[fc].items():
-            assert abs(P_so[row, col] - ref) < 1e-6, (fc, row, col, P_so[row, col], ref)
+            assert abs(E_so[row, col] - ref) < 1e-6, (fc, row, col, E_so[row, col], ref)
 
 
 def test_mp2_aat_gauge_invariance():
-    """The AAT total is invariant to the orbital gauge of the redundant magnetic oo/vv response
-    (non-canonical default vs canonical), all-electron and frozen-core, both spin paths."""
+    """The MP2 correlation AAT is invariant to the orbital gauge of the redundant magnetic oo/vv
+    response (non-canonical default vs canonical), all-electron and frozen-core, both spin paths.
+    (The dropped SCF-reference block is itself gauge invariant, so the correlation is too.)"""
     for fc in ('false', 'true'):
         for ob in ('spatial', 'spinorbital'):
             mp = _mpwfn(ob, fc)

--- a/pycc/tests/test_073_mp2_vg_apt.py
+++ b/pycc/tests/test_073_mp2_vg_apt.py
@@ -52,24 +52,25 @@ def _mpwfn(orbital_basis='spatial', freeze_core='false'):
 
 
 def test_mp2_vg_apt_all_electron():
-    """All-electron spatial MP2 VG APT reproduces the regression reference for (P)-H2O2/STO-3G."""
-    P = np.asarray(_mpwfn()[0].velocity_dipole_derivatives()).reshape(-1, 3)
+    """All-electron spatial MP2 VG APT (total, via the pycc.apt velocity-gauge facade) reproduces
+    the regression reference for (P)-H2O2/STO-3G."""
+    P = np.asarray(pycc.apt(_mpwfn()[0], gauge='velocity').total).reshape(-1, 3)
     for (row, col), ref in VG_REF['false'].items():
         assert abs(P[row, col] - ref) < 1e-6, (row, col, P[row, col], ref)
 
 
 def test_mp2_vg_apt_frozen_core():
-    """Frozen-core spatial MP2 VG APT reproduces the regression reference."""
-    P = np.asarray(_mpwfn(freeze_core='true')[0].velocity_dipole_derivatives()).reshape(-1, 3)
+    """Frozen-core spatial MP2 VG APT (total) reproduces the regression reference."""
+    P = np.asarray(pycc.apt(_mpwfn(freeze_core='true')[0], gauge='velocity').total).reshape(-1, 3)
     for (row, col), ref in VG_REF['true'].items():
         assert abs(P[row, col] - ref) < 1e-6, (row, col, P[row, col], ref)
 
 
 def test_mp2_vg_apt_reduces_to_hf():
-    """The MP2 VG APT reduces to the (Amos-pinned) HF VG APT as the correlation vanishes: the
-    difference is the small MP2 correlation contribution."""
+    """The MP2 VG APT total reduces to the (Amos-pinned) HF VG APT total as the correlation
+    vanishes: the difference is the small MP2 correlation contribution."""
     mp, wfn = _mpwfn()
-    VG = np.asarray(mp.velocity_dipole_derivatives())
+    VG = np.asarray(pycc.apt(mp, gauge='velocity').total)
     HF = np.asarray(pycc.HFwfn(wfn).velocity_dipole_derivatives())
     diff = np.max(np.abs(VG - HF))
     assert diff < 0.05, diff            # small correlation contribution
@@ -77,7 +78,8 @@ def test_mp2_vg_apt_reduces_to_hf():
 
 
 def test_mp2_vg_apt_so_equals_spatial():
-    """Spin-orbital MP2 VG APT == spin-adapted (the keystone), all-electron and frozen-core."""
+    """Spin-orbital MP2 VG APT correlation == spin-adapted (the keystone), all-electron and
+    frozen-core."""
     for fc in ('false', 'true'):
         P = np.asarray(_mpwfn(freeze_core=fc)[0].velocity_dipole_derivatives())
         P_so = np.asarray(_mpwfn('spinorbital', fc)[0].velocity_dipole_derivatives())

--- a/pycc/tests/test_074_property_facade.py
+++ b/pycc/tests/test_074_property_facade.py
@@ -1,0 +1,107 @@
+"""
+Property facade -- pycc.aat() and pycc.PropertyComponents.
+
+The facade returns the additive physical decomposition ``total = nuclear + reference +
+correlation`` for any supported wavefunction type, with the pieces genuinely computed apart
+(the correlation excludes the SCF reference density; the reference is the independent SCF AAT).
+"""
+
+import psi4
+import pycc
+import numpy as np
+
+
+H2O2 = """
+H -1.780954530308296   1.411647335546379   0.872055376436941
+H  1.780954530308296  -1.411647335546379   0.872055376436941
+O -1.371214332646589  -0.115525249760340  -0.054947416764017
+O  1.371214332646589   0.115525249760340  -0.054947416764017
+no_com
+no_reorient
+symmetry c1
+units bohr
+"""
+
+
+def _wfns(freeze_core='false'):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(H2O2)
+    psi4.set_options({'basis': 'STO-3G', 'scf_type': 'pk', 'freeze_core': freeze_core,
+                      'e_convergence': 1e-11, 'd_convergence': 1e-11})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    mp = pycc.MPwfn(wfn)
+    mp.compute_energy()
+    return pycc.HFwfn(wfn), mp
+
+
+def test_aat_decomposition_identities():
+    """total == nuclear + reference + correlation; electronic == reference + correlation; the
+    derived accessors and the scf/hf aliases are self-consistent."""
+    _, mp = _wfns()
+    r = pycc.aat(mp)
+    assert np.max(np.abs(r.total - (r.nuclear + r.reference + r.correlation))) < 1e-14
+    assert np.max(np.abs(r.electronic - (r.reference + r.correlation))) < 1e-14
+    assert np.array_equal(r.scf, r.reference) and np.array_equal(r.hf, r.reference)
+    assert r.origin == (0.0, 0.0, 0.0)
+
+
+def test_aat_genuine_separation():
+    """The reference block is exactly the independent SCF AAT, and the correlation block is a
+    real, nonzero contribution computed apart from it."""
+    hf, mp = _wfns()
+    r = pycc.aat(mp)
+    assert np.max(np.abs(r.reference - np.asarray(hf.atomic_axial_tensors()))) < 1e-12
+    assert np.max(np.abs(r.correlation - np.asarray(mp.atomic_axial_tensors()))) < 1e-12
+    assert np.max(np.abs(r.correlation)) > 1e-4      # correlation really present
+
+
+def test_aat_nuclear_term():
+    """The nuclear block is (Z_A/4) eps_{alpha,beta,gamma} R_{A,gamma}."""
+    _, mp = _wfns()
+    r = pycc.aat(mp)
+    mol = mp.ref.molecule()
+    R = mol.geometry().np
+    for A in range(mol.natom()):
+        Z, (x, y, z) = mol.Z(A), R[A]
+        expect = 0.25 * Z * np.array([[0, z, -y], [-z, 0, x], [y, -x, 0]])
+        assert np.max(np.abs(r.nuclear[A] - expect)) < 1e-12, A
+
+
+def test_aat_hf_wavefunction():
+    """pycc.aat(HFwfn): correlation is an all-zeros array (same shape/type as for MP2), and the
+    reference is the SCF AAT."""
+    hf, _ = _wfns()
+    r = pycc.aat(hf)
+    assert r.correlation.shape == r.reference.shape
+    assert np.all(r.correlation == 0.0)
+    assert np.max(np.abs(r.reference - np.asarray(hf.atomic_axial_tensors()))) < 1e-12
+    assert np.max(np.abs(r.electronic - r.reference)) < 1e-14
+
+
+def test_aat_origin_argument():
+    """A non-default origin shifts only the nuclear block (electronic terms unchanged), by the
+    expected -(Z_A/4) eps O."""
+    _, mp = _wfns()
+    r0 = pycc.aat(mp)
+    O = (0.5, -0.3, 0.1)
+    rO = pycc.aat(mp, origin=O)
+    assert np.max(np.abs(rO.electronic - r0.electronic)) < 1e-14
+    mol = mp.ref.molecule()
+    ox, oy, oz = O
+    shift = -0.25 * np.array([[0, oz, -oy], [-oz, 0, ox], [oy, -ox, 0]])
+    for A in range(mol.natom()):
+        assert np.max(np.abs((rO.nuclear[A] - r0.nuclear[A]) - mol.Z(A) * shift)) < 1e-12, A
+    assert rO.origin == O
+
+
+def test_aat_frozen_core_total():
+    """Frozen core: total = all-electron SCF reference + frozen-core correlation + nuclear; the
+    reference is unaffected by freezing (it is the all-electron SCF AAT)."""
+    _, mp_ae = _wfns('false')
+    _, mp_fc = _wfns('true')
+    r_ae, r_fc = pycc.aat(mp_ae), pycc.aat(mp_fc)
+    assert np.max(np.abs(r_fc.reference - r_ae.reference)) < 1e-12
+    assert np.max(np.abs(r_fc.nuclear - r_ae.nuclear)) < 1e-14
+    # freezing changes the correlation (and hence the total) a little, but not wildly
+    assert 1e-6 < np.max(np.abs(r_fc.correlation - r_ae.correlation)) < 1e-2

--- a/pycc/tests/test_074_property_facade.py
+++ b/pycc/tests/test_074_property_facade.py
@@ -161,3 +161,26 @@ def test_apt_bad_gauge():
         assert False, "expected ValueError"
     except ValueError:
         pass
+
+
+def test_facade_route_option():
+    """route (MP2 correlation algorithm) is exposed and gives the same total; ignored for HF."""
+    hf, mp = _wfns()
+    assert np.max(np.abs(pycc.polarizability(mp, route='explicit').total
+                         - pycc.polarizability(mp, route='2n+1').total)) < 1e-12
+    assert np.max(np.abs(pycc.hessian(mp, route='explicit').total
+                         - pycc.hessian(mp, route='2n+1').total)) < 1e-12
+    assert np.max(np.abs(pycc.apt(mp, 'length', route='explicit').total
+                         - pycc.apt(mp, 'length', route='2n+1-nuclear').total)) < 1e-10
+    assert np.all(pycc.hessian(hf, route='2n+1').correlation == 0.0)
+
+
+def test_facade_orbital_gauge_option():
+    """orbital_gauge (expert-only) is exposed on aat / apt(velocity); the tensor is invariant to
+    it (the knob reaches the correlation method, which is gauge invariant), ignored for HF."""
+    hf, mp = _wfns()
+    assert np.max(np.abs(pycc.aat(mp, orbital_gauge='non-canonical').total
+                         - pycc.aat(mp, orbital_gauge='canonical').total)) < 1e-9
+    assert np.max(np.abs(pycc.apt(mp, 'velocity', orbital_gauge='non-canonical').total
+                         - pycc.apt(mp, 'velocity', orbital_gauge='canonical').total)) < 1e-9
+    assert np.all(pycc.apt(hf, 'velocity', orbital_gauge='canonical').correlation == 0.0)

--- a/pycc/tests/test_074_property_facade.py
+++ b/pycc/tests/test_074_property_facade.py
@@ -105,3 +105,59 @@ def test_aat_frozen_core_total():
     assert np.max(np.abs(r_fc.nuclear - r_ae.nuclear)) < 1e-14
     # freezing changes the correlation (and hence the total) a little, but not wildly
     assert 1e-6 < np.max(np.abs(r_fc.correlation - r_ae.correlation)) < 1e-2
+
+
+# ---- the other properties under the same umbrella ----
+
+def _facade_and_pieces(hf, mp):
+    """Each facade function paired with (HF public method, MP2 correlation method) that
+    reconstruct the physical total, for the composition check."""
+    return [
+        ("dipole",         pycc.dipole(mp),               hf.dipole(),                     mp.relaxed_dipole()),
+        ("gradient",       pycc.gradient(mp),             hf.gradient(),                   mp.gradient()),
+        ("polarizability", pycc.polarizability(mp),       hf.polarizability(),             mp.polarizability()),
+        ("hessian",        pycc.hessian(mp),              hf.hessian(),                    mp.hessian()),
+        ("apt-length",     pycc.apt(mp, 'length'),        hf.dipole_derivatives(),         mp.dipole_derivatives()),
+        ("apt-velocity",   pycc.apt(mp, 'velocity'),      hf.velocity_dipole_derivatives(), mp.velocity_dipole_derivatives()),
+    ]
+
+
+def test_facade_decomposition_and_total():
+    """For every property: PropertyComponents.total == nuclear + reference + correlation, and it
+    equals the physical total (SCF-reference public method + MP2 correlation method)."""
+    hf, mp = _wfns()
+    for name, comp, hf_pub, mp_corr in _facade_and_pieces(hf, mp):
+        assert np.max(np.abs(comp.total - (comp.nuclear + comp.reference + comp.correlation))) < 1e-12, name
+        assert np.max(np.abs(comp.total - (np.asarray(hf_pub) + np.asarray(mp_corr)))) < 1e-10, name
+
+
+def test_facade_hf_wavefunction():
+    """pycc.<property>(HFwfn): correlation is an all-zeros block and the total equals the SCF
+    public method (same shape/type as the MP2 result)."""
+    hf, _ = _wfns()
+    for name, fn, pub in [
+            ("dipole", pycc.dipole, hf.dipole()),
+            ("gradient", pycc.gradient, hf.gradient()),
+            ("polarizability", pycc.polarizability, hf.polarizability()),
+            ("hessian", pycc.hessian, hf.hessian()),
+            ("apt-length", lambda w: pycc.apt(w, 'length'), hf.dipole_derivatives()),
+            ("apt-velocity", lambda w: pycc.apt(w, 'velocity'), hf.velocity_dipole_derivatives())]:
+        r = fn(hf)
+        assert np.all(r.correlation == 0.0), name
+        assert np.max(np.abs(r.total - np.asarray(pub))) < 1e-12, name
+
+
+def test_facade_polarizability_no_nuclear():
+    """The polarizability has no nuclear contribution (pure electronic response)."""
+    _, mp = _wfns()
+    assert np.all(pycc.polarizability(mp).nuclear == 0.0)
+
+
+def test_apt_bad_gauge():
+    """pycc.apt rejects an unknown gauge."""
+    _, mp = _wfns()
+    try:
+        pycc.apt(mp, gauge='nonsense')
+        assert False, "expected ValueError"
+    except ValueError:
+        pass


### PR DESCRIPTION
# Uniform property facade: `pycc.PropertyComponents` + `pycc.aat/apt/dipole/gradient/polarizability/hessian`

## What

A single, wavefunction-type-agnostic interface for every analytic derivative property, returning
its additive physical decomposition:

```python
r = pycc.aat(mp2)                     # or pycc.apt/dipole/gradient/polarizability/hessian
r.total                              # nuclear + reference + correlation
r.nuclear                            # geometry+charge term only
r.reference                          # SCF electronic  (== r.scf == r.hf)
r.correlation                        # post-SCF (MP2) correction; zeros for an HFwfn
r.electronic                         # reference + correlation
```

The same call works for `HFwfn` and `MPwfn` alike (HF's `correlation` is an all-zeros block),
and the pieces are genuinely computed apart — never by subtracting a total.

## API

```python
pycc.dipole(wfn)
pycc.gradient(wfn)
pycc.polarizability(wfn, route='explicit')
pycc.hessian(wfn, route='explicit')
pycc.apt(wfn, gauge='length', route='explicit', orbital_gauge='non-canonical')
pycc.aat(wfn, origin=None, orbital_gauge='non-canonical')
```

`pycc.PropertyComponents` is a frozen dataclass: it stores `nuclear`/`reference`/`correlation`
(+ `origin`) and *derives* `total` and `electronic` so they can never drift out of sync; `scf`/`hf`
alias `reference`. Access is by name only (no array coercion).

Exposed options are limited to those that change the result or the cost:
- **`origin`** (AAT) — physical (origin-dependent tensor); default is the current coordinate origin
  `(0,0,0)` in the input frame (honors `no_com`/`no_reorient`).
- **`gauge='length'|'velocity'`** (APT) — the two APT formulations.
- **`route='explicit'|'2n+1...'`** — MP2 correlation algorithm; identical results, `2n+1` is O(N)
  cheaper (esp. the Hessian).
- **`orbital_gauge='non-canonical'|'canonical'`** (AAT / velocity APT) — **expert only**: the tensor
  is provably invariant to it (~1e-14), so it exists for verification/debugging.

`route`/`orbital_gauge` are MP2-only (the SCF electronic parts are ov-only) and are ignored for an
`HFwfn`. `orbital_gauge` is named distinctly to avoid colliding with the APT length/velocity `gauge`.

## How

- **Un-bundled the nuclear term** from the HF electronic methods (decision "(a)"): each HFwfn
  property method is refactored into a pure-electronic core (`_gradient_electronic`,
  `_dipole_electronic`, `_dipole_derivatives_electronic`, `_hessian_electronic`,
  `_velocity_dipole_derivatives_electronic`, + spin-orbital cores); the public method is
  `core + nuclear`, so **public HF behavior is unchanged** while the facade reads the cores (the
  reference block is computed directly, not subtracted).
- **`MPwfn.atomic_axial_tensors()` and `velocity_dipole_derivatives()` are now correlation-only**
  (drop the reference density / `Zδ`), consistent with the other MP2 correlation methods. Dropping
  the AAT reference is gauge-safe: that block is itself orbital-gauge invariant (the antisymmetric
  magnetic/momentum oo/vv response contracts to zero against the symmetric nuclear response).
- **Nuclear terms are single-sourced** in `properties.py` (`_nuclear_dipole`, `_nuclear_apt`,
  `_nuclear_aat`, grouped in one labeled section) or taken from `Derivatives` (`nuclear_repulsion`,
  `nuclear_repulsion2` for gradient/Hessian).
- **Removed `MPwfn.total_*`** (`total_dipole/gradient/dipole_derivatives/hessian`); callers now use
  the facade `.total`. `_reference_hf` is retained (used by the facade).

## Validation

- Every facade `.total` equals the previous total (HF public method + MP2 correlation method) to
  ≤1e-10; `.total == nuclear + reference + correlation` exactly; polarizability nuclear = 0.
- AAT electronic == the independent apyib reference to ~4e-9 (all-electron and frozen core);
  `reference` == the SCF AAT exactly; correlation gauge-invariant (~9e-16) and SO==spatial.
- HF facade: zero correlation block, `.total` == the HF public method.
- `route` explicit==2n+1 and `orbital_gauge` non-canonical==canonical to machine precision.
- Full property test suite (`test_046`–`test_074`) passes; new `test_074_property_facade.py`.

## Notes / follow-ups

- Extend the facade to `CCwfn` when CC derivative properties exist (add a branch in `_dispatch`/`aat`).
- The AAT non-default-`origin` electronic-gauge shift is a Psi4-level magnetic-dipole-integral
  origin matter, considered out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
