### PR TITLE
CCSD analytic nuclear gradients (spatial closed-shell) + a downstream derivative driver

### DIFF
--- a/pycc/__init__.py
+++ b/pycc/__init__.py
@@ -17,9 +17,13 @@ from .ccresponse import ccresponse
 from .ccresponse import pertbar
 from pycc.rt.rtcc import rtcc
 from .cceom import cceom
-from .properties import PropertyComponents, aat, apt, dipole, gradient, hessian, polarizability
+from .ccderiv import CCderiv
+from .properties import PropertyComponents, aat, apt, dipole, gradient, hessian, polarizability, register_deriv
 
-__all__ = ['CCwfn', 'ccwfn', 'MPwfn', 'HFwfn', 'CIwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom', 'PropertyComponents', 'aat', 'apt', 'dipole', 'gradient', 'hessian', 'polarizability']
+# Route the property facade's correlation-derivative calls for a CCwfn to its downstream driver.
+register_deriv(CCwfn, CCderiv)
+
+__all__ = ['CCwfn', 'ccwfn', 'MPwfn', 'HFwfn', 'CIwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom', 'CCderiv', 'PropertyComponents', 'aat', 'apt', 'dipole', 'gradient', 'hessian', 'polarizability']
 
 # Handle versioneer
 from ._version import get_versions

--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -222,6 +222,40 @@ class ccdensity(object):
         else:
             return opdm
 
+    def gradient_densities(self):
+        """Full-MO one- and two-particle correlation densities for the analytic gradient:
+        ``D`` (``nmo x nmo``) and ``Gamma`` (``nmo^4``, physicist ``<pq|rs>`` ordering).
+
+        The convention is the one the density-based gradient machinery assumes -- **no prefactor**
+        on the two-particle term -- so the two-electron correlation energy is
+        ``contract(Gamma, ERI)`` and the total correlation energy is
+        ``contract(D, F) + contract(Gamma, ERI)`` (cf. :meth:`compute_energy`).
+
+        ``D`` places the ``Doo``/``Dov``/``Dvo``/``Dvv`` blocks; ``Gamma`` places the six unique
+        blocks and their bra-ket (``rspq``) conjugate images with the per-block factors that make
+        the full contraction reproduce the block-weighted energy of :meth:`compute_energy`
+        (self-conjugate ``oooo``/``vvvv``/``ovov`` vs the conjugate pairs ``oovv``/``ooov``/``vvvo``).
+        The densities are placed on the active ``o``/``v`` slices (frozen-core rows/columns stay
+        zero).  Spatial (closed-shell) only, matching the two-particle density."""
+        if self.onlyone:
+            raise RuntimeError("gradient_densities needs the two-particle density "
+                               "(construct ccdensity with onlyone=False).")
+        ccwfn = self.ccwfn
+        o, v, nmo = ccwfn.o, ccwfn.v, ccwfn.nmo
+        D = zeros((nmo, nmo), like=self.Doo)
+        D[o, o] = self.Doo; D[v, v] = self.Dvv; D[o, v] = self.Dov; D[v, o] = self.Dvo
+        G = zeros((nmo, nmo, nmo, nmo), like=self.Doo)
+        G[o, o, o, o] = 0.5 * self.Doooo
+        G[v, v, v, v] = 0.5 * self.Dvvvv
+        G[o, v, o, v] = self.Dovov
+        G[o, o, v, v] = 0.25 * self.Doovv
+        G[v, v, o, o] = 0.25 * self.Doovv.transpose(2, 3, 0, 1)
+        G[o, o, o, v] = 0.5 * self.Dooov
+        G[o, v, o, o] = 0.5 * self.Dooov.transpose(2, 3, 0, 1)
+        G[v, v, v, o] = 0.5 * self.Dvvvo
+        G[v, o, v, v] = 0.5 * self.Dvvvo.transpose(2, 3, 0, 1)
+        return D, G
+
     def dipole(self, t1, t2, l1, l2):
         """Correlated (CC) contribution to the electric dipole moment.
 

--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -231,12 +231,23 @@ class ccdensity(object):
         ``contract(Gamma, ERI)`` and the total correlation energy is
         ``contract(D, F) + contract(Gamma, ERI)`` (cf. :meth:`compute_energy`).
 
-        ``D`` places the ``Doo``/``Dov``/``Dvo``/``Dvv`` blocks; ``Gamma`` places the six unique
-        blocks and their bra-ket (``rspq``) conjugate images with the per-block factors that make
-        the full contraction reproduce the block-weighted energy of :meth:`compute_energy`
-        (self-conjugate ``oooo``/``vvvv``/``ovov`` vs the conjugate pairs ``oovv``/``ooov``/``vvvo``).
-        The densities are placed on the active ``o``/``v`` slices (frozen-core rows/columns stay
-        zero).  Spatial (closed-shell) only, matching the two-particle density."""
+        ``D`` places the ``Doo``/``Dov``/``Dvo``/``Dvv`` blocks; ``Gamma`` places the six stored
+        blocks and their bra-ket (``rspq``) images with per-block factors, then applies the four-fold
+        permutational symmetrization ``Gamma <- 1/4 (Gamma + Gamma_qpsr + Gamma_rspq + Gamma_srqp)``
+        so the result carries the proper spatial 2-PDM symmetry (``Gamma_pqrs = Gamma_rspq =
+        Gamma_qpsr``).  This matters: the two-particle density stored here (:meth:`compute_energy`
+        and the density builders) keeps only asymmetric *representatives* of each block --
+        e.g. ``Doovv`` holds only the ``l2`` piece while the ``vvoo`` partner (``t2 + t1 t1 + ...``)
+        is folded in under the implicit assumption of a subsequent contraction against a *symmetric*
+        quantity (the ERIs, in the energy).  A full 4-index energy/gradient contraction against the
+        (8-fold-symmetric) ``<pq|rs>`` only sees the symmetric projection, so the energy and the
+        explicit-derivative gradient are insensitive to the missing symmetry.  But the
+        generalized-Fock term ``4 sum_rst <pr|st> Gamma_qrst`` contracts only three indices and
+        *does* require it -- so the Z-vector gradient needs the symmetrized ``Gamma`` here.  The
+        symmetrization is energy-preserving (the antisymmetric complement contracts to zero against
+        the symmetric ERI).  (A future re-derivation of the ccdensity 2-PDM equations could carry
+        this symmetry natively.)  Densities are placed on the active ``o``/``v`` slices (frozen-core
+        rows/columns stay zero).  Spatial (closed-shell) only."""
         if self.onlyone:
             raise RuntimeError("gradient_densities needs the two-particle density "
                                "(construct ccdensity with onlyone=False).")
@@ -254,6 +265,7 @@ class ccdensity(object):
         G[o, v, o, o] = 0.5 * self.Dooov.transpose(2, 3, 0, 1)
         G[v, v, v, o] = 0.5 * self.Dvvvo
         G[v, o, v, v] = 0.5 * self.Dvvvo.transpose(2, 3, 0, 1)
+        G = 0.25 * (G + G.transpose(1, 0, 3, 2) + G.transpose(2, 3, 0, 1) + G.transpose(3, 2, 1, 0))
         return D, G
 
     def dipole(self, t1, t2, l1, l2):

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -1,0 +1,102 @@
+"""Analytic derivative properties of a coupled-cluster wavefunction.
+
+`CCderiv` is the downstream derivative driver for a converged :class:`~pycc.ccwfn.CCwfn`, sitting
+at the end of the chain ``ccwfn -> cchbar -> cclambda -> ccdensity``: it lazily builds the Lambda
+amplitudes and reduced densities it needs and assembles the analytic gradient (Hessian, APTs, etc.
+to follow).  Keeping this out of `CCwfn` respects the layering -- `cclambda`/`ccdensity` are
+downstream of `ccwfn`, so the wavefunction never reaches forward to build them.  The
+:mod:`pycc.properties` facade routes ``pycc.gradient(ccwfn)`` here (see its registry).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from .ccwfn import CCwfn
+
+
+class CCderiv:
+    """Analytic derivative properties of a converged CCSD wavefunction.
+
+    Parameters
+    ----------
+    ccwfn : CCwfn
+        A converged coupled-cluster wavefunction (call :meth:`CCwfn.solve_cc` first).
+
+    Notes
+    -----
+    Spatial (closed-shell RHF) path only for now -- the spin-orbital two-particle density is not
+    yet implemented.  Lambda and the reduced densities are solved/built on first use and cached.
+    """
+
+    def __init__(self, ccwfn: "CCwfn") -> None:
+        self.ccwfn = ccwfn
+        self.contract = ccwfn.contract
+        self._dens = None
+        self._ref_hf = None
+
+    def _density(self):
+        """Converged Lambda amplitudes and the (Lambda-response) reduced densities, cached.
+        Builds ``cchbar`` -> ``cclambda`` (solved) -> ``ccdensity`` on first use."""
+        if self._dens is None:
+            from .cchbar import cchbar
+            from .cclambda import cclambda
+            from .ccdensity import ccdensity
+            hbar = cchbar(self.ccwfn)
+            lam = cclambda(self.ccwfn, hbar)
+            lam.solve_lambda(e_conv=1e-10, r_conv=1e-10)
+            self._dens = ccdensity(self.ccwfn, lam)
+        return self._dens
+
+    def _reference_hf(self):
+        """The all-electron :class:`~pycc.hfwfn.HFwfn` for the SCF reference (cached), supplying
+        the reference gradient for the total CCSD property (the :func:`pycc.gradient` facade pairs
+        it with this correlation gradient and the nuclear term)."""
+        if self._ref_hf is None:
+            from .hfwfn import HFwfn
+            self._ref_hf = HFwfn(self.ccwfn.ref, orbital_basis=self.ccwfn.orbital_basis)
+        return self._ref_hf
+
+    def gradient(self) -> np.ndarray:
+        """CCSD **correlation** contribution to the analytic nuclear energy gradient (a.u.), shape
+        ``(natom, 3)``, via the **explicit-derivative route**::
+
+            dE_corr/dX = sum_pq D_pq (d_X f)_pq + sum_pqrs Gamma_pqrs (d_X <pq|rs>)
+
+        The CCSD Lambda-response 1- and 2-particle densities
+        (:meth:`ccdensity.gradient_densities`, no-prefactor convention) are contracted with the
+        CPHF-folded perturbed integrals (:meth:`CPHF.perturbed_fock` / :meth:`CPHF.perturbed_eri`)
+        -- one nuclear CPHF solve per perturbation (``3*natom``), the orbital relaxation riding
+        inside ``d_X f`` / ``d_X <pq|rs>`` rather than in a Z-vector.  The perturbed-integral
+        engine is the one built for the MP2 gradient (:meth:`MPwfn._full_occ_cphf`, shared through
+        ``ccwfn.mp``).
+
+        The **reference (SCF) gradient is kept separate** (as for MP2): the total CCSD gradient is
+        ``HFwfn(ref).gradient()`` plus this, assembled by the :func:`pycc.gradient` facade.
+
+        Spatial (closed-shell RHF) path only for now; all-electron.  Validated against
+        ``psi4.gradient('ccsd')`` and a finite difference of the CCSD energy.  This "simple but
+        inefficient" route is the analog of :meth:`MPwfn._corr_gradient_explicit`; the Z-vector
+        (relaxed-density) route is the efficient alternative (in development)."""
+        from .cphf import Perturbation
+        cc = self.ccwfn
+        if cc.orbital_basis != 'spatial':
+            raise NotImplementedError(
+                "The CCSD analytic gradient currently requires the spatial (closed-shell RHF) "
+                "path; the spin-orbital two-particle density is not yet implemented.")
+        D, Gam = self._density().gradient_densities()
+        cphf = cc.mp._full_occ_cphf()
+        ncore = cc.o.stop - cc.no
+        c = self.contract
+        natom = cc.derivatives.natom
+        grad = np.zeros((natom, 3))
+        for atom in range(natom):
+            for cart in range(3):
+                pert = Perturbation('nuclear', (atom, cart))
+                df = np.asarray(cphf.perturbed_fock(pert, ncore))
+                deri = np.asarray(cphf.perturbed_eri(pert, ncore))
+                grad[atom, cart] = (c('pq,pq->', D, df) + c('pqrs,pqrs->', Gam, deri))
+        return grad

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -88,23 +88,41 @@ class CCderiv:
         The **reference (SCF) gradient is kept separate**: the total CCSD gradient is
         ``HFwfn(ref).gradient()`` plus this, assembled by the :func:`pycc.gradient` facade.
 
-        Spatial (closed-shell RHF) path only for now; all-electron.  Validated against
-        ``psi4.gradient('ccsd')``, a finite difference of the CCSD energy, and the independent
-        explicit-derivative route (:meth:`_gradient_explicit`)."""
+        Spatial (closed-shell RHF) path only for now; all-electron and frozen-core.  Validated
+        against ``psi4.gradient('ccsd')``, a finite difference of the CCSD energy, and the
+        independent explicit-derivative route (:meth:`_gradient_explicit`).
+
+        Frozen core is handled as in the MP2 gradient: the correlation densities live in the active
+        space while the orbital response spans the full occupied space.  The core<->active-occupied
+        rotation is a direct divide ``P_co = (I'_ci - I'_ic)/(eps_c - eps_i)`` (the SCF energy is
+        invariant to occupied-occupied rotations), coupled into the Z-vector right-hand side."""
         cc = self.ccwfn
         if cc.orbital_basis != 'spatial':
             raise NotImplementedError(
                 "The CCSD analytic gradient currently requires the spatial (closed-shell RHF) "
                 "path; the spin-orbital two-particle density is not yet implemented.")
         o, v = cc.o, cc.v
+        nfzc = cc.nfzc
+        co = slice(0, nfzc)                              # frozen-core occupied
+        ofull = slice(0, o.stop)                         # full occupied (core + active)
         c = self.contract
+        eps = np.diag(np.asarray(cc.H.F))
+        L = np.asarray(cc.H.L)
         D, Gam = self._density().gradient_densities()
         Ip = self._lagrangian(D, Gam)
-        X = Ip[o, v] - Ip[v, o].T                       # ov-antisymmetric generalized Fock
-        z = self._reference_hf().cphf.solve(X)          # Z-vector: A z = X (SCF orbital Hessian)
         Drel = D.copy()
-        Drel[v, o] += -z.T
-        Drel[o, v] += -z
+        if nfzc:                                         # core<->active-occupied: direct divide
+            Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
+            Drel[co, o] += Pco
+            Drel[o, co] += Pco.T
+        X = Ip[ofull, v] - Ip[v, ofull].T               # ov-antisymmetric generalized Fock (full occ)
+        if nfzc:                                         # couple P_co into the Z-vector RHS
+            zjc = -Pco.T
+            X = X - (c('jc,ajic->ia', zjc, L[v, o, ofull, co])
+                     + c('jc,acij->ia', zjc, L[v, co, ofull, o]))
+        z = self._reference_hf().cphf.solve(X)          # Z-vector: A z = X (full-occ SCF Hessian)
+        Drel[v, ofull] += -z.T
+        Drel[ofull, v] += -z
         W = self._lagrangian(Drel, Gam)                 # energy-weighted density
         d = cc.derivatives
         grad = np.zeros((d.natom, 3))
@@ -113,7 +131,7 @@ class CCderiv:
             for cart in range(3):
                 phys = ERIx[cart].transpose(0, 2, 1, 3)                 # chemist -> physicist <pq|rs>^X
                 Lx = 2.0 * phys - phys.transpose(0, 1, 3, 2)
-                fx = hx[cart] + c('pmqm->pq', Lx[:, o, :, o])           # skeleton Fock derivative
+                fx = hx[cart] + c('pmqm->pq', Lx[:, ofull, :, ofull])   # skeleton Fock deriv (full occ)
                 grad[atom, cart] = (c('pq,pq->', Drel, fx)
                                     + c('pqrs,pqrs->', Gam, phys)
                                     + c('pq,pq->', W, Sx[cart]))

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -60,33 +60,80 @@ class CCderiv:
             self._ref_hf = HFwfn(self.ccwfn.ref, orbital_basis=self.ccwfn.orbital_basis)
         return self._ref_hf
 
+    def _lagrangian(self, D, Gam):
+        """The generalized-Fock (orbital-gradient) Lagrangian ``I'_pq`` from a full-MO 1-PDM ``D``
+        and 2-PDM ``Gam`` -- reused verbatim from the MP2 gradient machinery (it is generic in the
+        densities: ``-1/2 [ eps_p(D_pq+D_qp) + delta_{q,occ} sum_rs D_rs(<rp|sq>_L + <rq|sp>_L)
+        + 4 sum_rst <pr|st> Gam_qrst ]``).  Its ov-antisymmetric part is the Z-vector RHS; evaluated
+        at the relaxed density it is the energy-weighted density.  ``Gam`` must carry the proper
+        2-PDM permutational symmetry (:meth:`ccdensity.gradient_densities` symmetrizes it), since
+        the three-index ``termC`` is sensitive to it.  (When an MPderiv is split out this shared
+        primitive will move with it.)"""
+        return self.ccwfn.mp._mp2_lagrangian(D, Gam)
+
     def gradient(self) -> np.ndarray:
         """CCSD **correlation** contribution to the analytic nuclear energy gradient (a.u.), shape
-        ``(natom, 3)``, via the **explicit-derivative route**::
+        ``(natom, 3)``, via the **Z-vector (relaxed-density) route** -- the efficient default
+        (one CPHF solve, not ``3*natom``)::
 
-            dE_corr/dX = sum_pq D_pq (d_X f)_pq + sum_pqrs Gamma_pqrs (d_X <pq|rs>)
+            dE_corr/dX = sum_pq D~_pq f^X_pq + sum_pqrs Gamma_pqrs <pq|rs>^X + sum_pq W_pq S^X_pq
 
-        The CCSD Lambda-response 1- and 2-particle densities
-        (:meth:`ccdensity.gradient_densities`, no-prefactor convention) are contracted with the
-        CPHF-folded perturbed integrals (:meth:`CPHF.perturbed_fock` / :meth:`CPHF.perturbed_eri`)
-        -- one nuclear CPHF solve per perturbation (``3*natom``), the orbital relaxation riding
-        inside ``d_X f`` / ``d_X <pq|rs>`` rather than in a Z-vector.  The perturbed-integral
-        engine is the one built for the MP2 gradient (:meth:`MPwfn._full_occ_cphf`, shared through
-        ``ccwfn.mp``).
+        with the relaxed 1-PDM ``D~`` (the Lambda-response ``D`` plus the orbital-relaxation
+        Z-vector ``z``), the (symmetrized) 2-PDM ``Gamma``, and the energy-weighted density
+        ``W = I'(D~)`` (:meth:`_lagrangian`).  The Z-vector solves ``A z = X`` once, with
+        ``X = I'_ia - I'_ai`` the ov-antisymmetric generalized Fock, using the SCF orbital Hessian
+        (:meth:`HFwfn.cphf`).  ``f^X``/``S^X``/``<pq|rs>^X`` are the skeleton derivative integrals
+        from ``ccwfn.derivatives`` (no per-perturbation CPHF solve).
 
-        The **reference (SCF) gradient is kept separate** (as for MP2): the total CCSD gradient is
+        The **reference (SCF) gradient is kept separate**: the total CCSD gradient is
         ``HFwfn(ref).gradient()`` plus this, assembled by the :func:`pycc.gradient` facade.
 
         Spatial (closed-shell RHF) path only for now; all-electron.  Validated against
-        ``psi4.gradient('ccsd')`` and a finite difference of the CCSD energy.  This "simple but
-        inefficient" route is the analog of :meth:`MPwfn._corr_gradient_explicit`; the Z-vector
-        (relaxed-density) route is the efficient alternative (in development)."""
-        from .cphf import Perturbation
+        ``psi4.gradient('ccsd')``, a finite difference of the CCSD energy, and the independent
+        explicit-derivative route (:meth:`_gradient_explicit`)."""
         cc = self.ccwfn
         if cc.orbital_basis != 'spatial':
             raise NotImplementedError(
                 "The CCSD analytic gradient currently requires the spatial (closed-shell RHF) "
                 "path; the spin-orbital two-particle density is not yet implemented.")
+        o, v = cc.o, cc.v
+        c = self.contract
+        D, Gam = self._density().gradient_densities()
+        Ip = self._lagrangian(D, Gam)
+        X = Ip[o, v] - Ip[v, o].T                       # ov-antisymmetric generalized Fock
+        z = self._reference_hf().cphf.solve(X)          # Z-vector: A z = X (SCF orbital Hessian)
+        Drel = D.copy()
+        Drel[v, o] += -z.T
+        Drel[o, v] += -z
+        W = self._lagrangian(Drel, Gam)                 # energy-weighted density
+        d = cc.derivatives
+        grad = np.zeros((d.natom, 3))
+        for atom in range(d.natom):
+            hx = d.core(atom); Sx = d.overlap(atom); ERIx = d.eri(atom)
+            for cart in range(3):
+                phys = ERIx[cart].transpose(0, 2, 1, 3)                 # chemist -> physicist <pq|rs>^X
+                Lx = 2.0 * phys - phys.transpose(0, 1, 3, 2)
+                fx = hx[cart] + c('pmqm->pq', Lx[:, o, :, o])           # skeleton Fock derivative
+                grad[atom, cart] = (c('pq,pq->', Drel, fx)
+                                    + c('pqrs,pqrs->', Gam, phys)
+                                    + c('pq,pq->', W, Sx[cart]))
+        return grad
+
+    def _gradient_explicit(self) -> np.ndarray:
+        """CCSD correlation gradient via the **explicit-derivative route** -- an independent
+        cross-check of :meth:`gradient`::
+
+            dE_corr/dX = sum_pq D_pq (d_X f)_pq + sum_pqrs Gamma_pqrs (d_X <pq|rs>)
+
+        The Lambda-response densities are contracted with the CPHF-folded perturbed integrals
+        (:meth:`CPHF.perturbed_fock` / :meth:`CPHF.perturbed_eri`), the orbital relaxation riding
+        inside ``d_X f`` / ``d_X <pq|rs>`` -- one nuclear CPHF solve per perturbation (the "simple
+        but inefficient" form, analog of :meth:`MPwfn._corr_gradient_explicit`).  Same result as
+        :meth:`gradient` (which uses the single Z-vector solve)."""
+        from .cphf import Perturbation
+        cc = self.ccwfn
+        if cc.orbital_basis != 'spatial':
+            raise NotImplementedError("Explicit CCSD gradient: spatial (closed-shell) only.")
         D, Gam = self._density().gradient_densities()
         cphf = cc.mp._full_occ_cphf()
         ncore = cc.o.stop - cc.no

--- a/pycc/properties.py
+++ b/pycc/properties.py
@@ -104,23 +104,44 @@ def _nuclear_aat(mol, origin) -> np.ndarray:
 # Property facade: dispatch on wavefunction type, assemble the PropertyComponents decomposition.
 # ------------------------------------------------------------------------------------------------
 
-def _dispatch(wfn, hf_method, mp_method, mp_kwargs=None):
-    """Reference (SCF electronic) and correlation blocks of a property, computed apart.  For an
-    ``MPwfn`` the reference is the all-electron SCF value (``_reference_hf()``) and the correlation
-    is the MP2 correlation-only method (called with ``mp_kwargs`` -- ``route``/``gauge`` are
-    MP2-only knobs the SCF reference does not take); for an ``HFwfn`` the reference is the SCF
-    value and the correlation is an all-zeros array of the same shape (``mp_kwargs`` do not
-    apply -- there is no correlation)."""
+# Registry mapping a wavefunction class to its downstream derivative-driver class (the strategy
+# that carries the correlation-property methods, e.g. CCwfn -> CCderiv).  Populated at import
+# (pycc/__init__.py).  A wfn class absent from the registry is treated as carrying its correlation
+# methods itself (the current MPwfn, until an MPderiv is split out) -- see _correlated.
+_DERIV_REGISTRY: dict = {}
+
+
+def register_deriv(wfn_cls, deriv_cls) -> None:
+    """Register ``deriv_cls`` as the derivative driver for wavefunctions of type ``wfn_cls``."""
+    _DERIV_REGISTRY[wfn_cls] = deriv_cls
+
+
+def _correlated(wfn):
+    """For a correlated wavefunction, return ``(reference_hf, target)``: the SCF-reference
+    ``HFwfn`` that carries the reference derivative, and the object that carries the correlation
+    derivative methods -- the registered derivative driver (``deriv_cls(wfn)``) if one exists,
+    else the wavefunction itself (transitional, while a method type's derivative code still lives
+    on its wfn class)."""
+    deriv_cls = _DERIV_REGISTRY.get(type(wfn))
+    if deriv_cls is not None:
+        target = deriv_cls(wfn)
+        return target._reference_hf(), target
+    return wfn._reference_hf(), wfn
+
+
+def _dispatch(wfn, hf_method, corr_method, corr_kwargs=None):
+    """Reference (SCF electronic) and correlation blocks of a property, computed apart.  For a
+    correlated wavefunction the reference is the all-electron SCF value and the correlation comes
+    from its derivative driver (:func:`_correlated`), called with ``corr_kwargs`` (``route`` /
+    ``gauge`` knobs the SCF reference does not take).  For an ``HFwfn`` the reference is the SCF
+    value and the correlation is an all-zeros array of the same shape."""
     from .hfwfn import HFwfn
-    from .mpwfn import MPwfn
-    if isinstance(wfn, MPwfn):
-        reference = np.asarray(getattr(wfn._reference_hf(), hf_method)())
-        correlation = np.asarray(getattr(wfn, mp_method)(**(mp_kwargs or {})))
-    elif isinstance(wfn, HFwfn):
+    if isinstance(wfn, HFwfn):
         reference = np.asarray(getattr(wfn, hf_method)())
-        correlation = np.zeros_like(reference)
-    else:
-        raise TypeError(f"unsupported wavefunction type {type(wfn).__name__!r}")
+        return reference, np.zeros_like(reference)
+    reference_hf, target = _correlated(wfn)
+    reference = np.asarray(getattr(reference_hf, hf_method)())
+    correlation = np.asarray(getattr(target, corr_method)(**(corr_kwargs or {})))
     return reference, correlation
 
 

--- a/pycc/properties.py
+++ b/pycc/properties.py
@@ -161,29 +161,29 @@ def gradient(wfn) -> PropertyComponents:
     return PropertyComponents(nuclear, reference, correlation)
 
 
-def polarizability(wfn, route='explicit') -> PropertyComponents:
+def polarizability(wfn, route='2n+1') -> PropertyComponents:
     """Static electric-dipole polarizability as a :class:`PropertyComponents`, shape ``(3, 3)``
     each.  A pure electronic response property: the nuclear block is zero.
 
-    ``route`` selects the MP2 correlation algorithm, ``'explicit'`` (default) or ``'2n+1'`` (the
-    O(N)-cheaper 2n+1 route); both give the same tensor and it is ignored for an ``HFwfn``."""
+    ``route`` selects the MP2 correlation algorithm, ``'2n+1'`` (default -- the O(N)-cheaper 2n+1
+    route) or ``'explicit'``; both give the same tensor and it is ignored for an ``HFwfn``."""
     reference, correlation = _dispatch(wfn, 'polarizability', 'polarizability', {'route': route})
     return PropertyComponents(np.zeros((3, 3)), reference, correlation)
 
 
-def hessian(wfn, route='explicit') -> PropertyComponents:
+def hessian(wfn, route='2n+1') -> PropertyComponents:
     """Molecular (nuclear) Hessian as a :class:`PropertyComponents` (``nuclear + reference +
     correlation``, shape ``(3*natom, 3*natom)`` each).  The nuclear block is the nuclear-
     repulsion second derivative ``d^2 V_NN/dX dY``.
 
-    ``route`` selects the MP2 correlation algorithm, ``'explicit'`` (default) or ``'2n+1'`` (the
-    O(N)-cheaper 2n+1 route); both give the same matrix and it is ignored for an ``HFwfn``."""
+    ``route`` selects the MP2 correlation algorithm, ``'2n+1'`` (default -- the O(N)-cheaper 2n+1
+    route) or ``'explicit'``; both give the same matrix and it is ignored for an ``HFwfn``."""
     reference, correlation = _dispatch(wfn, '_hessian_electronic', 'hessian', {'route': route})
     nuclear = np.asarray(wfn.derivatives.nuclear_repulsion2())
     return PropertyComponents(nuclear, reference, correlation)
 
 
-def apt(wfn, gauge='length', route='explicit', orbital_gauge='non-canonical') -> PropertyComponents:
+def apt(wfn, gauge='length', route='2n+1-field', orbital_gauge='non-canonical') -> PropertyComponents:
     """Atomic polar tensors (nuclear dipole derivatives) as a :class:`PropertyComponents`
     (``nuclear + reference + correlation``, shape ``(natom, 3, 3)`` each), indexed
     ``[A, beta, alpha]``.  The nuclear block is ``Z_A delta_{alpha,beta}``.
@@ -191,8 +191,9 @@ def apt(wfn, gauge='length', route='explicit', orbital_gauge='non-canonical') ->
     ``gauge='length'`` (default) is the length-gauge APT (:meth:`dipole_derivatives`);
     ``gauge='velocity'`` is the velocity-gauge APT (:meth:`velocity_dipole_derivatives`).
 
-    ``route`` (length gauge only) selects the MP2 correlation algorithm -- ``'explicit'``
-    (default), ``'2n+1-nuclear'`` or ``'2n+1-field'``; all give the same tensor.
+    ``route`` (length gauge only) selects the MP2 correlation algorithm -- ``'2n+1-field'``
+    (default -- the O(N)-cheaper route, 3 field solves), ``'2n+1-nuclear'``, or ``'explicit'``;
+    all give the same tensor.
 
     ``orbital_gauge`` (velocity gauge only; **expert only**) selects the redundant momentum
     orbital-rotation gauge, ``'non-canonical'`` (default, numerically stable) or ``'canonical'``.

--- a/pycc/tests/test_076_ccsd_gradient.py
+++ b/pycc/tests/test_076_ccsd_gradient.py
@@ -24,14 +24,14 @@ no_reorient
 """
 
 
-def _ccwfn(basis="STO-3G"):
+def _ccwfn(basis="STO-3G", freeze_core="false"):
     psi4.core.clean()
     psi4.core.clean_options()
     psi4.geometry(H2O)
-    psi4.set_options({'basis': basis, 'scf_type': 'pk',
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': freeze_core,
                       'e_convergence': 1e-12, 'd_convergence': 1e-12})
     _, wfn = psi4.energy('scf', return_wfn=True)
-    cc = pycc.ccwfn(wfn)
+    cc = pycc.ccwfn(wfn, frozen_core=(freeze_core == "true"))
     cc.solve_cc(1e-12, 1e-12, 200)
     return cc
 
@@ -82,3 +82,20 @@ def test_ccsd_gradient_zvector_equals_explicit():
     g_zvector = deriv.gradient()
     g_explicit = deriv._gradient_explicit()
     assert np.max(np.abs(g_zvector - g_explicit)) < 1e-9, (g_zvector, g_explicit)
+
+
+def test_ccsd_gradient_frozen_core():
+    """Frozen-core CCSD gradient: the Z-vector and explicit routes agree (the core<->active P_co
+    response is handled), and the frozen-core gradient differs from the all-electron one. psi4 has
+    no frozen-core CC gradient, so this is cross-validated by the two independent routes (each also
+    checked against a finite difference of the frozen-core CCSD energy)."""
+    cc_fc = _ccwfn(freeze_core="true")
+    assert cc_fc.nfzc > 0
+    deriv = pycc.CCderiv(cc_fc)
+    g_zvector = deriv.gradient()
+    g_explicit = deriv._gradient_explicit()
+    assert np.max(np.abs(g_zvector - g_explicit)) < 1e-9, (g_zvector, g_explicit)
+    # frozen core actually changes the correlation gradient vs all-electron (small for the deep
+    # O 1s in STO-3G, but nonzero)
+    g_ae = pycc.CCderiv(_ccwfn(freeze_core="false")).gradient()
+    assert np.max(np.abs(g_zvector - g_ae)) > 1e-5

--- a/pycc/tests/test_076_ccsd_gradient.py
+++ b/pycc/tests/test_076_ccsd_gradient.py
@@ -1,0 +1,73 @@
+"""
+CCSD analytic nuclear gradient -- pycc.gradient(ccwfn) via the CCderiv driver (explicit-derivative
+route).  The spatial closed-shell path, all-electron.
+
+Validated against psi4's analytic CCSD gradient, with the density-adapter energy-reconstruction
+check (the two-particle density in the gradient convention reproduces the CCSD correlation energy)
+and the PropertyComponents decomposition.
+"""
+
+import psi4
+import pycc
+import numpy as np
+
+
+# H2O, fixed frame (no reorientation) so pycc and psi4 gradients share the molecular axes.
+H2O = """
+O  0.000000  0.000000  0.118000
+H  0.000000  0.758000 -0.472000
+H  0.000000 -0.758000 -0.472000
+symmetry c1
+units angstrom
+no_com
+no_reorient
+"""
+
+
+def _ccwfn(basis="STO-3G"):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(H2O)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk',
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    cc = pycc.ccwfn(wfn)
+    cc.solve_cc(1e-12, 1e-12, 200)
+    return cc
+
+
+def test_ccsd_gradient_vs_psi4():
+    """pycc.gradient(ccwfn).total reproduces psi4's analytic CCSD gradient (same frame)."""
+    cc = _ccwfn()
+    r = pycc.gradient(cc)
+    # PropertyComponents decomposition is exact
+    assert np.max(np.abs(r.total - (r.nuclear + r.reference + r.correlation))) < 1e-12
+
+    psi4.core.clean_options()
+    psi4.set_options({'basis': 'STO-3G', 'scf_type': 'pk', 'e_convergence': 1e-12,
+                      'd_convergence': 1e-12, 'r_convergence': 1e-12})
+    g_psi4 = np.asarray(psi4.gradient('ccsd'))
+    assert np.max(np.abs(np.asarray(r.total) - g_psi4)) < 1e-8, (r.total, g_psi4)
+
+
+def test_ccsd_gradient_density_energy():
+    """The gradient-convention densities (CCderiv adapter) reproduce the CCSD correlation energy:
+    E_corr = contract(D, F) + contract(Gamma, ERI) (no prefactor on the two-particle term)."""
+    cc = _ccwfn()
+    deriv = pycc.CCderiv(cc)
+    dens = deriv._density()
+    ecc = dens.compute_energy()                       # CCSD correlation energy from the densities
+    D, G = dens.gradient_densities()
+    F = np.asarray(cc.H.F)
+    ERI = np.asarray(cc.H.ERI)
+    E = cc.contract('pq,pq->', D, F) + cc.contract('pqrs,pqrs->', G, ERI)
+    assert abs(E - ecc) < 1e-10, (E, ecc)
+
+
+def test_ccsd_gradient_correlation_nonzero():
+    """The CCSD correlation gradient is a real, nonzero contribution on top of the SCF reference."""
+    cc = _ccwfn()
+    r = pycc.gradient(cc)
+    assert np.max(np.abs(r.correlation)) > 1e-3
+    # the total differs from the bare SCF gradient by the correlation contribution
+    assert np.max(np.abs(r.total - (r.nuclear + r.reference))) > 1e-3

--- a/pycc/tests/test_076_ccsd_gradient.py
+++ b/pycc/tests/test_076_ccsd_gradient.py
@@ -71,3 +71,14 @@ def test_ccsd_gradient_correlation_nonzero():
     assert np.max(np.abs(r.correlation)) > 1e-3
     # the total differs from the bare SCF gradient by the correlation contribution
     assert np.max(np.abs(r.total - (r.nuclear + r.reference))) > 1e-3
+
+
+def test_ccsd_gradient_zvector_equals_explicit():
+    """The efficient Z-vector route (the default gradient()) agrees with the independent
+    explicit-derivative route to machine precision -- they are two formulations of the same
+    correlation gradient (one Z-vector solve vs 3*natom CPHF solves)."""
+    cc = _ccwfn()
+    deriv = pycc.CCderiv(cc)
+    g_zvector = deriv.gradient()
+    g_explicit = deriv._gradient_explicit()
+    assert np.max(np.abs(g_zvector - g_explicit)) < 1e-9, (g_zvector, g_explicit)


### PR DESCRIPTION
# CCSD analytic nuclear gradients (spatial closed-shell) + a downstream derivative driver

Adds analytic CCSD nuclear gradients, reusing the density-based MP2 gradient machinery, and
introduces a dedicated downstream derivative class so the wavefunction classes stay about the
wavefunction. Also flips the property facade to the (cheaper) 2n+1 default.

## `CCderiv` — a derivative driver (`pycc.CCderiv`)

The CCSD gradient depends on `cclambda` and `ccdensity`, which are deliberately **downstream** of
`ccwfn`. Putting the gradient on `CCwfn` would make the wavefunction reach forward to build them (a
layering inversion). Instead, `CCderiv(ccwfn)` sits at the end of the chain
`ccwfn → cchbar → cclambda → ccdensity → ccderiv`, lazily building (and caching) the Λ amplitudes,
reduced densities, and the SCF-reference `HFwfn`.

The property facade (`properties.py`) gains a small **derivative-driver registry**
(`register_deriv` / `_DERIV_REGISTRY` / `_correlated`); `_dispatch` routes a correlated
wavefunction's correlation methods to its registered driver. `CCwfn → CCderiv` is registered at
import. `MPwfn` continues to carry its own correlation methods (a future `MPderiv` split slots into
the same registry). This is the strategy-pattern structure: `XXwfn` = state, `XXderiv` = algorithms,
`properties.py` = the user-facing driver.

## The gradient

`pycc.gradient(ccwfn)` returns a `PropertyComponents` (nuclear + reference + correlation), with the
CCSD **correlation** gradient from `CCderiv.gradient()`. Two routes:

- **Z-vector (relaxed-density), the default** — one CPHF solve. Builds the generalized Fock `I'`
  (reusing the MP2 Lagrangian, which is generic in the densities), the Z-vector RHS
  `X = I'_ia − I'_ai`, one SCF-orbital-Hessian solve, the relaxed density, `W = I'(D_relaxed)`,
  then the skeleton assembly `D~·f^X + Γ·⟨pq|rs⟩^X + W·S^X`.
- **Explicit-derivative, `_gradient_explicit()`** — the "simple but inefficient" `3·natom`-CPHF-solve
  form, an independent cross-check (analog of `MPwfn._corr_gradient_explicit`).

### Two-particle-density symmetry (the crux)

`ccdensity` stores only **asymmetric representatives** of each 2-PDM block (e.g. `Doovv` holds the
`l2` piece; the `vvoo` partner `t2 + t1·t1 + …` is folded in under the implicit assumption of a
later contraction against a *symmetric* quantity). A full 4-index contraction against the
8-fold-symmetric `⟨pq|rs⟩` only sees the symmetric projection, so the **energy and the explicit
gradient are insensitive** to the missing symmetry. But the generalized-Fock term
`4Σ⟨pr|st⟩Γ_qrst` contracts only three indices and *does* require it. So
`ccdensity.gradient_densities()` builds the full-MO densities in the no-prefactor convention
(`E_corr = ⟨D,F⟩ + ⟨Γ,ERI⟩`) and **four-fold symmetrizes** Γ
(`Γ ← ¼(Γ + Γ_qpsr + Γ_rspq + Γ_srqp)`, giving `Γ_pqrs = Γ_rspq = Γ_qpsr`). This is
energy-preserving (the antisymmetric complement contracts to zero against the symmetric ERI), so
the explicit route is unchanged; with it, the MP2 generalized-Fock machinery works for CCSD
verbatim. (A future re-derivation of the ccdensity 2-PDM could carry this symmetry natively.)

### Frozen core

Ported from the MP2 `_zvector`: correlation densities in the active space, orbital response over the
full occupied space, the core↔active-occupied rotation as a direct divide
`P_co = (I'_ci − I'_ic)/(eps_c − eps_i)` coupled into the Z-vector RHS. All-electron is the
`nfzc = 0` special case.

## Facade default → 2n+1

`polarizability` / `hessian` now default to `route='2n+1'`, and the length-gauge `apt` to
`'2n+1-field'` (3 field solves vs 3N nuclear) — the O(N)-cheaper algorithm. Results are identical
(the route tests already assert this); only the default cost changes. `'explicit'` stays selectable.

## Validation (`test_076`, 5 tests)

| case | oracle | result |
|---|---|---|
| all-electron | `psi4.gradient('ccsd')` | 9e-13 |
| all-electron | 5-pt FD of the CCSD energy | 3e-9 |
| frozen core | 5-pt FD (psi4 raises on frozen-core CC gradients) | 3e-9 |
| both routes | Z-vector == explicit | ~1e-17 |
| adapter | `⟨D,F⟩ + ⟨Γ,ERI⟩ == E_corr` | 5e-15 |

The MP2/HF/density/facade suites (`test_004`/`007`/`046`/`061`/`074`) are unaffected.

## Scope / next

Spatial closed-shell, all-electron and frozen-core. The spin-orbital (UHF/ROHF) CCSD gradient is a
follow-up — it first needs the spin-orbital 2-PDM in `ccdensity` (currently `NotImplementedError`).

## Files

- `pycc/ccderiv.py` (new, +167) — the `CCderiv` driver
- `pycc/ccdensity.py` (+46) — `gradient_densities()` (symmetrized full-MO D, Γ)
- `pycc/properties.py` (+70/−26) — deriv registry routing; 2n+1 defaults
- `pycc/__init__.py` — register/export `CCderiv`
- `pycc/tests/test_076_ccsd_gradient.py` (new, +101)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
