### PR TITLE
Spin-orbital EOM-CCSD, part 1: right-hand roots

### DIFF
--- a/pycc/cceom.py
+++ b/pycc/cceom.py
@@ -65,9 +65,14 @@ class cceom(object):
                 hbar_vir.reshape(-1,1) - hbar_vir)
         self.D = np.hstack((Dia.flatten(), Dijab.flatten()))
 
-        # Get the initial guess for l1 and l2
-        self.l1 = 2.0 * self.ccwfn.t1
-        self.l2 = 2.0 * (2.0 * self.ccwfn.t2 - self.ccwfn.t2.swapaxes(2, 3))
+        # Get the initial guess for l1 and l2.  The spin-orbital seed is l1 = t1, l2 = t2
+        # (the 2*t1 / 2(2*t2 - t2.T) spin-adaptation factors apply only to the spatial path).
+        if self.ccwfn.orbital_basis == 'spinorbital':
+            self.l1 = self.ccwfn.t1.copy()
+            self.l2 = self.ccwfn.t2.copy()
+        else:
+            self.l1 = 2.0 * self.ccwfn.t1
+            self.l2 = 2.0 * (2.0 * self.ccwfn.t2 - self.ccwfn.t2.swapaxes(2, 3))
 
     def solve_eom(self, N: int = 1, e_conv: float = 1e-5, r_conv: float = 1e-5, maxiter: int = 100, guess: str = 'HBAR_SS', eom_type: str = 'RIGHT'):
         """
@@ -220,11 +225,16 @@ class cceom(object):
             s2_len = no * no * nv * nv
             norm_eigvec = []
 
+            so = (self.ccwfn.orbital_basis == 'spinorbital')
             for itm in range(len(R_full)):
                 r1 = R_full[itm, :s1_len]
                 r2 = R_full[itm, s1_len:]
                 r2 = np.reshape(r2, (no,no,nv,nv))
-                norm = 1/np.sqrt(2*np.sum(r1**2) + contract('ijab,ijab->', (2*r2-r2.swapaxes(2,3)), r2))
+                if so:
+                    # spin-orbital metric <R|R> = r1.r1 + 1/4 r2.r2 (antisymmetrized amplitudes)
+                    norm = 1/np.sqrt(np.sum(r1**2) + 0.25*contract('ijab,ijab->', r2, r2))
+                else:
+                    norm = 1/np.sqrt(2*np.sum(r1**2) + contract('ijab,ijab->', (2*r2-r2.swapaxes(2,3)), r2))
                 norm_eigvec.append(R_full[itm]*norm)
 
             return E, norm_eigvec
@@ -265,14 +275,26 @@ class cceom(object):
         # Use CIS eigenvectors
         elif method == 'CIS':
             F = hbar.ccwfn.H.F
-            L = hbar.ccwfn.H.L
-            H = L[v,o,o,v].swapaxes(0,1).swapaxes(0,2).copy()
+            if hbar.ccwfn.orbital_basis == 'spinorbital':
+                # spin-orbital CIS matrix H_{ia,jb} = f_ab d_ij - f_ij d_ab + <aj||ib>,
+                # using the antisymmetrized <pq||rs> (no L, no factor of 2 -- this yields all
+                # spin states, singlets and triplets, not just the spin-adapted singlets)
+                ERI = hbar.ccwfn.H.ERI
+                H = ERI[v,o,o,v].swapaxes(0,1).swapaxes(0,2).copy()
+            else:
+                L = hbar.ccwfn.H.L
+                H = L[v,o,o,v].swapaxes(0,1).swapaxes(0,2).copy()
             H += contract('ab,ij->iajb', F[v,v], np.eye(no))
             H -= contract('ij,ab->iajb', F[o,o], np.eye(nv))
             eps, c = np.linalg.eigh(np.reshape(H, (no*nv,no*nv)))
         # Use eigenvectors of singles-singles block of hbar (mimics Psi4)
         elif method == 'HBAR_SS':
-            H = (2.0 * hbar.Hovvo.swapaxes(1,2).swapaxes(2,3) - hbar.Hovov.swapaxes(1,3)).copy()
+            if hbar.ccwfn.orbital_basis == 'spinorbital':
+                # spin-orbital singles-singles block: single antisymmetrized Hovvo (no Hovov,
+                # no factor of 2)
+                H = hbar.Hovvo.swapaxes(1,2).swapaxes(2,3).copy()
+            else:
+                H = (2.0 * hbar.Hovvo.swapaxes(1,2).swapaxes(2,3) - hbar.Hovov.swapaxes(1,3)).copy()
             H += contract('ab,ij->iajb', hbar.Hvv, np.eye(no))
             H -= contract('ij,ab->iajb', hbar.Hoo, np.eye(nv))
             eps, c = np.linalg.eig(np.reshape(H, (no*nv,no*nv)))
@@ -300,6 +322,8 @@ class cceom(object):
         s1 : NumPy array
             the singles components of sigma
         """
+        if self.ccwfn.orbital_basis == 'spinorbital':
+            return self._so_s_r1(hbar, C1, C2)
         contract = hbar.contract
 
         s1 = contract('ie,ae->ia', C1, hbar.Hvv)
@@ -313,6 +337,18 @@ class cceom(object):
         s1 -= contract('mnie,mnae->ia', hbar.Hooov, C2) * 2.0
         s1 += contract('nmie,mnae->ia', hbar.Hooov, C2)
 
+        return s1.copy()
+
+    def _so_s_r1(self, hbar, C1, C2):
+        """Spin-orbital singles sigma (right), sigma = HBAR * C.  Built from the
+        antisymmetrized spin-orbital HBAR (single Hovvo, no Hovov; <pq||rs> for the ERI)."""
+        contract = hbar.contract
+        s1 = contract('ie,ae->ia', C1, hbar.Hvv)
+        s1 -= contract('mi,ma->ia', hbar.Hoo, C1)
+        s1 += contract('maei,me->ia', hbar.Hovvo, C1)
+        s1 += contract('imae,me->ia', C2, hbar.Hov)
+        s1 += 0.5 * contract('imef,amef->ia', C2, hbar.Hvovv)
+        s1 -= 0.5 * contract('mnie,mnae->ia', hbar.Hooov, C2)
         return s1.copy()
 
 
@@ -331,6 +367,8 @@ class cceom(object):
         s2 : NumPy array
             the doubles components of sigma
         """
+        if self.ccwfn.orbital_basis == 'spinorbital':
+            return self._so_s_r2(hbar, C1, C2)
         contract = hbar.contract
         L = hbar.ccwfn.H.L
         t2 = hbar.ccwfn.t2
@@ -360,14 +398,56 @@ class cceom(object):
 
         return (s2 + s2.swapaxes(0,1).swapaxes(2,3)).copy()
 
+    def _so_s_r2(self, hbar, C1, C2):
+        """Spin-orbital doubles sigma (right), sigma = HBAR * C.  Built already antisymmetric
+        under i<->j and a<->b (explicit permutations), from the antisymmetrized spin-orbital
+        HBAR (single Hovvo, no Hovov) and the <pq||rs> ERI."""
+        contract = hbar.contract
+        ERI = hbar.ccwfn.H.ERI
+        t2 = hbar.ccwfn.t2
+        o = hbar.o
+        v = hbar.v
+
+        # C1-into-doubles coupling intermediates (built from C1 and the C2 x <mn||ef> pieces)
+        Zvv = contract('amef,mf->ae', hbar.Hvovv, C1)
+        Zvv -= 0.5 * contract('mnaf,mnef->ae', C2, ERI[o,o,v,v])
+        Zoo = -contract('mnie,ne->mi', hbar.Hooov, C1)
+        Zoo -= 0.5 * contract('mnef,inef->mi', ERI[o,o,v,v], C2)
+
+        # terms already antisymmetric in the surviving pair get only the other permutation
+        tmp = contract('ie,abej->ijab', C1, hbar.Hvvvo)          # antisym ab (Hvvvo)
+        s2 = tmp - tmp.swapaxes(0,1)
+        tmp = -contract('mbij,ma->ijab', hbar.Hovoo, C1)         # antisym ij (Hovoo)
+        s2 += tmp - tmp.swapaxes(2,3)
+        tmp = contract('ijeb,ae->ijab', t2, Zvv)                 # antisym ij (t2)
+        s2 += tmp - tmp.swapaxes(2,3)
+        tmp = contract('mi,mjab->ijab', Zoo, t2)                 # antisym ab (t2)
+        s2 += tmp - tmp.swapaxes(0,1)
+        tmp = contract('ijeb,ae->ijab', C2, hbar.Hvv)            # antisym ij (C2)
+        s2 += tmp - tmp.swapaxes(2,3)
+        tmp = -contract('mi,mjab->ijab', hbar.Hoo, C2)           # antisym ab (C2)
+        s2 += tmp - tmp.swapaxes(0,1)
+        # fully antisymmetric ladder terms
+        s2 += 0.5 * contract('mnij,mnab->ijab', hbar.Hoooo, C2)
+        s2 += 0.5 * contract('ijef,abef->ijab', C2, hbar.Hvvvv)
+        # ring term: single antisymmetrized Hovvo, full P(ij)P(ab)
+        tmp = contract('imae,mbej->ijab', C2, hbar.Hovvo)
+        s2 += (tmp - tmp.swapaxes(0,1) - tmp.swapaxes(2,3)
+               + tmp.swapaxes(0,1).swapaxes(2,3))
+        return s2.copy()
+
 
     def build_Goo(self, t2, l2):
         contract = self.contract
+        if self.ccwfn.orbital_basis == 'spinorbital':
+            return 0.5 * contract('mnef,inef->mi', t2, l2)
         return contract('mjab,ijab->mi', t2, l2)
 
 
     def build_Gvv(self, t2, l2):
         contract = self.contract
+        if self.ccwfn.orbital_basis == 'spinorbital':
+            return -0.5 * contract('mnef,mnaf->ae', t2, l2)
         return -1.0 * contract('ijeb,ijab->ae', t2, l2)
 
 

--- a/pycc/cceom.py
+++ b/pycc/cceom.py
@@ -74,7 +74,7 @@ class cceom(object):
             self.l1 = 2.0 * self.ccwfn.t1
             self.l2 = 2.0 * (2.0 * self.ccwfn.t2 - self.ccwfn.t2.swapaxes(2, 3))
 
-    def solve_eom(self, N: int = 1, e_conv: float = 1e-5, r_conv: float = 1e-5, maxiter: int = 100, guess: str = 'HBAR_SS', eom_type: str = 'RIGHT'):
+    def solve_eom(self, N: int = 1, e_conv: float = 1e-5, r_conv: float = 1e-5, maxiter: int = 100, guess: str = 'HBAR_SS', eom_type: str = 'RIGHT', root_floor: float = 1e-3):
         """
         Solves the left and right-hand EOM-CC eigenvalue problem using the Davidson algorithm
 
@@ -92,6 +92,10 @@ class cceom(object):
             method to use for computing guess vectors
         eom_type : str
             type of the eienvalue problem to solve, left or right
+        root_floor : float
+            lower bound (hartree) on the real part of an accepted excitation energy; Ritz values
+            below it (the spurious near-zero manifold) are skipped during root selection. Relevant
+            mainly to the spin-orbital path, whose redundant doubles produce many ~0 eigenvalues.
 
         Returns
         -------
@@ -180,8 +184,17 @@ class cceom(object):
                 G = S @ C.T
                 E, a = scipy.linalg.eig(G, left=True,right=False)
 
-            # Sort eigenvalues and corresponding eigenvectors into ascending order
-            idx = E.argsort()[:N]
+            # Select the N target roots.  Physical EOM excitation energies are real and positive;
+            # skip the spurious near-zero manifold (the redundant, non-antisymmetric doubles
+            # components -- ~0 eigenvalues, far more numerous in the spin-orbital basis) and any
+            # complex Ritz values, then take the N smallest of what remains.  Early iterations may
+            # expose fewer than N physical roots, so pad with the next-smallest by real part to
+            # keep N correction vectors flowing.
+            order = E.real.argsort()
+            physical = [i for i in order if abs(E[i].imag) < 1e-6 and E[i].real > root_floor]
+            if len(physical) < N:
+                physical += [i for i in order if i not in physical]
+            idx = np.array(physical[:N])
             E = E[idx]; a = a[:,idx]
 
             # Build correction vectors
@@ -193,7 +206,7 @@ class cceom(object):
             dE = E - E_old
             print("             E/state                   dE                 norm")
             for state in range(N):
-                print("%20.12f %20.12f %20.12f" % (E[state], dE[state], r_norm[state]))
+                print("%20.12f %20.12f %20.12f" % (E[state].real, dE[state].real, r_norm[state]))
 
             if (np.abs(np.linalg.norm(dE)) <= e_conv):
                 converged = True
@@ -298,6 +311,12 @@ class cceom(object):
             H += contract('ab,ij->iajb', hbar.Hvv, np.eye(no))
             H -= contract('ij,ab->iajb', hbar.Hoo, np.eye(nv))
             eps, c = np.linalg.eig(np.reshape(H, (no*nv,no*nv)))
+            # The HBAR singles block is non-Hermitian, so eig can return complex conjugate
+            # eigenpairs for (near-)degenerate roots (e.g. the spin-orbital triplets). Keep the
+            # real span: complex guess vectors otherwise seed spurious near-zero roots in the
+            # Davidson. The real parts of a conjugate pair span the same real subspace, and the
+            # QR orthonormalization in solve_eom removes any resulting redundancy.
+            eps = eps.real; c = c.real
             idx = eps.argsort()
             eps = eps[idx]; c = c[:,idx]
 

--- a/pycc/cceom.py
+++ b/pycc/cceom.py
@@ -230,7 +230,7 @@ class cceom(object):
             print("-----  ------------  ------------")
             eVconv = psi4.qcel.constants.get("hartree energy in ev")
             for state in range(N):
-                print("  %3d  %12.10f  %12.10f" %(state, E[state], E[state]*eVconv))
+                print("  %3d  %12.10f  %12.10f" %(state, E[state].real, E[state].real*eVconv))
 
             # Build converged eigenvectors (R vectors) from Krylov basis
             R_full = a.T @ C  # shape (N, s1_len + s2_len)

--- a/pycc/tests/test_075_spinorbital_eomccsd.py
+++ b/pycc/tests/test_075_spinorbital_eomccsd.py
@@ -1,0 +1,96 @@
+"""
+Spin-orbital EOM-CCSD (right-hand roots).
+
+The spin-orbital sigma vectors (cceom._so_s_r1 / _so_s_r2) extend the RHF EOM-CCSD code to
+UHF/ROHF references. Two validations, mirroring the spin-orbital idiom used elsewhere in the
+suite:
+
+1. Closed-shell keystone (iterative): a closed-shell RHF run through the spin-orbital path must
+   reproduce every spatial (spin-adapted singlet) excitation energy, and additionally produce the
+   lower-lying triplet roots that the spin-adapted path cannot represent.
+
+2. Open-shell sigma vs psi4 (dense): for the OH radical (UHF) the spin-orbital sigma operator,
+   diagonalized densely, reproduces psi4's UHF-EOM-CCSD roots. The dense check validates the sigma
+   physics directly, independent of the iterative Davidson (whose robust resolution of the
+   near-degenerate open-shell roots is a separate block-Davidson upgrade, PR2).
+"""
+
+import psi4
+import pycc
+import numpy as np
+
+
+OH = """
+0 2
+O  0.000000  0.000000  0.000000
+H  0.000000  0.000000  0.969000
+symmetry c1
+"""
+
+H2O = """
+O
+H 1 0.96
+H 1 0.96 2 104.5
+symmetry c1
+"""
+
+
+def _eom(wfn, orbital_basis):
+    cc = pycc.ccwfn(wfn, orbital_basis=orbital_basis, frozen_core=False)
+    cc.solve_cc(1e-11, 1e-11, 75)
+    return cc, pycc.cceom(cc, pycc.cchbar(cc))
+
+
+def _dense_so_spectrum(eom):
+    """Excitation energies from a dense diagonalization of the spin-orbital sigma operator
+    (built column by column from _so_s_r1 / _so_s_r2), keeping the real, positive roots."""
+    cc = eom.ccwfn
+    no, nv = cc.no, cc.nv
+    n1 = no * nv
+    n = n1 + n1 * n1
+    H = np.zeros((n, n))
+    for k in range(n):
+        vec = np.zeros(n); vec[k] = 1.0
+        C1 = vec[:n1].reshape(no, nv)
+        C2 = vec[n1:].reshape(no, no, nv, nv)
+        H[:n1, k] = eom.s_r1(eom.hbar, C1, C2).ravel()
+        H[n1:, k] = eom.s_r2(eom.hbar, C1, C2).ravel()
+    E = np.linalg.eigvals(H)
+    E = np.sort(E[np.abs(E.imag) < 1e-8].real)
+    return E[E > 1e-3]
+
+
+def test_so_eom_closed_shell_keystone(rhf_wfn):
+    """Closed-shell H2O/STO-3G: the spin-orbital EOM spectrum contains every spatial (spin-adapted
+    singlet) root, plus lower-lying triplets. The spatial singlets come from the (robust) iterative
+    solver; the full spin-orbital spectrum from a dense diagonalization (the triplets interleave the
+    singlets, so covering all singlets iteratively would need many roots)."""
+    wfn = rhf_wfn(H2O, "STO-3G", freeze_core="false")
+    _, eom_s = _eom(wfn, "spatial")
+    _, eom_o = _eom(wfn, "spinorbital")
+
+    E_spatial = np.sort(eom_s.solve_eom(3, 1e-6, 1e-6, 150, "cis", "right")[0].real)
+    E_so = _dense_so_spectrum(eom_o)
+
+    # every spatial singlet root appears in the spin-orbital spectrum
+    for e in E_spatial:
+        assert np.min(np.abs(E_so - e)) < 1e-5, (e, E_so[:12])
+    # the spin-orbital path also finds lower roots (the triplets) the spatial path cannot
+    assert E_so.min() < E_spatial.min() - 1e-3
+
+    # the iterative spin-orbital solver reproduces the lowest (triplet) root
+    E_iter = np.sort(eom_o.solve_eom(4, 1e-6, 1e-6, 150, "cis", "right")[0].real)
+    assert abs(E_iter.min() - E_so.min()) < 1e-5
+
+
+def test_so_eom_sigma_vs_psi4_uhf(uhf_wfn):
+    """Open-shell OH/UHF/STO-3G: the dense spin-orbital EOM spectrum reproduces psi4's
+    UHF-EOM-CCSD roots (the sigma physics, independent of the iterative solver)."""
+    wfn = uhf_wfn(OH, "STO-3G", freeze_core="false")
+    _, eom = _eom(wfn, "spinorbital")
+    E = _dense_so_spectrum(eom)
+
+    # psi4 UHF-EOM-CCSD roots for this geometry (energy('eom-ccsd'), reference uhf)
+    psi4_roots = [0.224266, 0.404873]
+    for e in psi4_roots:
+        assert np.min(np.abs(E - e)) < 1e-5, (e, E[:8])


### PR DESCRIPTION
# Spin-orbital EOM-CCSD, part 1: right-hand roots

Extends the RHF-only EOM-CCSD code to UHF/ROHF references via a spin-orbital path, dispatched on
`ccwfn.orbital_basis` (the same idiom cclambda/ccresponse use). This PR covers the **right-hand**
eigenvectors; the left-hand sigma and a block Davidson for robust open-shell iterative convergence
follow in PR2.

## What

- **Spin-orbital right-hand sigma** — `cceom._so_s_r1` / `_so_s_r2`, built from the antisymmetrized
  `<pq||rs>` HBAR (single `Hovvo`, no `Hovov`; `0.5` on the doubles contractions; explicit
  `P(ij)P(ab)`). `s_r1`/`s_r2` dispatch to them when `orbital_basis == 'spinorbital'`.
- **Supporting spin-orbital paths** — CIS and HBAR_SS guesses, the `l1`/`l2` seed (`t1`/`t2`), the
  eigenvector normalization (`<R|R> = r1.r1 + 1/4 r2.r2`), and `0.5`-factor `build_Goo`/`build_Gvv`
  (used by the forthcoming left path).
- **Davidson robustness (helps both bases)** —
  - real-ify the HBAR_SS guess: the non-Hermitian singles block gives complex conjugate eigenpairs
    for the (near-)degenerate spin-orbital triplets, and the complex guess vectors seeded a spurious
    near-zero root; keep the real span.
  - `root_floor` guard (default `1e-3`): skip the spurious near-zero manifold (the redundant,
    non-antisymmetric doubles — many more `~0` eigenvalues in the spin-orbital basis) and complex
    Ritz values during root selection.

## Validation (`test_075`)

- **Closed-shell keystone** (H2O/STO-3G): every spatial spin-adapted singlet root appears in the
  spin-orbital spectrum, which additionally carries the lower-lying triplets the spin-adapted path
  cannot represent; the iterative spin-orbital solver reproduces the lowest (triplet) root.
- **Open-shell sigma vs psi4** (OH/UHF/STO-3G): a dense diagonalization of the spin-orbital sigma
  reproduces psi4's UHF-EOM-CCSD roots (0.224266, 0.404873) — validating the sigma physics directly,
  independent of the iterative Davidson.
- Spatial EOM (`test_043`) is unregressed.

The closed-shell iterative path converges for all three guesses at N = 1, 3, 4, 6 (triplet 0.394601
+ singlet 0.454230).

## Deferred to PR2

The open-shell **iterative** path converges the lowest root but a single-vector Davidson cannot
resolve the near-degenerate excited pairs of an open-shell radical (e.g. OH's 0.223912 / 0.224303).
The sigma is exact there (the dense check confirms it); robust open-shell iterative roots need a
**block/robust Davidson**, which PR2 adds alongside the left-hand sigma.

## Files

- `pycc/cceom.py` (+125/−13)
- `pycc/tests/test_075_spinorbital_eomccsd.py` (+96)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
