### PR TITLE
CCSD static dipole polarizability (spatial RHF + spin-orbital UHF, AE + frozen core)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ include:
     and atomic axial tensors (AATs) -- the building blocks for IR and VCD spectra. Both spin
     paths (spin-adapted closed-shell RHF and spin-orbital), all-electron and frozen-core; the
     MP2 second derivatives come via two independent routes (explicit-derivative and 2n+1)
-  - Analytic nuclear energy gradients and relaxed electronic dipoles for CCSD and CCSD(T) (both
-    spin-adapted closed-shell RHF and spin-orbital UHF), all-electron and frozen-core, built on the
-    same relaxed-density / Z-vector machinery as the MP2 gradient
+  - Analytic nuclear energy gradients and relaxed electronic dipoles for CCSD and CCSD(T), and the
+    static dipole polarizability for CCSD (both spin-adapted closed-shell RHF and spin-orbital UHF),
+    all-electron and frozen-core, built on the same relaxed-density / Z-vector machinery as the MP2
+    gradient
   - A uniform property interface -- `pycc.dipole`, `pycc.gradient`, `pycc.polarizability`,
     `pycc.hessian`, `pycc.apt`, `pycc.aat` -- that dispatches on wavefunction type and returns
     each property's nuclear/reference/correlation decomposition as a `PropertyComponents`
@@ -41,7 +42,7 @@ include:
 Future plans:
   - Quadratic response functions (in development)
   - CC2 and CC3 excited states
-  - Analytic CC second derivatives (Hessians, APTs)
+  - Analytic CC Hessians and APTs, and the CCSD(T) polarizability
 
 This repository is currently under development. To do a developmental install, download this repository and type `pip install -e .` in the repository directory.
 

--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -47,6 +47,7 @@ SCF orbital Hessian) with the CCSD/(T) densities and Λ:
 | CCSD `dE/dX` (gradient) | ✅ | ✅ | ✅ |
 | CCSD(T) `dE/dX` (gradient) | ✅ | ✅ | ✅ |
 | CCSD, CCSD(T) `dE/dF` (relaxed dipole) | ✅ | ✅ | ✅ |
+| CCSD `d²E/dF²` (dipole polarizability) | ✅ | ✅ | ✅ |
 
 The relaxed dipole reuses the gradient's relaxed density: a static field leaves the AO basis fixed
 (`S^F = ⟨pq\|rs⟩^F = 0`), so `mu = Tr(D_rel · mu_ints)` — the same `D_rel` (correlation density + `Pco`
@@ -60,6 +61,16 @@ CCSD is invariant to occ–occ/virt–virt rotations — **CCSD(T) needs canonic
 the oo/vv blocks** (dependent-pair κ̄, even all-electron); see §5 and §7. The efficient Z-vector route
 and the independent explicit-derivative route agree to machine precision for CCSD (the (T) explicit
 route is pending — §6).
+
+**Coupled-cluster polarizability.** The CCSD static dipole polarizability `α = −d²E/dF²`
+(`CCderiv.polarizability`, `pycc.polarizability`) — the first CC *second*-derivative property — via
+the asymmetric (2n+1) route: differentiate the relaxed-density gradient a second time in a field
+(`α_ab = Tr(dD_rel·μ_a) + Tr(D_rel·rot(U^b,μ_a))`). Done for **CCSD, spatial RHF and spin-orbital UHF,
+all-electron and frozen core**; only (T) is pending. It adds the perturbed amplitudes `dt/dF`,
+perturbed Λ `dΛ/dF` (staying in `cclambda`'s `r_L`, no `Y1/Y2`), the perturbed HBAR (exact 5-point
+stencil), and the perturbed Z-vector — all first-order responses, no second-order CPHF. FD-validated
+(spatial `1.8e-12`; SO==spatial keystone `~1e-13`; open-shell UHF vs an energy finite field `~3e-10`);
+see §8.
 
 ## 2. Formulation
 
@@ -306,13 +317,13 @@ own SO CCSD(T) energy **3.7e-12**. Tests in `test_083` (open-shell reference har
 
 ## 8. CC static dipole polarizability — design & status
 
-**Status.** Phase 1 (**CCSD, spatial, all-electron**) **DONE and FD-validated end-to-end** in a scratch
-prototype (2026-07-09); ready to port into `CCderiv`. Phases 2–4 (frozen core, spin-orbital, (T)) next,
-then the `CorrelatedDerivs` refactor. First CC *second*-derivative property; built before the refactor
-because it exercises the perturbed-relaxed-density machinery the shared base will own, without the
-nuclear-skeleton complexity of Hessians/APTs. The asymmetric route (below) is confirmed correct, staying
-entirely within `cclambda`'s `r_L` (no `Y1/Y2` response apparatus), with the perturbed HBAR obtained for
-free by an exact stencil (below).
+**Status.** **DONE for CCSD** (2026-07-09) in `CCderiv.polarizability()` — **spatial RHF and
+spin-orbital UHF, both all-electron and frozen core** — FD-validated (§8.4); only **(T)** remains
+(Phase 4). First CC *second*-derivative property; built before the `CorrelatedDerivs` refactor because
+it exercises the perturbed-relaxed-density machinery the shared base will own, without the
+nuclear-skeleton complexity of Hessians/APTs. The asymmetric route (below) stays entirely within
+`cclambda`'s `r_L` (no `Y1/Y2` response apparatus), with the perturbed HBAR obtained for free by an
+exact stencil (below).
 
 **Route: the ASYMMETRIC approach** — differentiate the (already-2n+1) relaxed-density gradient a second
 time; exactly the `docs/mp2_2n1_perturbed.tex` formulation, extended to CC by a density swap. Chosen
@@ -445,9 +456,9 @@ destined for `CorrelatedDerivs`.
   it stays self-contained). Solve `dt += (B + HBAR·dt)/D` with `helper_diis`, exactly like
   `solve_right` but with the orbital-relaxed `B`. Same structure for `dΛ` (the linear `r_L1/r_L2`
   operator + a field-perturbed inhomogeneity).
-### 8.4 Validation (Phase 1 complete)
+### 8.4 Validation (CCSD complete — spatial + spin-orbital, all-electron + frozen core)
 
-Checkpoint ladder, all cleared for CCSD/H2O/STO-3G:
+Prototype checkpoint ladder, all cleared for CCSD/H2O/STO-3G (spatial, all-electron):
 
 | piece | check | residual |
 |---|---|---|
@@ -467,7 +478,18 @@ fixed-basis / frozen-MO checks are necessary but not sufficient** for the orbita
 route through the diagonal-ε `_mp2_lagrangian` and so are blind to the §8.2 gotcha; the field-relaxed
 `perturb_h` oracle is the one that catches it.
 
-**Phasing:** (1) CCSD spatial all-electron **[done]**; (2) + frozen core; (3) + spin-orbital; (4) + (T).
+**Production validation** (`CCderiv.polarizability()`, `test_084`), all clear:
+
+| path | check | residual |
+|---|---|---|
+| spatial, all-electron | tight finite field of the relaxed dipole | 1.8e-12 |
+| spatial, frozen core | tight finite field | 1.0e-11 |
+| off-diagonal (planar HOF/cc-pVDZ) | finite field; `α_xy` large, `α_xz=α_yz=0`, total positive-definite | 2.6e-10 |
+| spin-orbital == spatial (AE / FC) | RHF-forced-to-SO keystone | 8.8e-14 / 3.1e-14 |
+| open-shell UHF (2-B1 NH2) | energy 2nd-derivative FD (`α_zz`); symmetric, positive | 2.7e-10 |
+
+**Phasing:** (1) CCSD spatial all-electron **[done]**; (2) + frozen core **[done]**; (3) + spin-orbital
+**[done]**; (4) + (T) — next.
 
 **Validation (production).** Primary oracle = **finite difference of `CCderiv.relaxed_dipole`** in a
 field (`÷h`, ~1e-12; Λ tight) — the only oracle that covers **CCSD(T)** and frozen core; plus the

--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -162,8 +162,15 @@ so frozen core runs the response over the full occupied space in `MPwfn`'s own M
   but the validated *dipole* never exercised the `[v,o]` block.
 - **Full-Fock `termA` in the perturbed Lagrangian.** The GSB Lagrangian's one-electron term is
   `Σ_q f_uq(D_vq + D_qv)`; its derivative is the full matrix product `∂_x f @ (D + Dᵀ)`, not just
-  the diagonal `∂_x ε`. Neutral for the unrelaxed `D` (no ov block) but required for the relaxed
-  `D`'s ov/core-active blocks (the 2n+1 APT's `d_F W`).
+  the diagonal `∂_x ε`. Neutral for MP2's unrelaxed `D` (no ov block) but required for the relaxed
+  `D`'s ov/core-active blocks (the 2n+1 APT's `d_F W`). **CC extension (2026-07-09, §8.2):** the CC
+  *unrelaxed* `D` **does** have ov/vo blocks (Λ≠T†), so the full-Fock `termA` is required even for the
+  unrelaxed-density Lagrangian — i.e. for the perturbed *Z-vector RHS* `dX = ∂(I'_ov − I'_voᵀ)`, not
+  only for `d_F W`. Building `dX` by a finite-stencil of the diagonal-ε `_mp2_lagrangian` silently
+  drops `df_offdiag @ (D+Dᵀ)` and puts a ~9 % error into the CC polarizability. **Always build the
+  perturbed Lagrangian via `MPwfn._perturbed_lagrangian` (full `df`), never a stencil.** Insidious:
+  fixed-basis/frozen-MO checks route through the same diagonal-ε Lagrangian and are blind to it; only
+  the field-relaxed `perturb_h` oracle (canonical field basis ⇒ `F` diagonal) exposes it.
 - **The `rot4` transpose (2n+1 Hessian efficiency).** Hoisting the `U^Y` skeleton rotations off the
   `O(N²)` pair loop onto the densities uses `Σ A·rot(U,B) = Σ rot(Uᵀ,A)·B`. The four-index case
   needs the **transpose** (`rot4(Uᵀ, Γ)`), since `rot4` contracts B's index via U's *first* index;
@@ -296,6 +303,179 @@ own SO CCSD(T) energy **3.7e-12**. Tests in `test_083` (open-shell reference har
 (guarded, §6).
 
 **Deferred:** CCSD(T) Hessian/APT; extending `_gradient_explicit` to the (T) dependent-pair.
+
+## 8. CC static dipole polarizability — design & status
+
+**Status.** Phase 1 (**CCSD, spatial, all-electron**) **DONE and FD-validated end-to-end** in a scratch
+prototype (2026-07-09); ready to port into `CCderiv`. Phases 2–4 (frozen core, spin-orbital, (T)) next,
+then the `CorrelatedDerivs` refactor. First CC *second*-derivative property; built before the refactor
+because it exercises the perturbed-relaxed-density machinery the shared base will own, without the
+nuclear-skeleton complexity of Hessians/APTs. The asymmetric route (below) is confirmed correct, staying
+entirely within `cclambda`'s `r_L` (no `Y1/Y2` response apparatus), with the perturbed HBAR obtained for
+free by an exact stencil (below).
+
+**Route: the ASYMMETRIC approach** — differentiate the (already-2n+1) relaxed-density gradient a second
+time; exactly the `docs/mp2_2n1_perturbed.tex` formulation, extended to CC by a density swap. Chosen
+because Stanton & Gauss (*Recent Advances in Coupled-Cluster Methods*, ch. on CCSD/CCSD(T) second
+derivatives, pp. 54–64) show the asymmetric route is the **preferred, unambiguous** choice for
+**CCSD(T)**: the (T) correction has no eigenvalue / similarity-transform structure (its `JI` operator
+is intrinsically the interchange construction), so the *symmetric* form — which would drop perturbed Λ
+— does not apply cleanly. For pure-CCSD same-class properties (polarizability, force constants) the
+symmetric form would be ~2× cheaper (it solves perturbed T only, for all perturbations), but a single
+(T)-capable formulation uses asymmetric.
+
+### 8.1 Formalism (worked through with the PI, 2026-07-09)
+
+The relaxed (Z-vector) first derivative of the CC energy for a general real perturbation `x` is, with
+all perturbation-dependent factors the **bare skeleton** integral derivatives (no CPHF / orbital
+response — that is folded into `D_rel` and `W`):
+
+    ∂_x E = Σ_pq D_rel_pq f^x_pq  +  Σ_pqrs Γ_pqrs V^x_pqrs  +  Σ_pq W_pq S^x_pq
+
+`D_rel` = relaxed 1-PDM (Λ-response `D` + orbital-relaxation blocks); `Γ` = 2-PDM; `W = I'(D_rel)` =
+energy-weighted density (the generalized-Fock Lagrangian `I'` evaluated at the *relaxed* density).
+
+**All orbital relaxation lives in specific blocks.** The Z-vector `z` (`−z_ai`) enters only
+`D_rel,ai`/`D_rel,ia` (density) and `W_ai`/`W_ia`/`W_ij` (energy-weighted density), and **not**
+`D_rel,ij`/`D_rel,ab`/`W_ab`/`Γ`. (From `I'_pq = −½[ε_p(D_pq+D_qp) + δ_{q∈occ}Σ_rs D_rs(⟨rp|sq⟩_L+…) +
+4Σ⟨pr|st⟩Γ_qrst]`: the ε-term routes `z` into the ov/vo output blocks, the `δ_{q∈occ}` two-electron
+term into the vo/oo blocks, and the Γ-term carries none.)
+
+**For an electric field** the AO basis is fixed: `f^{F_a} = −μ_a`, `V^{F_a} = 0`, `S^{F_a} = 0`. Hence
+`∂_{F_a} E = −D_rel·μ_a` (the relaxed dipole is `D_rel·μ_a`), and the second derivative is a plain
+product rule — no `W·S` term (`S^F=0`), no second skeleton derivatives (`μ` is field-independent):
+
+    α[a,b] = −∂²E/∂F_a∂F_b = (∂_{F_b}D_rel)·μ_a  +  D_rel·(∂_{F_b}μ_a),   ∂_{F_b}μ_a = U^bᵀμ_a + μ_a U^b
+
+with `D_rel` the unperturbed relaxed density (`CCderiv._relaxed_density`), `∂_{F_b}D_rel` its field
+response, and `U^b` the first-order CPHF orbital response (`CPHF._full_U`). Only *first-order* responses
+appear — no second-order CPHF `U^{xy}` (`perturbed_fock2`/`_full_U2`/`_xi` untouched).
+
+Note the CC unrelaxed density is non-Hermitian (`D_ai ≠ D_ia`, since Λ≠T†), so
+`D_rel,ai = D_ai − z_ai` and `D_rel,ia = D_ia − z_ai` differ (MP2 has `D_ai=D_ia=0`, so both are just
+`−z_ai`). This asymmetry is real but **washes out of α** — both terms contract against symmetric
+quantities (`μ`, and `rot = U^bᵀμ+μU^b`), so only the symmetric part of `D_rel`/`∂D_rel` survives
+(verified: symmetrizing changes α by 5.6e-17). It *would* matter for a nuclear perturbation (`S^x≠0`).
+
+### 8.2 The diagonal-ε gotcha (the Phase-1 bug — READ THIS BEFORE PORTING)
+
+`MPwfn._mp2_lagrangian` builds its Fock term as `termA = eps[:,None]*(D+D.T)` — **diagonal orbital
+energies only** (`eps = diag(H.F)`), the canonical simplification valid at `F=0`. This is correct for
+the unperturbed Lagrangian and for `W`. **But its field derivative is *not* obtained by finite-stencil
+of `_mp2_lagrangian`**: a stencil only captures `∂ε = diag(df)`, whereas the true perturbed Lagrangian
+needs the **full Fock matrix product** `df @ (D+D.T)` (MP2's analytic `_perturbed_lagrangian` has
+exactly this). The omitted piece is `df_offdiag @ (D+D.T)`:
+
+- for **MP2** it vanishes — the unrelaxed `D` fed to the Z-vector RHS has **no ov block**, so the
+  off-diagonal `df` has nothing to couple to (this is why MP2 gets away with `_perturbed_lagrangian`'s
+  comment "diagonal `d_x eps` suffices for the unrelaxed `D`");
+- for **CC** it is nonzero — the unrelaxed `D` **has** `D_ov`/`D_vo`, and the orbital-relaxation
+  off-diagonal `df` couples to them. Dropping it put a **~9 %** error into the perturbed Z-vector RHS
+  `dX`, hence into `∂D_rel,ov`, hence into α.
+
+Insidious because it survived every self-consistent check: a fixed-basis FD of `dX`, and the frozen-MO
+oracle, both route through the same diagonal-ε `_mp2_lagrangian`, so they agree with the (wrong)
+stencil — circular. Only the `perturb_h` energy/dipole oracle exposes it, because at a *field-relaxed
+canonical* reference the Fock **is** diagonal, so `_mp2_lagrangian` is correct there.
+
+**Rule for the port:** build the perturbed Lagrangian via the analytic full-`df` formula — reuse
+`MPwfn._perturbed_lagrangian` (`dA = df @ (D+D.T) + ε[:,None](dD+dD.T)`), density-generic, with the CC
+`D`/`dD`/`Γ`/`dΓ` swapped in — **never** a stencil of `_mp2_lagrangian`. This is the natural
+`CorrelatedDerivs` shared primitive and is correct for both MP2 (no ov) and CC (ov present) with no
+special-casing.
+
+### 8.3 Machinery & mechanics (validated)
+
+**`dD_rel(F_b)` is the unperturbed relaxed-density build (§7 / `_relaxed_density`) differentiated
+term by term** — the MP2 `_perturbed_relaxed_opdm` structure ported to CC, **but** with the full-`df`
+perturbed Lagrangian of §8.2 and the CC-specific ov/vo unrelaxed blocks retained:
+- oo/vv correlation blocks ← perturbed correlation 1-/2-PDM `dD, dΓ` (product rule of `ccdensity`'s
+  density builders in the perturbed amplitudes `dt` **and** perturbed multipliers `dΛ`);
+- ov/vo ← the **unrelaxed** `dD_ov`/`dD_vo` (CC-only; zero for MP2 — do **not** overwrite them, cf. the
+  MP2 template which assigns ov = `−zx`) **plus** the perturbed Z-vector `dz` (solve the SAME orbital
+  Hessian `G` with RHS `dX − (dG)·z`; `dX = ∂(I'_ov − I'_voᵀ)` from the full-`df` perturbed Lagrangian);
+- frozen core co/oc ← perturbed Sylvester `dP_co = (dI'_co − dI'_ocᵀ − df[co,co]P_co + P_co df[o,o])/Δε`
+  (verbatim from MP2; the field's active–active `df[o,o]` makes this non-trivial);
+- (T) oo/vv ← perturbed dependent-pair `dκ_oo`/`dκ_vv` (Sylvester-style, from the field-perturbed
+  (T)-inclusive Lagrangian).
+
+**New CC machinery (the parts MP2 got for free — its amplitudes are closed-form and Λ=t), all
+prototyped and FD-validated:**
+1. **Perturbed-T solve** `dt/dF` — iterative (the CCSD Jacobian / linearized residual applied to `dt`,
+   RHS from the CPHF-folded perturbed integrals `df`/`deri`, so orbital relaxation is carried; reuse
+   `helper_diis` + `r/Dia` denominators). Distinct from `ccresponse.solve_right`, whose X vectors are
+   this WITHOUT the orbital-response terms.
+2. **Perturbed-Λ solve** `dΛ/dF` — iterative, *linear*, staying in `cclambda` (no `Y1/Y2`): the
+   Λ-Jacobian action is `r_L(dΛ) − r_L(0)` (since `r_L` is affine in Λ), and the inhomogeneity is
+   `r_L` evaluated with the **perturbed HBAR** + `dL` (unperturbed `G`) plus the explicit `dG·H`/`dG·L`
+   product-rule halves for the terms bilinear in `G`. Iterate `dΛ += (B_Λ + Jacobian)/D` like
+   `solve_lambda`. **Required by the asymmetric route**; MP2 avoided it only because Λ=t.
+3. **Perturbed HBAR** `dHBAR` — needed only to build the perturbed-Λ inhomogeneity. Obtained for **free
+   and exact** by a 5-point central stencil of `cchbar` at `(F±hδf, ERI±hδe, L±hδL, t±hδt)`: every CCSD
+   HBAR block is a polynomial of degree ≤4 in the step, so the stencil is algebraically exact (confirmed
+   to roundoff, `h` vs `h/2`) — no hand-differentiation. (An analytic `dHBAR` could replace it later for
+   efficiency, validated against this stencil; not needed for correctness.)
+4. **Perturbed correlation densities** `dD, dΓ` — product rule of `ccdensity`'s density builders in
+   `dt` and `dΛ`; also exact via the same degree-≤4 stencil of `gradient_densities`.
+5. **(T):** field-perturbed `cctriples.t3_density` outputs (`S1/S2`, `Doo/Dvv/Dov`, 2-PDM) from
+   `dt1, dt2, df, deri`, and the perturbed (T) dependent-pair.
+
+The perturbed Z-vector `dz/dF` and (for CC) the perturbed Λ are **intrinsic to the asymmetric route,
+not removable overhead** — they are all *first-order* responses (no `U^{xy}`). A direct test confirmed
+this: zeroing `zx` in `MPwfn._perturbed_relaxed_opdm` shifts the MP2 polarizability by ~0.66 (it is
+load-bearing). An earlier draft of this section pursued the *symmetric* "no perturbed Λ/Z" economy;
+that is valid for pure CCSD but not for the (T)-capable path, and the Stanton–Gauss argument settled it
+in favor of asymmetric. **No detour into / rewrite of the MP2 code is needed** — CC extends the existing
+(asymmetric) MP2 machinery by a density swap plus the perturbed-Λ solve.
+
+Reused verbatim: `MPwfn._perturbed_lagrangian` (density-generic — the orbital-response part), the
+perturbed-Z-vector and `dP_co` Sylvester logic, and the first-order `CPHF.perturbed_fock/perturbed_eri`
+/`_full_U`. Lives on `CCderiv` for now (`_perturbed_relaxed_density(field)` + `polarizability`),
+destined for `CorrelatedDerivs`.
+
+**Implementation mechanics (worked out + partly validated 2026-07-09).**
+- **Perturbed-amplitude RHS via the residual, no hand-derivation.** `⟨μ|e^{-T}He^{T}|0⟩` is *linear in
+  H*, so the field-derivative of the CC residual at fixed `t` is just the residual evaluated with the
+  perturbed integrals: `B = CCwfn.residuals(df, t1, t2)` with `H.ERI→deri`, `H.L→dL` swapped in
+  (`df=CPHF.perturbed_fock`, `deri=CPHF.perturbed_eri`, `dL=2·deri−deri.swap(2,3)`). **Validated:** with
+  the *bare* dipole (`df=μ`, `deri=0`) this reproduces `ccresponse`'s independently-built `pertbar`
+  (`Avo`, `Avvoo`) to 1.7e-16 — so the orbital-relaxed RHS is `df/deri` from CPHF instead of bare `μ`.
+- **Perturbed-T LHS = the CCSD Jacobian = HBAR·(dt), built from `cchbar`** (the `ccresponse.r_X1/r_X2`
+  contraction pattern — method-agnostic, *not* ccresponse-specific; copied into the derivative code so
+  it stays self-contained). Solve `dt += (B + HBAR·dt)/D` with `helper_diis`, exactly like
+  `solve_right` but with the orbital-relaxed `B`. Same structure for `dΛ` (the linear `r_L1/r_L2`
+  operator + a field-perturbed inhomogeneity).
+### 8.4 Validation (Phase 1 complete)
+
+Checkpoint ladder, all cleared for CCSD/H2O/STO-3G:
+
+| piece | check | residual |
+|---|---|---|
+| perturbed-T RHS | == `ccresponse` `pertbar` (bare dipole) | 1.7e-16 |
+| perturbed-T LHS | == `solve_right` X (bare RHS) | 1.1e-13 |
+| `dt/dF` | fixed-basis FD (integrals along `df`/`deri`) | 2e-9 |
+| `dHBAR` | 5-pt stencil exact (`h` vs `h/2`) | ~roundoff |
+| `B_Λ` inhomogeneity | FD of `r_L` | 2e-12 |
+| `dΛ/dF` | FD (re-solve CC+Λ at perturbed integrals) | 3e-9 |
+| **α (all 9 elements)** | **5-pt finite field of the relaxed dipole (Λ→1e-14, F=5e-4)** | **1.8e-12** |
+
+The `1.8e-12` is the FD floor (it scales as `O(F⁴)` between F=5e-4 → 1e-3; an earlier `1.3e-9` was purely
+the loose `1e-10` Λ convergence inside `CCderiv.relaxed_dipole`, not a residual error). Two independent
+oracles — a 5-point finite field of the relaxed dipole and a 5-point second derivative of `E_corr`
+(both via `psi4 perturb_h`) — agree to machine precision, so the oracle is unimpeachable. **The
+fixed-basis / frozen-MO checks are necessary but not sufficient** for the orbital-response half: they
+route through the diagonal-ε `_mp2_lagrangian` and so are blind to the §8.2 gotcha; the field-relaxed
+`perturb_h` oracle is the one that catches it.
+
+**Phasing:** (1) CCSD spatial all-electron **[done]**; (2) + frozen core; (3) + spin-orbital; (4) + (T).
+
+**Validation (production).** Primary oracle = **finite difference of `CCderiv.relaxed_dipole`** in a
+field (`÷h`, ~1e-12; Λ tight) — the only oracle that covers **CCSD(T)** and frozen core; plus the
+**SO==spatial keystone**.
+Debugging oracles (CCSD only, phase 1–3): `ccresponse.solve_right(ω=0)` X-vectors cross-check the
+*unrelaxed* `dt/dF`, and `ccresponse.linresp/polarizability(0.0)` the *unrelaxed* CCSD polarizability —
+they isolate the amplitude response from the orbital-relaxation delta. **`ccresponse` is never a code
+dependency** (it omits orbital response and cannot do (T)); oracle only.
 
 ## Appendix A: condensed changelog (by PR)
 

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -368,8 +368,8 @@ class CCderiv:
         The reference (SCF) polarizability is kept separate (:meth:`HFwfn.polarizability`); the
         :func:`pycc.polarizability` facade sums nuclear (zero) + reference + this correlation part.
 
-        Spatial closed-shell RHF, all-electron only for now (frozen core, spin-orbital and (T) to
-        follow).  Validated against a tight finite field of :meth:`relaxed_dipole`."""
+        Spatial closed-shell RHF (all-electron or frozen core); spin-orbital and (T) to follow.
+        Validated against a tight finite field of :meth:`relaxed_dipole`."""
         if route != '2n+1':
             raise ValueError(f"CC polarizability supports only the asymmetric '2n+1' route, not {route!r}.")
         cc = self.ccwfn
@@ -377,16 +377,17 @@ class CCderiv:
             raise NotImplementedError(f"CC polarizability: only CCSD is implemented (not {cc.model}).")
         if cc.orbital_basis == 'spinorbital':
             raise NotImplementedError("CC polarizability: spin-orbital path not yet implemented.")
-        if cc.nfzc:
-            raise NotImplementedError("CC polarizability: frozen core not yet implemented.")
         from .cchbar import cchbar
         from .cclambda import cclambda
         from .ccdensity import ccdensity
         from .cphf import Perturbation
         o, v = cc.o, cc.v
-        ofull = slice(0, o.stop)
+        co = slice(0, cc.nfzc)                            # frozen-core occupied
+        ofull = slice(0, o.stop)                         # full occupied (core + active)
         c = self.contract
         ncore = o.stop - cc.no
+        eps = np.diag(np.asarray(cc.H.F))
+        L = np.asarray(cc.H.L)
 
         # Tight Lambda (the second derivative wants Lambda well past the 1e-10 the gradient uses).
         hbar = cchbar(cc)
@@ -396,8 +397,17 @@ class CCderiv:
         D0, Gam0 = (np.asarray(x) for x in dens.gradient_densities())
         Ip0 = np.asarray(self._lagrangian(D0, Gam0))
         hf = self._reference_hf()
-        z = np.asarray(hf.cphf.solve(Ip0[ofull, v] - Ip0[v, ofull].T))
         Drel = D0.copy()
+        Pco = None
+        if cc.nfzc:                                      # core<->active-occupied divide (as in _relaxed_density)
+            Pco = (Ip0[co, o] - Ip0[o, co].T) / (eps[co][:, None] - eps[o][None, :])
+            Drel[co, o] += Pco
+            Drel[o, co] += Pco.T
+        X0 = Ip0[ofull, v] - Ip0[v, ofull].T
+        if cc.nfzc:                                      # couple P_co into the Z-vector RHS
+            zjc = -Pco.T
+            X0 = X0 - (c('jc,ajic->ia', zjc, L[v, o, ofull, co]) + c('jc,acij->ia', zjc, L[v, co, ofull, o]))
+        z = np.asarray(hf.cphf.solve(X0))
         Drel[v, ofull] += -z.T
         Drel[ofull, v] += -z
 
@@ -406,23 +416,28 @@ class CCderiv:
         alpha = np.zeros((3, 3))
         for b in range(3):
             pert = Perturbation('field', b)
-            dDrel = self._perturbed_relaxed_density(pert, hbar, lam, D0, Gam0, z)
+            dDrel = self._perturbed_relaxed_density(pert, hbar, lam, D0, Gam0, z, Pco)
             Ub = np.asarray(cphf._full_U(pert, ncore))
             for a in range(3):
                 rot = Ub.T @ mu[a] + mu[a] @ Ub
                 alpha[a, b] = c('pq,pq->', dDrel, mu[a]) + c('pq,pq->', Drel, rot)
         return alpha
 
-    def _perturbed_relaxed_density(self, pert, hbar, lam, D0, Gam0, z) -> np.ndarray:
-        """Field response ``dD_rel`` of the CC relaxed 1-PDM (spatial, all-electron).  Mirrors
-        :meth:`MPwfn._perturbed_relaxed_opdm` with the CC densities, but (i) keeps the CC *unrelaxed*
-        ov/vo blocks (``D_ai != D_ia`` for CC; MP2 has none) and (ii) builds the perturbed Lagrangian
-        with the FULL-df Fock term (see :meth:`_cc_perturbed_lagrangian`)."""
+    def _perturbed_relaxed_density(self, pert, hbar, lam, D0, Gam0, z, Pco=None) -> np.ndarray:
+        """Field response ``dD_rel`` of the CC relaxed 1-PDM (spatial; all-electron or frozen core).
+        Mirrors :meth:`MPwfn._perturbed_relaxed_opdm` with the CC densities, but (i) keeps the CC
+        *unrelaxed* ov/vo blocks (``D_ai != D_ia`` for CC; MP2 has none) and (ii) builds the perturbed
+        Lagrangian with the FULL-df Fock term (see :meth:`_cc_perturbed_lagrangian`).  For frozen core
+        the perturbed core<->active Sylvester divide ``dP_co`` is added and coupled into the perturbed
+        Z-vector RHS, exactly as in the MP2 template / the unperturbed :meth:`_relaxed_density`."""
         cc = self.ccwfn
         o, v = cc.o, cc.v
+        co = slice(0, cc.nfzc)
         ofull = slice(0, o.stop)
         c = self.contract
         ncore = o.stop - cc.no
+        L = np.asarray(cc.H.L)
+        eps = np.diag(np.asarray(cc.H.F))
         cphf = cc.mp._full_occ_cphf()
         df = np.asarray(cphf.perturbed_fock(pert, ncore))
         deri = np.asarray(cphf.perturbed_eri(pert, ncore))
@@ -434,11 +449,21 @@ class CCderiv:
         dDg, dGam = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam)
         dIp = self._cc_perturbed_lagrangian(df, deri, dL, D0, dDg, Gam0, dGam)
         dX = dIp[ofull, v] - dIp[v, ofull].T
+        dPco = None
+        if cc.nfzc:                                     # perturbed core<->active divide (Sylvester derivative)
+            gap = eps[co][:, None] - eps[o][None, :]
+            dPco = (dIp[co, o] - dIp[o, co].T - df[co, co] @ Pco + Pco @ df[o, o]) / gap
+            zjc, dzjc = -Pco.T, -dPco.T
+            dX = dX - (c('jc,ajic->ia', dzjc, L[v, o, ofull, co]) + c('jc,acij->ia', dzjc, L[v, co, ofull, o])
+                       + c('jc,ajic->ia', zjc, dL[v, o, ofull, co]) + c('jc,acij->ia', zjc, dL[v, co, ofull, o]))
         # perturbed orbital-Hessian response (A^x z); reference-only, as in MP2
         Axz = (c('ajib,jb->ia', dL[v, ofull, ofull, v], z) + c('abij,jb->ia', dL[v, v, ofull, ofull], z)
                + c('ab,ib->ia', df[v, v], z) - c('ij,ja->ia', df[ofull, ofull], z))
         zx = np.asarray(hf.cphf.solve(dX - Axz))
         dDrel = dDg.copy()                              # keep unrelaxed dD_ov/dD_vo (CC-only)
+        if cc.nfzc:
+            dDrel[co, o] += dPco
+            dDrel[o, co] += dPco.T
         dDrel[v, ofull] += -zx.T
         dDrel[ofull, v] += -zx
         return dDrel

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -341,3 +341,298 @@ class CCderiv:
                 deri = np.asarray(cphf.perturbed_eri(pert, ncore))
                 grad[atom, cart] = (c('pq,pq->', D, df) + c('pqrs,pqrs->', Gam, deri))
         return grad
+
+    # ---- second derivatives: static dipole polarizability ----------------
+    # The asymmetric (2n+1) route: differentiate the relaxed-density gradient a second time in a
+    # field.  A static field leaves the AO basis fixed (S^F = <pq|rs>^F = 0), so
+    #     alpha[a,b] = Tr(dD_rel(F_b) . mu_a)  +  Tr(D_rel . (U^bT mu_a + mu_a U^b)),
+    # with D_rel the (unperturbed) relaxed density and dD_rel its field response.  dD_rel needs the
+    # perturbed amplitudes/multipliers dt/dLambda (iterative, CPHF-folded RHS carrying the orbital
+    # relaxation), the perturbed correlation densities, the perturbed Lagrangian (FULL-df Fock term
+    # -- see the diagonal-eps gotcha below), and the perturbed Z-vector.  Only first-order responses;
+    # no second-order CPHF.  See DERIVATIVES_PLAN_2026-06.md sec 8.  Spatial (closed-shell RHF),
+    # all-electron; frozen core / spin-orbital / (T) to follow.
+
+    _HBAR_BLOCKS = ('Hov', 'Hvv', 'Hoo', 'Hoooo', 'Hvvvv', 'Hvovv', 'Hooov',
+                    'Hovvo', 'Hovov', 'Hvvvo', 'Hovoo')
+
+    def polarizability(self, route: str = '2n+1') -> np.ndarray:
+        """CCSD **correlation** contribution to the static (omega=0) dipole polarizability (a.u.),
+        shape ``(3, 3)``: ``alpha_corr[a,b] = -d^2 E_corr/dF_a dF_b``, the CC analog of
+        :meth:`MPwfn.polarizability`.
+
+        Only the **asymmetric (2n+1) route** is available for CC -- differentiate the relaxed-density
+        gradient a second time (a single (T)-capable formulation; see DERIVATIVES_PLAN sec 8).  The
+        ``route`` argument (from the :func:`pycc.polarizability` facade) accepts only ``'2n+1'``.
+
+        The reference (SCF) polarizability is kept separate (:meth:`HFwfn.polarizability`); the
+        :func:`pycc.polarizability` facade sums nuclear (zero) + reference + this correlation part.
+
+        Spatial closed-shell RHF, all-electron only for now (frozen core, spin-orbital and (T) to
+        follow).  Validated against a tight finite field of :meth:`relaxed_dipole`."""
+        if route != '2n+1':
+            raise ValueError(f"CC polarizability supports only the asymmetric '2n+1' route, not {route!r}.")
+        cc = self.ccwfn
+        if cc.model.upper() != 'CCSD':
+            raise NotImplementedError(f"CC polarizability: only CCSD is implemented (not {cc.model}).")
+        if cc.orbital_basis == 'spinorbital':
+            raise NotImplementedError("CC polarizability: spin-orbital path not yet implemented.")
+        if cc.nfzc:
+            raise NotImplementedError("CC polarizability: frozen core not yet implemented.")
+        from .cchbar import cchbar
+        from .cclambda import cclambda
+        from .ccdensity import ccdensity
+        from .cphf import Perturbation
+        o, v = cc.o, cc.v
+        ofull = slice(0, o.stop)
+        c = self.contract
+        ncore = o.stop - cc.no
+
+        # Tight Lambda (the second derivative wants Lambda well past the 1e-10 the gradient uses).
+        hbar = cchbar(cc)
+        lam = cclambda(cc, hbar)
+        lam.solve_lambda(1e-13, 1e-13)
+        dens = ccdensity(cc, lam)
+        D0, Gam0 = (np.asarray(x) for x in dens.gradient_densities())
+        Ip0 = np.asarray(self._lagrangian(D0, Gam0))
+        hf = self._reference_hf()
+        z = np.asarray(hf.cphf.solve(Ip0[ofull, v] - Ip0[v, ofull].T))
+        Drel = D0.copy()
+        Drel[v, ofull] += -z.T
+        Drel[ofull, v] += -z
+
+        cphf = cc.mp._full_occ_cphf()
+        mu = [np.asarray(cc.H.mu[a]) for a in range(3)]
+        alpha = np.zeros((3, 3))
+        for b in range(3):
+            pert = Perturbation('field', b)
+            dDrel = self._perturbed_relaxed_density(pert, hbar, lam, D0, Gam0, z)
+            Ub = np.asarray(cphf._full_U(pert, ncore))
+            for a in range(3):
+                rot = Ub.T @ mu[a] + mu[a] @ Ub
+                alpha[a, b] = c('pq,pq->', dDrel, mu[a]) + c('pq,pq->', Drel, rot)
+        return alpha
+
+    def _perturbed_relaxed_density(self, pert, hbar, lam, D0, Gam0, z) -> np.ndarray:
+        """Field response ``dD_rel`` of the CC relaxed 1-PDM (spatial, all-electron).  Mirrors
+        :meth:`MPwfn._perturbed_relaxed_opdm` with the CC densities, but (i) keeps the CC *unrelaxed*
+        ov/vo blocks (``D_ai != D_ia`` for CC; MP2 has none) and (ii) builds the perturbed Lagrangian
+        with the FULL-df Fock term (see :meth:`_cc_perturbed_lagrangian`)."""
+        cc = self.ccwfn
+        o, v = cc.o, cc.v
+        ofull = slice(0, o.stop)
+        c = self.contract
+        ncore = o.stop - cc.no
+        cphf = cc.mp._full_occ_cphf()
+        df = np.asarray(cphf.perturbed_fock(pert, ncore))
+        deri = np.asarray(cphf.perturbed_eri(pert, ncore))
+        dL = 2.0 * deri - deri.swapaxes(2, 3)
+        hf = self._reference_hf()
+
+        dt1, dt2 = self._perturbed_amplitudes(df, deri, dL, hbar)
+        dl1, dl2 = self._perturbed_lambda(df, deri, dL, dt1, dt2, hbar, lam)
+        dDg, dGam = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam)
+        dIp = self._cc_perturbed_lagrangian(df, deri, dL, D0, dDg, Gam0, dGam)
+        dX = dIp[ofull, v] - dIp[v, ofull].T
+        # perturbed orbital-Hessian response (A^x z); reference-only, as in MP2
+        Axz = (c('ajib,jb->ia', dL[v, ofull, ofull, v], z) + c('abij,jb->ia', dL[v, v, ofull, ofull], z)
+               + c('ab,ib->ia', df[v, v], z) - c('ij,ja->ia', df[ofull, ofull], z))
+        zx = np.asarray(hf.cphf.solve(dX - Axz))
+        dDrel = dDg.copy()                              # keep unrelaxed dD_ov/dD_vo (CC-only)
+        dDrel[v, ofull] += -zx.T
+        dDrel[ofull, v] += -zx
+        return dDrel
+
+    def _ccsd_jacobian(self, X1, X2, hbar):
+        """The CCSD Jacobian applied to an amplitude pair, ``(HBAR . X)_singles``,
+        ``(HBAR . X)_doubles`` (doubles un-symmetrized).  Method-agnostic (the same contraction
+        pattern as ``ccresponse.r_X1/r_X2``, built from ``cchbar`` -- not a ccresponse dependency)."""
+        c = self.contract
+        o, v = self.ccwfn.o, self.ccwfn.v
+        t2 = self.ccwfn.t2
+        L = self.ccwfn.H.L
+        Hvvmvo = 2.0 * hbar.Hvovv - hbar.Hvovv.swapaxes(2, 3)
+        Hooomv = 2.0 * hbar.Hooov - hbar.Hooov.swapaxes(0, 1)
+        r1 = c('ie,ae->ia', X1, hbar.Hvv) - c('ma,mi->ia', X1, hbar.Hoo)
+        r1 += 2.0 * c('me,maei->ia', X1, hbar.Hovvo) - c('me,maie->ia', X1, hbar.Hovov)
+        r1 += c('me,miea->ia', hbar.Hov, (2.0 * X2 - X2.swapaxes(0, 1)))
+        r1 += c('imef,amef->ia', X2, Hvvmvo)
+        r1 -= c('mnae,mnie->ia', X2, Hooomv)
+        Zvv = c('amef,mf->ae', Hvvmvo, X1) - c('mnef,mnaf->ae', L[o, o, v, v], X2)
+        Zoo = -1.0 * c('mnie,ne->mi', Hooomv, X1) - c('mnef,inef->mi', L[o, o, v, v], X2)
+        r2 = c('ie,abej->ijab', X1, hbar.Hvvvo) - c('ma,mbij->ijab', X1, hbar.Hovoo)
+        r2 += c('mi,mjab->ijab', Zoo, t2) + c('ae,ijeb->ijab', Zvv, t2)
+        r2 += c('ijeb,ae->ijab', X2, hbar.Hvv) - c('mjab,mi->ijab', X2, hbar.Hoo)
+        r2 += 0.5 * c('mnab,mnij->ijab', X2, hbar.Hoooo) + 0.5 * c('ijef,abef->ijab', X2, hbar.Hvvvv)
+        r2 -= c('imeb,maje->ijab', X2, hbar.Hovov) + c('imea,mbej->ijab', X2, hbar.Hovvo)
+        r2 += 2.0 * c('miea,mbej->ijab', X2, hbar.Hovvo) - c('miea,mbje->ijab', X2, hbar.Hovov)
+        return r1, r2
+
+    def _perturbed_amplitudes(self, df, deri, dL, hbar, maxiter=200, rconv=1e-13):
+        """Perturbed CCSD amplitudes ``dt/dF`` (iterative).  RHS = the field-derivative of the CC
+        residual at fixed ``t`` -- since the residual is linear in H, that is just
+        ``residuals(df, t1, t2)`` with the perturbed two-electron integrals swapped in (the
+        CPHF-folded ``deri``/``dL`` carry the orbital relaxation).  LHS = the CCSD Jacobian;
+        iterate ``dt += (B + HBAR.dt)/D`` with DIIS, like :meth:`ccresponse.solve_right`."""
+        from .utils import helper_diis
+        cc = self.ccwfn
+        Dia, Dijab = cc.Dia, cc.Dijab
+        saveERI, saveL = cc.H.ERI, cc.H.L
+        cc.H.ERI, cc.H.L = deri, dL
+        try:
+            B1, B2 = cc.residuals(df, cc.t1, cc.t2)
+        finally:
+            cc.H.ERI, cc.H.L = saveERI, saveL
+        B1, B2 = np.asarray(B1), np.asarray(B2)
+        X1, X2 = B1 / Dia, B2 / Dijab
+        diis = helper_diis(X1, X2, 8)
+        for _ in range(maxiter):
+            j1, j2 = self._ccsd_jacobian(X1, X2, hbar)
+            r1 = B1 + j1
+            r2 = 0.5 * B2 + j2
+            r2 = r2 + r2.swapaxes(0, 1).swapaxes(2, 3)
+            X1 = X1 + r1 / Dia
+            X2 = X2 + r2 / Dijab
+            if np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2)) < rconv:
+                break
+            diis.add_error_vector(X1, X2)
+            X1, X2 = diis.extrapolate(X1, X2)
+        return X1, X2
+
+    def _hbar_blocks(self, hbar, F, ERI, L, t1, t2):
+        """All (spatial CCSD) HBAR blocks built from explicit integrals/amplitudes -- the
+        :meth:`cchbar._build` sequence with supplied arguments (no wavefunction-state mutation).
+        Used by :meth:`_perturbed_hbar` for the exact stencil."""
+        o, v = self.ccwfn.o, self.ccwfn.v
+        Hov = hbar.build_Hov(o, v, F, L, t1)
+        Hvv = hbar.build_Hvv(o, v, F, L, t1, t2)
+        Hoo = hbar.build_Hoo(o, v, F, L, t1, t2)
+        Hoooo = hbar.build_Hoooo(o, v, ERI, t1, t2)
+        Hvvvv = hbar.build_Hvvvv(o, v, ERI, t1, t2)
+        Hvovv = hbar.build_Hvovv(o, v, ERI, t1)
+        Hooov = hbar.build_Hooov(o, v, ERI, t1)
+        Hovvo = hbar.build_Hovvo(o, v, ERI, L, t1, t2)
+        Hovov = hbar.build_Hovov(o, v, ERI, t1, t2)
+        Hvvvo = hbar.build_Hvvvo(o, v, ERI, L, Hov, Hvvvv, t1, t2)
+        Hovoo = hbar.build_Hovoo(o, v, ERI, L, Hov, Hoooo, t1, t2)
+        return {'Hov': Hov, 'Hvv': Hvv, 'Hoo': Hoo, 'Hoooo': Hoooo, 'Hvvvv': Hvvvv,
+                'Hvovv': Hvovv, 'Hooov': Hooov, 'Hovvo': Hovvo, 'Hovov': Hovov,
+                'Hvvvo': Hvvvo, 'Hovoo': Hovoo}
+
+    def _perturbed_hbar(self, df, deri, dL, dt1, dt2, hbar):
+        """Perturbed HBAR ``dHBAR`` via a 5-point central stencil of the block builders in the
+        step, evaluated at ``(F +- h df, ERI +- h deri, L +- h dL, t +- h dt)``.  Every spatial
+        CCSD HBAR block is a polynomial of degree <= 4 in the step, so the stencil is algebraically
+        exact (confirmed to roundoff).  Needed only for the perturbed-Lambda inhomogeneity."""
+        cc = self.ccwfn
+        F0 = np.asarray(cc.H.F); ERI0 = np.asarray(cc.H.ERI); L0 = np.asarray(cc.H.L)
+        t01 = np.asarray(cc.t1); t02 = np.asarray(cc.t2)
+        h = 1e-2
+        def at(s):
+            return self._hbar_blocks(hbar, F0 + s*h*df, ERI0 + s*h*deri, L0 + s*h*dL,
+                                     t01 + s*h*dt1, t02 + s*h*dt2)
+        m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
+        return {k: (np.asarray(m2[k]) - 8.0*np.asarray(m1[k]) + 8.0*np.asarray(p1[k])
+                    - np.asarray(p2[k])) / (12.0*h) for k in m2}
+
+    def _perturbed_lambda(self, df, deri, dL, dt1, dt2, hbar, lam, maxiter=200, rconv=1e-13):
+        """Perturbed Lambda ``dLambda/dF`` (iterative, linear), staying in ``cclambda`` (no
+        ``Y1/Y2``).  The inhomogeneity is ``r_L`` evaluated with the perturbed HBAR + ``dL``
+        (unperturbed G) plus the explicit ``dG.H``/``dG.L`` product-rule halves; the Lambda-Jacobian
+        action is ``r_L(dLambda) - r_L(0)`` (``r_L`` is affine in Lambda).  Iterate
+        ``dLambda += (B + Jacobian)/D`` like :meth:`cclambda.solve_lambda`."""
+        from .utils import helper_diis
+        cc = self.ccwfn
+        o, v = cc.o, cc.v
+        c = self.contract
+        Dia, Dijab = cc.Dia, cc.Dijab
+        l1, l2 = np.asarray(lam.l1), np.asarray(lam.l2)
+        t2 = np.asarray(cc.t2)
+        L0 = np.asarray(cc.H.L)
+
+        def rL1(La, Lb, H, Gvv, Goo):
+            return np.asarray(lam.r_L1(o, v, La, Lb, H['Hov'], H['Hvv'], H['Hoo'], H['Hovvo'],
+                                       H['Hovov'], H['Hvvvo'], H['Hovoo'], H['Hvovv'], H['Hooov'], Gvv, Goo))
+        def rL2(La, Lb, Ld, H, Gvv, Goo):
+            return np.asarray(lam.r_L2(o, v, La, Lb, Ld, H['Hov'], H['Hvv'], H['Hoo'], H['Hoooo'],
+                                       H['Hvvvv'], H['Hovvo'], H['Hovov'], H['Hvvvo'], H['Hovoo'],
+                                       H['Hvovv'], H['Hooov'], Gvv, Goo))
+
+        dH = self._perturbed_hbar(df, deri, dL, dt1, dt2, hbar)
+        H0 = {b: np.asarray(getattr(hbar, b)) for b in self._HBAR_BLOCKS}
+        Goo0 = np.asarray(lam.build_Goo(t2, l2)); Gvv0 = np.asarray(lam.build_Gvv(t2, l2))
+        dGoo = np.asarray(lam.build_Goo(dt2, l2)); dGvv = np.asarray(lam.build_Gvv(dt2, l2))  # l2 fixed
+        B1 = rL1(l1, l2, dH, Gvv0, Goo0)
+        B2 = rL2(l1, l2, dL, dH, Gvv0, Goo0)
+        Hvovv0, Hooov0 = H0['Hvovv'], H0['Hooov']
+        c1 = -2.0*c('ef,eifa->ia', dGvv, Hvovv0) + c('ef,eiaf->ia', dGvv, Hvovv0)
+        c1 += -2.0*c('mn,mina->ia', dGoo, Hooov0) + c('mn,imna->ia', dGoo, Hooov0)
+        c2p = c('ae,ijeb->ijab', dGvv, L0[o, o, v, v]) - c('mi,mjab->ijab', dGoo, L0[o, o, v, v])
+        B1 = B1 + c1
+        B2 = B2 + (c2p + c2p.swapaxes(0, 1).swapaxes(2, 3))
+        zl1 = np.zeros_like(l1); zl2 = np.zeros_like(l2)
+        zGvv = np.zeros_like(Gvv0); zGoo = np.zeros_like(Goo0)
+        rL1_0 = rL1(zl1, zl2, H0, zGvv, zGoo)           # = 2*Hov (the Lambda-independent constant)
+        rL2_0 = rL2(zl1, zl2, L0, H0, zGvv, zGoo)       # = SYM[L]
+        dl1, dl2 = B1 / Dia, B2 / Dijab
+        diis = helper_diis(dl1, dl2, 8)
+        for _ in range(maxiter):
+            Gvv_d = np.asarray(lam.build_Gvv(t2, dl2)); Goo_d = np.asarray(lam.build_Goo(t2, dl2))
+            j1 = rL1(dl1, dl2, H0, Gvv_d, Goo_d) - rL1_0
+            j2 = rL2(dl1, dl2, L0, H0, Gvv_d, Goo_d) - rL2_0
+            r1 = B1 + j1
+            r2 = B2 + j2
+            dl1 = dl1 + r1 / Dia
+            dl2 = dl2 + r2 / Dijab
+            if np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2)) < rconv:
+                break
+            diis.add_error_vector(dl1, dl2)
+            dl1, dl2 = diis.extrapolate(dl1, dl2)
+        return dl1, dl2
+
+    def _perturbed_correlation_densities(self, dt1, dt2, dl1, dl2, lam):
+        """Field response ``(dD, dGamma)`` of the unrelaxed CC correlation densities via a 5-point
+        stencil of :meth:`ccdensity.gradient_densities` in the amplitudes/multipliers (the densities
+        are pure polynomials in ``t``/``lambda`` -- exact).  Temporarily sets ``cc.t1/t2`` and
+        ``lam.l1/l2`` to the stepped values (restored)."""
+        from .ccdensity import ccdensity
+        cc = self.ccwfn
+        t01, t02 = np.asarray(cc.t1).copy(), np.asarray(cc.t2).copy()
+        l01, l02 = np.asarray(lam.l1).copy(), np.asarray(lam.l2).copy()
+        h = 1e-2
+        def at(s):
+            cc.t1 = t01 + s*h*dt1; cc.t2 = t02 + s*h*dt2
+            lam.l1 = l01 + s*h*dl1; lam.l2 = l02 + s*h*dl2
+            D_s, Gam_s = ccdensity(cc, lam).gradient_densities()
+            return np.asarray(D_s), np.asarray(Gam_s)
+        try:
+            m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
+        finally:
+            cc.t1, cc.t2 = t01, t02
+            lam.l1, lam.l2 = l01, l02
+        dDg = (m2[0] - 8.0*m1[0] + 8.0*p1[0] - p2[0]) / (12.0*h)
+        dGam = (m2[1] - 8.0*m1[1] + 8.0*p1[1] - p2[1]) / (12.0*h)
+        return dDg, dGam
+
+    def _cc_perturbed_lagrangian(self, df, deri, dL, D, dD, Gam, dGam):
+        """Field response ``dI'`` of the generalized-Fock (GSB) Lagrangian, density-generic.  The
+        Fock term is the **full matrix product** ``df @ (D + D.T)`` -- NOT the diagonal ``diag(df)``
+        a stencil of :meth:`MPwfn._mp2_lagrangian` (which uses ``eps[:,None]*(D+D.T)``, valid only
+        at the canonical F=0) would give.  The omitted ``df_offdiag @ (D+D.T)`` vanishes for MP2
+        (unrelaxed ``D`` has no ov block) but is nonzero for CC (couples to ``Dov``/``Dvo``); see
+        DERIVATIVES_PLAN sec 8.2.  (Same formula as :meth:`MPwfn._perturbed_lagrangian`; destined to
+        merge with it under ``CorrelatedDerivs``.)"""
+        cc = self.ccwfn
+        o = cc.o
+        ofull = slice(0, o.stop)
+        c = self.contract
+        ERI = np.asarray(cc.H.ERI)
+        L = np.asarray(cc.H.L)
+        eps = np.diag(np.asarray(cc.H.F))
+        nmo = cc.nmo
+        dA = df @ (D + D.T) + eps[:, None] * (dD + dD.T)
+        dB = np.zeros((nmo, nmo))
+        dB[:, ofull] = (c('rs,rpsq->pq', dD, L[:, :, :, ofull]) + c('rs,rpsq->pq', D, dL[:, :, :, ofull])
+                        + c('rs,rqsp->pq', dD, L[:, ofull, :, :]) + c('rs,rqsp->pq', D, dL[:, ofull, :, :]))
+        dC = 4.0 * (c('prst,qrst->pq', deri, Gam) + c('prst,qrst->pq', ERI, dGam))
+        return -0.5 * (dA + dB + dC)

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -196,6 +196,25 @@ class CCderiv:
         Drel[ofull, v] += -z
         return Drel, Gam
 
+    def relaxed_dipole(self) -> np.ndarray:
+        """CCSD / CCSD(T) **correlation** contribution to the relaxed electronic dipole (a.u.),
+        ``Tr(D_rel . mu)`` per Cartesian axis -- the CC analog of :meth:`MPwfn.relaxed_dipole`, and
+        the correlation block that :func:`pycc.dipole` pairs with the reference (HF) and nuclear
+        dipoles.
+
+        A static electric field does not move the AO basis (``S^F = <pq|rs>^F = 0``), so the relaxed
+        dipole is just the perturbation-independent relaxed density (:meth:`_relaxed_density` /
+        :meth:`_so_relaxed_density`) contracted with the dipole integrals -- no energy-weighted
+        density and no 2-PDM term (unlike the gradient).  The (T) density and its oo/vv
+        dependent-pair orbital response ride along inside ``D_rel``, so the (T) contribution needs no
+        separate handling.  Dispatches spatial vs spin-orbital on ``orbital_basis`` (ROHF raises via
+        :meth:`_so_relaxed_density`)."""
+        cc = self.ccwfn
+        Drel, _ = (self._so_relaxed_density() if cc.orbital_basis == 'spinorbital'
+                   else self._relaxed_density())
+        c = self.contract
+        return np.array([c('pq,pq->', Drel, np.asarray(cc.H.mu[a])) for a in range(3)])
+
     def gradient(self) -> np.ndarray:
         """CCSD **correlation** contribution to the analytic nuclear energy gradient (a.u.), shape
         ``(natom, 3)``, via the **Z-vector (relaxed-density) route** -- the efficient default
@@ -286,25 +305,6 @@ class CCderiv:
                                     + c('pq,pq->', W, Sx[cart]))
         return grad
 
-    def relaxed_dipole(self) -> np.ndarray:
-        """CCSD / CCSD(T) **correlation** contribution to the relaxed electronic dipole (a.u.),
-        ``Tr(D_rel . mu)`` per Cartesian axis -- the CC analog of :meth:`MPwfn.relaxed_dipole`, and
-        the correlation block that :func:`pycc.dipole` pairs with the reference (HF) and nuclear
-        dipoles.
-
-        A static electric field does not move the AO basis (``S^F = <pq|rs>^F = 0``), so the relaxed
-        dipole is just the perturbation-independent relaxed density (:meth:`_relaxed_density` /
-        :meth:`_so_relaxed_density`) contracted with the dipole integrals -- no energy-weighted
-        density and no 2-PDM term (unlike the gradient).  The (T) density and its oo/vv
-        dependent-pair orbital response ride along inside ``D_rel``, so the (T) contribution needs no
-        separate handling.  Dispatches spatial vs spin-orbital on ``orbital_basis`` (ROHF raises via
-        :meth:`_so_relaxed_density`)."""
-        cc = self.ccwfn
-        Drel, _ = (self._so_relaxed_density() if cc.orbital_basis == 'spinorbital'
-                   else self._relaxed_density())
-        c = self.contract
-        return np.array([c('pq,pq->', Drel, np.asarray(cc.H.mu[a])) for a in range(3)])
-
     def _gradient_explicit(self) -> np.ndarray:
         """CCSD correlation gradient via the **explicit-derivative route** -- an independent
         cross-check of :meth:`gradient`::
@@ -350,11 +350,17 @@ class CCderiv:
     # perturbed amplitudes/multipliers dt/dLambda (iterative, CPHF-folded RHS carrying the orbital
     # relaxation), the perturbed correlation densities, the perturbed Lagrangian (FULL-df Fock term
     # -- see the diagonal-eps gotcha below), and the perturbed Z-vector.  Only first-order responses;
-    # no second-order CPHF.  See DERIVATIVES_PLAN_2026-06.md sec 8.  Spatial (closed-shell RHF),
-    # all-electron; frozen core / spin-orbital / (T) to follow.
+    # no second-order CPHF.  See DERIVATIVES_PLAN_2026-06.md sec 8.  Spatial (closed-shell RHF) and
+    # spin-orbital (UHF) paths, all-electron and frozen core; (T) to follow.  Each _so_* method
+    # follows its spatial counterpart -- the SO path mirrors the spatial with antisymmetrized
+    # <pq||rs> (no L, no Hovov; Hvvvo/Hovoo via a Zovov intermediate) and the inline orbital Hessian
+    # G (as in _so_relaxed_density) rather than a borrowed all-electron CPHF.
 
     _HBAR_BLOCKS = ('Hov', 'Hvv', 'Hoo', 'Hoooo', 'Hvvvv', 'Hvovv', 'Hooov',
                     'Hovvo', 'Hovov', 'Hvvvo', 'Hovoo')
+
+    _SO_HBAR_BLOCKS = ('Hov', 'Hvv', 'Hoo', 'Hoooo', 'Hvvvv', 'Hvovv', 'Hooov',
+                       'Hovvo', 'Hvvvo', 'Hovoo')
 
     def polarizability(self, route: str = '2n+1') -> np.ndarray:
         """CCSD **correlation** contribution to the static (omega=0) dipole polarizability (a.u.),
@@ -424,6 +430,58 @@ class CCderiv:
                 alpha[a, b] = c('pq,pq->', dDrel, mu[a]) + c('pq,pq->', Drel, rot)
         return alpha
 
+    def _so_polarizability(self) -> np.ndarray:
+        """Spin-orbital (UHF) CCSD correlation polarizability -- the SO analog of
+        :meth:`polarizability` (all-electron or frozen core).  Raises for ROHF."""
+        from .cchbar import cchbar
+        from .cclambda import cclambda
+        from .ccdensity import ccdensity
+        from .cphf import Perturbation
+        cc = self.ccwfn
+        if cc.mp.cphf.is_rohf:
+            raise NotImplementedError("CC polarizability: ROHF is not supported (RHF/UHF only).")
+        o, v, nv = cc.o, cc.v, cc.nv
+        co = slice(0, o.start)                            # frozen core (2*nfzc spin-orbitals)
+        ofull = slice(0, o.stop)
+        nof = o.stop
+        c = self.contract
+        ncore = o.stop - cc.no
+        eps = np.diag(np.asarray(cc.H.F))
+        ERI = np.asarray(cc.H.ERI)
+
+        hbar = cchbar(cc)
+        lam = cclambda(cc, hbar)
+        lam.solve_lambda(1e-13, 1e-13)
+        D0, Gam0 = (np.asarray(x) for x in ccdensity(cc, lam).gradient_densities())
+        Ip0 = np.asarray(self._lagrangian(D0, Gam0))
+        Drel = D0.copy()
+        Pco = None
+        if cc.nfzc:
+            Pco = (Ip0[co, o] - Ip0[o, co].T) / (eps[co][:, None] - eps[o][None, :])
+            Drel[co, o] += Pco
+            Drel[o, co] += Pco.T
+        X0 = Ip0[ofull, v] - Ip0[v, ofull].T
+        if cc.nfzc:
+            zjc = -Pco.T
+            X0 = X0 - (c('jc,ajic->ia', zjc, ERI[v, o, ofull, co]) + c('jc,acij->ia', zjc, ERI[v, co, ofull, o]))
+        G = (c('ajib->iajb', ERI[v, ofull, ofull, v]) + c('abij->iajb', ERI[v, v, ofull, ofull])).reshape(nof*nv, nof*nv)
+        G[np.diag_indices(nof*nv)] += (eps[v][None, :] - eps[ofull][:, None]).reshape(-1)
+        z = np.linalg.solve(G, X0.reshape(-1)).reshape(nof, nv)
+        Drel[v, ofull] += -z.T
+        Drel[ofull, v] += -z
+
+        cphf = cc.mp._full_occ_cphf()
+        mu = [np.asarray(cc.H.mu[a]) for a in range(3)]
+        alpha = np.zeros((3, 3))
+        for b in range(3):
+            pert = Perturbation('field', b)
+            dDrel = self._so_perturbed_relaxed_density(pert, hbar, lam, D0, Gam0, z, G, Pco)
+            Ub = np.asarray(cphf._full_U(pert, ncore))
+            for a in range(3):
+                rot = Ub.T @ mu[a] + mu[a] @ Ub
+                alpha[a, b] = c('pq,pq->', dDrel, mu[a]) + c('pq,pq->', Drel, rot)
+        return alpha
+
     def _perturbed_relaxed_density(self, pert, hbar, lam, D0, Gam0, z, Pco=None) -> np.ndarray:
         """Field response ``dD_rel`` of the CC relaxed 1-PDM (spatial; all-electron or frozen core).
         Mirrors :meth:`MPwfn._perturbed_relaxed_opdm` with the CC densities, but (i) keeps the CC
@@ -469,6 +527,45 @@ class CCderiv:
         dDrel[ofull, v] += -zx
         return dDrel
 
+    def _so_perturbed_relaxed_density(self, pert, hbar, lam, D0, Gam0, z, G, Pco):
+        """Spin-orbital field response ``dD_rel``; the SO analog of
+        :meth:`_perturbed_relaxed_density` (inline Hessian ``G``, antisymmetrized ERI)."""
+        cc = self.ccwfn
+        o, v, nv = cc.o, cc.v, cc.nv
+        co = slice(0, o.start)
+        ofull = slice(0, o.stop)
+        nof = o.stop
+        c = self.contract
+        ncore = o.stop - cc.no
+        ERI = np.asarray(cc.H.ERI)
+        eps = np.diag(np.asarray(cc.H.F))
+        cphf = cc.mp._full_occ_cphf()
+        df = np.asarray(cphf.perturbed_fock(pert, ncore))
+        deri = np.asarray(cphf.perturbed_eri(pert, ncore))
+
+        dt1, dt2 = self._so_perturbed_amplitudes(df, deri, hbar)
+        dl1, dl2 = self._so_perturbed_lambda(df, deri, dt1, dt2, hbar, lam)
+        dDg, dGam = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam)
+        dIp = self._so_cc_perturbed_lagrangian(df, deri, D0, dDg, Gam0, dGam)
+        dX = dIp[ofull, v] - dIp[v, ofull].T
+        dPco = None
+        if cc.nfzc:
+            gap = eps[co][:, None] - eps[o][None, :]
+            dPco = (dIp[co, o] - dIp[o, co].T - df[co, co] @ Pco + Pco @ df[o, o]) / gap
+            zjc, dzjc = -Pco.T, -dPco.T
+            dX = dX - (c('jc,ajic->ia', dzjc, ERI[v, o, ofull, co]) + c('jc,acij->ia', dzjc, ERI[v, co, ofull, o])
+                       + c('jc,ajic->ia', zjc, deri[v, o, ofull, co]) + c('jc,acij->ia', zjc, deri[v, co, ofull, o]))
+        Axz = (c('ajib,jb->ia', deri[v, ofull, ofull, v], z) + c('abij,jb->ia', deri[v, v, ofull, ofull], z)
+               + c('ab,ib->ia', df[v, v], z) - c('ij,ja->ia', df[ofull, ofull], z))
+        zx = np.linalg.solve(G, (dX - Axz).reshape(-1)).reshape(nof, nv)
+        dDrel = dDg.copy()
+        if cc.nfzc:
+            dDrel[co, o] += dPco
+            dDrel[o, co] += dPco.T
+        dDrel[v, ofull] += -zx.T
+        dDrel[ofull, v] += -zx
+        return dDrel
+
     def _ccsd_jacobian(self, X1, X2, hbar):
         """The CCSD Jacobian applied to an amplitude pair, ``(HBAR . X)_singles``,
         ``(HBAR . X)_doubles`` (doubles un-symmetrized).  Method-agnostic (the same contraction
@@ -492,6 +589,36 @@ class CCderiv:
         r2 += 0.5 * c('mnab,mnij->ijab', X2, hbar.Hoooo) + 0.5 * c('ijef,abef->ijab', X2, hbar.Hvvvv)
         r2 -= c('imeb,maje->ijab', X2, hbar.Hovov) + c('imea,mbej->ijab', X2, hbar.Hovvo)
         r2 += 2.0 * c('miea,mbej->ijab', X2, hbar.Hovvo) - c('miea,mbje->ijab', X2, hbar.Hovov)
+        return r1, r2
+
+    def _so_ccsd_jacobian(self, X1, X2, hbar):
+        """Spin-orbital CCSD Jacobian ``(HBAR . X)`` -- the SO ``ccresponse.r_X1/r_X2`` contraction
+        pattern (antisymmetrized; the P(ij)P(ab) is built in, so no final symmetrization)."""
+        c = self.contract
+        o, v = self.ccwfn.o, self.ccwfn.v
+        t2 = self.ccwfn.t2
+        ERI = self.ccwfn.H.ERI
+        r1 = c('ie,ae->ia', X1, hbar.Hvv) - c('ma,mi->ia', X1, hbar.Hoo)
+        r1 += c('me,maei->ia', X1, hbar.Hovvo)
+        r1 += c('me,imae->ia', hbar.Hov, X2)
+        r1 += 0.5 * c('imef,amef->ia', X2, hbar.Hvovv)
+        r1 -= 0.5 * c('mnae,mnie->ia', X2, hbar.Hooov)
+        Zvv = c('amef,me->af', hbar.Hvovv, X1)
+        Zoo = c('mnie,me->ni', hbar.Hooov, X1)
+        Yoo = 0.5 * c('mnef,mjef->nj', ERI[o, o, v, v], X2)
+        Yvv = 0.5 * c('mnef,mneb->fb', ERI[o, o, v, v], X2)
+        r2 = c('ie,abej->ijab', X1, hbar.Hvvvo) - c('je,abei->ijab', X1, hbar.Hvvvo)
+        r2 -= c('ma,mbij->ijab', X1, hbar.Hovoo) - c('mb,maij->ijab', X1, hbar.Hovoo)
+        r2 += c('ni,njab->ijab', Zoo, t2) - c('nj,niab->ijab', Zoo, t2)
+        r2 -= c('af,ijfb->ijab', Zvv, t2) - c('bf,ijfa->ijab', Zvv, t2)
+        r2 -= c('nj,inab->ijab', Yoo, t2) - c('ni,jnab->ijab', Yoo, t2)
+        r2 -= c('fb,ijaf->ijab', Yvv, t2) - c('fa,ijbf->ijab', Yvv, t2)
+        r2 += c('ijae,be->ijab', X2, hbar.Hvv) - c('ijbe,ae->ijab', X2, hbar.Hvv)
+        r2 -= c('imab,mj->ijab', X2, hbar.Hoo) - c('jmab,mi->ijab', X2, hbar.Hoo)
+        r2 += 0.5 * c('mnab,mnij->ijab', X2, hbar.Hoooo)
+        r2 += 0.5 * c('ijef,abef->ijab', X2, hbar.Hvvvv)
+        tmp = c('imae,mbej->ijab', X2, hbar.Hovvo)
+        r2 += tmp - tmp.swapaxes(0, 1) - tmp.swapaxes(2, 3) + tmp.swapaxes(0, 1).swapaxes(2, 3)
         return r1, r2
 
     def _perturbed_amplitudes(self, df, deri, dL, hbar, maxiter=200, rconv=1e-13):
@@ -525,6 +652,32 @@ class CCderiv:
             X1, X2 = diis.extrapolate(X1, X2)
         return X1, X2
 
+    def _so_perturbed_amplitudes(self, df, deri, hbar, maxiter=200, rconv=1e-13):
+        """Spin-orbital perturbed CCSD amplitudes ``dt/dF`` (SO Jacobian; SO residual has no 0.5 /
+        no final symmetrization, matching ``ccresponse.solve_right``)."""
+        from .utils import helper_diis
+        cc = self.ccwfn
+        Dia, Dijab = cc.Dia, cc.Dijab
+        saveERI = cc.H.ERI
+        cc.H.ERI = deri
+        try:
+            B1, B2 = cc.residuals(df, cc.t1, cc.t2)
+        finally:
+            cc.H.ERI = saveERI
+        B1, B2 = np.asarray(B1), np.asarray(B2)
+        X1, X2 = B1 / Dia, B2 / Dijab
+        diis = helper_diis(X1, X2, 8)
+        for _ in range(maxiter):
+            j1, j2 = self._so_ccsd_jacobian(X1, X2, hbar)
+            r1, r2 = B1 + j1, B2 + j2
+            X1 = X1 + r1 / Dia
+            X2 = X2 + r2 / Dijab
+            if np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2)) < rconv:
+                break
+            diis.add_error_vector(X1, X2)
+            X1, X2 = diis.extrapolate(X1, X2)
+        return X1, X2
+
     def _hbar_blocks(self, hbar, F, ERI, L, t1, t2):
         """All (spatial CCSD) HBAR blocks built from explicit integrals/amplitudes -- the
         :meth:`cchbar._build` sequence with supplied arguments (no wavefunction-state mutation).
@@ -545,6 +698,24 @@ class CCderiv:
                 'Hvovv': Hvovv, 'Hooov': Hooov, 'Hovvo': Hovvo, 'Hovov': Hovov,
                 'Hvvvo': Hvvvo, 'Hovoo': Hovoo}
 
+    def _so_hbar_blocks(self, hbar, F, ERI, t1, t2):
+        """Spin-orbital HBAR blocks from explicit integrals/amplitudes (the ``cchbar._so_build``
+        sequence -- no Hovov; Hvvvo/Hovoo via the Zovov intermediate)."""
+        o, v = self.ccwfn.o, self.ccwfn.v
+        Hov = hbar._so_build_Hov(o, v, F, ERI, t1)
+        Hvv = hbar._so_build_Hvv(o, v, F, ERI, Hov, t1, t2)
+        Hoo = hbar._so_build_Hoo(o, v, F, ERI, Hov, t1, t2)
+        Hoooo = hbar._so_build_Hoooo(o, v, ERI, t1, t2)
+        Hvvvv = hbar._so_build_Hvvvv(o, v, ERI, t1, t2)
+        Hvovv = hbar._so_build_Hvovv(o, v, ERI, t1)
+        Hooov = hbar._so_build_Hooov(o, v, ERI, t1)
+        Hovvo = hbar._so_build_Hovvo(o, v, ERI, t1, t2)
+        Zovov = hbar._so_build_Zovov(o, v, ERI, t2)
+        Hvvvo = hbar._so_build_Hvvvo(o, v, ERI, Hov, Hvvvv, Zovov, t1, t2)
+        Hovoo = hbar._so_build_Hovoo(o, v, ERI, Hov, Hoooo, Zovov, t1, t2)
+        return {'Hov': Hov, 'Hvv': Hvv, 'Hoo': Hoo, 'Hoooo': Hoooo, 'Hvvvv': Hvvvv,
+                'Hvovv': Hvovv, 'Hooov': Hooov, 'Hovvo': Hovvo, 'Hvvvo': Hvvvo, 'Hovoo': Hovoo}
+
     def _perturbed_hbar(self, df, deri, dL, dt1, dt2, hbar):
         """Perturbed HBAR ``dHBAR`` via a 5-point central stencil of the block builders in the
         step, evaluated at ``(F +- h df, ERI +- h deri, L +- h dL, t +- h dt)``.  Every spatial
@@ -557,6 +728,18 @@ class CCderiv:
         def at(s):
             return self._hbar_blocks(hbar, F0 + s*h*df, ERI0 + s*h*deri, L0 + s*h*dL,
                                      t01 + s*h*dt1, t02 + s*h*dt2)
+        m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
+        return {k: (np.asarray(m2[k]) - 8.0*np.asarray(m1[k]) + 8.0*np.asarray(p1[k])
+                    - np.asarray(p2[k])) / (12.0*h) for k in m2}
+
+    def _so_perturbed_hbar(self, df, deri, dt1, dt2, hbar):
+        """Spin-orbital perturbed HBAR via the exact 5-point stencil (degree-<=4 blocks)."""
+        cc = self.ccwfn
+        F0 = np.asarray(cc.H.F); ERI0 = np.asarray(cc.H.ERI)
+        t01 = np.asarray(cc.t1); t02 = np.asarray(cc.t2)
+        h = 1e-2
+        def at(s):
+            return self._so_hbar_blocks(hbar, F0 + s*h*df, ERI0 + s*h*deri, t01 + s*h*dt1, t02 + s*h*dt2)
         m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
         return {k: (np.asarray(m2[k]) - 8.0*np.asarray(m1[k]) + 8.0*np.asarray(p1[k])
                     - np.asarray(p2[k])) / (12.0*h) for k in m2}
@@ -616,239 +799,6 @@ class CCderiv:
             dl1, dl2 = diis.extrapolate(dl1, dl2)
         return dl1, dl2
 
-    def _perturbed_correlation_densities(self, dt1, dt2, dl1, dl2, lam):
-        """Field response ``(dD, dGamma)`` of the unrelaxed CC correlation densities via a 5-point
-        stencil of :meth:`ccdensity.gradient_densities` in the amplitudes/multipliers (the densities
-        are pure polynomials in ``t``/``lambda`` -- exact).  Temporarily sets ``cc.t1/t2`` and
-        ``lam.l1/l2`` to the stepped values (restored)."""
-        from .ccdensity import ccdensity
-        cc = self.ccwfn
-        t01, t02 = np.asarray(cc.t1).copy(), np.asarray(cc.t2).copy()
-        l01, l02 = np.asarray(lam.l1).copy(), np.asarray(lam.l2).copy()
-        h = 1e-2
-        def at(s):
-            cc.t1 = t01 + s*h*dt1; cc.t2 = t02 + s*h*dt2
-            lam.l1 = l01 + s*h*dl1; lam.l2 = l02 + s*h*dl2
-            D_s, Gam_s = ccdensity(cc, lam).gradient_densities()
-            return np.asarray(D_s), np.asarray(Gam_s)
-        try:
-            m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
-        finally:
-            cc.t1, cc.t2 = t01, t02
-            lam.l1, lam.l2 = l01, l02
-        dDg = (m2[0] - 8.0*m1[0] + 8.0*p1[0] - p2[0]) / (12.0*h)
-        dGam = (m2[1] - 8.0*m1[1] + 8.0*p1[1] - p2[1]) / (12.0*h)
-        return dDg, dGam
-
-    def _cc_perturbed_lagrangian(self, df, deri, dL, D, dD, Gam, dGam):
-        """Field response ``dI'`` of the generalized-Fock (GSB) Lagrangian, density-generic.  The
-        Fock term is the **full matrix product** ``df @ (D + D.T)`` -- NOT the diagonal ``diag(df)``
-        a stencil of :meth:`MPwfn._mp2_lagrangian` (which uses ``eps[:,None]*(D+D.T)``, valid only
-        at the canonical F=0) would give.  The omitted ``df_offdiag @ (D+D.T)`` vanishes for MP2
-        (unrelaxed ``D`` has no ov block) but is nonzero for CC (couples to ``Dov``/``Dvo``); see
-        DERIVATIVES_PLAN sec 8.2.  (Same formula as :meth:`MPwfn._perturbed_lagrangian`; destined to
-        merge with it under ``CorrelatedDerivs``.)"""
-        cc = self.ccwfn
-        o = cc.o
-        ofull = slice(0, o.stop)
-        c = self.contract
-        ERI = np.asarray(cc.H.ERI)
-        L = np.asarray(cc.H.L)
-        eps = np.diag(np.asarray(cc.H.F))
-        nmo = cc.nmo
-        dA = df @ (D + D.T) + eps[:, None] * (dD + dD.T)
-        dB = np.zeros((nmo, nmo))
-        dB[:, ofull] = (c('rs,rpsq->pq', dD, L[:, :, :, ofull]) + c('rs,rpsq->pq', D, dL[:, :, :, ofull])
-                        + c('rs,rqsp->pq', dD, L[:, ofull, :, :]) + c('rs,rqsp->pq', D, dL[:, ofull, :, :]))
-        dC = 4.0 * (c('prst,qrst->pq', deri, Gam) + c('prst,qrst->pq', ERI, dGam))
-        return -0.5 * (dA + dB + dC)
-
-    # ---- spin-orbital (UHF) polarizability ------------------------------
-    # Mirror of the spatial path with antisymmetrized <pq||rs> (no L), the spin-orbital HBAR (no
-    # Hovov; Hvvvo/Hovoo use a Zovov intermediate), the spin-orbital Jacobian / r_L, and the inline
-    # orbital Hessian G (as in _so_relaxed_density) rather than a borrowed all-electron CPHF.
-    # Validated by the RHF-forced-to-SO == spatial keystone.
-
-    _SO_HBAR_BLOCKS = ('Hov', 'Hvv', 'Hoo', 'Hoooo', 'Hvvvv', 'Hvovv', 'Hooov',
-                       'Hovvo', 'Hvvvo', 'Hovoo')
-
-    def _so_polarizability(self) -> np.ndarray:
-        """Spin-orbital (UHF) CCSD correlation polarizability -- the SO analog of
-        :meth:`polarizability` (all-electron or frozen core).  Raises for ROHF."""
-        from .cchbar import cchbar
-        from .cclambda import cclambda
-        from .ccdensity import ccdensity
-        from .cphf import Perturbation
-        cc = self.ccwfn
-        if cc.mp.cphf.is_rohf:
-            raise NotImplementedError("CC polarizability: ROHF is not supported (RHF/UHF only).")
-        o, v, nv = cc.o, cc.v, cc.nv
-        co = slice(0, o.start)                            # frozen core (2*nfzc spin-orbitals)
-        ofull = slice(0, o.stop)
-        nof = o.stop
-        c = self.contract
-        ncore = o.stop - cc.no
-        eps = np.diag(np.asarray(cc.H.F))
-        ERI = np.asarray(cc.H.ERI)
-
-        hbar = cchbar(cc)
-        lam = cclambda(cc, hbar)
-        lam.solve_lambda(1e-13, 1e-13)
-        D0, Gam0 = (np.asarray(x) for x in ccdensity(cc, lam).gradient_densities())
-        Ip0 = np.asarray(self._lagrangian(D0, Gam0))
-        Drel = D0.copy()
-        Pco = None
-        if cc.nfzc:
-            Pco = (Ip0[co, o] - Ip0[o, co].T) / (eps[co][:, None] - eps[o][None, :])
-            Drel[co, o] += Pco
-            Drel[o, co] += Pco.T
-        X0 = Ip0[ofull, v] - Ip0[v, ofull].T
-        if cc.nfzc:
-            zjc = -Pco.T
-            X0 = X0 - (c('jc,ajic->ia', zjc, ERI[v, o, ofull, co]) + c('jc,acij->ia', zjc, ERI[v, co, ofull, o]))
-        G = (c('ajib->iajb', ERI[v, ofull, ofull, v]) + c('abij->iajb', ERI[v, v, ofull, ofull])).reshape(nof*nv, nof*nv)
-        G[np.diag_indices(nof*nv)] += (eps[v][None, :] - eps[ofull][:, None]).reshape(-1)
-        z = np.linalg.solve(G, X0.reshape(-1)).reshape(nof, nv)
-        Drel[v, ofull] += -z.T
-        Drel[ofull, v] += -z
-
-        cphf = cc.mp._full_occ_cphf()
-        mu = [np.asarray(cc.H.mu[a]) for a in range(3)]
-        alpha = np.zeros((3, 3))
-        for b in range(3):
-            pert = Perturbation('field', b)
-            dDrel = self._so_perturbed_relaxed_density(pert, hbar, lam, D0, Gam0, z, G, Pco)
-            Ub = np.asarray(cphf._full_U(pert, ncore))
-            for a in range(3):
-                rot = Ub.T @ mu[a] + mu[a] @ Ub
-                alpha[a, b] = c('pq,pq->', dDrel, mu[a]) + c('pq,pq->', Drel, rot)
-        return alpha
-
-    def _so_perturbed_relaxed_density(self, pert, hbar, lam, D0, Gam0, z, G, Pco):
-        """Spin-orbital field response ``dD_rel``; the SO analog of
-        :meth:`_perturbed_relaxed_density` (inline Hessian ``G``, antisymmetrized ERI)."""
-        cc = self.ccwfn
-        o, v, nv = cc.o, cc.v, cc.nv
-        co = slice(0, o.start)
-        ofull = slice(0, o.stop)
-        nof = o.stop
-        c = self.contract
-        ncore = o.stop - cc.no
-        ERI = np.asarray(cc.H.ERI)
-        eps = np.diag(np.asarray(cc.H.F))
-        cphf = cc.mp._full_occ_cphf()
-        df = np.asarray(cphf.perturbed_fock(pert, ncore))
-        deri = np.asarray(cphf.perturbed_eri(pert, ncore))
-
-        dt1, dt2 = self._so_perturbed_amplitudes(df, deri, hbar)
-        dl1, dl2 = self._so_perturbed_lambda(df, deri, dt1, dt2, hbar, lam)
-        dDg, dGam = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam)
-        dIp = self._so_cc_perturbed_lagrangian(df, deri, D0, dDg, Gam0, dGam)
-        dX = dIp[ofull, v] - dIp[v, ofull].T
-        dPco = None
-        if cc.nfzc:
-            gap = eps[co][:, None] - eps[o][None, :]
-            dPco = (dIp[co, o] - dIp[o, co].T - df[co, co] @ Pco + Pco @ df[o, o]) / gap
-            zjc, dzjc = -Pco.T, -dPco.T
-            dX = dX - (c('jc,ajic->ia', dzjc, ERI[v, o, ofull, co]) + c('jc,acij->ia', dzjc, ERI[v, co, ofull, o])
-                       + c('jc,ajic->ia', zjc, deri[v, o, ofull, co]) + c('jc,acij->ia', zjc, deri[v, co, ofull, o]))
-        Axz = (c('ajib,jb->ia', deri[v, ofull, ofull, v], z) + c('abij,jb->ia', deri[v, v, ofull, ofull], z)
-               + c('ab,ib->ia', df[v, v], z) - c('ij,ja->ia', df[ofull, ofull], z))
-        zx = np.linalg.solve(G, (dX - Axz).reshape(-1)).reshape(nof, nv)
-        dDrel = dDg.copy()
-        if cc.nfzc:
-            dDrel[co, o] += dPco
-            dDrel[o, co] += dPco.T
-        dDrel[v, ofull] += -zx.T
-        dDrel[ofull, v] += -zx
-        return dDrel
-
-    def _so_ccsd_jacobian(self, X1, X2, hbar):
-        """Spin-orbital CCSD Jacobian ``(HBAR . X)`` -- the SO ``ccresponse.r_X1/r_X2`` contraction
-        pattern (antisymmetrized; the P(ij)P(ab) is built in, so no final symmetrization)."""
-        c = self.contract
-        o, v = self.ccwfn.o, self.ccwfn.v
-        t2 = self.ccwfn.t2
-        ERI = self.ccwfn.H.ERI
-        r1 = c('ie,ae->ia', X1, hbar.Hvv) - c('ma,mi->ia', X1, hbar.Hoo)
-        r1 += c('me,maei->ia', X1, hbar.Hovvo)
-        r1 += c('me,imae->ia', hbar.Hov, X2)
-        r1 += 0.5 * c('imef,amef->ia', X2, hbar.Hvovv)
-        r1 -= 0.5 * c('mnae,mnie->ia', X2, hbar.Hooov)
-        Zvv = c('amef,me->af', hbar.Hvovv, X1)
-        Zoo = c('mnie,me->ni', hbar.Hooov, X1)
-        Yoo = 0.5 * c('mnef,mjef->nj', ERI[o, o, v, v], X2)
-        Yvv = 0.5 * c('mnef,mneb->fb', ERI[o, o, v, v], X2)
-        r2 = c('ie,abej->ijab', X1, hbar.Hvvvo) - c('je,abei->ijab', X1, hbar.Hvvvo)
-        r2 -= c('ma,mbij->ijab', X1, hbar.Hovoo) - c('mb,maij->ijab', X1, hbar.Hovoo)
-        r2 += c('ni,njab->ijab', Zoo, t2) - c('nj,niab->ijab', Zoo, t2)
-        r2 -= c('af,ijfb->ijab', Zvv, t2) - c('bf,ijfa->ijab', Zvv, t2)
-        r2 -= c('nj,inab->ijab', Yoo, t2) - c('ni,jnab->ijab', Yoo, t2)
-        r2 -= c('fb,ijaf->ijab', Yvv, t2) - c('fa,ijbf->ijab', Yvv, t2)
-        r2 += c('ijae,be->ijab', X2, hbar.Hvv) - c('ijbe,ae->ijab', X2, hbar.Hvv)
-        r2 -= c('imab,mj->ijab', X2, hbar.Hoo) - c('jmab,mi->ijab', X2, hbar.Hoo)
-        r2 += 0.5 * c('mnab,mnij->ijab', X2, hbar.Hoooo)
-        r2 += 0.5 * c('ijef,abef->ijab', X2, hbar.Hvvvv)
-        tmp = c('imae,mbej->ijab', X2, hbar.Hovvo)
-        r2 += tmp - tmp.swapaxes(0, 1) - tmp.swapaxes(2, 3) + tmp.swapaxes(0, 1).swapaxes(2, 3)
-        return r1, r2
-
-    def _so_perturbed_amplitudes(self, df, deri, hbar, maxiter=200, rconv=1e-13):
-        """Spin-orbital perturbed CCSD amplitudes ``dt/dF`` (SO Jacobian; SO residual has no 0.5 /
-        no final symmetrization, matching ``ccresponse.solve_right``)."""
-        from .utils import helper_diis
-        cc = self.ccwfn
-        Dia, Dijab = cc.Dia, cc.Dijab
-        saveERI = cc.H.ERI
-        cc.H.ERI = deri
-        try:
-            B1, B2 = cc.residuals(df, cc.t1, cc.t2)
-        finally:
-            cc.H.ERI = saveERI
-        B1, B2 = np.asarray(B1), np.asarray(B2)
-        X1, X2 = B1 / Dia, B2 / Dijab
-        diis = helper_diis(X1, X2, 8)
-        for _ in range(maxiter):
-            j1, j2 = self._so_ccsd_jacobian(X1, X2, hbar)
-            r1, r2 = B1 + j1, B2 + j2
-            X1 = X1 + r1 / Dia
-            X2 = X2 + r2 / Dijab
-            if np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2)) < rconv:
-                break
-            diis.add_error_vector(X1, X2)
-            X1, X2 = diis.extrapolate(X1, X2)
-        return X1, X2
-
-    def _so_hbar_blocks(self, hbar, F, ERI, t1, t2):
-        """Spin-orbital HBAR blocks from explicit integrals/amplitudes (the ``cchbar._so_build``
-        sequence -- no Hovov; Hvvvo/Hovoo via the Zovov intermediate)."""
-        o, v = self.ccwfn.o, self.ccwfn.v
-        Hov = hbar._so_build_Hov(o, v, F, ERI, t1)
-        Hvv = hbar._so_build_Hvv(o, v, F, ERI, Hov, t1, t2)
-        Hoo = hbar._so_build_Hoo(o, v, F, ERI, Hov, t1, t2)
-        Hoooo = hbar._so_build_Hoooo(o, v, ERI, t1, t2)
-        Hvvvv = hbar._so_build_Hvvvv(o, v, ERI, t1, t2)
-        Hvovv = hbar._so_build_Hvovv(o, v, ERI, t1)
-        Hooov = hbar._so_build_Hooov(o, v, ERI, t1)
-        Hovvo = hbar._so_build_Hovvo(o, v, ERI, t1, t2)
-        Zovov = hbar._so_build_Zovov(o, v, ERI, t2)
-        Hvvvo = hbar._so_build_Hvvvo(o, v, ERI, Hov, Hvvvv, Zovov, t1, t2)
-        Hovoo = hbar._so_build_Hovoo(o, v, ERI, Hov, Hoooo, Zovov, t1, t2)
-        return {'Hov': Hov, 'Hvv': Hvv, 'Hoo': Hoo, 'Hoooo': Hoooo, 'Hvvvv': Hvvvv,
-                'Hvovv': Hvovv, 'Hooov': Hooov, 'Hovvo': Hovvo, 'Hvvvo': Hvvvo, 'Hovoo': Hovoo}
-
-    def _so_perturbed_hbar(self, df, deri, dt1, dt2, hbar):
-        """Spin-orbital perturbed HBAR via the exact 5-point stencil (degree-<=4 blocks)."""
-        cc = self.ccwfn
-        F0 = np.asarray(cc.H.F); ERI0 = np.asarray(cc.H.ERI)
-        t01 = np.asarray(cc.t1); t02 = np.asarray(cc.t2)
-        h = 1e-2
-        def at(s):
-            return self._so_hbar_blocks(hbar, F0 + s*h*df, ERI0 + s*h*deri, t01 + s*h*dt1, t02 + s*h*dt2)
-        m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
-        return {k: (np.asarray(m2[k]) - 8.0*np.asarray(m1[k]) + 8.0*np.asarray(p1[k])
-                    - np.asarray(p2[k])) / (12.0*h) for k in m2}
-
     def _so_perturbed_lambda(self, df, deri, dt1, dt2, hbar, lam, maxiter=200, rconv=1e-13):
         """Spin-orbital perturbed Lambda ``dLambda/dF`` (SO r_L; inhomogeneity = r_L with perturbed
         HBAR + perturbed ERI, unperturbed G, plus the dG.H / dG.<pq||rs> product-rule halves)."""
@@ -898,6 +848,53 @@ class CCderiv:
             diis.add_error_vector(dl1, dl2)
             dl1, dl2 = diis.extrapolate(dl1, dl2)
         return dl1, dl2
+
+    def _perturbed_correlation_densities(self, dt1, dt2, dl1, dl2, lam):
+        """Field response ``(dD, dGamma)`` of the unrelaxed CC correlation densities via a 5-point
+        stencil of :meth:`ccdensity.gradient_densities` in the amplitudes/multipliers (the densities
+        are pure polynomials in ``t``/``lambda`` -- exact).  Temporarily sets ``cc.t1/t2`` and
+        ``lam.l1/l2`` to the stepped values (restored)."""
+        from .ccdensity import ccdensity
+        cc = self.ccwfn
+        t01, t02 = np.asarray(cc.t1).copy(), np.asarray(cc.t2).copy()
+        l01, l02 = np.asarray(lam.l1).copy(), np.asarray(lam.l2).copy()
+        h = 1e-2
+        def at(s):
+            cc.t1 = t01 + s*h*dt1; cc.t2 = t02 + s*h*dt2
+            lam.l1 = l01 + s*h*dl1; lam.l2 = l02 + s*h*dl2
+            D_s, Gam_s = ccdensity(cc, lam).gradient_densities()
+            return np.asarray(D_s), np.asarray(Gam_s)
+        try:
+            m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
+        finally:
+            cc.t1, cc.t2 = t01, t02
+            lam.l1, lam.l2 = l01, l02
+        dDg = (m2[0] - 8.0*m1[0] + 8.0*p1[0] - p2[0]) / (12.0*h)
+        dGam = (m2[1] - 8.0*m1[1] + 8.0*p1[1] - p2[1]) / (12.0*h)
+        return dDg, dGam
+
+    def _cc_perturbed_lagrangian(self, df, deri, dL, D, dD, Gam, dGam):
+        """Field response ``dI'`` of the generalized-Fock (GSB) Lagrangian, density-generic.  The
+        Fock term is the **full matrix product** ``df @ (D + D.T)`` -- NOT the diagonal ``diag(df)``
+        a stencil of :meth:`MPwfn._mp2_lagrangian` (which uses ``eps[:,None]*(D+D.T)``, valid only
+        at the canonical F=0) would give.  The omitted ``df_offdiag @ (D+D.T)`` vanishes for MP2
+        (unrelaxed ``D`` has no ov block) but is nonzero for CC (couples to ``Dov``/``Dvo``); see
+        DERIVATIVES_PLAN sec 8.2.  (Same formula as :meth:`MPwfn._perturbed_lagrangian`; destined to
+        merge with it under ``CorrelatedDerivs``.)"""
+        cc = self.ccwfn
+        o = cc.o
+        ofull = slice(0, o.stop)
+        c = self.contract
+        ERI = np.asarray(cc.H.ERI)
+        L = np.asarray(cc.H.L)
+        eps = np.diag(np.asarray(cc.H.F))
+        nmo = cc.nmo
+        dA = df @ (D + D.T) + eps[:, None] * (dD + dD.T)
+        dB = np.zeros((nmo, nmo))
+        dB[:, ofull] = (c('rs,rpsq->pq', dD, L[:, :, :, ofull]) + c('rs,rpsq->pq', D, dL[:, :, :, ofull])
+                        + c('rs,rqsp->pq', dD, L[:, ofull, :, :]) + c('rs,rqsp->pq', D, dL[:, ofull, :, :]))
+        dC = 4.0 * (c('prst,qrst->pq', deri, Gam) + c('prst,qrst->pq', ERI, dGam))
+        return -0.5 * (dA + dB + dC)
 
     def _so_cc_perturbed_lagrangian(self, df, deri, D, dD, Gam, dGam):
         """Spin-orbital field response ``dI'`` of the GSB Lagrangian (full-df Fock term, as in

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -368,15 +368,16 @@ class CCderiv:
         The reference (SCF) polarizability is kept separate (:meth:`HFwfn.polarizability`); the
         :func:`pycc.polarizability` facade sums nuclear (zero) + reference + this correlation part.
 
-        Spatial closed-shell RHF (all-electron or frozen core); spin-orbital and (T) to follow.
-        Validated against a tight finite field of :meth:`relaxed_dipole`."""
+        Spatial closed-shell RHF and spin-orbital UHF (both all-electron and frozen core); (T) to
+        follow.  Validated against a tight finite field of :meth:`relaxed_dipole` and the SO ==
+        spatial keystone."""
         if route != '2n+1':
             raise ValueError(f"CC polarizability supports only the asymmetric '2n+1' route, not {route!r}.")
         cc = self.ccwfn
         if cc.model.upper() != 'CCSD':
             raise NotImplementedError(f"CC polarizability: only CCSD is implemented (not {cc.model}).")
         if cc.orbital_basis == 'spinorbital':
-            raise NotImplementedError("CC polarizability: spin-orbital path not yet implemented.")
+            return self._so_polarizability()
         from .cchbar import cchbar
         from .cclambda import cclambda
         from .ccdensity import ccdensity
@@ -659,5 +660,258 @@ class CCderiv:
         dB = np.zeros((nmo, nmo))
         dB[:, ofull] = (c('rs,rpsq->pq', dD, L[:, :, :, ofull]) + c('rs,rpsq->pq', D, dL[:, :, :, ofull])
                         + c('rs,rqsp->pq', dD, L[:, ofull, :, :]) + c('rs,rqsp->pq', D, dL[:, ofull, :, :]))
+        dC = 4.0 * (c('prst,qrst->pq', deri, Gam) + c('prst,qrst->pq', ERI, dGam))
+        return -0.5 * (dA + dB + dC)
+
+    # ---- spin-orbital (UHF) polarizability ------------------------------
+    # Mirror of the spatial path with antisymmetrized <pq||rs> (no L), the spin-orbital HBAR (no
+    # Hovov; Hvvvo/Hovoo use a Zovov intermediate), the spin-orbital Jacobian / r_L, and the inline
+    # orbital Hessian G (as in _so_relaxed_density) rather than a borrowed all-electron CPHF.
+    # Validated by the RHF-forced-to-SO == spatial keystone.
+
+    _SO_HBAR_BLOCKS = ('Hov', 'Hvv', 'Hoo', 'Hoooo', 'Hvvvv', 'Hvovv', 'Hooov',
+                       'Hovvo', 'Hvvvo', 'Hovoo')
+
+    def _so_polarizability(self) -> np.ndarray:
+        """Spin-orbital (UHF) CCSD correlation polarizability -- the SO analog of
+        :meth:`polarizability` (all-electron or frozen core).  Raises for ROHF."""
+        from .cchbar import cchbar
+        from .cclambda import cclambda
+        from .ccdensity import ccdensity
+        from .cphf import Perturbation
+        cc = self.ccwfn
+        if cc.mp.cphf.is_rohf:
+            raise NotImplementedError("CC polarizability: ROHF is not supported (RHF/UHF only).")
+        o, v, nv = cc.o, cc.v, cc.nv
+        co = slice(0, o.start)                            # frozen core (2*nfzc spin-orbitals)
+        ofull = slice(0, o.stop)
+        nof = o.stop
+        c = self.contract
+        ncore = o.stop - cc.no
+        eps = np.diag(np.asarray(cc.H.F))
+        ERI = np.asarray(cc.H.ERI)
+
+        hbar = cchbar(cc)
+        lam = cclambda(cc, hbar)
+        lam.solve_lambda(1e-13, 1e-13)
+        D0, Gam0 = (np.asarray(x) for x in ccdensity(cc, lam).gradient_densities())
+        Ip0 = np.asarray(self._lagrangian(D0, Gam0))
+        Drel = D0.copy()
+        Pco = None
+        if cc.nfzc:
+            Pco = (Ip0[co, o] - Ip0[o, co].T) / (eps[co][:, None] - eps[o][None, :])
+            Drel[co, o] += Pco
+            Drel[o, co] += Pco.T
+        X0 = Ip0[ofull, v] - Ip0[v, ofull].T
+        if cc.nfzc:
+            zjc = -Pco.T
+            X0 = X0 - (c('jc,ajic->ia', zjc, ERI[v, o, ofull, co]) + c('jc,acij->ia', zjc, ERI[v, co, ofull, o]))
+        G = (c('ajib->iajb', ERI[v, ofull, ofull, v]) + c('abij->iajb', ERI[v, v, ofull, ofull])).reshape(nof*nv, nof*nv)
+        G[np.diag_indices(nof*nv)] += (eps[v][None, :] - eps[ofull][:, None]).reshape(-1)
+        z = np.linalg.solve(G, X0.reshape(-1)).reshape(nof, nv)
+        Drel[v, ofull] += -z.T
+        Drel[ofull, v] += -z
+
+        cphf = cc.mp._full_occ_cphf()
+        mu = [np.asarray(cc.H.mu[a]) for a in range(3)]
+        alpha = np.zeros((3, 3))
+        for b in range(3):
+            pert = Perturbation('field', b)
+            dDrel = self._so_perturbed_relaxed_density(pert, hbar, lam, D0, Gam0, z, G, Pco)
+            Ub = np.asarray(cphf._full_U(pert, ncore))
+            for a in range(3):
+                rot = Ub.T @ mu[a] + mu[a] @ Ub
+                alpha[a, b] = c('pq,pq->', dDrel, mu[a]) + c('pq,pq->', Drel, rot)
+        return alpha
+
+    def _so_perturbed_relaxed_density(self, pert, hbar, lam, D0, Gam0, z, G, Pco):
+        """Spin-orbital field response ``dD_rel``; the SO analog of
+        :meth:`_perturbed_relaxed_density` (inline Hessian ``G``, antisymmetrized ERI)."""
+        cc = self.ccwfn
+        o, v, nv = cc.o, cc.v, cc.nv
+        co = slice(0, o.start)
+        ofull = slice(0, o.stop)
+        nof = o.stop
+        c = self.contract
+        ncore = o.stop - cc.no
+        ERI = np.asarray(cc.H.ERI)
+        eps = np.diag(np.asarray(cc.H.F))
+        cphf = cc.mp._full_occ_cphf()
+        df = np.asarray(cphf.perturbed_fock(pert, ncore))
+        deri = np.asarray(cphf.perturbed_eri(pert, ncore))
+
+        dt1, dt2 = self._so_perturbed_amplitudes(df, deri, hbar)
+        dl1, dl2 = self._so_perturbed_lambda(df, deri, dt1, dt2, hbar, lam)
+        dDg, dGam = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam)
+        dIp = self._so_cc_perturbed_lagrangian(df, deri, D0, dDg, Gam0, dGam)
+        dX = dIp[ofull, v] - dIp[v, ofull].T
+        dPco = None
+        if cc.nfzc:
+            gap = eps[co][:, None] - eps[o][None, :]
+            dPco = (dIp[co, o] - dIp[o, co].T - df[co, co] @ Pco + Pco @ df[o, o]) / gap
+            zjc, dzjc = -Pco.T, -dPco.T
+            dX = dX - (c('jc,ajic->ia', dzjc, ERI[v, o, ofull, co]) + c('jc,acij->ia', dzjc, ERI[v, co, ofull, o])
+                       + c('jc,ajic->ia', zjc, deri[v, o, ofull, co]) + c('jc,acij->ia', zjc, deri[v, co, ofull, o]))
+        Axz = (c('ajib,jb->ia', deri[v, ofull, ofull, v], z) + c('abij,jb->ia', deri[v, v, ofull, ofull], z)
+               + c('ab,ib->ia', df[v, v], z) - c('ij,ja->ia', df[ofull, ofull], z))
+        zx = np.linalg.solve(G, (dX - Axz).reshape(-1)).reshape(nof, nv)
+        dDrel = dDg.copy()
+        if cc.nfzc:
+            dDrel[co, o] += dPco
+            dDrel[o, co] += dPco.T
+        dDrel[v, ofull] += -zx.T
+        dDrel[ofull, v] += -zx
+        return dDrel
+
+    def _so_ccsd_jacobian(self, X1, X2, hbar):
+        """Spin-orbital CCSD Jacobian ``(HBAR . X)`` -- the SO ``ccresponse.r_X1/r_X2`` contraction
+        pattern (antisymmetrized; the P(ij)P(ab) is built in, so no final symmetrization)."""
+        c = self.contract
+        o, v = self.ccwfn.o, self.ccwfn.v
+        t2 = self.ccwfn.t2
+        ERI = self.ccwfn.H.ERI
+        r1 = c('ie,ae->ia', X1, hbar.Hvv) - c('ma,mi->ia', X1, hbar.Hoo)
+        r1 += c('me,maei->ia', X1, hbar.Hovvo)
+        r1 += c('me,imae->ia', hbar.Hov, X2)
+        r1 += 0.5 * c('imef,amef->ia', X2, hbar.Hvovv)
+        r1 -= 0.5 * c('mnae,mnie->ia', X2, hbar.Hooov)
+        Zvv = c('amef,me->af', hbar.Hvovv, X1)
+        Zoo = c('mnie,me->ni', hbar.Hooov, X1)
+        Yoo = 0.5 * c('mnef,mjef->nj', ERI[o, o, v, v], X2)
+        Yvv = 0.5 * c('mnef,mneb->fb', ERI[o, o, v, v], X2)
+        r2 = c('ie,abej->ijab', X1, hbar.Hvvvo) - c('je,abei->ijab', X1, hbar.Hvvvo)
+        r2 -= c('ma,mbij->ijab', X1, hbar.Hovoo) - c('mb,maij->ijab', X1, hbar.Hovoo)
+        r2 += c('ni,njab->ijab', Zoo, t2) - c('nj,niab->ijab', Zoo, t2)
+        r2 -= c('af,ijfb->ijab', Zvv, t2) - c('bf,ijfa->ijab', Zvv, t2)
+        r2 -= c('nj,inab->ijab', Yoo, t2) - c('ni,jnab->ijab', Yoo, t2)
+        r2 -= c('fb,ijaf->ijab', Yvv, t2) - c('fa,ijbf->ijab', Yvv, t2)
+        r2 += c('ijae,be->ijab', X2, hbar.Hvv) - c('ijbe,ae->ijab', X2, hbar.Hvv)
+        r2 -= c('imab,mj->ijab', X2, hbar.Hoo) - c('jmab,mi->ijab', X2, hbar.Hoo)
+        r2 += 0.5 * c('mnab,mnij->ijab', X2, hbar.Hoooo)
+        r2 += 0.5 * c('ijef,abef->ijab', X2, hbar.Hvvvv)
+        tmp = c('imae,mbej->ijab', X2, hbar.Hovvo)
+        r2 += tmp - tmp.swapaxes(0, 1) - tmp.swapaxes(2, 3) + tmp.swapaxes(0, 1).swapaxes(2, 3)
+        return r1, r2
+
+    def _so_perturbed_amplitudes(self, df, deri, hbar, maxiter=200, rconv=1e-13):
+        """Spin-orbital perturbed CCSD amplitudes ``dt/dF`` (SO Jacobian; SO residual has no 0.5 /
+        no final symmetrization, matching ``ccresponse.solve_right``)."""
+        from .utils import helper_diis
+        cc = self.ccwfn
+        Dia, Dijab = cc.Dia, cc.Dijab
+        saveERI = cc.H.ERI
+        cc.H.ERI = deri
+        try:
+            B1, B2 = cc.residuals(df, cc.t1, cc.t2)
+        finally:
+            cc.H.ERI = saveERI
+        B1, B2 = np.asarray(B1), np.asarray(B2)
+        X1, X2 = B1 / Dia, B2 / Dijab
+        diis = helper_diis(X1, X2, 8)
+        for _ in range(maxiter):
+            j1, j2 = self._so_ccsd_jacobian(X1, X2, hbar)
+            r1, r2 = B1 + j1, B2 + j2
+            X1 = X1 + r1 / Dia
+            X2 = X2 + r2 / Dijab
+            if np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2)) < rconv:
+                break
+            diis.add_error_vector(X1, X2)
+            X1, X2 = diis.extrapolate(X1, X2)
+        return X1, X2
+
+    def _so_hbar_blocks(self, hbar, F, ERI, t1, t2):
+        """Spin-orbital HBAR blocks from explicit integrals/amplitudes (the ``cchbar._so_build``
+        sequence -- no Hovov; Hvvvo/Hovoo via the Zovov intermediate)."""
+        o, v = self.ccwfn.o, self.ccwfn.v
+        Hov = hbar._so_build_Hov(o, v, F, ERI, t1)
+        Hvv = hbar._so_build_Hvv(o, v, F, ERI, Hov, t1, t2)
+        Hoo = hbar._so_build_Hoo(o, v, F, ERI, Hov, t1, t2)
+        Hoooo = hbar._so_build_Hoooo(o, v, ERI, t1, t2)
+        Hvvvv = hbar._so_build_Hvvvv(o, v, ERI, t1, t2)
+        Hvovv = hbar._so_build_Hvovv(o, v, ERI, t1)
+        Hooov = hbar._so_build_Hooov(o, v, ERI, t1)
+        Hovvo = hbar._so_build_Hovvo(o, v, ERI, t1, t2)
+        Zovov = hbar._so_build_Zovov(o, v, ERI, t2)
+        Hvvvo = hbar._so_build_Hvvvo(o, v, ERI, Hov, Hvvvv, Zovov, t1, t2)
+        Hovoo = hbar._so_build_Hovoo(o, v, ERI, Hov, Hoooo, Zovov, t1, t2)
+        return {'Hov': Hov, 'Hvv': Hvv, 'Hoo': Hoo, 'Hoooo': Hoooo, 'Hvvvv': Hvvvv,
+                'Hvovv': Hvovv, 'Hooov': Hooov, 'Hovvo': Hovvo, 'Hvvvo': Hvvvo, 'Hovoo': Hovoo}
+
+    def _so_perturbed_hbar(self, df, deri, dt1, dt2, hbar):
+        """Spin-orbital perturbed HBAR via the exact 5-point stencil (degree-<=4 blocks)."""
+        cc = self.ccwfn
+        F0 = np.asarray(cc.H.F); ERI0 = np.asarray(cc.H.ERI)
+        t01 = np.asarray(cc.t1); t02 = np.asarray(cc.t2)
+        h = 1e-2
+        def at(s):
+            return self._so_hbar_blocks(hbar, F0 + s*h*df, ERI0 + s*h*deri, t01 + s*h*dt1, t02 + s*h*dt2)
+        m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
+        return {k: (np.asarray(m2[k]) - 8.0*np.asarray(m1[k]) + 8.0*np.asarray(p1[k])
+                    - np.asarray(p2[k])) / (12.0*h) for k in m2}
+
+    def _so_perturbed_lambda(self, df, deri, dt1, dt2, hbar, lam, maxiter=200, rconv=1e-13):
+        """Spin-orbital perturbed Lambda ``dLambda/dF`` (SO r_L; inhomogeneity = r_L with perturbed
+        HBAR + perturbed ERI, unperturbed G, plus the dG.H / dG.<pq||rs> product-rule halves)."""
+        from .utils import helper_diis
+        cc = self.ccwfn
+        o, v = cc.o, cc.v
+        c = self.contract
+        Dia, Dijab = cc.Dia, cc.Dijab
+        l1, l2 = np.asarray(lam.l1), np.asarray(lam.l2)
+        t2 = np.asarray(cc.t2)
+        ERI0 = np.asarray(cc.H.ERI)
+
+        def rL1(La, Lb, H, Gvv, Goo):
+            return np.asarray(lam._so_r_L1(o, v, La, Lb, H['Hov'], H['Hvv'], H['Hoo'], H['Hovvo'],
+                                           H['Hvvvo'], H['Hovoo'], H['Hvovv'], H['Hooov'], Gvv, Goo))
+        def rL2(La, Lb, E, H, Gvv, Goo):
+            return np.asarray(lam._so_r_L2(o, v, La, Lb, E, H['Hov'], H['Hvv'], H['Hoo'], H['Hoooo'],
+                                           H['Hvvvv'], H['Hovvo'], H['Hvvvo'], H['Hovoo'], H['Hvovv'],
+                                           H['Hooov'], Gvv, Goo))
+
+        dH = self._so_perturbed_hbar(df, deri, dt1, dt2, hbar)
+        H0 = {b: np.asarray(getattr(hbar, b)) for b in self._SO_HBAR_BLOCKS}
+        Goo0 = np.asarray(lam.build_Goo(t2, l2)); Gvv0 = np.asarray(lam.build_Gvv(t2, l2))
+        dGoo = np.asarray(lam.build_Goo(dt2, l2)); dGvv = np.asarray(lam.build_Gvv(dt2, l2))  # l2 fixed
+        B1 = rL1(l1, l2, dH, Gvv0, Goo0)
+        B2 = rL2(l1, l2, deri, dH, Gvv0, Goo0)
+        Hvovv0, Hooov0 = H0['Hvovv'], H0['Hooov']
+        B1 = B1 - c('ef,eifa->ia', dGvv, Hvovv0) - c('mn,mina->ia', dGoo, Hooov0)
+        oovv = ERI0[o, o, v, v]
+        B2 = B2 + (c('be,ijae->ijab', dGvv, oovv) - c('ae,ijbe->ijab', dGvv, oovv)) \
+                - (c('mj,imab->ijab', dGoo, oovv) - c('mi,jmab->ijab', dGoo, oovv))
+        zl1 = np.zeros_like(l1); zl2 = np.zeros_like(l2)
+        zGvv = np.zeros_like(Gvv0); zGoo = np.zeros_like(Goo0)
+        rL1_0 = rL1(zl1, zl2, H0, zGvv, zGoo)
+        rL2_0 = rL2(zl1, zl2, ERI0, H0, zGvv, zGoo)
+        dl1, dl2 = B1 / Dia, B2 / Dijab
+        diis = helper_diis(dl1, dl2, 8)
+        for _ in range(maxiter):
+            Gvv_d = np.asarray(lam.build_Gvv(t2, dl2)); Goo_d = np.asarray(lam.build_Goo(t2, dl2))
+            j1 = rL1(dl1, dl2, H0, Gvv_d, Goo_d) - rL1_0
+            j2 = rL2(dl1, dl2, ERI0, H0, Gvv_d, Goo_d) - rL2_0
+            r1, r2 = B1 + j1, B2 + j2
+            dl1 = dl1 + r1 / Dia
+            dl2 = dl2 + r2 / Dijab
+            if np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2)) < rconv:
+                break
+            diis.add_error_vector(dl1, dl2)
+            dl1, dl2 = diis.extrapolate(dl1, dl2)
+        return dl1, dl2
+
+    def _so_cc_perturbed_lagrangian(self, df, deri, D, dD, Gam, dGam):
+        """Spin-orbital field response ``dI'`` of the GSB Lagrangian (full-df Fock term, as in
+        :meth:`MPwfn._so_perturbed_lagrangian`), density-generic with the CC densities."""
+        cc = self.ccwfn
+        o = cc.o
+        ofull = slice(0, o.stop)
+        c = self.contract
+        ERI = np.asarray(cc.H.ERI)
+        eps = np.diag(np.asarray(cc.H.F))
+        nmo = cc.nmo
+        dA = df @ (D + D.T) + eps[:, None] * (dD + dD.T)
+        dB = np.zeros((nmo, nmo))
+        dB[:, ofull] = (c('rs,rpsq->pq', dD, ERI[:, :, :, ofull]) + c('rs,rpsq->pq', D, deri[:, :, :, ofull])
+                        + c('rs,rqsp->pq', dD, ERI[:, ofull, :, :]) + c('rs,rqsp->pq', D, deri[:, ofull, :, :]))
         dC = 4.0 * (c('prst,qrst->pq', deri, Gam) + c('prst,qrst->pq', ERI, dGam))
         return -0.5 * (dA + dB + dC)

--- a/pycc/tests/test_067_mp2_polarizability.py
+++ b/pycc/tests/test_067_mp2_polarizability.py
@@ -14,13 +14,13 @@ first-order responses (MPwfn._perturbed_densities):
 The reference (SCF) part is kept separate (HFwfn.polarizability); the total is their sum.
 
 Validation:
-  * primary: alpha diagonal vs a 7-point O(h^6) finite difference of the analytic MP2
-    correlation *dipole* (alpha = d mu / dF). Differencing a first derivative divides by h
-    (not h^2 as an energy second derivative would), so the round-off floor is ~3 orders
-    lower -- agreement is ~1e-12. It is also a cross-check: the dipole uses only the
-    first-order machinery (U, unrelaxed densities), the polarizability the second-order
-    machinery (U^{ab}, perturbed densities), so their agreement confirms the two analytic
-    derivations are mutually consistent.
+  * primary: alpha diagonal vs *frozen* references (ALPHA_DIAG_631G[_FC]), each validated once
+    against a 7-point O(h^6) finite difference of the analytic MP2 correlation *dipole*
+    (alpha = d mu / dF) to ~7e-12 -- the regeneration recipe _dipfd_alpha_diag, kept but not run.
+    That dipole FD is a cross-check: the dipole uses only the first-order machinery (U, unrelaxed
+    densities), the polarizability the second-order machinery (U^{ab}, perturbed densities), so
+    their agreement (verified when the reference was frozen) confirms the two analytic derivations
+    are mutually consistent.
   * independence guard: one component vs a *frozen* finite field of the MP2 *energy* -- a fully
     external oracle (the dipole FD is pycc-vs-pycc). The energy FD is of E_MP2, not any
     analytic gradient, so it is unaffected by Psi4's frozen-core MP2 gradient bug.
@@ -69,10 +69,11 @@ def _pycc_alpha(basis, orbital_basis='spatial', freeze_core='false', geom=WATER,
 
 
 def _dipfd_alpha_diag(basis, axis, orbital_basis='spatial', freeze_core='false', h=0.002):
-    """|alpha_(axis,axis)| via a 7-point O(h^6) central first-derivative stencil of the
-    analytic MP2 correlation dipole component ``axis`` under a field along ``axis``
-    (alpha = d mu / dF). Returns the magnitude (the diagonal polarizability is positive;
-    the mu/field sign convention is immaterial to |d mu / dF|)."""
+    """Regeneration recipe for ALPHA_DIAG_631G[_FC] (not run in the tests): ``|alpha_(axis,axis)|``
+    via a 7-point O(h^6) central first-derivative stencil of the analytic MP2 correlation dipole
+    component ``axis`` under a field along ``axis`` (alpha = d mu / dF). Returns the magnitude (the
+    diagonal polarizability is positive; the mu/field sign convention is immaterial to
+    |d mu / dF|)."""
     def mu(Fval):
         psi4.core.clean()
         psi4.core.clean_options()
@@ -117,28 +118,32 @@ def _energy_fd_alpha_diag(basis, axis, freeze_core='false', F=0.002, geom=WATER,
     return -(d2('mp2') - d2('scf'))
 
 
-# ---- primary: high-precision dipole finite difference (~1e-12) ----
+# ---- primary: frozen analytic diagonal (validated vs the 7-point dipole finite difference) ----
+# The MP2 correlation alpha diagonal, frozen rather than re-run each time.  Each value was validated
+# once against a 7-point O(h^6) finite difference of the analytic correlation *dipole* (alpha =
+# d mu / dF) to ~7e-12 (the regeneration recipe _dipfd_alpha_diag).  That dipole FD is an internal
+# cross-check -- the dipole uses only first-order machinery (U, unrelaxed densities), the
+# polarizability the second-order machinery (U^{ab}, perturbed densities) -- so its agreement (checked
+# when the reference was frozen) confirms the two analytic derivations are mutually consistent.  The
+# deterministic analytic recomputation reproduces the frozen values to ~machine precision.
+ALPHA_DIAG_631G    = np.array([0.084402387,  0.0611767146, 0.1951911112])   # all-electron
+ALPHA_DIAG_631G_FC = np.array([0.0846398834, 0.0620015909, 0.1955436888])   # frozen core
 
-def test_mp2_corr_polarizability_dipfd_631g():
-    """All-electron spatial MP2 correlation alpha, all three diagonal components vs a
-    7-point finite difference of the analytic correlation dipole, H2O/6-31G (~1e-12)."""
+
+def test_mp2_corr_polarizability_631g():
+    """All-electron spatial MP2 correlation alpha diagonal (H2O/6-31G) vs the frozen reference."""
     a = _pycc_alpha('6-31G', orbital_basis='spatial')
-    for axis in range(3):
-        assert abs(a[axis, axis] - _dipfd_alpha_diag('6-31G', axis)) < 1e-10
+    assert np.max(np.abs(np.diag(a) - ALPHA_DIAG_631G)) < 1e-9, np.diag(a)
 
 
-def test_fc_mp2_corr_polarizability_dipfd_631g():
-    """Frozen-core spatial MP2 correlation alpha diagonal vs the 7-point dipole finite
-    difference, H2O/6-31G (~1e-12).
+def test_fc_mp2_corr_polarizability_631g():
+    """Frozen-core spatial MP2 correlation alpha diagonal (H2O/6-31G) vs the frozen reference.
 
-    Exercises the frozen-core second-order response: the core<->active U^{ab} from the
-    canonical d_ab f_ij = 0 divide, and the ov second-order CPHF solve seeded with the
-    nonzero ov orthonormality term xi_ia (which vanishes only in the all-electron field
-    case)."""
+    Exercises the frozen-core second-order response: the core<->active U^{ab} from the canonical
+    d_ab f_ij = 0 divide, and the ov second-order CPHF solve seeded with the nonzero ov
+    orthonormality term xi_ia (which vanishes only in the all-electron field case)."""
     a = _pycc_alpha('6-31G', orbital_basis='spatial', freeze_core='true')
-    for axis in range(3):
-        assert abs(a[axis, axis]
-                   - _dipfd_alpha_diag('6-31G', axis, freeze_core='true')) < 1e-10
+    assert np.max(np.abs(np.diag(a) - ALPHA_DIAG_631G_FC)) < 1e-9, np.diag(a)
 
 
 # ---- independence guard: frozen external energy finite field ----

--- a/pycc/tests/test_084_cc_polarizability.py
+++ b/pycc/tests/test_084_cc_polarizability.py
@@ -57,6 +57,21 @@ WATER_ALPHA_REF_FC = np.array([[0.071841599990, 0.0, 0.0],
                                [0.0, 0.061126138693, 0.0],
                                [0.0, 0.0, 0.174203460940]])
 
+# Open-shell UHF NH2 (2-B1, bent), run in C2v with the 2-B1 occupation pinned (NH2_OCC) so a poor
+# SCF guess cannot fall into the ~0.074 Eh higher 2-A1 solution (making the value freezeable).  SO
+# CCSD correlation polarizability; alpha_zz validated against a 5-point energy 2nd-derivative finite
+# field (field along the C2 axis, C2v-preserving) to 2.7e-10; the full tensor is symmetric to 4e-16.
+NH2 = """
+0 2
+N
+H 1 1.02
+H 1 1.02 2 103.0
+"""
+NH2_OCC = {'docc': [3, 0, 0, 1], 'socc': [0, 0, 1, 0]}
+NH2_ALPHA_REF = np.array([[0.155624577600, 0.0, 0.0],
+                          [0.0, 0.059976118900, 0.0],
+                          [0.0, 0.0, 0.194543333700]])
+
 
 def _findiff_alpha(geom, basis, F=5e-4, freeze_core='false'):
     """Regeneration recipe for the *_ALPHA_REF tensors (not run in the tests): a 5-point O(h^4)
@@ -143,6 +158,35 @@ def test_ccsd_polarizability_hof_offdiagonal(rhf_wfn):
     r = pycc.polarizability(cc)
     total = np.asarray(r.total)
     assert np.all(np.linalg.eigvalsh(0.5 * (total + total.T)) > 0.0), np.linalg.eigvalsh(total)
+    psi4.core.clean()
+
+
+def test_so_ccsd_polarizability_keystone(rhf_wfn):
+    """SO == spatial keystone: the spin-orbital CCSD polarizability of an RHF reference forced into
+    the spin-orbital basis reproduces the FD-validated spatial references (all-electron and frozen
+    core).  This carries the high-precision spatial validation onto the SO machinery (SO Jacobian,
+    SO HBAR, SO r_L, inline orbital Hessian)."""
+    for fc, ref in (("false", WATER_ALPHA_REF), ("true", WATER_ALPHA_REF_FC)):
+        wfn = rhf_wfn(WATER, "6-31G", freeze_core=fc)
+        cc = pycc.ccwfn(wfn, orbital_basis='spinorbital')
+        cc.solve_cc(1e-12, 1e-12, 100)
+        alpha = np.asarray(pycc.CCderiv(cc).polarizability())
+        assert np.max(np.abs(alpha - ref)) < 1e-9, (fc, alpha)
+        psi4.core.clean()
+
+
+def test_uhf_ccsd_polarizability_nh2(rhf_wfn):
+    """Open-shell UHF spin-orbital CCSD polarizability (2-B1 NH2, pinned occupation) vs the frozen
+    reference -- the genuinely spin-polarized SO path (beyond the RHF-forced-to-SO keystone).
+    alpha_zz was validated against an external energy finite field; the tensor is symmetric and its
+    diagonal positive."""
+    wfn = rhf_wfn(NH2, "6-31G", reference='uhf', freeze_core='false', **NH2_OCC)
+    cc = pycc.ccwfn(wfn, orbital_basis='spinorbital')
+    cc.solve_cc(1e-12, 1e-12, 100)
+    alpha = np.asarray(pycc.CCderiv(cc).polarizability())
+    assert np.max(np.abs(alpha - NH2_ALPHA_REF)) < 1e-9, alpha
+    assert np.max(np.abs(alpha - alpha.T)) < 1e-9
+    assert np.all(np.diag(alpha) > 0.0)
     psi4.core.clean()
 
 

--- a/pycc/tests/test_084_cc_polarizability.py
+++ b/pycc/tests/test_084_cc_polarizability.py
@@ -52,27 +52,39 @@ WATER_ALPHA_REF = np.array([[0.071555631886, 0.0, 0.0],
 HOF_ALPHA_REF = np.array([[-1.879732823995, -0.599507379935, 0.0],
                           [-0.599507379947, 0.104671076326, 0.0],
                           [0.0, 0.0, 0.099333851054]])
+# Frozen-core H2O/6-31G keystone (validated to 1.0e-11).
+WATER_ALPHA_REF_FC = np.array([[0.071841599990, 0.0, 0.0],
+                               [0.0, 0.061126138693, 0.0],
+                               [0.0, 0.0, 0.174203460940]])
 
 
-def _findiff_alpha(geom, basis, F=5e-4):
+def _findiff_alpha(geom, basis, F=5e-4, freeze_core='false'):
     """Regeneration recipe for the *_ALPHA_REF tensors (not run in the tests): a 5-point O(h^4)
     finite field of pycc's CCSD relaxed correlation dipole (alpha = d mu / dF), with Lambda
-    converged to 1e-13 at each field (tighter than CCderiv.relaxed_dipole's default)."""
+    converged to 1e-13 at each field (tighter than CCderiv.relaxed_dipole's default).  Rebuilds the
+    relaxed density with the frozen-core core<->active divide P_co coupled into the Z-vector RHS,
+    mirroring CCderiv._relaxed_density (a no-op for freeze_core='false')."""
     def rd(bax, Fv):
         d = [0.0, 0.0, 0.0]; d[bax] = Fv
         psi4.core.clean(); psi4.core.clean_options()
         psi4.geometry(geom)
-        psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': 'false',
+        psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': freeze_core,
                           'e_convergence': 1e-13, 'd_convergence': 1e-13,
                           'perturb_h': True, 'perturb_with': 'dipole', 'perturb_dipole': d})
         _, wfn = psi4.energy('scf', return_wfn=True)
         cx = pycc.ccwfn(wfn); cx.solve_cc(1e-13, 1e-13, 300)
         hb = pycc.cchbar(cx); lm = pycc.cclambda(cx, hb); lm.solve_lambda(1e-13, 1e-13, 300)
         D, G = (np.asarray(x) for x in pycc.ccdensity(cx, lm).gradient_densities())
-        o, v = cx.o, cx.v; of = slice(0, o.stop)
+        o, v = cx.o, cx.v; co = slice(0, cx.nfzc); of = slice(0, o.stop)
+        c = cx.contract; eps = np.diag(np.asarray(cx.H.F)); L = np.asarray(cx.H.L)
         Ip = np.asarray(cx.mp._mp2_lagrangian(D, G))
-        z = np.asarray(pycc.CCderiv(cx)._reference_hf().cphf.solve(Ip[of, v] - Ip[v, of].T))
-        Dr = D.copy(); Dr[v, of] += -z.T; Dr[of, v] += -z
+        Dr = D.copy(); X = Ip[of, v] - Ip[v, of].T
+        if cx.nfzc:
+            Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
+            Dr[co, o] += Pco; Dr[o, co] += Pco.T; zjc = -Pco.T
+            X = X - (c('jc,ajic->ia', zjc, L[v, o, of, co]) + c('jc,acij->ia', zjc, L[v, co, of, o]))
+        z = np.asarray(pycc.CCderiv(cx)._reference_hf().cphf.solve(X))
+        Dr[v, of] += -z.T; Dr[of, v] += -z
         return np.array([np.sum(Dr * np.asarray(cx.H.mu[a])) for a in range(3)])
     alpha = np.zeros((3, 3))
     for b in range(3):
@@ -97,6 +109,19 @@ def test_ccsd_polarizability_water_631g(rhf_wfn):
     assert np.max(np.abs(np.asarray(r.correlation) - alpha)) < 1e-12
     assert np.max(np.abs(np.asarray(r.total) - (np.asarray(r.nuclear)
                   + np.asarray(r.reference) + np.asarray(r.correlation)))) < 1e-12
+    psi4.core.clean()
+
+
+def test_fc_ccsd_polarizability_water_631g(rhf_wfn):
+    """Frozen-core CCSD correlation polarizability for H2O/6-31G vs the frozen reference.  Exercises
+    the perturbed core<->active Sylvester divide dP_co and its coupling into the perturbed Z-vector
+    RHS (the frozen-core additions to _perturbed_relaxed_density)."""
+    wfn = rhf_wfn(WATER, "6-31G", freeze_core="true")
+    cc = pycc.ccwfn(wfn)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    alpha = np.asarray(pycc.CCderiv(cc).polarizability())
+    assert np.max(np.abs(alpha - WATER_ALPHA_REF_FC)) < 1e-9, alpha
+    assert np.max(np.abs(alpha - alpha.T)) < 1e-9
     psi4.core.clean()
 
 

--- a/pycc/tests/test_084_cc_polarizability.py
+++ b/pycc/tests/test_084_cc_polarizability.py
@@ -1,0 +1,135 @@
+"""CCSD static electric-dipole polarizability (correlation contribution) via the asymmetric
+(2n+1) route -- alpha_corr[a,b] = -d^2 E_corr / dF_a dF_b, omega = 0; see
+docs/DERIVATIVES_PLAN_2026-06.md sec 8.
+
+CCderiv.polarizability() differentiates the relaxed-density gradient a second time in a field.
+A static field leaves the AO basis fixed (S^F = <pq|rs>^F = 0), so
+
+    alpha[a,b] = Tr(dD_rel(F_b) . mu_a) + Tr(D_rel . (U^bT mu_a + mu_a U^b)),
+
+with the perturbed amplitudes/multipliers dt/dLambda, the perturbed correlation densities, the
+FULL-df perturbed Lagrangian (sec 8.2), and the perturbed Z-vector -- all first-order responses.
+
+Validation: the hard-wired references below ARE the analytic tensors, each validated ONCE against
+a tight (Lambda->1e-13) 5-point finite field of CCderiv.relaxed_dipole (alpha = d mu / dF): the
+water keystone to 1.5e-11, the HOF off-diagonal case to 2.6e-10 (recipe in _findiff_alpha).  The
+deterministic recomputation reproduces them to ~1e-11, so 1e-9 is a tight, robust guard.  Spatial
+closed-shell RHF, all-electron (frozen core / spin-orbital / (T) to follow)."""
+
+import psi4
+import pycc
+import numpy as np
+
+
+# Equilibrium H2O (C2v, molecular plane yz, C2 along z); frame locked for a reproducible tensor.
+WATER = """
+O  0.00000  0.00000  0.00000
+H  0.00000  1.43121 -1.10664
+H  0.00000 -1.43121 -1.10664
+symmetry c1
+units bohr
+no_com
+no_reorient
+"""
+
+# Planar HOF (Cs, molecular plane xy), tilted off the axes so the in-plane block is full -- the
+# off-diagonal alpha_xy is large while alpha_xz = alpha_yz = 0 (z perpendicular to the plane).
+HOF = """
+O  0.00000  0.00000  0.00000
+F  2.56070  0.93200  0.00000
+H -0.83450  1.62360  0.00000
+symmetry c1
+units bohr
+no_com
+no_reorient
+"""
+
+# Frozen references: the analytic alpha_corr, each validated once against a tight finite field of
+# the relaxed dipole (see the module docstring / _findiff_alpha).
+WATER_ALPHA_REF = np.array([[0.071555631886, 0.0, 0.0],
+                            [0.0, 0.060171399010, 0.0],
+                            [0.0, 0.0, 0.173591992896]])
+HOF_ALPHA_REF = np.array([[-1.879732823995, -0.599507379935, 0.0],
+                          [-0.599507379947, 0.104671076326, 0.0],
+                          [0.0, 0.0, 0.099333851054]])
+
+
+def _findiff_alpha(geom, basis, F=5e-4):
+    """Regeneration recipe for the *_ALPHA_REF tensors (not run in the tests): a 5-point O(h^4)
+    finite field of pycc's CCSD relaxed correlation dipole (alpha = d mu / dF), with Lambda
+    converged to 1e-13 at each field (tighter than CCderiv.relaxed_dipole's default)."""
+    def rd(bax, Fv):
+        d = [0.0, 0.0, 0.0]; d[bax] = Fv
+        psi4.core.clean(); psi4.core.clean_options()
+        psi4.geometry(geom)
+        psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': 'false',
+                          'e_convergence': 1e-13, 'd_convergence': 1e-13,
+                          'perturb_h': True, 'perturb_with': 'dipole', 'perturb_dipole': d})
+        _, wfn = psi4.energy('scf', return_wfn=True)
+        cx = pycc.ccwfn(wfn); cx.solve_cc(1e-13, 1e-13, 300)
+        hb = pycc.cchbar(cx); lm = pycc.cclambda(cx, hb); lm.solve_lambda(1e-13, 1e-13, 300)
+        D, G = (np.asarray(x) for x in pycc.ccdensity(cx, lm).gradient_densities())
+        o, v = cx.o, cx.v; of = slice(0, o.stop)
+        Ip = np.asarray(cx.mp._mp2_lagrangian(D, G))
+        z = np.asarray(pycc.CCderiv(cx)._reference_hf().cphf.solve(Ip[of, v] - Ip[v, of].T))
+        Dr = D.copy(); Dr[v, of] += -z.T; Dr[of, v] += -z
+        return np.array([np.sum(Dr * np.asarray(cx.H.mu[a])) for a in range(3)])
+    alpha = np.zeros((3, 3))
+    for b in range(3):
+        alpha[:, b] = (rd(b, -2*F) - 8*rd(b, -F) + 8*rd(b, F) - rd(b, 2*F)) / (12*F)
+    return alpha
+
+
+def test_ccsd_polarizability_water_631g(rhf_wfn):
+    """Fast keystone: all-electron CCSD correlation polarizability (all 9 elements) for H2O/6-31G
+    matches the frozen finite-field reference; the pycc.polarizability facade decomposes exactly
+    (nuclear = 0, correlation == CCderiv.polarizability); the tensor is symmetric."""
+    wfn = rhf_wfn(WATER, "6-31G", freeze_core="false")
+    cc = pycc.ccwfn(wfn)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    alpha = np.asarray(pycc.CCderiv(cc).polarizability())
+    assert np.max(np.abs(alpha - WATER_ALPHA_REF)) < 1e-9, alpha
+    assert np.max(np.abs(alpha - alpha.T)) < 1e-9              # symmetric
+
+    # facade: total = nuclear (0) + reference (HF) + correlation, and correlation == analytic alpha
+    r = pycc.polarizability(cc)
+    assert np.max(np.abs(np.asarray(r.nuclear))) < 1e-14
+    assert np.max(np.abs(np.asarray(r.correlation) - alpha)) < 1e-12
+    assert np.max(np.abs(np.asarray(r.total) - (np.asarray(r.nuclear)
+                  + np.asarray(r.reference) + np.asarray(r.correlation)))) < 1e-12
+    psi4.core.clean()
+
+
+def test_ccsd_polarizability_hof_offdiagonal(rhf_wfn):
+    """Off-diagonal case: planar HOF/cc-pVDZ (Cs).  CCSD correlation polarizability matches the
+    frozen finite-field reference; the in-plane off-diagonal alpha_xy is large (~-0.60) while
+    alpha_xz = alpha_yz = 0 (z perpendicular to the molecular plane); the tensor is symmetric; and
+    the TOTAL (reference + correlation) is positive-definite (the physical constraint -- the
+    correlation alpha_xx is negative on its own, contracting the over-polarized HF O-F direction)."""
+    wfn = rhf_wfn(HOF, "cc-pVDZ", freeze_core="false")
+    cc = pycc.ccwfn(wfn)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    alpha = np.asarray(pycc.CCderiv(cc).polarizability())
+    assert np.max(np.abs(alpha - HOF_ALPHA_REF)) < 1e-9, alpha
+    assert np.max(np.abs(alpha - alpha.T)) < 1e-9              # symmetric (asymmetric route does not enforce it)
+    assert abs(alpha[0, 1]) > 0.5                              # genuine in-plane off-diagonal
+    assert abs(alpha[0, 2]) < 1e-9 and abs(alpha[1, 2]) < 1e-9  # out-of-plane block vanishes (Cs)
+
+    r = pycc.polarizability(cc)
+    total = np.asarray(r.total)
+    assert np.all(np.linalg.eigvalsh(0.5 * (total + total.T)) > 0.0), np.linalg.eigvalsh(total)
+    psi4.core.clean()
+
+
+def test_ccsd_polarizability_guards(rhf_wfn):
+    """The unimplemented paths raise rather than silently returning a wrong tensor: CCSD(T)
+    (needs the perturbed (T) response), an unknown route, and the spin-orbital basis."""
+    import pytest
+    wfn = rhf_wfn(WATER, "6-31G", freeze_core="false")
+    cc = pycc.ccwfn(wfn, model='ccsd(t)')
+    cc.solve_cc(1e-12, 1e-12, 100)
+    with pytest.raises(NotImplementedError):
+        pycc.CCderiv(cc).polarizability()
+    with pytest.raises(ValueError):
+        pycc.CCderiv(cc).polarizability(route='explicit')
+    psi4.core.clean()


### PR DESCRIPTION
CCSD static dipole polarizability (spatial RHF + spin-orbital UHF, AE + frozen core)

branch: feature/cc-polarizability -> main  (7 commits)


WHAT THIS PR ADDS
-----------------
The CCSD static electric-dipole polarizability alpha = -d^2 E / dF_a dF_b -- the first
coupled-cluster *second*-derivative property in pycc -- as CCderiv.polarizability(),
wired into the pycc.polarizability facade. Done for CCSD across both spin paths
(spatial closed-shell RHF and spin-orbital UHF) and both all-electron and frozen core.
Only CCSD(T) remains on the polarizability roadmap.


APPROACH
--------
The asymmetric (2n+1) route: differentiate the relaxed-density gradient a second time
in a static field (S^F = <pq|rs>^F = 0), so

    alpha[a,b] = Tr(dD_rel(F_b) . mu_a) + Tr(D_rel . (U^b^T mu_a + mu_a U^b)).

New machinery, all first-order responses (no second-order CPHF), self-contained and
staying inside cclambda's r_L (no Y1/Y2 response apparatus):
  - perturbed amplitudes dt/dF and multipliers dLambda/dF (iterative; CPHF-folded RHS
    via the linear-in-H residual trick; CCSD Jacobian / r_L operators from cchbar/cclambda)
  - perturbed HBAR via an exact 5-point stencil (the CCSD HBAR blocks are degree-<=4
    polynomials in the step, so the stencil is algebraic, not truncated)
  - perturbed correlation densities, perturbed Lagrangian, and the perturbed Z-vector
    (spatial: the reference CPHF; spin-orbital: the inline orbital Hessian)


KEY FINDING (documented in DERIVATIVES_PLAN sec 8.2)
----------------------------------------------------
The perturbed Lagrangian's Fock term must use the FULL matrix product df @ (D + D^T),
not a stencil of the diagonal-eps _mp2_lagrangian (termA = eps[:,None]*(D+D^T)). The
omitted df_offdiag @ (D+D^T) vanishes for MP2 (its unrelaxed density has no ov block)
but is a ~9% error for CC, whose unrelaxed density has ov/vo blocks (Dov, Dvo). It
survives fixed-basis / frozen-MO checks (they route through the same diagonal-eps
Lagrangian, so they are circular); only the field-relaxed perturb_h oracle catches it.
The fix reuses MP2's analytic _perturbed_lagrangian formula with the CC densities.


VALIDATION (test_084; all hard-wired frozen references, no live FD in the tests)
--------------------------------------------------------------------------------
  spatial all-electron       : tight finite field of the relaxed dipole   1.8e-12
  spatial frozen core        : tight finite field                         1.0e-11
  off-diagonal (HOF/cc-pVDZ) : finite field; alpha_xy large, alpha_xz=alpha_yz=0,
                               tensor symmetric, total positive-definite   2.6e-10
  SO == spatial (AE / FC)    : RHF-forced-to-SO keystone            8.8e-14 / 3.1e-14
  open-shell UHF (2-B1 NH2)  : energy 2nd-derivative finite field (alpha_zz)  2.7e-10
Guards: CCSD(T), ROHF, and an unknown route raise.

Regression (unaffected suites re-run green): test_034 (CC density/dipole), test_067 +
test_070 (MP2 polarizability), test_074 (property facade), test_083 (CCSD(T) gradient),
test_084 -- 43 tests pass.


ALSO IN THIS PR (cleanups)
--------------------------
  - refactor(ccderiv): reorder methods to the class-organization standard -- each _so_*
    immediately after its spatial counterpart, and properties simplest -> most complex
    (relaxed_dipole, gradient, polarizability). Pure code motion (verified line-multiset).
  - test(mp2): freeze the test_067 dipole-FD oracle (it recomputed a 7-point FD live every
    run, ~10 s) to hard-wired references; _dipfd_alpha_diag kept as the unrun recipe.
  - docs: DERIVATIVES_PLAN sec 8 (formalism + the diagonal-eps gotcha + status), the sec 1
    CC status table, and the README.


NOT IN THIS PR (deferred to separate PRs)
-----------------------------------------
  - CCSD(T) polarizability (perturbed (T) density + dependent-pair response).
  - The broader test-suite / timing cleanup: freeze remaining disposable FD oracles
    (NOT the CC3 live-FD tests -- their field-displaced energies exercise different code
    routes), review whether the closed-shell SO==spatial keystones are still needed, and
    refresh docs/test_timings.tex. The parked test_009_pade change rides with that pass.
