### PR TITLE
CCSD/CCSD(T) relaxed dipole

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ include:
     and atomic axial tensors (AATs) -- the building blocks for IR and VCD spectra. Both spin
     paths (spin-adapted closed-shell RHF and spin-orbital), all-electron and frozen-core; the
     MP2 second derivatives come via two independent routes (explicit-derivative and 2n+1)
-  - Analytic nuclear energy gradients for CCSD and CCSD(T) (both spin-adapted closed-shell RHF and
-    spin-orbital UHF), all-electron and frozen-core, built on the same relaxed-density / Z-vector
-    machinery as the MP2 gradient
+  - Analytic nuclear energy gradients and relaxed electronic dipoles for CCSD and CCSD(T) (both
+    spin-adapted closed-shell RHF and spin-orbital UHF), all-electron and frozen-core, built on the
+    same relaxed-density / Z-vector machinery as the MP2 gradient
   - A uniform property interface -- `pycc.dipole`, `pycc.gradient`, `pycc.polarizability`,
     `pycc.hessian`, `pycc.apt`, `pycc.aat` -- that dispatches on wavefunction type and returns
     each property's nuclear/reference/correlation decomposition as a `PropertyComponents`

--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -38,17 +38,24 @@ invariant, with a numerically stable non-canonical default (`gauge=`).
 see Roadmap). These supply the reference contribution to every MP2 total property and anchor the
 SO machinery through the RHF-forced-to-SO == spatial keystone.
 
-**Coupled-cluster gradients.** Analytic nuclear gradients through the `CCderiv` driver, reusing the
-MP2 Z-vector / relaxed-density assembly (`_lagrangian`, the SCF orbital Hessian) with the CCSD/(T)
-densities and Λ:
+**Coupled-cluster gradients and dipoles.** Analytic nuclear gradients and relaxed electronic dipoles
+through the `CCderiv` driver, reusing the MP2 Z-vector / relaxed-density assembly (`_lagrangian`, the
+SCF orbital Hessian) with the CCSD/(T) densities and Λ:
 
 | Method | spatial (closed-shell RHF) | spin-orbital (UHF) | frozen core |
 |---|---|---|---|
-| CCSD `dE/dX` | ✅ | ✅ | ✅ |
-| CCSD(T) `dE/dX` | ✅ | ✅ | ✅ |
+| CCSD `dE/dX` (gradient) | ✅ | ✅ | ✅ |
+| CCSD(T) `dE/dX` (gradient) | ✅ | ✅ | ✅ |
+| CCSD, CCSD(T) `dE/dF` (relaxed dipole) | ✅ | ✅ | ✅ |
 
-Validated against a tight finite difference of pycc's own correlation energy (5-point O(h⁴), ~1e-12),
-**not** psi4's analytic gradient (§4). Unlike CCSD — which reuses the −½Sˣ ov-only Z-vector because
+The relaxed dipole reuses the gradient's relaxed density: a static field leaves the AO basis fixed
+(`S^F = ⟨pq\|rs⟩^F = 0`), so `mu = Tr(D_rel · mu_ints)` — the same `D_rel` (correlation density + `Pco`
++ (T) κ̄ + ov Z-vector), built by the shared `CCderiv._relaxed_density`/`_so_relaxed_density`, that the
+gradient contracts with the skeleton integrals. `pycc.dipole(CCwfn)` returns the usual
+nuclear/reference/correlation `PropertyComponents`. Validated against a tight finite difference of
+pycc's own correlation energy — 5-point O(h⁴), the gradient ~1e-12 and the relaxed dipole a finite
+field of `(E_CC − E_SCF)` ~1e-12 — **not** psi4's analytic derivatives (§4). Unlike CCSD — which reuses
+the −½Sˣ ov-only Z-vector because
 CCSD is invariant to occ–occ/virt–virt rotations — **CCSD(T) needs canonical perturbed orbitals for
 the oo/vv blocks** (dependent-pair κ̄, even all-electron); see §5 and §7. The efficient Z-vector route
 and the independent explicit-derivative route agree to machine precision for CCSD (the (T) explicit
@@ -107,11 +114,14 @@ One-directional layering: **`Derivatives` ← `CPHF` ← `HFwfn` / `MPwfn`**.
   `_perturbed_densities`, `_(so_)perturbed_relaxed_opdm`, `_(so_)perturbed_lagrangian` — the last
   takes an optional `(D, dD)`: unrelaxed → Z-vector RHS, relaxed → `d_x I`); and the property
   methods with their `route=` options.
-- **`CCderiv`** — the CCSD / CCSD(T) analytic gradient. Reuses `MPwfn._lagrangian` and the SCF orbital
-  Hessian (through a persistent `HFwfn`/`CPHF`); takes the CC relaxed density + Λ from `ccdensity`,
-  and for (T) the densities/Λ from `CCwfn.t3_density`. `_dependent_pairs` builds the canonical oo/vv
-  κ̄ divides for (T) (§7). Spatial `gradient()` + spin-orbital `_so_gradient()`; the independent
-  `_gradient_explicit()` cross-check (CCSD only so far).
+- **`CCderiv`** — the CCSD / CCSD(T) analytic gradient and relaxed dipole. Reuses `MPwfn._lagrangian`
+  and the SCF orbital Hessian (through a persistent `HFwfn`/`CPHF`); takes the CC relaxed density + Λ
+  from `ccdensity`, and for (T) the densities/Λ from `CCwfn.t3_density`. `_dependent_pairs` builds the
+  canonical oo/vv κ̄ divides for (T) (§7). The relaxed density `D_rel` is built once by the shared
+  `_relaxed_density()` / `_so_relaxed_density()` (the (T) κ̄ + `Pco` + ov Z-vector), then consumed by
+  `gradient()` / `_so_gradient()` (skeleton integrals) and `relaxed_dipole()` (dipole integrals);
+  `pycc.dipole(CCwfn)` routes the correlation block to the latter. The independent
+  `_gradient_explicit()` cross-check is CCSD only so far.
 
 Conventions: spatial methods unlabeled, spin-orbital prefixed `_so_`. `MPwfn` holds a persistent
 full-occupied `CPHF` (`_full_occ_cphf`) so the response caches survive across property calls, and
@@ -317,6 +327,7 @@ Reference layer, then the MP2 derivative effort:
 | #183 | **CCSD(T) gradient** — spatial RHF, all-electron; + frozen core sourced from psi4 only (`frozen_core` pycc override removed) |
 | #184 | **frozen-core CCSD(T) gradient** — oo/vv dependent-pair κ̄ generalized from the frozen-core `Pco`; diagonal-only (T) `Doo`/`Dvv` |
 | #185 | **spin-orbital CCSD(T) gradient** — SO (T) density + oo/vv κ̄ in `_so_gradient` (all-electron + frozen core); (T) density builders moved to `cctriples` (no `ccwfn`→`ccdensity` dependency) |
+| #186 | **CCSD/CCSD(T) relaxed dipole** — `CCderiv.relaxed_dipole` = `Tr(D_rel·μ)`; shared `_relaxed_density`/`_so_relaxed_density` factored out of the gradients; wires `pycc.dipole(CCwfn)` (both spins, all-electron + frozen core) |
 
 Tests: `test_046`–`test_050` (spatial HF), `test_062`–`test_066` (SO HF), `test_061` (MP2
 gradient/relaxed density), `test_067` (polarizability), `test_068` (APT), `test_069` (Hessian),

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -95,35 +95,16 @@ class CCderiv:
         P[m] = num[m] / den[m]
         return P
 
-    def gradient(self) -> np.ndarray:
-        """CCSD **correlation** contribution to the analytic nuclear energy gradient (a.u.), shape
-        ``(natom, 3)``, via the **Z-vector (relaxed-density) route** -- the efficient default
-        (one CPHF solve, not ``3*natom``)::
-
-            dE_corr/dX = sum_pq D~_pq f^X_pq + sum_pqrs Gamma_pqrs <pq|rs>^X + sum_pq W_pq S^X_pq
-
-        with the relaxed 1-PDM ``D~`` (the Lambda-response ``D`` plus the orbital-relaxation
-        Z-vector ``z``), the (symmetrized) 2-PDM ``Gamma``, and the energy-weighted density
-        ``W = I'(D~)`` (:meth:`_lagrangian`).  The Z-vector solves ``A z = X`` once, with
-        ``X = I'_ia - I'_ai`` the ov-antisymmetric generalized Fock, using the SCF orbital Hessian
-        (:meth:`HFwfn.cphf`).  ``f^X``/``S^X``/``<pq|rs>^X`` are the skeleton derivative integrals
-        from ``ccwfn.derivatives`` (no per-perturbation CPHF solve).
-
-        The **reference (SCF) gradient is kept separate**: the total CCSD gradient is
-        ``HFwfn(ref).gradient()`` plus this, assembled by the :func:`pycc.gradient` facade.
-
-        Spatial (closed-shell RHF) path; all-electron and frozen-core.  Validated against
-        ``psi4.gradient('ccsd')``, a finite difference of the CCSD energy, and the independent
-        explicit-derivative route (:meth:`_gradient_explicit`).  The spin-orbital (UHF) path is
-        dispatched to :meth:`_so_gradient`.
-
-        Frozen core is handled as in the MP2 gradient: the correlation densities live in the active
-        space while the orbital response spans the full occupied space.  The core<->active-occupied
-        rotation is a direct divide ``P_co = (I'_ci - I'_ic)/(eps_c - eps_i)`` (the SCF energy is
-        invariant to occupied-occupied rotations), coupled into the Z-vector right-hand side."""
+    def _relaxed_density(self):
+        """The relaxed correlation 1-PDM ``Drel`` and the symmetrized 2-PDM ``Gam`` (spatial
+        closed-shell RHF).  ``Drel`` is the Lambda-response 1-PDM ``D`` plus the orbital-relaxation
+        blocks: the frozen-core core<->active-occupied divide ``P_co``, the CCSD(T) oo/vv
+        dependent-pair ``kappa_oo``/``kappa_vv`` (model-gated), and the ov Z-vector ``-z`` (one CPHF
+        solve, RHS = the ov-antisymmetric generalized Fock ``I'_ia - I'_ai``).  This is the
+        **perturbation-independent** relaxed density shared by :meth:`gradient` (contracted with the
+        skeleton derivative integrals) and :meth:`relaxed_dipole` (contracted with the dipole
+        integrals); the (T) response rides along in ``Drel`` for both."""
         cc = self.ccwfn
-        if cc.orbital_basis == 'spinorbital':
-            return self._so_gradient()
         o, v = cc.o, cc.v
         nfzc = cc.nfzc
         co = slice(0, nfzc)                              # frozen-core occupied
@@ -162,6 +143,92 @@ class CCderiv:
         z = self._reference_hf().cphf.solve(X)          # Z-vector: A z = X (full-occ SCF Hessian)
         Drel[v, ofull] += -z.T
         Drel[ofull, v] += -z
+        return Drel, Gam
+
+    def _so_relaxed_density(self):
+        """Spin-orbital (UHF) analog of :meth:`_relaxed_density`: the relaxed correlation 1-PDM
+        ``Drel`` and 2-PDM ``Gam``, with the antisymmetrized-ERI Lagrangian and the inline orbital
+        Hessian (``G_ia,jb = <aj||ib> + <ab||ij> + delta (eps_a - eps_i)``) rather than a borrowed
+        all-electron CPHF.  **UHF only** -- raises for ROHF (the semicanonical response does not
+        reproduce the restricted ROHF response)."""
+        cc = self.ccwfn
+        if cc.mp.cphf.is_rohf:
+            raise NotImplementedError(
+                "The spin-orbital CCSD/CCSD(T) gradient and relaxed dipole are not implemented for "
+                "ROHF references (the semicanonical response does not reproduce the restricted ROHF "
+                "response); RHF and UHF are supported.")
+        o, v = cc.o, cc.v
+        nfzc, nv = cc.nfzc, cc.nv
+        co = slice(0, o.start)                            # frozen-core occupied (2*nfzc spin-orbitals)
+        ofull = slice(0, o.stop)                          # full occupied (core + active)
+        nof = o.stop
+        c = self.contract
+        eps = np.diag(np.asarray(cc.H.F))
+        ERI = np.asarray(cc.H.ERI)                        # spin-orbital <pq||rs>
+        D, Gam = self._density().gradient_densities()
+        Ip = self._lagrangian(D, Gam)
+        Drel = D.copy()
+        if nfzc:                                          # core<->active-occupied: direct divide
+            Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
+            Drel[co, o] += Pco
+            Drel[o, co] += Pco.T
+        X = Ip[ofull, v] - Ip[v, ofull].T                # ov-antisymmetric generalized Fock
+        if nfzc:                                          # couple P_co into the Z-vector RHS
+            zjc = -Pco.T
+            X = X - (c('jc,ajic->ia', zjc, ERI[v, o, ofull, co])
+                     + c('jc,acij->ia', zjc, ERI[v, co, ofull, o]))
+        if cc.model.upper() == 'CCSD(T)':
+            # (T) breaks the occ-occ / virt-virt rotation invariance: the canonical perturbed
+            # orbitals acquire dependent-pair rotations kappa_oo/kappa_vv beyond the ov Z-vector --
+            # the spin-orbital analog of the (T) branch in :meth:`_relaxed_density` (spatial L ->
+            # <pq||rs>).  For CCSD both blocks vanish.
+            Poo = self._dependent_pairs(Ip[o, o], eps[o])
+            Pvv = self._dependent_pairs(Ip[v, v], eps[v])
+            Drel[o, o] += Poo
+            Drel[v, v] += Pvv
+            X = X + (c('kl,akil->ia', Poo, ERI[v, o, ofull, o])
+                     + c('bc,ibac->ia', Pvv, ERI[ofull, v, v, v]))
+        G = (c('ajib->iajb', ERI[v, ofull, ofull, v])    # orbital Hessian, built inline
+             + c('abij->iajb', ERI[v, v, ofull, ofull])).reshape(nof * nv, nof * nv)
+        G[np.diag_indices(nof * nv)] += (eps[v][None, :] - eps[ofull][:, None]).reshape(-1)
+        z = np.linalg.solve(G, X.reshape(-1)).reshape(nof, nv)   # Z-vector A z = X
+        Drel[v, ofull] += -z.T
+        Drel[ofull, v] += -z
+        return Drel, Gam
+
+    def gradient(self) -> np.ndarray:
+        """CCSD **correlation** contribution to the analytic nuclear energy gradient (a.u.), shape
+        ``(natom, 3)``, via the **Z-vector (relaxed-density) route** -- the efficient default
+        (one CPHF solve, not ``3*natom``)::
+
+            dE_corr/dX = sum_pq D~_pq f^X_pq + sum_pqrs Gamma_pqrs <pq|rs>^X + sum_pq W_pq S^X_pq
+
+        with the relaxed 1-PDM ``D~`` (the Lambda-response ``D`` plus the orbital-relaxation
+        Z-vector ``z``), the (symmetrized) 2-PDM ``Gamma``, and the energy-weighted density
+        ``W = I'(D~)`` (:meth:`_lagrangian`).  The Z-vector solves ``A z = X`` once, with
+        ``X = I'_ia - I'_ai`` the ov-antisymmetric generalized Fock, using the SCF orbital Hessian
+        (:meth:`HFwfn.cphf`).  ``f^X``/``S^X``/``<pq|rs>^X`` are the skeleton derivative integrals
+        from ``ccwfn.derivatives`` (no per-perturbation CPHF solve).
+
+        The **reference (SCF) gradient is kept separate**: the total CCSD gradient is
+        ``HFwfn(ref).gradient()`` plus this, assembled by the :func:`pycc.gradient` facade.
+
+        Spatial (closed-shell RHF) path; all-electron and frozen-core.  Validated against
+        ``psi4.gradient('ccsd')``, a finite difference of the CCSD energy, and the independent
+        explicit-derivative route (:meth:`_gradient_explicit`).  The spin-orbital (UHF) path is
+        dispatched to :meth:`_so_gradient`.
+
+        Frozen core is handled as in the MP2 gradient: the correlation densities live in the active
+        space while the orbital response spans the full occupied space.  The core<->active-occupied
+        rotation is a direct divide ``P_co = (I'_ci - I'_ic)/(eps_c - eps_i)`` (the SCF energy is
+        invariant to occupied-occupied rotations), coupled into the Z-vector right-hand side."""
+        cc = self.ccwfn
+        if cc.orbital_basis == 'spinorbital':
+            return self._so_gradient()
+        o = cc.o
+        ofull = slice(0, o.stop)                         # full occupied (core + active)
+        c = self.contract
+        Drel, Gam = self._relaxed_density()             # D + P_co + (T) kappa_oo/vv + ov Z-vector
         W = self._lagrangian(Drel, Gam)                 # energy-weighted density
         d = cc.derivatives
         grad = np.zeros((d.natom, 3))
@@ -203,50 +270,10 @@ class CCderiv:
         UHF), and the explicit-derivative route (:meth:`_gradient_explicit`, CCSD only -- the (T)
         dependent-pair is not yet carried there)."""
         cc = self.ccwfn
-        if cc.mp.cphf.is_rohf:
-            raise NotImplementedError(
-                "The spin-orbital CCSD gradient is not implemented for ROHF references (the "
-                "semicanonical response does not reproduce the restricted ROHF response); RHF and "
-                "UHF are supported.")
-        o, v = cc.o, cc.v
-        nfzc, nv = cc.nfzc, cc.nv
-        co = slice(0, o.start)                            # frozen-core occupied (2*nfzc spin-orbitals)
+        o = cc.o
         ofull = slice(0, o.stop)                          # full occupied (core + active)
-        nof = o.stop
         c = self.contract
-        eps = np.diag(np.asarray(cc.H.F))
-        ERI = np.asarray(cc.H.ERI)                        # spin-orbital <pq||rs>
-        D, Gam = self._density().gradient_densities()
-        Ip = self._lagrangian(D, Gam)
-        Drel = D.copy()
-        if nfzc:                                          # core<->active-occupied: direct divide
-            Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
-            Drel[co, o] += Pco
-            Drel[o, co] += Pco.T
-        X = Ip[ofull, v] - Ip[v, ofull].T                # ov-antisymmetric generalized Fock
-        if nfzc:                                          # couple P_co into the Z-vector RHS
-            zjc = -Pco.T
-            X = X - (c('jc,ajic->ia', zjc, ERI[v, o, ofull, co])
-                     + c('jc,acij->ia', zjc, ERI[v, co, ofull, o]))
-        if cc.model.upper() == 'CCSD(T)':
-            # (T) breaks the occ-occ / virt-virt rotation invariance, so the canonical perturbed
-            # orbitals acquire dependent-pair rotations kappa_oo/kappa_vv beyond the ov Z-vector:
-            # (I'_ij-I'_ji)/(eps_i-eps_j) over the oo pairs and the vv analog
-            # (:meth:`_dependent_pairs`), added to the relaxed density and coupled into the ov
-            # Z-vector RHS through the antisymmetrized ERI -- the spin-orbital analog of the (T)
-            # branch in :meth:`gradient` (spatial L -> <pq||rs>).  For CCSD both blocks vanish.
-            Poo = self._dependent_pairs(Ip[o, o], eps[o])
-            Pvv = self._dependent_pairs(Ip[v, v], eps[v])
-            Drel[o, o] += Poo
-            Drel[v, v] += Pvv
-            X = X + (c('kl,akil->ia', Poo, ERI[v, o, ofull, o])
-                     + c('bc,ibac->ia', Pvv, ERI[ofull, v, v, v]))
-        G = (c('ajib->iajb', ERI[v, ofull, ofull, v])    # orbital Hessian, built inline
-             + c('abij->iajb', ERI[v, v, ofull, ofull])).reshape(nof * nv, nof * nv)
-        G[np.diag_indices(nof * nv)] += (eps[v][None, :] - eps[ofull][:, None]).reshape(-1)
-        z = np.linalg.solve(G, X.reshape(-1)).reshape(nof, nv)   # Z-vector A z = X
-        Drel[v, ofull] += -z.T
-        Drel[ofull, v] += -z
+        Drel, Gam = self._so_relaxed_density()           # raises for ROHF; D + P_co + (T) kappa + z
         W = self._lagrangian(Drel, Gam)                  # energy-weighted density
         d = cc.derivatives
         grad = np.zeros((d.natom, 3))
@@ -258,6 +285,25 @@ class CCderiv:
                                     + c('pqrs,pqrs->', Gam, ERIx[cart])
                                     + c('pq,pq->', W, Sx[cart]))
         return grad
+
+    def relaxed_dipole(self) -> np.ndarray:
+        """CCSD / CCSD(T) **correlation** contribution to the relaxed electronic dipole (a.u.),
+        ``Tr(D_rel . mu)`` per Cartesian axis -- the CC analog of :meth:`MPwfn.relaxed_dipole`, and
+        the correlation block that :func:`pycc.dipole` pairs with the reference (HF) and nuclear
+        dipoles.
+
+        A static electric field does not move the AO basis (``S^F = <pq|rs>^F = 0``), so the relaxed
+        dipole is just the perturbation-independent relaxed density (:meth:`_relaxed_density` /
+        :meth:`_so_relaxed_density`) contracted with the dipole integrals -- no energy-weighted
+        density and no 2-PDM term (unlike the gradient).  The (T) density and its oo/vv
+        dependent-pair orbital response ride along inside ``D_rel``, so the (T) contribution needs no
+        separate handling.  Dispatches spatial vs spin-orbital on ``orbital_basis`` (ROHF raises via
+        :meth:`_so_relaxed_density`)."""
+        cc = self.ccwfn
+        Drel, _ = (self._so_relaxed_density() if cc.orbital_basis == 'spinorbital'
+                   else self._relaxed_density())
+        c = self.contract
+        return np.array([c('pq,pq->', Drel, np.asarray(cc.H.mu[a])) for a in range(3)])
 
     def _gradient_explicit(self) -> np.ndarray:
         """CCSD correlation gradient via the **explicit-derivative route** -- an independent

--- a/pycc/tests/test_034_ccsd_t_density.py
+++ b/pycc/tests/test_034_ccsd_t_density.py
@@ -120,3 +120,74 @@ def test_ccsd_t_dipole(rhf_wfn):
     assert abs(mu_analytic - T_DIPOLE_Z_REF) < 1e-11, mu_analytic
 
     psi4.core.clean()
+
+
+# Frozen 5-point O(h^4) finite-field oracle for the CCSD(T) RELAXED correlation dipole mu_z
+# (H2O/6-31G, _T_DIPOLE_GEOM).  Unlike the unrelaxed T_DIPOLE_Z_REF above (a fixed-orbital Fock
+# perturbation of the (T) density only), this is the full CCSD(T) relaxed correlation dipole
+# CCderiv.relaxed_dipole = Tr(D_rel . mu), with D_rel the gradient's relaxed density (correlation D +
+# frozen-core P_co + (T) kappa_oo/kappa_vv + ov Z-vector).  Validated (once) against a 5-point finite
+# field of pycc's own CCSD(T) correlation energy (E_CCSD(T) - E_SCF) under a field-relaxed SCF (psi4
+# perturb_h, F=0.0005): 1.4e-12 all-electron, 1.1e-12 frozen core (see _findiff_relaxed_dipole_z).
+RELAXED_DIPOLE_Z_REF = 0.0888679557555765
+RELAXED_DIPOLE_Z_REF_FC = 0.0889835346143946
+
+
+def _findiff_relaxed_dipole_z(freeze_core='false', F=0.0005):
+    """Regeneration recipe for RELAXED_DIPOLE_Z_REF[_FC] (not run in the tests): 5-point O(h^4)
+    finite field of pycc's CCSD(T) correlation energy (E_CCSD(T) - E_SCF) under a field-relaxed SCF
+    (the SCF orbitals relax in the field via psi4 perturb_h), on _T_DIPOLE_GEOM / 6-31G."""
+    def ecorr(Fz):
+        psi4.core.clean(); psi4.core.clean_options()
+        psi4.geometry(_T_DIPOLE_GEOM)
+        opt = {'basis': '6-31G', 'scf_type': 'pk', 'freeze_core': freeze_core,
+               'e_convergence': 1e-13, 'd_convergence': 1e-13}
+        if Fz:
+            opt.update({'perturb_h': True, 'perturb_with': 'dipole', 'perturb_dipole': [0., 0., Fz]})
+        psi4.set_options(opt)
+        _, wfn = psi4.energy('scf', return_wfn=True)
+        return pycc.ccwfn(wfn, model='ccsd(t)').solve_cc(1e-13, 1e-13, 200)
+    e = {s: ecorr(s * F) for s in (-2, -1, 1, 2)}
+    return (-e[2] + 8 * e[1] - 8 * e[-1] + e[-2]) / (12 * F)
+
+
+def test_ccsdt_relaxed_dipole(rhf_wfn):
+    """The analytic CCSD(T) RELAXED correlation dipole mu_z (CCderiv.relaxed_dipole = Tr(D_rel . mu))
+    matches the finite-field-validated frozen reference (H2O/6-31G), and the pycc.dipole facade
+    decomposes exactly.  A static field does not move the AO basis (S^F = <pq|rs>^F = 0), so the
+    relaxed dipole reuses the gradient's relaxed density -- the (T) density and its oo/vv
+    dependent-pair ride along inside D_rel with no separate handling."""
+    wfn = rhf_wfn(_T_DIPOLE_GEOM, "6-31G", freeze_core="false")
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', make_t3_density=True)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    mu = np.asarray(pycc.CCderiv(cc).relaxed_dipole())
+    assert abs(mu[2] - RELAXED_DIPOLE_Z_REF) < 1e-10, mu[2]
+    # facade: total = nuclear + reference + correlation, and correlation == relaxed_dipole
+    r = pycc.dipole(cc)
+    assert np.max(np.abs(np.asarray(r.total) - (np.asarray(r.nuclear)
+                  + np.asarray(r.reference) + np.asarray(r.correlation)))) < 1e-12
+    assert np.max(np.abs(np.asarray(r.correlation) - mu)) < 1e-12
+    psi4.core.clean()
+
+
+def test_ccsdt_relaxed_dipole_spinorbital(rhf_wfn):
+    """SO == spatial: a closed-shell RHF driven through the spin-orbital path reproduces the spatial
+    CCSD(T) relaxed correlation dipole."""
+    wfn = rhf_wfn(_T_DIPOLE_GEOM, "6-31G", freeze_core="false")
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', make_t3_density=True, orbital_basis='spinorbital')
+    cc.solve_cc(1e-12, 1e-12, 100)
+    mu = np.asarray(pycc.CCderiv(cc).relaxed_dipole())
+    assert abs(mu[2] - RELAXED_DIPOLE_Z_REF) < 1e-9, mu[2]
+    psi4.core.clean()
+
+
+def test_ccsdt_relaxed_dipole_frozen_core(rhf_wfn):
+    """Frozen-core CCSD(T) relaxed correlation dipole (H2O/6-31G, O 1s frozen): the core<->active (T)
+    response rides the P_co divide and the active oo/vv the dependent pair, inside D_rel."""
+    wfn = rhf_wfn(_T_DIPOLE_GEOM, "6-31G", freeze_core="true")
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', make_t3_density=True)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    assert cc.nfzc > 0
+    mu = np.asarray(pycc.CCderiv(cc).relaxed_dipole())
+    assert abs(mu[2] - RELAXED_DIPOLE_Z_REF_FC) < 1e-10, mu[2]
+    psi4.core.clean()


### PR DESCRIPTION
# CCSD/CCSD(T) relaxed dipole

Branch: `feature/ccsdt-relaxed-dipole` -> `main`  (one commit)

Adds the CCSD / CCSD(T) relaxed electronic dipole, for consistency with the MP2 relaxed
dipole, and wires `pycc.dipole(CCwfn)` end-to-end.

## What changed

### `ccderiv.py`

- **`CCderiv.relaxed_dipole()`** -- the CC analog of `MPwfn.relaxed_dipole`: `Tr(D_rel . mu)`
  per Cartesian axis. A static electric field does not move the AO basis
  (`S^F = <pq|rs>^F = 0`), so the relaxed dipole is just the perturbation-independent relaxed
  density contracted with the dipole integrals -- no energy-weighted density and no 2-PDM term
  (unlike the gradient). The (T) density and its oo/vv dependent-pair orbital response ride
  along inside `D_rel`, so (T) needs no separate handling. Dispatches spatial vs spin-orbital on
  `orbital_basis` (ROHF raises).

- **Refactor (pure extraction):** the relaxed-density build is factored out of
  `gradient()`/`_so_gradient()` into shared `_relaxed_density()` / `_so_relaxed_density()`
  (returning `(Drel, Gam)`). Both the gradient and the relaxed dipole now share one source of
  truth for the (T) `kappa_oo`/`kappa_vv` dependent pair + frozen-core `P_co` + ov Z-vector. The
  gradient methods keep only their skeleton-integral loop. The ROHF `NotImplementedError` guard
  moves into `_so_relaxed_density` (so the SO relaxed dipole also raises for ROHF). No physics
  changed -- the CCSD/CCSD(T) gradient tests are unchanged and pass.

### Facade

No facade change needed: `pycc.dipole(CCwfn)` already dispatches its correlation block to
`CCderiv.relaxed_dipole` (registry set in `__init__.py`), pairing it with the reference (HF) and
nuclear dipoles into the usual `PropertyComponents`. This PR supplied the missing method.

## Validation

All against pycc's own internal oracle. Geometry is `_T_DIPOLE_GEOM` (H2O / 6-31G, in bohr).

| Check | Result |
| --- | --- |
| All-electron mu_z -- analytic vs 5-point O(h^4) finite field of `(E_CCSD(T) - E_SCF)` | 1.4e-12 |
| Frozen-core mu_z -- analytic vs finite field (nfzc=1) | 1.1e-12 |
| SO == spatial keystone | 3.5e-14 |
| Facade: `total == nuclear + reference + correlation`, `correlation == relaxed_dipole` | exact |

The finite-field oracle uses a field-relaxed SCF (psi4 `perturb_h`, F=0.0005), so the orbital
relaxation is active -- the true relaxed dipole. 6-31G, not STO-3G, so the (T) vv dependent-pair
is actually exercised.

## Tests

`pycc/tests/test_034_ccsd_t_density.py` gains three tests, with the finite-field reference
**hard-wired** (`RELAXED_DIPOLE_Z_REF`, `RELAXED_DIPOLE_Z_REF_FC`) and a not-run regeneration
recipe `_findiff_relaxed_dipole_z`:

- `test_ccsdt_relaxed_dipole` (all-electron + facade decomposition)
- `test_ccsdt_relaxed_dipole_spinorbital` (SO == spatial)
- `test_ccsdt_relaxed_dipole_frozen_core`

Full sweep `test_034 / test_074 / test_076 / test_078 / test_083`: 34 passed.

## Docs

`docs/DERIVATIVES_PLAN_2026-06.md` (section 1 CC table + relaxed-dipole note, section 3 `CCderiv`
description, changelog #186) and the README updated to record the CCSD/CCSD(T) relaxed dipole and
the shared `_relaxed_density` extraction.