### PR TITLE
fix(triples): 1/4 on the spin-orbital (T) occ-virt 1-PDM

### DIFF
--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -982,8 +982,14 @@ def so_t3_density(o, v, no, nv, t1, t2, F, ERI, contract):
                 dvv += (1/12) * contract('abc,abc->a', (t3c + t3d), t3c)
                 doo[i] -= (1/12) * contract('abc,abc->', t3c, (t3c + t3d))
 
-                # (T) contribution to the ov block of the one-electron density
-                Dov[i] += contract('ade,de->a', t3c, t2[j,k])
+                # (T) contribution to the ov block of the one-electron density.  The 1/4 is the
+                # T2^dagger normalization (D_ia = 1/4 sum_{lm,ef} t3c^{aef}_{ilm} t^{ef}_{lm}); the
+                # free (j,k)/(d,e) loop sums carry no combinatorial cancellation here.  This block
+                # is invisible to any relaxed first-order property -- the Z-vector/orbital response
+                # absorbs the ov 1-PDM exactly (Handy-Schaefer stationarity), so the CCSD(T) gradient
+                # is blind to this factor -- but it enters unrelaxed one-electron properties and the
+                # perturbed density of second derivatives (e.g. the (T) polarizability) directly.
+                Dov[i] += (1/4) * contract('ade,de->a', t3c, t2[j,k])
 
                 # (T) contributions to the two-electron density
                 Goovv[i,j] += contract('abc,c->ab', t3c, t1[k])

--- a/pycc/tests/test_086_ccsdt_unrelaxed_dipole.py
+++ b/pycc/tests/test_086_ccsdt_unrelaxed_dipole.py
@@ -1,0 +1,101 @@
+"""CCSD(T) unrelaxed one-electron property -- guards the (T) occ-virt (ov) 1-PDM.
+
+The analytic CCSD(T) *gradient* (test_083) is completely blind to the ov block of the one-particle
+density: the Z-vector / orbital-relaxation absorbs the ov 1-PDM exactly (Handy-Schaefer
+stationarity), so zeroing the entire (T) ov density moves the gradient by ~1e-17.  Any relaxed
+first-order property (gradient, relaxed dipole) is likewise blind.  A latent factor error in the
+(T) ov density therefore hides completely behind test_083.
+
+The property that *does* exercise the ov 1-PDM is an UNRELAXED one-electron expectation value.  This
+test finite-differences the CCSD(T) correlation energy in a static electric-dipole field with the
+orbitals held frozen (the field is added to the spin-orbital Fock *after* SCF, so the HF orbitals do
+not relax): mu_a = -dE_corr/d(field_a) = Tr(D . mu_a) with D the unrelaxed correlation 1-PDM.  This
+is the exact oracle that pinned the spin-orbital (T) ov density to the 1/4 (T2-dagger normalization)
+of D_ia = 1/4 sum_{lm,ef} t3c^{aef}_{ilm} t^{ef}_{lm}; a missing 1/4 in so_t3_density shows up here
+at ~2e-3.  It is also the class of property (unrelaxed / perturbed density) that the (T)
+polarizability depends on, so this guards that path too.
+
+H2O/6-31G in a fixed, fully asymmetric (C1) frame so all three dipole components are nonzero.
+"""
+
+import contextlib
+import os
+
+import numpy as np
+import psi4
+import pycc
+
+ATOMS = ['O', 'H', 'H']
+# Asymmetric frame (one H pushed off the yz-plane) so mu_x, mu_y, mu_z are all nonzero and the ov
+# density is exercised in every direction.  Frame locked (no_com/no_reorient) for reproducibility.
+GEOM = np.array([
+    [0.0,          0.000000000000,  0.143225857167],
+    [0.1,         -1.638037301628, -1.136549142277],
+    [0.0,          1.638037301628, -1.136549142277],
+])
+AXIS_LABEL = ['X', 'Y', 'Z']
+
+
+def _scf_wfn():
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.core.be_quiet()
+    body = "\n".join(f"{s} {c[0]:.15f} {c[1]:.15f} {c[2]:.15f}" for s, c in zip(ATOMS, GEOM))
+    psi4.geometry(body + "\nsymmetry c1\nunits bohr\nno_com\nno_reorient\n")
+    psi4.set_options({'basis': '6-31G', 'scf_type': 'pk', 'freeze_core': 'false',
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    return wfn
+
+
+def _ccwfn(wfn, orbital_basis):
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', make_t3_density=True, orbital_basis=orbital_basis)
+    with open(os.devnull, 'w') as dn, contextlib.redirect_stdout(dn):
+        cc.solve_cc(1e-12, 1e-12, 200)
+    return cc
+
+
+def _unrelaxed_dipole(cc):
+    """Unrelaxed correlation dipole Tr(D . mu) for all three axes, from the full unrelaxed 1-PDM
+    (gradient_densities places the Doo/Dov/Dvo/Dvv blocks, including the (T) ov increment)."""
+    D = np.asarray(pycc.CCderiv(cc)._density().gradient_densities()[0])
+    return np.array([np.einsum('pq,pq->', D, np.asarray(cc.H.mu[a])) for a in range(3)])
+
+
+def _findiff_dipole_so(wfn, h=1e-3):
+    """Independent oracle: mu_a = -dE_corr/d(field_a) of the spin-orbital CCSD(T) correlation energy,
+    5-point O(h^4) central difference.  The static field V = -field * mu[a] is added to the SO Fock
+    (orbitals frozen), so this is the *unrelaxed* dipole.  (The field is implemented only in the
+    spin-orbital Hamiltonian.)"""
+    def E(s, a):
+        cc = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis='spinorbital',
+                        field=(s != 0.0), field_strength=s, field_axis=AXIS_LABEL[a])
+        with open(os.devnull, 'w') as dn, contextlib.redirect_stdout(dn):
+            return cc.solve_cc(1e-12, 1e-12, 200)
+
+    mu = np.zeros(3)
+    for a in range(3):
+        mu[a] = -(-E(2*h, a) + 8*E(h, a) - 8*E(-h, a) + E(-2*h, a)) / (12*h)
+    return mu
+
+
+def test_so_ccsdt_unrelaxed_dipole_vs_findiff():
+    """The spin-orbital analytic unrelaxed CCSD(T) dipole Tr(D . mu) matches a finite difference of
+    the CCSD(T) correlation energy in a frozen-orbital field.  This is the check the gradient cannot
+    make: it directly exercises the (T) ov 1-PDM.  Guard 1e-7 (5-point FD is good to ~1e-10 here);
+    a missing 1/4 on the (T) ov density fails by ~2e-3."""
+    wfn = _scf_wfn()
+    mu_an = _unrelaxed_dipole(_ccwfn(wfn, 'spinorbital'))
+    mu_fd = _findiff_dipole_so(wfn)
+    assert np.max(np.abs(mu_an - mu_fd)) < 1e-7, (mu_an, mu_fd)
+
+
+def test_ccsdt_unrelaxed_dipole_so_equals_spatial():
+    """SO == spatial keystone for the unrelaxed CCSD(T) dipole.  Because every relaxed property is
+    blind to the ov 1-PDM, this unrelaxed contraction is the keystone that actually tests the ov
+    block: it fails if the spin-orbital (1/4 T2-dagger) and spatial (spin-adapted) (T) ov densities
+    disagree."""
+    wfn = _scf_wfn()
+    mu_so = _unrelaxed_dipole(_ccwfn(wfn, 'spinorbital'))
+    mu_sp = _unrelaxed_dipole(_ccwfn(wfn, 'spatial'))
+    assert np.max(np.abs(mu_so - mu_sp)) < 1e-9, (mu_so, mu_sp)


### PR DESCRIPTION
**PR: fix(triples) -- 1/4 on the spin-orbital (T) occ-virt 1-PDM**

Branch: fix/so-t3-dov-quarter  (off main, 1 commit)
Files:  pycc/cctriples.py  (+8 / -1, the fix + comment)
        pycc/tests/test_086_ccsdt_unrelaxed_dipole.py  (new, regression guard)

THE BUG
-------
so_t3_density built the spin-orbital (T) occ-virt one-particle density without
its 1/4 T2-dagger normalization.  The correct block is

    D_ia = 1/4 sum_{lm,ef} t3c^{aef}_{ilm} t^{ef}_{lm}

The code had coefficient 1 (a free j,k / d,e loop-sum with no compensating
combinatorial factor).  One-line fix on the Dov accumulation.

The spatial t3_density is CORRECT and untouched -- its spin-adapted 4,-2
factors already carry the right normalization (the SO == spatial keystone in
the new test confirms it).

WHY IT WAS INVISIBLE
--------------------
Every relaxed first-order property is blind to the ov 1-PDM.  The Z-vector /
orbital relaxation absorbs the ov block exactly (Handy-Schaefer stationarity):
zeroing the ENTIRE (T) ov density (magnitude ~2e-3) moves the CCSD(T) gradient
by ~1e-17.  So test_083 passes at 1.8e-12 with ANY coefficient on this block --
the gradient simply cannot see it.  The factor only surfaces in an unrelaxed
one-electron property, and in the perturbed density of second derivatives
(the (T) polarizability -- see below).

VALIDATION (H2O / 6-31G, all-electron, asymmetric C1 frame)
-----------------------------------------------------------
Independent oracle: finite difference of the CCSD(T) correlation energy in a
static electric-dipole field with the orbitals held frozen (field added to the
SO Fock after SCF).  This gives the unrelaxed dipole mu_a = -dE_corr/d(field_a)
= Tr(D . mu_a), which the ov 1-PDM enters directly.

    coefficient the FD oracle wants:  c* = 0.250000
    gap at coeff 1/4 (this PR):        2.3e-11   (FD-limited)
    gap at coeff 1   (old code):       2.3e-03

test_086 (new) is that oracle at test time:
  - test_so_ccsdt_unrelaxed_dipole_vs_findiff:  SO analytic Tr(D.mu) vs the
    frozen-orbital field FD (5-point), all three axes, guard 1e-7.
  - test_ccsdt_unrelaxed_dipole_so_equals_spatial:  SO == spatial keystone on
    the unrelaxed dipole (the ov-sensitive contraction), guard 1e-9.
  Verified it FAILS by ~2e-3 with the 1/4 reverted.

Regression suite (all pass, unchanged -- all blind to the ov block):
  test_083_ccsdt_gradient    test_034_ccsd_t_density
  test_005_ccsd_t_energy     test_054_rohf   (+ test_086)   19 passed

IMPACT
------
The (T) ov 1-PDM enters unrelaxed one-electron properties and the perturbed
density of second derivatives, but is absorbed by orbital relaxation in every
first-order relaxed property.  So: no public API change; no change to the (T)
energy, gradient, or any relaxed property.  Pure correction to the unrelaxed
spin-orbital (T) ov 1-PDM.
