### PR TITLE
Open-shell UHF-MP2 derivative-property tests (NH2)

### DIFF
--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -34,13 +34,13 @@ H 1 1.02 2 103.0
 """
 
 
-def _ff_corr_dipole(geom, basis, F=0.0005, freeze_core='false'):
+def _ff_corr_dipole(geom, basis, F=0.0005, freeze_core='false', reference='rhf'):
     """Relaxed correlation mu_z by a 5-point finite field of (E_MP2 - E_SCF)."""
     def e(model, Fz):
         psi4.core.clean()
         psi4.core.clean_options()
         psi4.geometry(geom)
-        opt = {'basis': basis, 'scf_type': 'pk', 'mp2_type': 'conv',
+        opt = {'basis': basis, 'scf_type': 'pk', 'mp2_type': 'conv', 'reference': reference,
                'freeze_core': freeze_core, 'e_convergence': 1e-12, 'd_convergence': 1e-12}
         if Fz:
             opt.update({'perturb_h': True, 'perturb_with': 'dipole',
@@ -54,14 +54,14 @@ def _ff_corr_dipole(geom, basis, F=0.0005, freeze_core='false'):
     return mu('mp2') - mu('scf')
 
 
-def _pycc_corr_dipole(geom, basis, orbital_basis='spinorbital', freeze_core='false'):
+def _pycc_corr_dipole(geom, basis, orbital_basis='spinorbital', freeze_core='false', reference='rhf'):
     """PyCC relaxed-MP2 electronic correlation mu_z (spin-orbital or spin-adapted),
     via the user-API :meth:`MPwfn.relaxed_dipole`."""
     psi4.core.clean()
     psi4.core.clean_options()
     psi4.geometry(geom)
-    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': freeze_core,
-                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'reference': reference,
+                      'freeze_core': freeze_core, 'e_convergence': 1e-12, 'd_convergence': 1e-12})
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
@@ -87,6 +87,14 @@ def test_mp2_relaxed_dipole_ccpvdz():
     and A2-irrep MOs). Exercises symmetry-adapted MOs in the relaxed density."""
     assert abs(_pycc_corr_dipole(WATER, 'cc-pVDZ')
                - _ff_corr_dipole(WATER, 'cc-pVDZ')) < 1e-8
+
+
+def test_ump2_relaxed_dipole_nh2_631g():
+    """Open-shell UHF-MP2 relaxed correlation dipole (mu_z) vs finite field, NH2 (2-B1) / 6-31G.
+    The open-shell oracle for the spin-orbital relaxed density (Z-vector orbital response)."""
+    geom = NH2 + "symmetry c1\n"
+    assert abs(_pycc_corr_dipole(geom, '6-31G', reference='uhf')
+               - _ff_corr_dipole(geom, '6-31G', reference='uhf')) < 1e-8
 
 
 # ---- explicit-derivative route (derivints.pdf): correlation dipole from the full

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -23,6 +23,16 @@ H 1 0.96
 H 1 0.96 2 104.5
 """
 
+# Open-shell UHF reference: NH2 (2-B1, bent -- non-degenerate SOMO).  Deliberately not OH (2-Pi),
+# whose degenerate pi orbitals leave the UHF solution non-reproducible across platforms and the
+# orbital Hessian near-singular.
+NH2 = """
+0 2
+N
+H 1 1.02
+H 1 1.02 2 103.0
+"""
+
 
 def _ff_corr_dipole(geom, basis, F=0.0005, freeze_core='false'):
     """Relaxed correlation mu_z by a 5-point finite field of (E_MP2 - E_SCF)."""
@@ -209,23 +219,23 @@ def test_fc_so_mp2_explicit_corr_gradient_631g():
     assert np.max(np.abs(g_explicit - g_relaxed)) < 1e-9
 
 
-def _pycc_gradient(geom, basis, orbital_basis='spinorbital', freeze_core='false'):
+def _pycc_gradient(geom, basis, orbital_basis='spinorbital', freeze_core='false', reference='rhf'):
     psi4.core.clean()
     psi4.core.clean_options()
     psi4.geometry(geom)
-    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': freeze_core,
-                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'reference': reference,
+                      'freeze_core': freeze_core, 'e_convergence': 1e-12, 'd_convergence': 1e-12})
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
     return np.asarray(pycc.gradient(mp).total)
 
 
-def _psi4_mp2_gradient(geom, basis):
+def _psi4_mp2_gradient(geom, basis, reference='rhf'):
     psi4.core.clean()
     psi4.core.clean_options()
     psi4.geometry(geom)
-    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'mp2_type': 'conv',
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'mp2_type': 'conv', 'reference': reference,
                       'freeze_core': 'false', 'e_convergence': 1e-12,
                       'd_convergence': 1e-12})
     return np.asarray(psi4.gradient('mp2'))
@@ -243,6 +253,20 @@ def test_sa_mp2_gradient_631g():
     geom = WATER + "symmetry c1\n"
     assert np.max(np.abs(_pycc_gradient(geom, '6-31G', orbital_basis='spatial')
                          - _psi4_mp2_gradient(geom, '6-31G'))) < 1e-8
+
+
+def test_ump2_gradient_nh2_631g():
+    """Open-shell UHF-MP2 analytic nuclear gradient vs Psi4, NH2 (2-B1) / 6-31G (C1).
+
+    The open-shell oracle for the spin-orbital Z-vector gradient (``_so_zvector``).  psi4 is the
+    right check here rather than the explicit == relaxed identity: an open-shell UHF spin-orbital
+    orbital Hessian carries a near-zero mode, so the single linear solve both internal routes run
+    through is ill-conditioned and their difference is platform-dependent -- but the final gradient
+    is orthogonal to that mode and reproduces psi4 to machine precision.  NH2 is non-degenerate
+    (unlike OH, 2-Pi, whose degeneracy also makes the reference itself non-reproducible)."""
+    geom = NH2 + "symmetry c1\n"
+    assert np.max(np.abs(_pycc_gradient(geom, '6-31G', reference='uhf')
+                         - _psi4_mp2_gradient(geom, '6-31G', reference='uhf'))) < 1e-8
 
 
 def test_mp2_gradient_spatial_vs_so_631g():

--- a/pycc/tests/test_067_mp2_polarizability.py
+++ b/pycc/tests/test_067_mp2_polarizability.py
@@ -41,13 +41,22 @@ H 1 0.96 2 104.5
 symmetry c1
 """
 
+# Open-shell UHF reference: NH2 (2-B1, non-degenerate).
+NH2 = """
+0 2
+N
+H 1 1.02
+H 1 1.02 2 103.0
+symmetry c1
+"""
 
-def _pycc_alpha(basis, orbital_basis='spatial', freeze_core='false'):
+
+def _pycc_alpha(basis, orbital_basis='spatial', freeze_core='false', geom=WATER, reference='rhf'):
     psi4.core.clean()
     psi4.core.clean_options()
-    psi4.geometry(WATER)
-    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': freeze_core,
-                      'e_convergence': 1e-14, 'd_convergence': 1e-14})
+    psi4.geometry(geom)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'reference': reference,
+                      'freeze_core': freeze_core, 'e_convergence': 1e-14, 'd_convergence': 1e-14})
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
@@ -79,16 +88,16 @@ def _dipfd_alpha_diag(basis, axis, orbital_basis='spatial', freeze_core='false',
     return abs(d1)
 
 
-def _energy_fd_alpha_diag(basis, axis, freeze_core='false', F=0.002):
+def _energy_fd_alpha_diag(basis, axis, freeze_core='false', F=0.002, geom=WATER, reference='rhf'):
     """alpha_corr_(axis,axis) = -d^2(E_MP2 - E_SCF)/dF^2 by a 5-point finite field of the
     energy -- a fully external oracle (independence guard for the dipole cross-check)."""
     def e(model, Fval):
         psi4.core.clean()
         psi4.core.clean_options()
-        psi4.geometry(WATER)
+        psi4.geometry(geom)
         d = [0.0, 0.0, 0.0]
         d[axis] = Fval
-        opt = {'basis': basis, 'scf_type': 'pk', 'mp2_type': 'conv',
+        opt = {'basis': basis, 'scf_type': 'pk', 'mp2_type': 'conv', 'reference': reference,
                'freeze_core': freeze_core, 'e_convergence': 1e-13, 'd_convergence': 1e-13}
         if Fval:
             opt.update({'perturb_h': True, 'perturb_with': 'dipole', 'perturb_dipole': d})
@@ -133,6 +142,14 @@ def test_mp2_corr_polarizability_energy_fd_631g():
     derivatives divide by h^2), so a looser tolerance."""
     a = _pycc_alpha('6-31G', orbital_basis='spatial')
     assert abs(a[2, 2] - _energy_fd_alpha_diag('6-31G', 2)) < 1e-7
+
+
+def test_ump2_corr_polarizability_energy_fd_nh2_631g():
+    """Open-shell UHF-MP2 correlation alpha_zz vs a 5-point finite field of the MP2 energy --
+    the external open-shell oracle for the spin-orbital second-order response, NH2 (2-B1) / 6-31G.
+    (Energy second derivatives divide by h^2, so a looser tolerance than the dipole FD.)"""
+    a = _pycc_alpha('6-31G', orbital_basis='spinorbital', geom=NH2, reference='uhf')
+    assert abs(a[2, 2] - _energy_fd_alpha_diag('6-31G', 2, geom=NH2, reference='uhf')) < 1e-6
 
 
 # ---- keystone: spin-orbital == spin-adapted (carries the checks to the SO path) ----

--- a/pycc/tests/test_070_mp2_2n1_polarizability.py
+++ b/pycc/tests/test_070_mp2_2n1_polarizability.py
@@ -27,13 +27,22 @@ H 1 0.96 2 104.5
 symmetry c1
 """
 
+# Open-shell UHF reference: NH2 (2-B1, non-degenerate).
+NH2 = """
+0 2
+N
+H 1 1.02
+H 1 1.02 2 103.0
+symmetry c1
+"""
 
-def _mpwfn(basis, orbital_basis='spinorbital', freeze_core='false'):
+
+def _mpwfn(basis, orbital_basis='spinorbital', freeze_core='false', geom=WATER, reference='rhf'):
     psi4.core.clean()
     psi4.core.clean_options()
-    psi4.geometry(WATER)
-    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': freeze_core,
-                      'e_convergence': 1e-13, 'd_convergence': 1e-13})
+    psi4.geometry(geom)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'reference': reference,
+                      'freeze_core': freeze_core, 'e_convergence': 1e-13, 'd_convergence': 1e-13})
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
@@ -82,6 +91,21 @@ def test_2n1_polarizability_so_vs_spatial_631g():
         a_so = np.asarray(_mpwfn('6-31G', 'spinorbital', fc).polarizability(route='2n+1'))
         a_sa = np.asarray(_mpwfn('6-31G', 'spatial', fc).polarizability(route='2n+1'))
         assert np.max(np.abs(a_so - a_sa)) < 1e-11
+
+
+def test_2n1_polarizability_uhf_nh2_631g():
+    """Open-shell UHF-MP2: 2n+1 == explicit correlation polarizability, NH2 (2-B1) / 6-31G.
+
+    The open-shell exercise of the perturbed relaxed density / perturbed Z-vector.  Unlike the
+    nuclear-gradient Z-vector, this second-derivative identity is well-conditioned open-shell (the
+    field-perturbation RHS is clean of the near-zero orbital-Hessian mode), so it holds to machine
+    precision.  The explicit route is anchored to a finite-field oracle for the open shell in
+    test_067."""
+    mp = _mpwfn('6-31G', geom=NH2, reference='uhf')
+    a_2n1 = np.asarray(mp.polarizability(route='2n+1'))
+    a_exp = np.asarray(mp.polarizability(route='explicit'))
+    assert np.max(np.abs(a_2n1 - a_exp)) < 1e-11
+    assert np.max(np.abs(a_2n1 - a_2n1.T)) < 1e-11            # symmetric
 
 
 def test_2n1_polarizability_guards():


### PR DESCRIPTION
# Open-shell UHF-MP2 derivative-property tests (NH2)

The spin-orbital MP2 derivative properties — gradient, relaxed dipole, and polarizability — had **no open-shell coverage**: every test ran on closed-shell H2O, even though the underlying UHF/spin-orbital machinery (`_so_zvector`, the relaxed density, the perturbed Z-vector) is exactly the open-shell code. This adds actual open-shell tests against external oracles, all on **NH2** (²B₁, non-degenerate).

## Tests added

- **Gradient** (`test_061::test_ump2_gradient_nh2_631g`): UHF-MP2 nuclear gradient vs `psi4.gradient('mp2')` (~1e-13).
- **Relaxed dipole** (`test_061::test_ump2_relaxed_dipole_nh2_631g`): relaxed correlation dipole vs a finite field of (E_MP2 − E_SCF) (~4e-12).
- **Polarizability, external oracle** (`test_067::test_ump2_corr_polarizability_energy_fd_nh2_631g`): correlation α_zz vs a 5-point finite field of the MP2 energy (~2e-9).
- **Polarizability, 2n+1 route** (`test_070::test_2n1_polarizability_uhf_nh2_631g`): 2n+1 == explicit correlation polarizability (~1e-15), exercising the perturbed relaxed density / perturbed Z-vector open-shell.

## Notes

- **NH2, not OH.** OH (²Π) is degenerate: its π orbitals leave the UHF solution non-reproducible across platforms and the orbital Hessian near-singular (and symmetry does not fix it). NH2's SOMO is non-degenerate, so the reference is unique and the responses are well-conditioned.
- **Which oracle.** The nuclear-gradient `explicit == relaxed` identity runs through a single solve of the (open-shell near-singular) orbital Hessian, so it is validated against psi4 instead. The second-derivative `2n+1 == explicit` identity is well-conditioned open-shell (the field-perturbation RHS is clean of the near-zero mode), so it holds to machine precision; the polarizability is additionally anchored to a finite-field energy oracle.
- The shared test helpers gain a `reference` argument (default `'rhf'`, a no-op for the existing closed-shell tests) and, where they were hard-coded to water, a `geom` argument.

All four affected test files pass (existing closed-shell tests unchanged).
