### PR TITLE
Spin-orbital CCSD(T) analytic gradient

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ include:
     and atomic axial tensors (AATs) -- the building blocks for IR and VCD spectra. Both spin
     paths (spin-adapted closed-shell RHF and spin-orbital), all-electron and frozen-core; the
     MP2 second derivatives come via two independent routes (explicit-derivative and 2n+1)
-  - Analytic nuclear energy gradients for CCSD (spin-adapted closed-shell RHF and spin-orbital UHF)
-    and CCSD(T) (spin-adapted closed-shell RHF), all-electron and frozen-core, built on the same
-    relaxed-density / Z-vector machinery as the MP2 gradient
+  - Analytic nuclear energy gradients for CCSD and CCSD(T) (both spin-adapted closed-shell RHF and
+    spin-orbital UHF), all-electron and frozen-core, built on the same relaxed-density / Z-vector
+    machinery as the MP2 gradient
   - A uniform property interface -- `pycc.dipole`, `pycc.gradient`, `pycc.polarizability`,
     `pycc.hessian`, `pycc.apt`, `pycc.aat` -- that dispatches on wavefunction type and returns
     each property's nuclear/reference/correlation decomposition as a `PropertyComponents`
@@ -41,7 +41,7 @@ include:
 Future plans:
   - Quadratic response functions (in development)
   - CC2 and CC3 excited states
-  - Analytic CC second derivatives (Hessians, APTs) and the spin-orbital CCSD(T) gradient
+  - Analytic CC second derivatives (Hessians, APTs)
 
 This repository is currently under development. To do a developmental install, download this repository and type `pip install -e .` in the repository directory.
 

--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -45,7 +45,7 @@ densities and Λ:
 | Method | spatial (closed-shell RHF) | spin-orbital (UHF) | frozen core |
 |---|---|---|---|
 | CCSD `dE/dX` | ✅ | ✅ | ✅ |
-| CCSD(T) `dE/dX` | ✅ | ⏳ next | ✅ (spatial) |
+| CCSD(T) `dE/dX` | ✅ | ✅ | ✅ |
 
 Validated against a tight finite difference of pycc's own correlation energy (5-point O(h⁴), ~1e-12),
 **not** psi4's analytic gradient (§4). Unlike CCSD — which reuses the −½Sˣ ov-only Z-vector because
@@ -184,13 +184,11 @@ so frozen core runs the response over the full occupied space in `MPwfn`'s own M
 
 ## 6. Roadmap
 
-- **CC gradients — done, extending.** CCSD analytic gradients (spatial RHF, spin-orbital UHF,
-  all-electron + frozen core) and the CCSD(T) gradient (spatial RHF, all-electron + frozen core) are
-  implemented via `CCderiv`, reusing the MP2 Z-vector / relaxed-density assembly with the CCSD/(T)
-  densities and Λ (details + validation in §7). **Next:** spin-orbital CCSD(T) gradient (port the (T)
-  density + oo/vv dependent-pair to the SO path; anchor on the SO==spatial keystone); CCSD(T)
-  Hessian/APT; and extending `_gradient_explicit` to carry the (T) dependent-pair (so the
-  z-vector==explicit cross-check works for (T), as it does for CCSD). `CCderiv` reuses the MP2
+- **CC gradients — done, extending.** CCSD *and* CCSD(T) analytic gradients are implemented for
+  **spatial RHF and spin-orbital UHF, all-electron + frozen core**, via `CCderiv`, reusing the MP2
+  Z-vector / relaxed-density assembly with the CCSD/(T) densities and Λ (details + validation in §7).
+  **Next:** CCSD(T) Hessian/APT; and extending `_gradient_explicit` to carry the (T) dependent-pair
+  (so the z-vector==explicit cross-check works for (T), as it does for CCSD). `CCderiv` reuses the MP2
   Lagrangian/CPHF primitives via delegation; the fuller "shared Lagrangian → Z-vector → density →
   gradient" layer refactor is still deferred (no premature abstraction).
 - **ROHF orbital response — deferred, guarded.** The semicanonical spin-orbital response is UHF-like
@@ -198,11 +196,13 @@ so frozen core runs the response over the full occupied space in `MPwfn`'s own M
   ROHF HF gradient is unaffected.
 - Out of scope: 2n+2 / higher-order (cubic-response) economies.
 
-## 7. CCSD(T) gradient — spatial RHF (design & status)
+## 7. CCSD(T) gradient — spatial RHF + spin-orbital UHF (design & status)
 
-**Status.** Done and FD-validated for **closed-shell RHF, spatial MOs, all-electron *and* frozen
-core** (`pycc.gradient(CCwfn(wfn, model='CCSD(T)'))` through `CCderiv`/`ccdensity`). Spin-orbital and
-the CCSD(T) Hessian/APT are deferred (below).
+**Status.** Done and FD-validated for **closed-shell RHF (spatial MOs) and UHF (spin-orbital),
+all-electron *and* frozen core** (`pycc.gradient(CCwfn(wfn, model='CCSD(T)'))` through
+`CCderiv`/`ccdensity`). The CCSD(T) Hessian/APT are deferred (below). The theory below is written for
+the spatial path; the spin-orbital path is the same construction with `H.L → <pq||rs>` (see
+**Spin-orbital** at the end of this section).
 
 **References.**
 - **Paper A** — T. J. Lee & A. P. Rendell, *J. Chem. Phys.* **94**, 6229 (1991): closed-shell
@@ -242,10 +242,13 @@ the active space when `nfzc=0`. `Pco` from the (T)-inclusive `I'` **fully captur
 response** — FD-confirmed to 1.9e-12, no extra core term needed.
 
 **Implementation.**
-- `CCwfn.t3_density()` (bottom of `ccwfn.py`; called from the energy code so T3 is built once) yields
-  the (T) contributions: the **diagonal** 1-PDM `diag(Doo)`/`diag(Dvv)` (computed directly —
-  `acd,acd->a` / `ikl,ikl->i` — not full blocks then filtered) plus `Dov`; the 2-PDM
-  `Goovv/Gooov/Gvvvo`; and the Λ residuals `S1/S2` (Paper A's η/γ), added into Λ₁/Λ₂.
+- `cctriples.t3_density` (a free function returning `(ET, {intermediates})`; `CCwfn.t3_density` is a
+  thin delegate-and-cache wrapper, called from the energy code so T3 is built once) yields the (T)
+  contributions: the **diagonal** 1-PDM `diag(Doo)`/`diag(Dvv)` (computed directly — `acd,acd->a` /
+  `ikl,ikl->i` — not full blocks then filtered) plus `Dov`; the 2-PDM `Goovv/Gooov/Gvvvo`; and the Λ
+  residuals `S1/S2` (Paper A's η/γ), added into Λ₁/Λ₂. Housing the builder in `cctriples` (not
+  `CCwfn`) keeps the wavefunction from computing density components and avoids a `ccwfn → ccdensity`
+  dependency, while preserving the single T3 build.
 - `CCderiv.gradient` — `_dependent_pairs(I'[block], ε)` builds the κ̄ divides (numerator-gated); the
   `model=='CCSD(T)'` branch adds κ̄_oo/κ̄_vv to `Drel` and couples them into the Z-vector RHS (ov index
   over `ofull`). Model-gated, so the CCSD path is untouched. Then the standard GSB assembly runs,
@@ -271,8 +274,18 @@ the canonical dependent-pair orbital response above. Also superseded: "ε (A 12�
 present — the energy validates it, and adding it explicitly double-counts). Corroborated by the PI's
 own Psi4 `relax_I_RHF` (its `delta_I/delta_f_{IJ,AB}` are the κ̄ divides). See Appendix B.
 
-**Deferred:** spin-orbital CCSD(T) gradient (port the (T) density + oo/vv κ̄ to the SO path;
-SO==spatial keystone); CCSD(T) Hessian/APT; extending `_gradient_explicit` to the (T) dependent-pair.
+**Spin-orbital (UHF).** The SO path is the same construction with the spin-adapted `H.L` replaced by
+the antisymmetrized `<pq||rs>`. `cctriples.so_t3_density` builds the SO (T) density/Λ (its own T3
+kernels `t3{c,d}_{ijk,abc}_so`); `ccdensity`/`cclambda` gate the SO (T) 1-/2-PDM and `S1`/`S2` on
+`model=='CCSD(T)'`; and `CCderiv._so_gradient` gains the same `model=='CCSD(T)'` branch — `κ̄_oo`/`κ̄_vv`
+from `_dependent_pairs` into `Drel`, coupled into the ov Z-vector RHS through the antisymmetrized ERI.
+Frozen core rides the SO `Pco` exactly as the spatial path. **Validation** (§4 oracle): closed-shell
+SO==spatial keystone **2.3e-13** (6-31G — STO-3G leaves `‖Pvv‖=0`, the minimal-basis trap), frozen-core
+keystone **1.4e-13**, and open-shell NH₂ (²B₁, C2v pinned occ / 6-31G) vs a 5-point O(h⁴) FD of pycc's
+own SO CCSD(T) energy **3.7e-12**. Tests in `test_083` (open-shell reference hard-wired). ROHF unsupported
+(guarded, §6).
+
+**Deferred:** CCSD(T) Hessian/APT; extending `_gradient_explicit` to the (T) dependent-pair.
 
 ## Appendix A: condensed changelog (by PR)
 
@@ -302,14 +315,15 @@ Reference layer, then the MP2 derivative effort:
 | #176 | **CCSD gradient** — spatial closed-shell RHF via `CCderiv` (CCSD relaxed density + Z-vector, reusing the MP2 assembly) |
 | #177 | **CCSD gradient** — spin-orbital UHF (SO 2-PDM + gradient; all-electron + frozen core) |
 | #183 | **CCSD(T) gradient** — spatial RHF, all-electron; + frozen core sourced from psi4 only (`frozen_core` pycc override removed) |
-| (current) | **frozen-core CCSD(T) gradient** — oo/vv dependent-pair κ̄ generalized from the frozen-core `Pco`; diagonal-only (T) `Doo`/`Dvv` |
+| #184 | **frozen-core CCSD(T) gradient** — oo/vv dependent-pair κ̄ generalized from the frozen-core `Pco`; diagonal-only (T) `Doo`/`Dvv` |
+| #185 | **spin-orbital CCSD(T) gradient** — SO (T) density + oo/vv κ̄ in `_so_gradient` (all-electron + frozen core); (T) density builders moved to `cctriples` (no `ccwfn`→`ccdensity` dependency) |
 
 Tests: `test_046`–`test_050` (spatial HF), `test_062`–`test_066` (SO HF), `test_061` (MP2
 gradient/relaxed density), `test_067` (polarizability), `test_068` (APT), `test_069` (Hessian),
 `test_070` (2n+1 polarizability), `test_071` (HF velocity APT), `test_072` (MP2 AAT), `test_073`
 (MP2 velocity APT), `test_074` (property facade). CC gradients: `test_076` (CCSD, spatial),
-`test_078` (CCSD, spin-orbital), `test_077` (SO 2-PDM), `test_083` (CCSD(T), all-electron + frozen
-core), `test_034` (CCSD(T) density/dipole). The 2n+1 APT/Hessian cross-checks live in
+`test_078` (CCSD, spin-orbital), `test_077` (SO 2-PDM), `test_083` (CCSD(T), spatial + spin-orbital,
+all-electron + frozen core), `test_034` (CCSD(T) density/dipole). The 2n+1 APT/Hessian cross-checks live in
 `test_068`/`test_069`.
 
 ## Appendix B: superseded early decisions

--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -154,7 +154,7 @@ class ccdensity(object):
                 + contract('ijab,ijab->', ERI[o,o,v,v], G['ijab'])
                 + contract('abij,abij->', ERI[v,v,o,o], G['abij'])
                 + 2.0 * contract('ijka,ijka->', ERI[o,o,o,v], G['ijka'])
-                + 2.0 * contract('akij,akij->', ERI[v,o,o,o], G['akij'])
+                + 2.0 * contract('kaij,kaij->', ERI[o,v,o,o], G['kaij'])
                 + 2.0 * contract('abci,abci->', ERI[v,v,v,o], G['abci'])
                 + 2.0 * contract('ciab,ciab->', ERI[v,o,v,v], G['ciab'])
                 + 4.0 * contract('ibaj,ibaj->', ERI[o,v,v,o], G['ibaj']))
@@ -326,8 +326,11 @@ class ccdensity(object):
     def build_Doo(self, t1, t2, l1, l2):  # complete
         contract = self.contract
         if self.ccwfn.orbital_basis == 'spinorbital':
-            return (-1.0 * contract('ie,je->ij', t1, l1)
-                    - 0.5 * contract('imef,jmef->ij', t2, l2))
+            Doo = (-1.0 * contract('ie,je->ij', t1, l1)
+                   - 0.5 * contract('imef,jmef->ij', t2, l2))
+            if self.ccwfn.model == 'CCSD(T)':
+                Doo = Doo + self.ccwfn.Doo
+            return Doo
         if self.ccwfn.model == 'CCD':
             Doo = -contract('imef,jmef->ij', t2, l2)
         else:
@@ -343,8 +346,11 @@ class ccdensity(object):
     def build_Dvv(self, t1, t2, l1, l2):  # complete
         contract = self.contract
         if self.ccwfn.orbital_basis == 'spinorbital':
-            return (contract('mb,ma->ab', t1, l1)
-                    + 0.5 * contract('mnbe,mnae->ab', t2, l2))
+            Dvv = (contract('mb,ma->ab', t1, l1)
+                   + 0.5 * contract('mnbe,mnae->ab', t2, l2))
+            if self.ccwfn.model == 'CCSD(T)':
+                Dvv = Dvv + self.ccwfn.Dvv
+            return Dvv
         if self.ccwfn.model == 'CCD':
             Dvv = contract('mnbe,mnae->ab', t2, l2)
         else:
@@ -370,6 +376,8 @@ class ccdensity(object):
             Dov = Dov - 0.5 * contract('ea,ie->ia', tmp, t1)
             tmp = contract('mnef,inef->mi', l2, t2)
             Dov = Dov - 0.5 * contract('mi,ma->ia', tmp, t1)
+            if self.ccwfn.model == 'CCSD(T)':
+                Dov = Dov + self.ccwfn.Dov
             return Dov
         if self.ccwfn.model == 'CCD':
             Dov = zeros_like(t1)
@@ -706,7 +714,7 @@ class ccdensity(object):
                      - Pab(contract('mnce,inae,mb->ciab', l2, t2, t1))
                      + 0.5 * Pab(contract('mnce,mnae,ib->ciab', l2, t2, t1)))
         G['abci'] = contract('miab,mc->abci', l2, t1)
-        G['akij'] = -contract('ijae,ke->akij', l2, t1)
+        G['kaij'] = -contract('ijea,ke->kaij', l2, t1)
         G['ibaj'] = (contract('ia,jb->ibaj', t1, l1)
                      + contract('jmbe,miea->ibaj', l2, t2)
                      - contract('jmbe,ma,ie->ibaj', l2, t1, t1))
@@ -720,6 +728,12 @@ class ccdensity(object):
                      - Pijab(contract('miae,me,jb->ijab', X, l1, t1))
                      + 3.0 * Pijab(contract('me,ia,je,mb->ijab', l1, t1, t1, t1)))
         G['abij'] = contract('ijab->abij', l2)
+        if self.ccwfn.model == 'CCSD(T)':
+            G['ijab'] = G['ijab'] + self.ccwfn.Goovv
+            G['ijka'] = G['ijka'] + self.ccwfn.Gooov
+            G['ciab'] = G['ciab'] + self.ccwfn.Gvovv
+            G['kaij'] = G['kaij'] + self.ccwfn.Govoo
+            G['abci'] = G['abci'] + self.ccwfn.Gvvvo
         return G
 
     def _so_full_twopdm(self):
@@ -734,7 +748,7 @@ class ccdensity(object):
         Gam[v, v, v, v] = G['abcd']
         Gam[o, o, v, v] = G['ijab']; Gam[v, v, o, o] = G['abij']
         Gam[o, o, o, v] = G['ijka']; Gam[o, o, v, o] = -G['ijka'].transpose(0, 1, 3, 2)
-        Gam[v, o, o, o] = G['akij']; Gam[o, v, o, o] = -G['akij'].transpose(1, 0, 2, 3)
+        Gam[o, v, o, o] = G['kaij']; Gam[v, o, o, o] = -G['kaij'].transpose(1, 0, 2, 3)
         Gam[v, v, v, o] = G['abci']; Gam[v, v, o, v] = -G['abci'].transpose(0, 1, 3, 2)
         Gam[v, o, v, v] = G['ciab']; Gam[o, v, v, v] = -G['ciab'].transpose(1, 0, 2, 3)
         ib = G['ibaj']

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -177,7 +177,7 @@ class CCderiv:
         return grad
 
     def _so_gradient(self) -> np.ndarray:
-        """Spin-orbital (UHF) CCSD **correlation** gradient via the Z-vector route -- the
+        """Spin-orbital (UHF) CCSD / CCSD(T) **correlation** gradient via the Z-vector route -- the
         spin-orbital analog of :meth:`gradient`, mirroring :meth:`MPwfn._so_gradient` /
         :meth:`MPwfn._so_zvector`::
 
@@ -191,11 +191,17 @@ class CCderiv:
         derivative integrals are the spin-orbital ``derivatives.so_*`` (``f^X = h^X + sum_m
         <pm||qm>^X`` over the full occupied space).
 
+        For ``model == 'CCSD(T)'`` the (T) density enters through ``gradient_densities`` and the
+        (T) occ-occ/virt-virt dependent-pair rotations ``kappa_oo``/``kappa_vv`` are added exactly
+        as in the spatial :meth:`gradient` (with the antisymmetrized ERI in place of ``H.L``).
+
         **UHF only** -- ROHF is not supported (the semicanonical response does not reproduce the
         restricted ROHF response).  Frozen-core aware (the core<->active-occupied ``P_co`` divide,
         coupled into the Z-vector RHS, exactly as the spatial path and :meth:`MPwfn._so_zvector`).
         Validated against ``psi4.gradient('ccsd')`` (UHF), the spatial closed-shell gradient (SO ==
-        spatial), and the explicit-derivative route (:meth:`_gradient_explicit`)."""
+        spatial, CCSD and CCSD(T)), a finite difference of pycc's own SO CCSD(T) energy (open-shell
+        UHF), and the explicit-derivative route (:meth:`_gradient_explicit`, CCSD only -- the (T)
+        dependent-pair is not yet carried there)."""
         cc = self.ccwfn
         if cc.mp.cphf.is_rohf:
             raise NotImplementedError(
@@ -222,6 +228,19 @@ class CCderiv:
             zjc = -Pco.T
             X = X - (c('jc,ajic->ia', zjc, ERI[v, o, ofull, co])
                      + c('jc,acij->ia', zjc, ERI[v, co, ofull, o]))
+        if cc.model.upper() == 'CCSD(T)':
+            # (T) breaks the occ-occ / virt-virt rotation invariance, so the canonical perturbed
+            # orbitals acquire dependent-pair rotations kappa_oo/kappa_vv beyond the ov Z-vector:
+            # (I'_ij-I'_ji)/(eps_i-eps_j) over the oo pairs and the vv analog
+            # (:meth:`_dependent_pairs`), added to the relaxed density and coupled into the ov
+            # Z-vector RHS through the antisymmetrized ERI -- the spin-orbital analog of the (T)
+            # branch in :meth:`gradient` (spatial L -> <pq||rs>).  For CCSD both blocks vanish.
+            Poo = self._dependent_pairs(Ip[o, o], eps[o])
+            Pvv = self._dependent_pairs(Ip[v, v], eps[v])
+            Drel[o, o] += Poo
+            Drel[v, v] += Pvv
+            X = X + (c('kl,akil->ia', Poo, ERI[v, o, ofull, o])
+                     + c('bc,ibac->ia', Pvv, ERI[ofull, v, v, v]))
         G = (c('ajib->iajb', ERI[v, ofull, ofull, v])    # orbital Hessian, built inline
              + c('abij->iajb', ERI[v, v, ofull, ofull])).reshape(nof * nv, nof * nv)
         G[np.diag_indices(nof * nv)] += (eps[v][None, :] - eps[ofull][:, None]).reshape(-1)

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -840,6 +840,8 @@ class cclambda(object):
         spin-orbital HBAR blocks (no Hovov)."""
         contract = self.contract
         r_l1 = clone(Hov)
+        if self.ccwfn.model == 'CCSD(T)':
+            r_l1 = r_l1 + self.ccwfn.S1
         r_l1 = r_l1 + contract('ie,ea->ia', l1, Hvv)
         r_l1 = r_l1 - contract('ma,im->ia', l1, Hoo)
         r_l1 = r_l1 + 0.5 * contract('imef,efam->ia', l2, Hvvvo)
@@ -855,6 +857,8 @@ class cclambda(object):
         already antisymmetric in i<->j and a<->b (no separate symmetrization)."""
         contract = self.contract
         r_l2 = clone(ERI[o,o,v,v])
+        if self.ccwfn.model == 'CCSD(T)':
+            r_l2 = r_l2 + self.ccwfn.S2
         r_l2 = r_l2 + (contract('ia,jb->ijab', l1, Hov) - contract('ja,ib->ijab', l1, Hov))
         r_l2 = r_l2 + (contract('jb,ia->ijab', l1, Hov) - contract('ib,ja->ijab', l1, Hov))
         r_l2 = r_l2 + (contract('ijae,eb->ijab', l2, Hvv) - contract('ijbe,ea->ijab', l2, Hvv))

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -711,6 +711,29 @@ def t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract, omega=0.0, WithDeno
         return t3/denom
     return t3
 
+def t3d_ijk_so(o, v, i, j, k, t1, t2, Woovv, F, contract, omega=0.0, WithDenom=True):
+    """Spin-orbital disconnected T3 amplitudes for fixed occupied i, j, k.
+
+    ``Woovv`` (<ab||ei>) are passed explicitly: bare ERI slices for (T) 
+    or the T1-dressed CC3 intermediates for CC3.
+    """
+    Fov = F[o,v]
+    abc = contract('a,bc->abc', t1[i], Woovv[j,k])
+    abc -= contract('a,bc->abc', t1[j], Woovv[i,k])
+    abc -= contract('a,bc->abc', t1[k], Woovv[j,i])
+    abc += contract('a,bc->abc', Fov[i], t2[j,k])
+    abc -= contract('a,bc->abc', Fov[j], t2[i,k])
+    abc -= contract('a,bc->abc', Fov[k], t2[j,i])
+    t3 = abc - abc.swapaxes(0,1) - abc.swapaxes(0,2)
+
+    if WithDenom is True:
+        occ = diag(F)[o]
+        vir = diag(F)[v]
+        denom = (occ[i] + occ[j] + occ[k] + omega
+                 - (vir.reshape(-1,1,1) + vir.reshape(-1,1) + vir))
+        return t3/denom
+    return t3
+
 
 def l3_ijk_so(o, v, i, j, k, l1, l2, F, Fov, Woovv, Wvovv, Wooov, contract, WithDenom=True):
     """Spin-orbital connected lambda-L3 amplitudes for fixed occupied i, j, k.
@@ -769,6 +792,28 @@ def t3c_abc_so(o, v, a, b, c, t2, Wvvvo, Wovoo, F, contract, omega=0.0, WithDeno
         return t3/denom
     return t3
 
+def t3d_abc_so(o, v, a, b, c, t1, t2, Woovv, F, contract, omega=0.0, WithDenom=True):
+    """Spin-orbital disconnected T3 amplitudes for fixed virtual a, b, c.
+
+    ``Woovv`` (<ab||ei>) are passed explicitly: bare ERI slices for (T) 
+    or the T1-dressed CC3 intermediates for CC3.
+    """
+    Fov = F[o,v]
+    ijk = contract('i,jk->ijk', t1[:,a], Woovv[:,:,b,c])
+    ijk -= contract('i,jk->ijk', t1[:,b], Woovv[:,:,a,c])
+    ijk -= contract('i,jk->ijk', t1[:,c], Woovv[:,:,b,a])
+    ijk += contract('i,jk->ijk', Fov[:,a], t2[:,:,b,c])
+    ijk -= contract('i,jk->ijk', Fov[:,b], t2[:,:,a,c])
+    ijk -= contract('i,jk->ijk', Fov[:,c], t2[:,:,b,a])
+    t3 = ijk - ijk.swapaxes(0,1) - ijk.swapaxes(0,2)
+
+    if WithDenom is True:
+        occ = diag(F)[o]
+        vir = diag(F)[v]
+        denom = (occ.reshape(-1,1,1) + occ.reshape(-1,1) + occ
+                 - (vir[a] + vir[b] + vir[c]) + omega)
+        return t3/denom
+    return t3
 
 def t_vikings_so(o, v, t1, t2, F, ERI, contract):
     """Spin-orbital (T) energy via the occupied-batched ("viking") algorithm.
@@ -796,15 +841,176 @@ def t_vikings_so(o, v, t1, t2, F, ERI, contract):
             for k in range(no):
                 t3 = t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
                 x1[i] += 0.25 * contract('bc,abc->a', Woovv[j,k], t3)
-                # Occ-vir Fock term (cf. the CC3 Fme[k] term): nonzero only for a
-                # non-canonical (semicanonical ROHF) reference, where f_kc != 0.
-                x2[i,j] += contract('c,abc->ab', Fov[k], t3)
-                tmp = 0.5 * contract('dbc,abc->ad', Wvovv[:,k], t3)
-                x2[i,j] += tmp - tmp.swapaxes(0,1)
-                for l in range(no):
-                    tmp = 0.5 * contract('c,abc->ab', Wooov[j,k,l], t3)
-                    x2[i,l] -= tmp
-                    x2[l,i] += tmp
+                # Doubles intermediate, built WITHOUT per-term antisymmetrization -- the
+                # P(ij)P(ab) antisymmetrizer is applied to x2 after the loops.  Every term
+                # carries a 1/4: the antisymmetrizer quadruples an already-antisymmetric
+                # contribution.  The occ-vir Fock term (cf. the CC3 Fme[k] term) is nonzero
+                # only for a non-canonical (semicanonical ROHF) reference, where f_kc != 0.
+                x2[i,j] += (1/4) * contract('c,abc->ab', Fov[k], t3)
+                x2[i,j] += (1/4) * contract('dbc,abc->ad', Wvovv[:,k], t3)
+                x2[i]   -= (1/4) * contract('md,abd->mab', Wooov[j,k], t3)
+
+    # P(ij)P(ab) antisymmetrization of the doubles intermediate (see the loop note)
+    x2 = x2 - x2.swapaxes(0,1) - x2.swapaxes(2,3) + x2.swapaxes(0,1).swapaxes(2,3)
 
     et = contract('ia,ia->', t1, x1) + 0.25 * contract('ijab,ijab->', t2, x2)
     return et
+
+
+# ---- (T) density / Lambda intermediates --------------------------------------
+# These build the same connected+disconnected T3 as the (T) energy, but contract it
+# into the (T) contributions to the one-/two-electron densities and the Lambda-1/2
+# residuals (needed for CCSD(T) gradients and properties).  They also return the (T)
+# energy correction as a byproduct, so the T3 is built only once.  Housed here (rather
+# than on CCwfn) so the wavefunction does not compute density components; solve_cc
+# delegates and caches the returned intermediates on the wfn for cclambda/ccdensity.
+
+def t3_density(o, v, no, nv, t1, t2, F, ERI, L, contract):
+    """(T) density/Lambda intermediates, spatial-orbital spin-adapted closed-shell RHF.
+
+    Returns (ET, intermediates), where ET is the (T) energy correction and
+    intermediates is a dict of the (T) contributions {Doo, Dvv, Dov, Goovv, Gooov,
+    Gvvvo, S1, S2} that the caller caches on the wavefunction.
+    """
+    dvv = np.zeros(nv)   # diagonal of the (T) vir-vir 1-PDM (see below)
+    doo = np.zeros(no)   # diagonal of the (T) occ-occ 1-PDM
+    Dov = np.zeros((no,nv))
+    Goovv = np.zeros_like(t2)
+    Gooov = np.zeros((no,no,no,nv))
+    Gvvvo = np.zeros((nv,nv,nv,no))
+    S1 = np.zeros_like(t1)
+    S2 = np.zeros_like(t2)
+    X2 = np.zeros_like(t2)
+
+    for i in range(no):
+        for j in range(no):
+            for k in range(no):
+                M3 = t3c_ijk(o, v, i, j, k, t2, ERI[v,v,v,o], ERI[o,v,o,o], F, contract, True)
+                N3 = t3d_ijk(o, v, i, j, k, t1, t2, ERI[o,o,v,v], F, contract, True)
+                X3 = 8*M3 - 4*M3.swapaxes(0,1) - 4*M3.swapaxes(1,2) - 4*M3.swapaxes(0,2) + 2*np.moveaxis(M3, 0, 2) + 2*np.moveaxis(M3, 2, 0)
+                Y3 = 8*N3 - 4*N3.swapaxes(0,1) - 4*N3.swapaxes(1,2) - 4*N3.swapaxes(0,2) + 2*np.moveaxis(N3, 0, 2) + 2*np.moveaxis(N3, 2, 0)
+
+                # Doubles contribution (T) correction (Viking's formulation)
+                X2[i,j] += contract('abc,c->ab',(M3 - M3.swapaxes(0,2)), F[o,v][k])
+                X2[i,j] += contract('abc,dbc->ad', (2*M3 - M3.swapaxes(1,2) - M3.swapaxes(0,2)),ERI[v,o,v,v][:,k])
+                X2[i] -= contract('abc,lc->lab', (2*M3 - M3.swapaxes(1,2) - M3.swapaxes(0,2)),ERI[o,o,o,v][j,k])
+
+                # (T) contribution to vir-vir block of one-electron density.  Only the
+                # diagonal is a genuine density term (the off-diagonal <0|L3[E_ab,T3]|0> block
+                # appears in neither Lee-Rendell nor Hald et al.; the oo/vv orbital response is
+                # the dependent-pair kappa-bar in CCderiv.gradient), so contract straight to it.
+                dvv += 0.5 * contract('acd,acd->a', M3, (X3 + Y3))
+
+                # (T) contribution to occ-vir block of one-electron density
+                Dov[i] += contract('abc,bc->a', (M3 - M3.swapaxes(0,2)), (4*t2[j,k] - 2*t2[j,k].T))
+
+                # (T) contributions to two-electron density
+                Z3 = 2*(M3 - M3.swapaxes(1,2)) - (M3.swapaxes(0,1) - np.moveaxis(M3, 2, 0))
+                Goovv[i,j,:,:] += 4*contract('c,abc->ab', t1[k,:], Z3)
+                Gooov[j,i] -= contract('abc,lbc->la', (2*X3 + Y3), t2[:,k])
+                Gvvvo[:,:,:,j] += contract('abc,cd->abd', (2*X3 + Y3), t2[k,i,:,:])
+
+                # (T) contribution to Lambda_1 residual
+                S1[i] += contract('abc,bc->a', 2*(M3 - M3.swapaxes(0,1)), L[o,o,v,v][j,k])
+                # (T) contribution to Lambda_2 residual
+                S2[i] -= contract('abc,lc->lab', (2*X3 + Y3), ERI[o,o,o,v][j,k])
+                S2[i,j] += contract('abc,dcb->ad', (2*X3 + Y3), ERI[o,v,v,v][k])
+
+    S2 = S2 + S2.swapaxes(0,1).swapaxes(2,3)
+
+    # (T) contribution to occ-occ block of one-electron density
+    for a in range(nv):
+        for b in range(nv):
+            for c in range(nv):
+                M3 = t3c_abc(o, v, a, b, c, t2, ERI[v,v,v,o], ERI[o,v,o,o], F, contract, True)
+                N3 = t3d_abc(o, v, a, b, c, t1, t2, ERI[o,o,v,v], F, contract, True)
+                X3 = 8*M3 - 4*M3.swapaxes(0,1) - 4*M3.swapaxes(1,2) - 4*M3.swapaxes(0,2) + 2*np.moveaxis(M3, 0, 2) + 2*np.moveaxis(M3, 2, 0)
+                Y3 = 8*N3 - 4*N3.swapaxes(0,1) - 4*N3.swapaxes(1,2) - 4*N3.swapaxes(0,2) + 2*np.moveaxis(N3, 0, 2) + 2*np.moveaxis(N3, 2, 0)
+                # (T) occ-occ 1-PDM: diagonal only (see the vir-vir note above).
+                doo -= 0.5 * contract('ikl,ikl->i', M3, (X3 + Y3))
+
+    # (T) correction
+    ET = contract('ia,ia->', t1, S1)  # NB: factor of two is already included in S1
+    ET += contract('ijab,ijab->', (4.0*t2 - 2.0*t2.swapaxes(2,3)), X2)
+
+    return ET, {'Doo': np.diag(doo), 'Dvv': np.diag(dvv), 'Dov': Dov,
+                'Goovv': Goovv, 'Gooov': Gooov, 'Gvvvo': Gvvvo,
+                'S1': S1, 'S2': S2}
+
+
+def so_t3_density(o, v, no, nv, t1, t2, F, ERI, contract):
+    """(T) density/Lambda intermediates, spin-orbital (UHF/ROHF references).
+
+    Returns (ET, intermediates), where ET is the (T) energy correction and
+    intermediates is a dict of the (T) contributions {Doo, Dvv, Dov, Goovv, Gooov,
+    Gvovv, Govoo, Gvvvo, S1, S2} that the caller caches on the wavefunction.
+    """
+    x2 = np.zeros_like(t2)
+    dvv = np.zeros(nv)
+    doo = np.zeros(no)
+    Dov = np.zeros((no,nv))
+    Goovv = np.zeros_like(t2)
+    Gooov = np.zeros((no,no,no,nv))
+    Gvovv = np.zeros((nv,no,nv,nv))
+    Govoo = np.zeros((no,nv,no,no))
+    Gvvvo = np.zeros((nv,nv,nv,no))
+    S1 = np.zeros_like(t1)
+    S2 = np.zeros_like(t2)
+
+    Wvvvo = ERI[v,v,v,o]
+    Wovoo = ERI[o,v,o,o]
+    Woovv = ERI[o,o,v,v]
+    Wvovv = ERI[v,o,v,v]
+    Wooov = ERI[o,o,o,v]
+    Fov = F[o,v]
+
+    for i in range(no):
+        for j in range(no):
+            for k in range(no):
+                t3c = t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
+                t3d = t3d_ijk_so(o, v, i, j, k, t1, t2, Woovv, F, contract)
+
+                # Singles and doubles contributions to the (T) energy correction, built
+                # WITHOUT per-term antisymmetrization -- the P(ij)P(ab) antisymmetrizer is
+                # applied to x2 after the loops (same structure as S2).  Every term carries a
+                # 1/4: the antisymmetrizer quadruples an already-antisymmetric contribution.
+                x2[i,j] += (1/4) * contract('c,abc->ab', Fov[k], t3c)
+                x2[i,j] += (1/4) * contract('dbc,abc->ad', Wvovv[:,k], t3c)
+                x2[i] -= (1/4) * contract('md,abd->mab', Wooov[j,k], t3c)
+
+                # (T) contribution to the vv block of the one-electron density (diagonal)
+                dvv += (1/12) * contract('abc,abc->a', (t3c + t3d), t3c)
+
+                # (T) contribution to the ov block of the one-electron density
+                Dov[i] += contract('ade,de->a', t3c, t2[j,k])
+
+                # (T) contributions to the two-electron density
+                Goovv[i,j] += contract('abc,c->ab', t3c, t1[k])
+                Gooov[i,j] -= (1/2) * contract('kbc,abc->ka', t2[k], t3c)
+                Gvovv[:,i] += (1/2) * contract('ec,abe->cab', t2[j,k], t3c)
+                Govoo[:,:,i,j] -= (1/2) * contract('kbc,abc->ka', t2[k], (t3c + t3d))
+                Gvvvo[:,:,:,i] += (1/2) * contract('abe,ec->abc', (t3c + t3d), t2[j,k])
+
+                # (T) contribution to the L1 residual
+                S1[i] += (1/4) * contract('abc,bc->a', t3c, Woovv[j,k])
+                # (T) contribution to the L2 residual
+                S2[i] -= (1/4) * contract('md,abd->mab', Wooov[j,k], (2*t3c + t3d))
+                S2[i,j] += (1/4) * contract('ade,bde->ab', (2*t3c+t3d), Wvovv[:,k])
+
+    for a in range(nv):
+        for b in range(nv):
+            for c in range(nv):
+                t3c = t3c_abc_so(o, v, a, b, c, t2, Wvvvo, Wovoo, F, contract)
+                t3d = t3d_abc_so(o, v, a, b, c, t1, t2, Woovv, F, contract)
+                doo -= (1/12) * contract('ijk,ijk->i', t3c, (t3c + t3d))
+
+    # P(ij)P(ab) antisymmetrization of the doubles intermediates (see the loop note)
+    S2 = S2 - S2.swapaxes(0,1) - S2.swapaxes(2,3) + S2.swapaxes(0,1).swapaxes(2,3)
+    x2 = x2 - x2.swapaxes(0,1) - x2.swapaxes(2,3) + x2.swapaxes(0,1).swapaxes(2,3)
+
+    # (T) correction
+    ET = contract('ia,ia->', t1, S1) + (1/4) * contract('ijab,ijab->', t2, x2)
+
+    return ET, {'Doo': np.diag(doo), 'Dvv': np.diag(dvv), 'Dov': Dov,
+                'Goovv': Goovv, 'Gooov': Gooov, 'Gvovv': Gvovv,
+                'Govoo': Govoo, 'Gvvvo': Gvvvo, 'S1': S1, 'S2': S2}

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -23,7 +23,9 @@ from .utils import helper_diis, zeros_like, clone, sqrt, permute_triples
 from .wavefunction import Wavefunction
 from .mpwfn import MPwfn
 from .local import Local
-from .cctriples import t_tjl, t3c_ijk, t3d_ijk, t3c_abc, t3d_abc, t3_pert_ijk, t_vikings_so, t3c_ijk_so
+from . import cctriples
+from .cctriples import t_tjl, t3c_ijk, t3_pert_ijk
+from .cctriples import t_vikings_so, t3c_ijk_so
 from .lccwfn import lccwfn
 from ._typing import Tensor
 from .exceptions import InvalidKeywordError
@@ -280,10 +282,13 @@ class CCwfn(Wavefunction):
                 print("E(REF)  = %20.15f" % self.eref)
                 if (self.model == 'CCSD(T)'):
                     print("E(CCSD) = %20.15f" % ecc)
-                    if self.orbital_basis == 'spinorbital':
+                    if self.make_t3_density is True:
+                        if self.orbital_basis == 'spinorbital':
+                            et = self.so_t3_density()
+                        else:
+                            et = self.t3_density()
+                    elif self.orbital_basis == 'spinorbital':
                         et = t_vikings_so(o, v, self.t1, self.t2, F, self.H.ERI, contract)
-                    elif self.make_t3_density is True:
-                        et = self.t3_density()
                     else:
                         et = t_tjl(self)
                     print("E(T)    = %20.15f" % et)
@@ -1265,97 +1270,28 @@ class CCwfn(Wavefunction):
         return x1, x2
 
     def t3_density(self):
+        """(T) contributions to the Lambda residuals and one-/two-electron densities.
+
+        Delegates the T3 build and contractions to cctriples.t3_density and caches the
+        returned intermediates on the wfn (for cclambda/ccdensity); returns the (T) energy.
         """
-        Computes (T) contributions to Lambda equations and one-/two-electron densities
+        et, dens = cctriples.t3_density(self.o, self.v, self.no, self.nv, self.t1, self.t2,
+                                        self.H.F, self.H.ERI, self.H.L, self.contract)
+        for name, value in dens.items():
+            setattr(self, name, value)
+        return et
+
+    def so_t3_density(self):
+        """Spin-orbital (T) contributions to the Lambda residuals and densities.
+
+        Delegates to cctriples.so_t3_density and caches the returned intermediates on the
+        wfn (for cclambda/ccdensity); returns the (T) energy correction.
         """
-
-        contract = self.contract
-
-        o = self.o
-        v = self.v
-        no = self.no
-        nv = self.nv
-        t1 = self.t1
-        t2 = self.t2
-        F = self.H.F
-        ERI = self.H.ERI
-        L = self.H.L
-
-        dvv = np.zeros(nv)   # diagonal of the (T) vir-vir 1-PDM (see below)
-        doo = np.zeros(no)   # diagonal of the (T) occ-occ 1-PDM
-        Dov = np.zeros((no,nv))
-        Goovv = np.zeros_like(t2)
-        Gooov = np.zeros((no,no,no,nv))
-        Gvvvo = np.zeros((nv,nv,nv,no))
-        S1 = np.zeros_like(t1)
-        S2 = np.zeros_like(t2)
-        Z3 = np.zeros((nv,nv,nv))
-        X1 = np.zeros_like(t1)
-        X2 = np.zeros_like(t2)
-
-        for i in range(no):
-            for j in range(no):
-                for k in range(no):
-                    M3 = t3c_ijk(o, v, i, j, k, t2, ERI[v,v,v,o], ERI[o,v,o,o], F, contract, True)
-                    N3 = t3d_ijk(o, v, i, j, k, t1, t2, ERI[o,o,v,v], F, contract, True)
-                    X3 = 8*M3 - 4*M3.swapaxes(0,1) - 4*M3.swapaxes(1,2) - 4*M3.swapaxes(0,2) + 2*np.moveaxis(M3, 0, 2) + 2*np.moveaxis(M3, 2, 0)
-                    Y3 = 8*N3 - 4*N3.swapaxes(0,1) - 4*N3.swapaxes(1,2) - 4*N3.swapaxes(0,2) + 2*np.moveaxis(N3, 0, 2) + 2*np.moveaxis(N3, 2, 0)
-
-                    # Doubles contribution (T) correction (Viking's formulation)
-                    X2[i,j] += contract('abc,c->ab',(M3 - M3.swapaxes(0,2)), F[o,v][k])
-                    X2[i,j] += contract('abc,dbc->ad', (2*M3 - M3.swapaxes(1,2) - M3.swapaxes(0,2)),ERI[v,o,v,v][:,k])
-                    X2[i] -= contract('abc,lc->lab', (2*M3 - M3.swapaxes(1,2) - M3.swapaxes(0,2)),ERI[o,o,o,v][j,k])
-
-                    # (T) contribution to vir-vir block of one-electron density.  Only the
-                    # diagonal is a genuine density term (the off-diagonal <0|L3[E_ab,T3]|0> block
-                    # appears in neither Lee-Rendell nor Hald et al.; the oo/vv orbital response is
-                    # the dependent-pair kappa-bar in CCderiv.gradient), so contract straight to it.
-                    dvv += 0.5 * contract('acd,acd->a', M3, (X3 + Y3))
-
-                    # (T) contribution to occ-vir block of one-electron density
-                    Dov[i] += contract('abc,bc->a', (M3 - M3.swapaxes(0,2)), (4*t2[j,k] - 2*t2[j,k].T))
-
-                    # (T) contributions to two-electron density
-                    Z3 = 2*(M3 - M3.swapaxes(1,2)) - (M3.swapaxes(0,1) - np.moveaxis(M3, 2, 0))
-                    Goovv[i,j,:,:] += 4*contract('c,abc->ab', t1[k,:], Z3)
-                    Gooov[j,i] -= contract('abc,lbc->la', (2*X3 + Y3), t2[:,k])
-                    Gvvvo[:,:,:,j] += contract('abc,cd->abd', (2*X3 + Y3), t2[k,i,:,:])
-
-                    # (T) contribution to Lambda_1 residual
-                    S1[i] += contract('abc,bc->a', 2*(M3 - M3.swapaxes(0,1)), L[o,o,v,v][j,k])
-                    # (T) contribution to Lambda_2 residual
-                    S2[i] -= contract('abc,lc->lab', (2*X3 + Y3), ERI[o,o,o,v][j,k])
-                    S2[i,j] += contract('abc,dcb->ad', (2*X3 + Y3), ERI[o,v,v,v][k])
-
-        S2 = S2 + S2.swapaxes(0,1).swapaxes(2,3)
-
-        # (T) contribution to occ-occ block of one-electron density
-        for a in range(nv):
-            for b in range(nv):
-                for c in range(nv):
-                    M3 = t3c_abc(o, v, a, b, c, t2, ERI[v,v,v,o], ERI[o,v,o,o], F, contract, True)
-                    N3 = t3d_abc(o, v, a, b, c, t1, t2, ERI[o,o,v,v], F, contract, True)
-                    X3 = 8*M3 - 4*M3.swapaxes(0,1) - 4*M3.swapaxes(1,2) - 4*M3.swapaxes(0,2) + 2*np.moveaxis(M3, 0, 2) + 2*np.moveaxis(M3, 2, 0)
-                    Y3 = 8*N3 - 4*N3.swapaxes(0,1) - 4*N3.swapaxes(1,2) - 4*N3.swapaxes(0,2) + 2*np.moveaxis(N3, 0, 2) + 2*np.moveaxis(N3, 2, 0)
-                    # (T) occ-occ 1-PDM: diagonal only (see the vir-vir note above).
-                    doo -= 0.5 * contract('ikl,ikl->i', M3, (X3 + Y3))
-
-        self.Dvv = np.diag(dvv)
-        self.Doo = np.diag(doo)
-        self.Dov = Dov # Needed for properties/gradients
-
-        self.Goovv = Goovv
-        self.Gooov = Gooov
-        self.Gvvvo = Gvvvo
-        self.S1 = S1
-        self.S2 = S2
-
-        # (T) correction
-        ET = contract('ia,ia->', t1, S1) # NB: Factor of two is already included in S1 definition
-        ET += contract('ijab,ijab->', (4.0*t2 - 2.0*t2.swapaxes(2,3)), X2)
-
-        return ET
-
+        et, dens = cctriples.so_t3_density(self.o, self.v, self.no, self.nv, self.t1, self.t2,
+                                           self.H.F, self.H.ERI, self.contract)
+        for name, value in dens.items():
+            setattr(self, name, value)
+        return et
 
 # Backward-compatibility alias: the class was renamed ccwfn -> CCwfn to match the
 # HFwfn/MPwfn/CIwfn method-class convention. Existing code using ``ccwfn`` still works.

--- a/pycc/tests/test_083_ccsdt_gradient.py
+++ b/pycc/tests/test_083_ccsdt_gradient.py
@@ -1,6 +1,7 @@
 """
-CCSD(T) analytic nuclear gradient -- pycc.gradient(ccwfn) / CCderiv, spatial closed-shell RHF,
-all-electron.
+CCSD(T) analytic nuclear gradient -- pycc.gradient(ccwfn) / CCderiv.  Spatial closed-shell RHF
+(all-electron and frozen-core) and the spin-orbital path (closed-shell keystones plus the open-shell
+UHF case), both routed through the same (T) density and oo/vv dependent-pair orbital response.
 
 The (T) correction requires canonical MOs, so its orbital response cannot use the -1/2 S^X
 non-canonical trick for the occ-occ / virt-virt blocks: (T) breaks the oo/vv rotation invariance,
@@ -55,9 +56,10 @@ def _ecorr(coords, basis, frozen_core=False):
         return cc.solve_cc(1e-12, 1e-12, 200)
 
 
-def _ccwfn_grad(coords, basis, frozen_core=False):
+def _ccwfn_grad(coords, basis, frozen_core=False, orbital_basis='spatial'):
     """CCSD(T) wavefunction with the (T) densities built, ready for the gradient."""
-    cc = pycc.ccwfn(_scf_wfn(coords, basis, frozen_core), model='ccsd(t)', make_t3_density=True)
+    cc = pycc.ccwfn(_scf_wfn(coords, basis, frozen_core), model='ccsd(t)',
+                    make_t3_density=True, orbital_basis=orbital_basis)
     with open(os.devnull, 'w') as dn, contextlib.redirect_stdout(dn):
         cc.solve_cc(1e-12, 1e-12, 200)
     return cc
@@ -138,3 +140,73 @@ def test_ccsdt_gradient_frozen_core():
     with open(os.devnull, 'w') as dn, contextlib.redirect_stdout(dn):
         lam.solve_lambda(1e-12, 1e-12)
     assert abs(pycc.ccdensity(cc, lam).compute_energy() - cc.ecc) < 1e-11
+
+
+# ---------------------------------------------------------------------------------------------------
+# Spin-orbital (UHF) CCSD(T) gradient -- CCderiv._so_gradient.  The (T) enters through the spin-orbital
+# density and the oo/vv dependent-pair kappa_oo/kappa_vv (the spatial branch with H.L -> <pq||rs>).
+# ---------------------------------------------------------------------------------------------------
+
+# NH2 (2-B1, bent) open-shell UHF reference.  Run in C2v with the 2-B1 ground-state occupation pinned
+# (NH2_OCC) so the SCF cannot fall into the 2-A1 solution ~0.074 Eh higher that a poor guess otherwise
+# reaches -- pinned, the reference is guess- and platform-independent (E_SCF/6-31G = -55.5322382101),
+# hence its gradient is freezeable.  6-31G, not STO-3G: STO-3G leaves the (T) vv dependent-pair
+# identically zero (nv too small), the "minimal basis hides sins" trap, so it would not guard that term.
+NH2 = "0 2\nN\nH 1 1.02\nH 1 1.02 2 103.0\n"
+NH2_OCC = {'docc': [3, 0, 0, 1], 'socc': [0, 0, 1, 0]}   # 2-B1 (C2v irreps A1,A2,B1,B2)
+
+
+def _nh2_so_ccsdt():
+    """NH2 (2-B1, C2v pinned) / 6-31G spin-orbital CCSD(T) wavefunction, (T) densities built."""
+    psi4.core.clean(); psi4.core.clean_options(); psi4.core.be_quiet()
+    psi4.geometry(NH2)
+    psi4.set_options({'basis': '6-31G', 'scf_type': 'pk', 'reference': 'uhf', **NH2_OCC,
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12, 'r_convergence': 1e-12})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', make_t3_density=True, orbital_basis='spinorbital')
+    with open(os.devnull, 'w') as dn, contextlib.redirect_stdout(dn):
+        cc.solve_cc(1e-12, 1e-12, 300)
+    return cc
+
+
+# Frozen open-shell reference: the analytic SO CCSD(T) correlation gradient (NH2 2-B1, C2v pinned occ /
+# 6-31G, in psi4's C2v-oriented frame).  Validated once against a 5-point O(h^4) central FD of pycc's
+# own SO CCSD(T) correlation energy (h=0.005, CC/SCF converged to 1e-13), agreeing to 3.7e-12 -- and
+# every FD point's SCF stayed on the 2-B1 state (E in [-55.5324, -55.5321], never the 2-A1 ~-55.46), so
+# no displaced C1 geometry slipped states.  The x-components vanish by the planar (yz) symmetry.
+GRAD_REF_SO_NH2 = np.array([
+    [0.0,  0.0,                 2.81754964293362e-02],
+    [0.0,  1.53549271288188e-02, -1.40877482146681e-02],
+    [0.0, -1.53549271288188e-02, -1.40877482146681e-02],
+])
+
+
+def test_so_ccsdt_gradient_keystone_equals_spatial():
+    """SO == spatial: a closed-shell RHF driven through the spin-orbital path reproduces the spatial
+    CCSD(T) correlation gradient (H2O/6-31G).  6-31G, not STO-3G, so the oo/vv dependent-pair is
+    actually exercised.  The strongest structural check -- and it validates Dov (the ov 1-PDM), which
+    the (T)-density energy reconstruction is blind to."""
+    g_sp = np.asarray(pycc.CCderiv(_ccwfn_grad(REF, "6-31G")).gradient())
+    g_so = np.asarray(pycc.CCderiv(_ccwfn_grad(REF, "6-31G", orbital_basis='spinorbital')).gradient())
+    assert np.max(np.abs(g_so - g_sp)) < 1e-10, (g_so, g_sp)
+
+
+def test_so_ccsdt_gradient_keystone_frozen_core():
+    """SO == spatial CCSD(T) gradient with a frozen core (the core spans 2*nfzc spin-orbitals): the
+    core<->active-occupied (T) response is carried by P_co, the active oo/vv pairs by the dependent
+    pair, in both bases."""
+    cc_so = _ccwfn_grad(REF, "6-31G", frozen_core=True, orbital_basis='spinorbital')
+    assert cc_so.nfzc > 0
+    g_so = np.asarray(pycc.CCderiv(cc_so).gradient())
+    g_sp = np.asarray(pycc.CCderiv(_ccwfn_grad(REF, "6-31G", frozen_core=True)).gradient())
+    assert np.max(np.abs(g_so - g_sp)) < 1e-10, (g_so, g_sp)
+
+
+def test_so_ccsdt_gradient_openshell_nh2():
+    """Open-shell UHF SO CCSD(T) correlation gradient (NH2 2-B1, C2v pinned occ / 6-31G) vs the frozen
+    5-point-FD-validated reference.  The genuinely new open-shell (T) physics.  The 1e-8 guard (looser
+    than the closed-shell keystones) reflects the near-singular open-shell spin-orbital orbital Hessian
+    -- the Z-vector solve carries a redundant near-zero mode whose cross-platform BLAS noise leaks into
+    the gradient at that level (cf. test_078); the FD oracle itself is tight to 3.7e-12."""
+    g = np.asarray(pycc.CCderiv(_nh2_so_ccsdt()).gradient())
+    assert np.max(np.abs(g - GRAD_REF_SO_NH2)) < 1e-8, g


### PR DESCRIPTION
# Spin-orbital CCSD(T) analytic gradient

Branch: `feature/so-ccsdt-gradient` -> `main`  (one commit)

Adds the spin-orbital (UHF) CCSD(T) analytic nuclear gradient, together with the
spin-orbital (T) reduced density it consumes. This completes the CCSD(T) gradient
across both orbital bases: the spatial closed-shell path landed earlier (all-electron
#183, frozen-core #184); this PR adds the spin-orbital path.

## What changed

### Gradient (`ccderiv.py`)

`CCderiv._so_gradient` gains a `model == 'CCSD(T)'` branch that mirrors the spatial
(T) branch with `H.L -> <pq||rs>`. (T) breaks the occ-occ / virt-virt rotation
invariance, so the canonical perturbed orbitals acquire dependent-pair rotations
`kappa_oo`/`kappa_vv` beyond the ov Z-vector:

    Poo = _dependent_pairs(Ip[o, o], eps[o])
    Pvv = _dependent_pairs(Ip[v, v], eps[v])
    Drel[o, o] += Poo;  Drel[v, v] += Pvv
    X = X + (Poo . <v o|ofull o||>  +  Pvv . <ofull v|v v||>)

Both blocks vanish for plain CCSD (oo/vv invariance), so the branch is a no-op there.
The `_dependent_pairs` divide is shared with the spatial path and the frozen-core
`P_co` machinery. Frozen core needs no new terms: the core<->active-occupied (T)
response is already carried by `P_co` (its Lagrangian is the (T)-inclusive one).

### SO (T) density groundwork

- **`cctriples.py`**
  - New disconnected-T3 kernels `t3d_ijk_so` / `t3d_abc_so`.
  - The (T) density/Lambda builders `t3_density` (spatial) and `so_t3_density`
    (spin-orbital) are now **free functions here**, returning `(ET, {intermediates})`,
    rather than methods on `CCwfn`. This keeps the density computation out of the
    wavefunction class (no `ccwfn -> ccdensity` dependency) while preserving the
    single T3 build. They sit alongside the existing `t_vikings_so` / `t_tjl` energy
    drivers and the T3 kernels.
  - `t_vikings_so`'s `x2` intermediate simplified to the same three `1/4` terms plus a
    single post-loop `P(ij)P(ab)` antisymmetrizer used by `so_t3_density` (energy
    bit-for-bit unchanged; the `l`-loop and per-term antisymmetrization are gone).

- **`ccwfn.py`**: `t3_density` / `so_t3_density` are now thin delegate-and-cache
  wrappers over the `cctriples` functions; `solve_cc`, `cclambda`, and `ccdensity`
  call sites are unchanged. Now-unused triples-kernel imports trimmed.

- **`ccdensity.py`**: the SO (T) contributions are gated on `model == 'CCSD(T)'` and
  added to the 1-PDM (`Doo`/`Dvv`/`Dov`) and 2-PDM (`Goovv`/`Gooov`/`Gvovv`/`Govoo`/
  `Gvvvo`). Also a self-contained SO CCSD 2-PDM relabel `akij -> kaij`
  (`Gamma[o,v,o,o]`), applied consistently across the builder, the antisymmetric-image
  assembly, and `compute_energy` (energy-preserving).

- **`cclambda.py`**: the SO (T) `S1`/`S2` contributions added to the L1/L2 residuals.

## Validation

All against pycc's own internal oracles (no dependence on a psi4 (T) gradient).

| Check | Result |
| --- | --- |
| Closed-shell SO == spatial CCSD(T) gradient (H2O/6-31G) | 2.3e-13 |
| Frozen-core SO == spatial CCSD(T) gradient (nfzc=1) | 1.4e-13 |
| Open-shell UHF NH2 (2-B1) analytic vs 5-point O(h^4) FD of the SO CCSD(T) energy | 3.7e-12 |

The closed-shell keystone also validates `Dov` (the ov 1-PDM), which the (T)-density
energy reconstruction cannot see. 6-31G is used deliberately: in STO-3G the (T) vv
dependent-pair is identically zero (`||Pvv|| = 0`) -- the "minimal basis hides sins"
trap -- so it would not guard that term.

The open-shell NH2 reference is run in C2v with the 2-B1 ground-state occupation pinned
(`docc [3,0,0,1]`, `socc [0,0,1,0]`); pinned, the reference is guess- and
platform-independent (`E_SCF/6-31G = -55.5322382101`). Every FD displacement point's
SCF was verified to stay on the 2-B1 state (never the 2-A1 solution ~0.074 Eh higher),
so no displaced C1 geometry slipped states.

## Tests

`pycc/tests/test_083_ccsdt_gradient.py` gains three tests (the open-shell reference is
**hard-wired** as the frozen `GRAD_REF_SO_NH2`, so no finite difference runs in the
suite):

- `test_so_ccsdt_gradient_keystone_equals_spatial`
- `test_so_ccsdt_gradient_keystone_frozen_core`
- `test_so_ccsdt_gradient_openshell_nh2`

Full sweep `test_005 / test_034 / test_077 / test_078 / test_083`: 24 passed.
ROHF remains unsupported (raises), as for the SO CCSD gradient.

