### PR TITLE
Compute the (T) occ-occ 1-PDM diagonal in the ijk loop

### DIFF
--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -973,8 +973,14 @@ def so_t3_density(o, v, no, nv, t1, t2, F, ERI, contract):
                 x2[i,j] += (1/4) * contract('dbc,abc->ad', Wvovv[:,k], t3c)
                 x2[i] -= (1/4) * contract('md,abd->mab', Wooov[j,k], t3c)
 
-                # (T) contribution to the vv block of the one-electron density (diagonal)
+                # (T) diagonal one-electron density (vv and oo).  Only the diagonal is a
+                # genuine density term; the oo/vv orbital response is the dependent-pair
+                # kappa-bar in CCderiv (canonical perturbed MOs).  doo and dvv are the same
+                # t3c*(t3c+t3d) contraction over the ijk-built T3, differing only in which
+                # index is left free, so the occ diagonal needs no separate abc loop
+                # (Lee-Rendell, J. Chem. Phys. 94, 6229 (1991)).
                 dvv += (1/12) * contract('abc,abc->a', (t3c + t3d), t3c)
+                doo[i] -= (1/12) * contract('abc,abc->', t3c, (t3c + t3d))
 
                 # (T) contribution to the ov block of the one-electron density
                 Dov[i] += contract('ade,de->a', t3c, t2[j,k])
@@ -991,13 +997,6 @@ def so_t3_density(o, v, no, nv, t1, t2, F, ERI, contract):
                 # (T) contribution to the L2 residual
                 S2[i] -= (1/4) * contract('md,abd->mab', Wooov[j,k], (2*t3c + t3d))
                 S2[i,j] += (1/4) * contract('ade,bde->ab', (2*t3c+t3d), Wvovv[:,k])
-
-    for a in range(nv):
-        for b in range(nv):
-            for c in range(nv):
-                t3c = t3c_abc_so(o, v, a, b, c, t2, Wvvvo, Wovoo, F, contract)
-                t3d = t3d_abc_so(o, v, a, b, c, t1, t2, Woovv, F, contract)
-                doo -= (1/12) * contract('ijk,ijk->i', t3c, (t3c + t3d))
 
     # P(ij)P(ab) antisymmetrization of the doubles intermediates (see the loop note)
     S2 = S2 - S2.swapaxes(0,1) - S2.swapaxes(2,3) + S2.swapaxes(0,1).swapaxes(2,3)

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -895,11 +895,17 @@ def t3_density(o, v, no, nv, t1, t2, F, ERI, L, contract):
                 X2[i,j] += contract('abc,dbc->ad', (2*M3 - M3.swapaxes(1,2) - M3.swapaxes(0,2)),ERI[v,o,v,v][:,k])
                 X2[i] -= contract('abc,lc->lab', (2*M3 - M3.swapaxes(1,2) - M3.swapaxes(0,2)),ERI[o,o,o,v][j,k])
 
-                # (T) contribution to vir-vir block of one-electron density.  Only the
-                # diagonal is a genuine density term (the off-diagonal <0|L3[E_ab,T3]|0> block
-                # appears in neither Lee-Rendell nor Hald et al.; the oo/vv orbital response is
-                # the dependent-pair kappa-bar in CCderiv.gradient), so contract straight to it.
+                # (T) diagonal one-electron density (occ-occ and vir-vir).  Only the
+                # diagonal is a genuine density term (the off-diagonal <0|L3[E_pq,T3]|0>
+                # blocks appear in neither Lee-Rendell nor Hald et al.; the oo/vv orbital
+                # response is the dependent-pair kappa-bar in CCderiv.gradient), so contract
+                # straight to it.  doo and dvv share this ijk build: the symmetrized
+                # combination X3+Y3 is invariant under the simultaneous occ<->vir index swap
+                # (t3 permutational symmetry), so the occ diagonal needs no separate abc loop
+                # (Lee-Rendell, J. Chem. Phys. 94, 6229 (1991), 2/3 the cost of Scuseria's
+                # off-diagonal, non-canonical-perturbed-MO formulation).
                 dvv += 0.5 * contract('acd,acd->a', M3, (X3 + Y3))
+                doo[i] -= 0.5 * contract('abc,abc->', M3, (X3 + Y3))
 
                 # (T) contribution to occ-vir block of one-electron density
                 Dov[i] += contract('abc,bc->a', (M3 - M3.swapaxes(0,2)), (4*t2[j,k] - 2*t2[j,k].T))
@@ -917,17 +923,6 @@ def t3_density(o, v, no, nv, t1, t2, F, ERI, L, contract):
                 S2[i,j] += contract('abc,dcb->ad', (2*X3 + Y3), ERI[o,v,v,v][k])
 
     S2 = S2 + S2.swapaxes(0,1).swapaxes(2,3)
-
-    # (T) contribution to occ-occ block of one-electron density
-    for a in range(nv):
-        for b in range(nv):
-            for c in range(nv):
-                M3 = t3c_abc(o, v, a, b, c, t2, ERI[v,v,v,o], ERI[o,v,o,o], F, contract, True)
-                N3 = t3d_abc(o, v, a, b, c, t1, t2, ERI[o,o,v,v], F, contract, True)
-                X3 = 8*M3 - 4*M3.swapaxes(0,1) - 4*M3.swapaxes(1,2) - 4*M3.swapaxes(0,2) + 2*np.moveaxis(M3, 0, 2) + 2*np.moveaxis(M3, 2, 0)
-                Y3 = 8*N3 - 4*N3.swapaxes(0,1) - 4*N3.swapaxes(1,2) - 4*N3.swapaxes(0,2) + 2*np.moveaxis(N3, 0, 2) + 2*np.moveaxis(N3, 2, 0)
-                # (T) occ-occ 1-PDM: diagonal only (see the vir-vir note above).
-                doo -= 0.5 * contract('ikl,ikl->i', M3, (X3 + Y3))
 
     # (T) correction
     ET = contract('ia,ia->', t1, S1)  # NB: factor of two is already included in S1


### PR DESCRIPTION
**PR: perf(triples) -- compute the (T) occ-occ 1-PDM diagonal in the ijk loop**

Branch: perf/t3-density-diagonal-doo  (off main, 2 commits)
File:   pycc/cctriples.py

  c8930ac  t3_density     (spatial closed-shell RHF)   +10 / -15
  3cd1645  so_t3_density  (spin-orbital UHF/ROHF)       +7  / -8

WHAT
----
Both (T) density builders computed the vir-vir 1-PDM diagonal (dvv) inside the
ijk loop but the occ-occ diagonal (doo) in a separate abc triple-loop -- an
entire extra t3c/t3d (N^7) build, and slow in practice, since n_occ << n_virt
makes an nv^3 outer loop the worst ordering.

Only the DIAGONAL of the oo/vv (T) 1-PDM is a genuine density term: with
canonical perturbed MOs the off-diagonal oo/vv orbital response is carried by
the dependent-pair kappa-bar in CCderiv.gradient, so t3_density never needs the
off-diagonal blocks.  The occ diagonal is the same contraction as the vir
diagonal over the already-built, ijk-organized T3, so it folds into the ijk loop
and the abc loop is deleted:

  spatial:  doo[i] -= 0.5    * contract('abc,abc->', M3,  (X3 + Y3))
  spin-orb: doo[i] -= (1/12) * contract('abc,abc->', t3c, (t3c + t3d))

(Spatial: X3+Y3 is invariant under the simultaneous occ<->vir swap by t3
permutational symmetry.  Spin-orbital: doo/dvv are literally the same
t3c*(t3c+t3d) product, differing only in the free index.)

WHY (theory)
------------
This is the Lee-Rendell vs. Scuseria distinction [T. J. Lee and A. P. Rendell,
J. Chem. Phys. 94, 6229 (1991)].  The (T) energy is invariant to oo/vv rotations
only through the full second-order T3; that invariance gives freedom in the
canonical-vs-non-canonical choice of *perturbed* MOs.  Canonical perturbed MOs
(Lee-Rendell) need only the diagonal (T) density and cost ~2/3 of Scuseria's
non-canonical formulation, which populates the off-diagonal density and pays one
extra N^7 set.  The abc loop was exactly that avoidable extra N^7 set.

VERIFICATION (H2O / 6-31G, all-electron; before vs. after, machine precision)
-----------------------------------------------------------------------------
                     t3_density (spatial)     so_t3_density (spin-orbital)
  max|dE(T)|             4.3e-19                    2.2e-19
  max|d diag Doo|        3.3e-19                    9.8e-19
  max|d diag Dvv|        8.1e-20                    1.1e-19
  max|d gradient|        4.9e-17                    3.5e-17
  wall time         0.925 s -> 0.284 s (3.3x)   5.34 s -> 2.05 s (2.6x)

Test suites (unchanged, all pass):
  test_083_ccsdt_gradient   (AE + frozen-core + spin-orbital)
  test_034_ccsd_t_density
  test_005_ccsd_t_energy
  test_054_rohf             (ROHF (T), spin-orbital path)

NOTES
-----
- No public API or numerical-result change; pure internal speedup.
- t3c_abc_so is still used by ccresponse.py, so its definition stays.  t3d_abc_so
  is now unused within cctriples but kept as the symmetric partner of t3d_ijk_so
  (removing it would be a separate cleanup).
