### PR TITLE
Analytic spatial CCSD(T) polarizability + (T) Lambda-source refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ include:
     and atomic axial tensors (AATs) -- the building blocks for IR and VCD spectra. Both spin
     paths (spin-adapted closed-shell RHF and spin-orbital), all-electron and frozen-core; the
     MP2 second derivatives come via two independent routes (explicit-derivative and 2n+1)
-  - Analytic nuclear energy gradients and relaxed electronic dipoles for CCSD and CCSD(T), and the
-    static dipole polarizability for CCSD (both spin-adapted closed-shell RHF and spin-orbital UHF),
-    all-electron and frozen-core, built on the same relaxed-density / Z-vector machinery as the MP2
-    gradient
+  - Analytic nuclear energy gradients, relaxed electronic dipoles, and static dipole polarizabilities
+    for CCSD and CCSD(T) (both spin-adapted closed-shell RHF and spin-orbital UHF), all-electron and
+    frozen-core, built on the same relaxed-density / Z-vector machinery as the MP2 gradient
   - A uniform property interface -- `pycc.dipole`, `pycc.gradient`, `pycc.polarizability`,
     `pycc.hessian`, `pycc.apt`, `pycc.aat` -- that dispatches on wavefunction type and returns
     each property's nuclear/reference/correlation decomposition as a `PropertyComponents`
@@ -42,7 +41,7 @@ include:
 Future plans:
   - Quadratic response functions (in development)
   - CC2 and CC3 excited states
-  - Analytic CC Hessians and APTs, and the CCSD(T) polarizability
+  - Analytic CC Hessians and APTs
 
 This repository is currently under development. To do a developmental install, download this repository and type `pip install -e .` in the repository directory.
 

--- a/docs/DERIVATIVES_PLAN_2026-06.md
+++ b/docs/DERIVATIVES_PLAN_2026-06.md
@@ -47,7 +47,7 @@ SCF orbital Hessian) with the CCSD/(T) densities and Λ:
 | CCSD `dE/dX` (gradient) | ✅ | ✅ | ✅ |
 | CCSD(T) `dE/dX` (gradient) | ✅ | ✅ | ✅ |
 | CCSD, CCSD(T) `dE/dF` (relaxed dipole) | ✅ | ✅ | ✅ |
-| CCSD `d²E/dF²` (dipole polarizability) | ✅ | ✅ | ✅ |
+| CCSD, CCSD(T) `d²E/dF²` (dipole polarizability) | ✅ | ✅ | ✅ |
 
 The relaxed dipole reuses the gradient's relaxed density: a static field leaves the AO basis fixed
 (`S^F = ⟨pq\|rs⟩^F = 0`), so `mu = Tr(D_rel · mu_ints)` — the same `D_rel` (correlation density + `Pco`
@@ -64,15 +64,21 @@ non-canonical route (off-diagonal density, one extra N^7 set); see §5 and §7. 
 and the independent explicit-derivative route agree to machine precision for CCSD (the (T) explicit
 route is pending — §6).
 
-**Coupled-cluster polarizability.** The CCSD static dipole polarizability `α = −d²E/dF²`
+**Coupled-cluster polarizability.** The static dipole polarizability `α = −d²E/dF²`
 (`CCderiv.polarizability`, `pycc.polarizability`) — the first CC *second*-derivative property — via
 the asymmetric (2n+1) route: differentiate the relaxed-density gradient a second time in a field
-(`α_ab = Tr(dD_rel·μ_a) + Tr(D_rel·rot(U^b,μ_a))`). Done for **CCSD, spatial RHF and spin-orbital UHF,
-all-electron and frozen core**; only (T) is pending. It adds the perturbed amplitudes `dt/dF`,
-perturbed Λ `dΛ/dF` (staying in `cclambda`'s `r_L`, no `Y1/Y2`), the perturbed HBAR (exact 5-point
-stencil), and the perturbed Z-vector — all first-order responses, no second-order CPHF. FD-validated
-(spatial `1.8e-12`; SO==spatial keystone `~1e-13`; open-shell UHF vs an energy finite field `~3e-10`);
-see §8.
+(`α_ab = Tr(dD_rel·μ_a) + Tr(D_rel·rot(U^b,μ_a))`). Done for **CCSD *and* CCSD(T), spatial RHF and
+spin-orbital UHF, all-electron and frozen core.** It adds the perturbed amplitudes `dt/dF`, perturbed
+Λ `dΛ/dF` (staying in `cclambda`'s `r_L`, no `Y1/Y2`), the perturbed HBAR (analytic product rule), and
+the perturbed Z-vector — all first-order responses, no second-order CPHF. CCSD is FD-validated (spatial
+`1.8e-12`; SO==spatial keystone `~1e-13`; open-shell UHF vs an energy finite field `~3e-10`). **CCSD(T)**
+additionally threads the perturbed (T) intermediates `dt3` (analytic `(dN − t3·dD)/D`), the perturbed
+(T) Λ sources `dS1/dS2`, and the perturbed oo/vv dependent-pairs `dP` into `dD_rel`; validated against
+the energy second derivative and, definitively, against **CFOUR** (`POLAR − POLARSCF`, matched GENBAS
+6-31G) to `~5e-11` on both routes, AE and FC. One subtlety cost real debugging (§8): the perturbed (T) Λ
+L2 source must carry the *same* `P_ij^ab` symmetrization that the unperturbed `r_L2` applies to `S2`, so
+the (T) source is now passed *into* the shared `r_L1`/`r_L2` residual (via their `s1`/`s2` argument)
+rather than corrected afterward. See §8.
 
 ## 2. Formulation
 
@@ -331,13 +337,14 @@ own SO CCSD(T) energy **3.7e-12**. Tests in `test_083` (open-shell reference har
 
 ## 8. CC static dipole polarizability — design & status
 
-**Status.** **DONE for CCSD** (2026-07-09) in `CCderiv.polarizability()` — **spatial RHF and
-spin-orbital UHF, both all-electron and frozen core** — FD-validated (§8.4); only **(T)** remains
-(Phase 4). First CC *second*-derivative property; built before the `CorrelatedDerivs` refactor because
+**Status.** **DONE for CCSD (2026-07-09) and CCSD(T) (2026-07-17)** in `CCderiv.polarizability()` —
+**spatial RHF and spin-orbital UHF, both all-electron and frozen core** — FD- and CFOUR-validated
+(§8.4). First CC *second*-derivative property; built before the `CorrelatedDerivs` refactor because
 it exercises the perturbed-relaxed-density machinery the shared base will own, without the
 nuclear-skeleton complexity of Hessians/APTs. The asymmetric route (below) stays entirely within
-`cclambda`'s `r_L` (no `Y1/Y2` response apparatus), with the perturbed HBAR obtained for free by an
-exact stencil (below).
+`cclambda`'s `r_L` (no `Y1/Y2` response apparatus), with the perturbed HBAR obtained by the analytic
+product rule of the `build_H*` block builders (the finite-difference stencil that seeded it during
+development has been retired).
 
 **Route: the ASYMMETRIC approach** — differentiate the (already-2n+1) relaxed-density gradient a second
 time; exactly the `docs/mp2_2n1_perturbed.tex` formulation, extended to CC by a density swap. Chosen
@@ -470,7 +477,7 @@ destined for `CorrelatedDerivs`.
   it stays self-contained). Solve `dt += (B + HBAR·dt)/D` with `helper_diis`, exactly like
   `solve_right` but with the orbital-relaxed `B`. Same structure for `dΛ` (the linear `r_L1/r_L2`
   operator + a field-perturbed inhomogeneity).
-### 8.4 Validation (CCSD complete — spatial + spin-orbital, all-electron + frozen core)
+### 8.4 Validation (CCSD + CCSD(T) complete — spatial + spin-orbital, all-electron + frozen core)
 
 Prototype checkpoint ladder, all cleared for CCSD/H2O/STO-3G (spatial, all-electron):
 
@@ -501,13 +508,20 @@ route through the diagonal-ε `_mp2_lagrangian` and so are blind to the §8.2 go
 | off-diagonal (planar HOF/cc-pVDZ) | finite field; `α_xy` large, `α_xz=α_yz=0`, total positive-definite | 2.6e-10 |
 | spin-orbital == spatial (AE / FC) | RHF-forced-to-SO keystone | 8.8e-14 / 3.1e-14 |
 | open-shell UHF (2-B1 NH2) | energy 2nd-derivative FD (`α_zz`); symmetric, positive | 2.7e-10 |
+| CCSD(T) spatial == SO (AE / FC) | SO==spatial keystone (water diagonal, HOF off-diagonal) | ~1e-12 |
+| CCSD(T) vs **CFOUR** (water/HOF, AE/FC, spatial + SO) | `POLAR − POLARSCF`, matched GENBAS 6-31G (`test_ccsdt_polarizability_cfour`) | ~5e-11 |
 
 **Phasing:** (1) CCSD spatial all-electron **[done]**; (2) + frozen core **[done]**; (3) + spin-orbital
-**[done]**; (4) + (T) — next.
+**[done]**; (4) + (T) **[done]** — spatial + SO, all-electron + frozen core, CFOUR-anchored.
 
-**Validation (production).** Primary oracle = **finite difference of `CCderiv.relaxed_dipole`** in a
-field (`÷h`, ~1e-12; Λ tight) — the only oracle that covers **CCSD(T)** and frozen core; plus the
-**SO==spatial keystone**.
+**Validation (production).** For **CCSD**, primary oracle = **finite difference of
+`CCderiv.relaxed_dipole`** in a field (`÷h`, ~1e-12; Λ tight) plus the **SO==spatial keystone**. For
+**CCSD(T)** the reliable oracles are the **energy second-derivative FD** and **CFOUR**
+(`POLAR − POLARSCF`, exactly matched GENBAS basis, ~5e-11); the relaxed-dipole FD is **not** reliable for
+(T) — its dependent-pair *numerator* gate (unperturbed side) disagrees with the analytic *gap* gate, so a
+symmetry-forbidden near-degenerate pair (`num=0` at zero field, `dnum≠0`) sits below the `1e-8` numerator
+gate at the stencil and the FD drops its `dnum/gap` contribution (~1e-4 floor; switching the FD path to
+gap-gating recovers ~2e-9). Both (T) oracles cover frozen core.
 Debugging oracles (CCSD only, phase 1–3): `ccresponse.solve_right(ω=0)` X-vectors cross-check the
 *unrelaxed* `dt/dF`, and `ccresponse.linresp/polarizability(0.0)` the *unrelaxed* CCSD polarizability —
 they isolate the amplitude response from the orbital-relaxation delta. **`ccresponse` is never a code

--- a/docs/cc_gradients_orbital_response.tex
+++ b/docs/cc_gradients_orbital_response.tex
@@ -1,6 +1,8 @@
 \documentclass[12pt]{article}
 \usepackage{amsmath}
 \usepackage{amssymb}
+\usepackage{float}   % [H] float specifier: pin tables exactly where they are written
+\usepackage{longtable}   % multi-page tables (derivative-density 2-PDM)
 \usepackage{fullpage}
 \usepackage{overcite}
 \renewcommand{\familydefault}{\sfdefault}
@@ -33,6 +35,7 @@ especially for coupled cluster theory, the results are sufficiently general so
 as to apply to any correlated method.
 
 \section{First Derivatives}
+\label{sec:first-derivs}
 
 The first derivative of the correlation energy with respect to a {\em real}
 perturbation (e.g., a nuclear-coordinate displacement or a static external electric
@@ -132,7 +135,8 @@ standard for most CC/CI gradient papers and leads to simpler later expressions.
 Equations \eqref{eq:dE-Iprime} and \eqref{eq:Iprime} match Eqs.~42 and 43 of
 Ref.~\citenum{Gauss91:UHF}.
 
-\section{Simplifying the Orbital-Gradient Term}
+\subsection{Simplifying the Orbital-Gradient Term}
+\label{sec:orbgrad}
 
 Separate the orbital-gradient term into MO subspaces:
 \begin{equation}
@@ -207,7 +211,8 @@ The total gradient may therefore be written as
 \end{equation}
 (Compare to Eq.~47 of Ref.~\citenum{Gauss91:UHF}.)
 
-\section{CPHF Equations and the Z-Vector}
+\subsection{CPHF Equations and the Z-Vector}
+\label{sec:cphf-z}
 
 The first-order CPHF equations for $U^x_{ai}$ are
 \begin{equation}
@@ -260,7 +265,8 @@ and, re-indexing the third term and splitting the first two,
 &+ \sum_{ij} S^{(x)}_{ij}\sum_{ak} Z_{ak}A_{aikj}.
 \end{align}
 
-\section{Total Gradient}
+\subsection{Total Gradient}
+\label{sec:total-grad}
 
 Collecting everything, the total gradient becomes
 \begin{equation}
@@ -284,9 +290,10 @@ be aware that the orbital Z-vector equations used here differ by a sign from
 those in Eq.~51 of that paper.  Hence the signs on the Z-vector contributions
 are reversed; otherwise everything matches.
 
-\section{Canonical Perturbed Orbitals}
+\subsection{Canonical Perturbed Orbitals}
+\label{sec:canon-mo}
 
-The reference derivation of \S2 uses the non-canonical perturbed-orbital
+The reference derivation of \S\ref{sec:orbgrad} uses the non-canonical perturbed-orbital
 conditions \eqref{eq:noncanon}, $U^x_{ij}=-\tfrac12 S^{(x)}_{ij}$ and
 $U^x_{ab}=-\tfrac12 S^{(x)}_{ab}$.  These are permissible only when the correlation
 energy is invariant to rotations within the occupied space and within the
@@ -295,7 +302,7 @@ $(i,j)$ or $(a,b)$, since neither the $f_{pp}$ prefactor ($f_{ii}$ vs.\ $f_{jj}$
 the three-index contraction ($\adb{ir}{st}\Gamma_{jrst}$ vs.\
 $\adb{jr}{st}\Gamma_{irst}$) is symmetric under the swap.  What matters instead is
 its {\em antisymmetric} part, which enters in exactly the way
-$X_{ai}=I'_{ia}-I'_{ai}$ did for the occ-vir block in \S2.  Applying the
+$X_{ai}=I'_{ia}-I'_{ai}$ did for the occ-vir block in \S\ref{sec:orbgrad}.  Applying the
 orthonormality condition \eqref{eq:ortho} to the occupied--occupied and
 virtual--virtual blocks of the subspace split of $-2\sum_{pq}U^x_{pq}I'_{pq}$
 (relabeling $i\leftrightarrow j$, resp.\ $a\leftrightarrow b$, in half of each
@@ -313,7 +320,7 @@ $I'_{ab}-I'_{ba}$ now appear explicitly.  Combining these with the occ-vir block
 already reduced in Eq.~\eqref{eq:orbgrad}, and collapsing every overlap-derivative
 term into the single sum $\sum_{pq}S^{(x)}_{pq}I''_{pq}$ (with $I''$ as defined in
 Eq.~\eqref{eq:Idouble}, since the occ-occ, vir-vir, and occ-vir overlap terms are identical to
-those of \S2), the orbital-gradient term becomes
+those of \S\ref{sec:orbgrad}), the orbital-gradient term becomes
 \begin{equation}
 -2\sum_{pq}U^x_{pq}I'_{pq}
 = -\sum_{ij}U^x_{ij} X_{ij}
@@ -392,17 +399,18 @@ orbital-response terms retained,
 + \sum_{pq} S^{(x)}_{pq} I''_{pq},
 \label{eq:grad-canon}
 \end{equation}
-with $U^x_{ai}$ obtained from the CPHF/Z-vector of \S3 and $U^x_{ij}$, $U^x_{ab}$
+with $U^x_{ai}$ obtained from the CPHF/Z-vector of \S\ref{sec:cphf-z} and $U^x_{ij}$, $U^x_{ab}$
 from Eqs.~\eqref{eq:canon-oo} and \eqref{eq:canon-vv}.  If the correlation
 method is invariant to occ-occ and vir-vir MO rotations, the two new terms
 vanish ($X_{ij}=X_{ab}=0$) and Eq.~\eqref{eq:grad-U} is recovered.  Note that $D_{pq}$ is still the unrelaxed
 one-electron density in this expression, comparable to Eq.~\eqref{eq:grad-U} where we used the non-canonical perturbed orbital
 approach.
 
-\section{CPHF and Z-Vector for Canonical-Perturbed MOs}
+\subsection{CPHF and Z-Vector for Canonical-Perturbed MOs}
+\label{sec:cphf-z-canon}
 
 In Eq.~\eqref{eq:grad-canon} the occ-vir orbital-response term $2\sum_{ai}U^x_{ai}X_{ai}$
-is handled exactly as in \S3: the occ-vir coefficients solve
+is handled exactly as in \S\ref{sec:cphf-z}: the occ-vir coefficients solve
 $\mathbf{G}\,\mathbf{U}^{x}=\mathbf{B}^{x}$, and the interchange
 $\mathbf{G}^{T}\mathbf{Z}=\mathbf{X}$ trades the per-perturbation solve for a single
 Z-vector.  What is new for the canonical perturbed MO case is the occupied--occupied and
@@ -412,7 +420,7 @@ whose rotations are given {\em explicitly} by Eqs.~\eqref{eq:canon-oo} and
 
 \noindent
 Substituting Eq.~\eqref{eq:canon-oo} and introducing the occupied--occupied
-{\em dependent-pair}
+{\em dependent pair}
 \begin{equation}
 P_{ij} \equiv \frac{X_{ij}}{\varepsilon_i-\varepsilon_j}
 = \frac{I'_{ij}-I'_{ji}}{\varepsilon_i-\varepsilon_j},
@@ -450,16 +458,16 @@ Collecting the terms of Eqs.~\eqref{eq:oo-sub} and \eqref{eq:vv-sub} sends each
 of them to one of the three density-like structures already present in the
 gradient, Eq.~\eqref{eq:grad-canon}.
 
-The leading terms, $P_{ij}f^{(x)}_{ij}$ and $P_{ab}f^{(x)}_{ab}$, have the same
-shape as the skeleton Fock term $\sum_{pq}D_{pq}f^{(x)}_{pq}$, so the
-dependent-pairs are absorbed by augmenting the one-particle density,
+The leading terms $P_{ij}f^{(x)}_{ij}$ and $P_{ab}f^{(x)}_{ab}$ have the shape
+of the skeleton Fock term $\sum_{pq}D_{pq}f^{(x)}_{pq}$, so the dependent pairs
+augment the one-particle density,
 \begin{equation}
 \tilde{D}_{ij} = D_{ij} + P_{ij}, \qquad \tilde{D}_{ab} = D_{ab} + P_{ab}.
 \label{eq:Dtilde}
 \end{equation}
 
-The terms carrying an overlap derivative $S^{(x)}$ match the energy-weighted density
-term $\sum_{pq}S^{(x)}_{pq}I''_{pq}$, so they are absorbed into $I''$,
+The terms carrying an overlap derivative $S^{(x)}$ match the energy-weighted
+density $\sum_{pq}S^{(x)}_{pq}I''_{pq}$, so they join $I''$,
 \begin{equation}
 \tilde{I}''_{ij} = I''_{ij} - P_{ij}\varepsilon_j
 - \tfrac12\sum_{kl}^{\occ}P_{kl}A_{kilj}
@@ -481,7 +489,7 @@ evaluated directly and must instead be carried through the Z-vector.  Because
 $U^x_{cm}$ sits in the same occ-vir block as the orbital term
 $2\sum_{ai}U^x_{ai}X_{ai}$, renaming the dummy label $(c,m)\to(a,i)$ lets the two
 be added under a single sum $\sum_{ai}U^x_{ai}(\cdots)$; factoring the common $2$
-then augments the Z-vector right-hand side $X_{ai}$ of \S3 to
+then augments the Z-vector right-hand side $X_{ai}$ of \S\ref{sec:cphf-z} to
 \begin{equation}
 \tilde{X}_{ai} = X_{ai}
 + \tfrac12\sum_{kl}^{\occ}P_{kl}\,A_{kali}
@@ -489,10 +497,11 @@ then augments the Z-vector right-hand side $X_{ai}$ of \S3 to
 \label{eq:Xtilde}
 \end{equation}
 The interchange $\mathbf{G}^{T}\mathbf{Z}=\tilde{\mathbf{X}}$ and the expansion of
-$B^x_{ai}$ then proceed exactly as in \S3, now with $\tilde{D}$, $\tilde{I}''$,
+$B^x_{ai}$ then proceed exactly as in \S\ref{sec:cphf-z}, now with $\tilde{D}$, $\tilde{I}''$,
 and $\tilde{X}$ in place of $D$, $I''$, and $X$.
 
-\section{Computational Summary}
+\subsection{Computational Summary}
+\label{sec:comp-summary-1}
 
 Both perturbed-orbital choices lead to the same compact gradient,
 Eq.~\eqref{eq:grad-final}, repeated here,
@@ -507,7 +516,7 @@ and differ only in how the relaxed one-particle density $\tilde{D}$ and the
 energy-weighted density $I$ are assembled from the unrelaxed densities $D$ and
 $\Gamma$.
 
-\subsection*{Non-Canonical Orbitals}
+\subsubsection{Non-Canonical Perturbed Orbitals}
 \begin{enumerate}
 \item Build $I'_{pq}$ from Eq.~\eqref{eq:Iprime} and $I''_{pq}$ from
 Eq.~\eqref{eq:Idouble}.
@@ -526,16 +535,16 @@ I_{ab}=I''_{ab}.
 \end{equation*}
 \end{enumerate}
 
-\subsection*{Canonical Orbitals}
+\subsubsection{Canonical Perturbed Orbitals}
 \begin{enumerate}
 \item Build $I'_{pq}$ and $I''_{pq}$ as above.
-\item Form the occupied--occupied and virtual--virtual dependent-pairs
+\item Form the occupied--occupied and virtual--virtual dependent pairs
 (Eq.~\eqref{eq:Poo}),
 \begin{equation*}
 P_{ij}=\frac{I'_{ij}-I'_{ji}}{\varepsilon_i-\varepsilon_j},\qquad
 P_{ab}=\frac{I'_{ab}-I'_{ba}}{\varepsilon_a-\varepsilon_b}.
 \end{equation*}
-\item Fold the dependent-pairs into the intermediates {\em before} the Z-vector
+\item Fold the dependent pairs into the intermediates {\em before} the Z-vector
 solve.  Augment the one-particle density,
 \begin{equation*}
 \tilde{D}_{ij}=D_{ij}+P_{ij},\qquad \tilde{D}_{ab}=D_{ab}+P_{ab};
@@ -570,13 +579,1137 @@ I_{ab}=\tilde{I}''_{ab}.
 \end{enumerate}
 
 For methods for which the energy is invariant to occupied--occupied and virtual--virtual
-rotations, the dependent-pairs vanish ($X_{ij}=X_{ab}=0$, hence
+rotations, the dependent pairs vanish ($X_{ij}=X_{ab}=0$, hence
 $P_{ij}=P_{ab}=0$), $\tilde{I}''=I''$, and $\tilde{X}=X$; the canonical recipe
 then reduces term by term to the non-canonical one.  The two routes diverge only
 when we choose to use canonical perturbed MOs (as is typically the choice for
 CCSD(T)).
 
+\subsection{First-Derivative Properties}
+\label{sec:first-deriv-props}
+
+Up to this point, we have made no assumptions about the perturbation $x$
+beyond its being real.  The two most common cases of such a perturbation are a
+{\em nuclear-coordinate displacement} and a {\em static, spatially-uniform
+electric field}, and, depending on the type of AO basis set used, they populate
+the three terms of Eq.~\eqref{eq:grad-final} very differently.
+
+In the vast majority of quantum chemical calculations on molecules, the AO
+basis functions are centered at the nuclei and thus depend on the
+nuclear coordinates. This means that all three components of
+Eq.~\eqref{eq:grad-final} contribute to the corresponding derivative: the
+relaxed one-particle density against the skeleton Fock derivative $f^{(x)}$,
+the two-particle density against the skeleton two-electron derivative
+$\adb{pq}{rs}^{(x)}$, and the energy-weighted density against the skeleton
+overlap derivative $S^{(x)}$.  The overlap term is present precisely because
+the displaced atomic orbitals are no longer orthonormal to the undisplaced
+set; it is the origin of the energy-weighted density $I$
+(\S\ref{sec:orbgrad}).
+
+On the other hand, most quantum chemical calculations do not use basis sets
+that depend on an external electric field (unlike magnetic fields for which
+gauge-including AOs are commonly employed).  A static electric field enters
+the Hamiltonian linearly through the length-gauge coupling $-\sum_a
+F_a\,\hat\mu^a$, where $F_a$ is the constant field strength along Cartesian
+direction $a$, and $\hat\mu^a$ is the dipole-moment operator in the same
+direction.  Because the dipole-moment operator is a one-electron operator, it
+contributes only to the Fock operator.  Thus, the overlap and two-electron
+skeleton derivatives vanish, $S^{(F_a)}_{pq}=\adb{pq}{rs}^{(F_a)}=0$, and the
+one-electron skeleton derivative is the (field-independent) dipole integral,
+$f^{(F_a)}_{pq}=-\mu^a_{pq}$.  As a result, Eq.~\eqref{eq:grad-final}
+collapses to a single term,
+\begin{equation}
+\frac{\partial E}{\partial F_a} = -\sum_{pq}\tilde D_{pq}\,\mu^a_{pq},
+\end{equation}
+and the (relaxed) electronic dipole moment is
+\begin{equation}
+\mu_a = -\frac{\partial E}{\partial F_a} = \sum_{pq}\tilde D_{pq}\,\mu^a_{pq},
+\label{eq:dipole}
+\end{equation}
+the relaxed one-particle density contracted with the dipole integrals.
+Neither the two-particle density nor the energy-weighted density appears, so,
+unlike the nuclear-coordinate derivative, the dipole moment is a pure
+one-electron property.  
+
+\section{Second Derivatives}
+\label{sec:second-derivs}
+
+The relaxed first derivative of \S\ref{sec:total-grad}, Eq.~\eqref{eq:grad-final}, is the natural
+starting point for second derivatives of the correlation energy, and hence for
+response properties such as the static dipole polarizability (two electric-field
+perturbations) and the nuclear Hessian (two geometric perturbations).  Because
+Eq.~\eqref{eq:grad-final} is already complete through first order in the
+perturbation $x$ (the orbital response to $x$ having been folded into $\tilde D$
+and $I$ by the Z-vector of \S\ref{sec:cphf-z}), the mixed second derivative follows by
+differentiating it once more, now with respect to a second perturbation $y$.
+This is the {\em asymmetric} $(2n+1)$ route: $x$ is carried by the relaxed
+densities, while the response to $y$ is taken explicitly.\cite{Stanton97}  Applying the product
+rule to Eq.~\eqref{eq:grad-final},
+\begin{align}
+\frac{\partial^2 E}{\partial x\,\partial y}
+&= \sum_{pq}\tilde D_{pq}\,\frac{\partial f^{(x)}_{pq}}{\partial y}
+ + \sum_{pqrs}\Gamma_{pqrs}\,\frac{\partial \adb{pq}{rs}^{(x)}}{\partial y}
+ + \sum_{pq} I_{pq}\,\frac{\partial S^{(x)}_{pq}}{\partial y}
+\nonumber\\
+&\quad
+ + \sum_{pq}\frac{\partial \tilde D_{pq}}{\partial y}\,f^{(x)}_{pq}
+ + \sum_{pqrs}\frac{\partial \Gamma_{pqrs}}{\partial y}\,\adb{pq}{rs}^{(x)}
+ + \sum_{pq}\frac{\partial I_{pq}}{\partial y}\,S^{(x)}_{pq}.
+\label{eq:d2E}
+\end{align}
+
+In the first three terms, the {\em undifferentiated} densities $\tilde D$,
+$\Gamma$, and $I$ contract the $y$-derivative of the skeleton first-derivative
+integrals; each such derivative carries both the doubly-skeleton integral (the
+second AO derivative transformed into the unperturbed MO basis) and the
+response of the MOs to $y$ through the CPHF coefficients $U^y$.  Explicitly,
+each such derivative follows the same rules as the first-derivative integrals of
+\S\ref{sec:first-derivs} [Eqs.~\eqref{eq:dfpq} and \eqref{eq:deri}], now with the skeleton integrals
+$f^{(x)}$, $\adb{pq}{rs}^{(x)}$, and $S^{(x)}$ in place of the bare ones and the
+orbital-rotation terms written in their general (non-diagonal) form, since the
+skeleton derivatives, unlike the unperturbed Fock matrix, are not diagonal in
+the MO basis:
+\begin{align}
+\frac{\partial f^{(x)}_{pq}}{\partial y}
+&= f^{(xy)}_{pq}
++ \sum_{t}^{\so}\left(U^y_{tp} f^{(x)}_{tq} + U^y_{tq} f^{(x)}_{pt}\right)
++ \sum_{t}^{\so}\sum_{m}^{\occ} U^y_{tm}\,A^{(x)}_{ptqm},
+\label{eq:df-skel-dy}\\
+\frac{\partial \adb{pq}{rs}^{(x)}}{\partial y}
+&= \adb{pq}{rs}^{(xy)}
++ \sum_{t}^{\so}\Big(U^y_{tp}\adb{tq}{rs}^{(x)} + U^y_{tq}\adb{pt}{rs}^{(x)}
+\nonumber\\
+&\qquad\qquad
++ U^y_{tr}\adb{pq}{ts}^{(x)} + U^y_{ts}\adb{pq}{rt}^{(x)}\Big),
+\label{eq:deri-skel-dy}\\
+\frac{\partial S^{(x)}_{pq}}{\partial y}
+&= S^{(xy)}_{pq}
++ \sum_{t}^{\so}\left(U^y_{tp} S^{(x)}_{tq} + U^y_{tq} S^{(x)}_{pt}\right),
+\label{eq:dS-skel-dy}
+\end{align}
+where $A^{(x)}_{ptqm}=\adb{pt}{qm}^{(x)}+\adb{pm}{qt}^{(x)}$ is the skeleton
+counterpart of the pair combination $A_{pqrs}$ of \S\ref{sec:first-derivs}, and $f^{(xy)}$,
+$\adb{pq}{rs}^{(xy)}$, and $S^{(xy)}$ are the doubly-skeleton integrals.  The
+occupied-sum term of \eqref{eq:df-skel-dy} arises from the $y$-rotation of the
+summed occupied index in the two-electron part of the skeleton Fock derivative
+$f^{(x)}_{pq}=h^{(x)}_{pq}+\sum_m^{\occ}\adb{pm}{qm}^{(x)}$.
+
+In the next three terms, the {\em first-order responses} of the densities,
+$\partial\tilde D/\partial y$, $\partial \Gamma/\partial y$, and
+$\partial I/\partial y$, contract the ordinary skeleton first-derivative
+integrals of \S\ref{sec:first-derivs}.
+These density responses require only the first derivatives of
+the wave function parameters and Z-vector; no second-order wave function
+response is needed.
+
+Substituting the skeleton-derivative expressions
+\eqref{eq:df-skel-dy}--\eqref{eq:dS-skel-dy} into the first three terms of
+Eq.~\eqref{eq:d2E} separates them into a doubly-skeleton group and a set of
+$U^y$-dependent terms.  The $U^y$-dependent terms are structurally identical to
+those collected for the first derivative in \S\ref{sec:first-derivs} [Eq.~\eqref{eq:collect}], now
+built from the skeleton derivative integrals $f^{(x)}$, $\adb{pq}{rs}^{(x)}$,
+$S^{(x)}$ in place of the bare integrals.  Re-indexing each so that $U^y$ carries
+the labels $pq$, and combining the four two-electron rotation terms through the
+antisymmetry and bra--ket symmetry of $\Gamma$ exactly as in \S\ref{sec:first-derivs}, the first
+three terms of Eq.~\eqref{eq:d2E} become
+\begin{equation}
+\sum_{pq}\tilde D_{pq} f^{(xy)}_{pq}
++ \sum_{pqrs}\Gamma_{pqrs}\adb{pq}{rs}^{(xy)}
++ \sum_{pq} I_{pq} S^{(xy)}_{pq}
+- 2\sum_{pq} U^y_{pq}\,I'^{(x)}_{pq},
+\label{eq:d2E-grouped}
+\end{equation}
+where the first three (doubly-skeleton) terms are the direct second-order analog
+of the skeleton terms of the first derivative, and the perturbed generalized
+Fock matrix is
+\begin{align}
+I'^{(x)}_{pq} = -\tfrac12\Big[
+&\sum_r\left(\tilde D_{qr} f^{(x)}_{pr} + \tilde D_{rq} f^{(x)}_{rp}\right)
++ \delta_{q,\occ}\sum_{rs}\tilde D_{rs} A^{(x)}_{rpsq}
+\nonumber\\
+&+ 4\sum_{rst}\adb{pr}{st}^{(x)}\Gamma_{qrst}
++ \sum_r\left(I_{qr} S^{(x)}_{pr} + I_{rq} S^{(x)}_{rp}\right)\Big].
+\label{eq:Iprime-x}
+\end{align}
+Equation~\eqref{eq:Iprime-x} is the $x$-skeleton analog of the generalized Fock
+$I'_{pq}$ of \S\ref{sec:first-derivs} [Eq.~\eqref{eq:Iprime}]: the one-particle density becomes the
+relaxed density ($D\to\tilde D$) and the integrals become their $x$-skeleton
+derivatives, with two changes of form.  First, the Fock-rotation term is written
+in its general (non-diagonal) form $\sum_r(\tilde D_{qr}f^{(x)}_{pr}+\tilde
+D_{rq}f^{(x)}_{rp})$ rather than the diagonal $f_{pp}(D_{pq}+D_{qp})$ of \S\ref{sec:first-derivs},
+because the skeleton derivative $f^{(x)}$ is not diagonal in the MO basis (the
+two forms coincide when $f^{(x)}$ is diagonal).  Second, a fourth term appears,
+the energy-weighted density contracted with the overlap-derivative rotation,
+because the relaxed gradient \eqref{eq:grad-final} carries the explicit
+$S^{(x)}$ term that the bare first derivative \eqref{eq:dE} did not.
+
+The orbital-response term $-2\sum_{pq}U^y_{pq}I'^{(x)}_{pq}$ is reduced by the
+same steps that carried the first-derivative term $-2\sum_{pq}U^x_{pq}I'_{pq}$ to
+Eq.~\eqref{eq:grad-U} in \S\ref{sec:orbgrad}.  The orthonormality condition \eqref{eq:ortho}
+relates the occupied--virtual and virtual--occupied blocks of $U^y$; the
+occupied--occupied and virtual--virtual blocks, however, are not fixed by
+orthonormality alone and require a {\em choice} of perturbed molecular orbitals,
+either the non-canonical conditions \eqref{eq:noncanon} of \S\ref{sec:orbgrad} or the canonical
+conditions of \S\ref{sec:canon-mo} and \S\ref{sec:cphf-z-canon}.
+
+\subsection{Non-Canonical Perturbed Orbitals}
+\label{sec:2nd-noncanon}
+
+Taking the non-canonical choice first,
+$U^y_{ij}=-\tfrac12 S^{(y)}_{ij}$ and $U^y_{ab}=-\tfrac12 S^{(y)}_{ab}$, the mixed
+second derivative becomes
+\begin{align}
+\frac{\partial^2 E}{\partial x\,\partial y}
+&= \sum_{pq}\tilde D_{pq} f^{(xy)}_{pq}
++ \sum_{pqrs}\Gamma_{pqrs}\adb{pq}{rs}^{(xy)}
++ \sum_{pq} I_{pq} S^{(xy)}_{pq}
+\nonumber\\
+&\quad
++ 2\sum_{a}^{\vir}\sum_{i}^{\occ} U^y_{ai}\,X^{(x)}_{ai}
++ \sum_{pq} S^{(y)}_{pq}\,I''^{(x)}_{pq}
+\nonumber\\
+&\quad
++ \sum_{pq}\frac{\partial \tilde D_{pq}}{\partial y}\,f^{(x)}_{pq}
++ \sum_{pqrs}\frac{\partial \Gamma_{pqrs}}{\partial y}\,\adb{pq}{rs}^{(x)}
++ \sum_{pq}\frac{\partial I_{pq}}{\partial y}\,S^{(x)}_{pq},
+\label{eq:d2E-noncanon}
+\end{align}
+with $X^{(x)}_{ai}=I'^{(x)}_{ia}-I'^{(x)}_{ai}$ and $I''^{(x)}_{pq}$ the
+second-derivative counterpart of $I''$ [Eq.~\eqref{eq:Idouble}]:
+$I''^{(x)}_{ai}=I'^{(x)}_{ia}$, and $I''^{(x)}_{pq}=I'^{(x)}_{pq}$ otherwise.
+
+The first two lines of Eq.~\eqref{eq:d2E-noncanon} are the direct analog of the
+non-canonical first-derivative gradient \eqref{eq:grad-U}: the doubly-skeleton
+integrals replace the skeleton integrals, the perturbed generalized Fock
+$I'^{(x)}$ replaces $I'$, and the overlap derivative $S^{(y)}$ (of the second
+perturbation) replaces $S^{(x)}$.  The third line, the first-order response of
+the densities, has no first-derivative counterpart; it is the $(2n+1)$ content
+of the second derivative.  One difference from \S\ref{sec:cphf-z} is decisive: there the
+occupied--virtual coefficients $U^x_{ai}$ of Eq.~\eqref{eq:grad-U} were traded,
+through the Handy--Schaefer interchange, for a single perturbation-independent
+Z-vector.  That step is unavailable here, because the contracting quantity
+$X^{(x)}_{ai}$ carries the perturbation $x$; the coefficients $U^y_{ai}$ must be
+obtained explicitly by solving the CPHF equations for $y$ (they are required for
+$\partial\tilde D/\partial y$ in any case).  For the static polarizability these
+are the field CPHF coefficients $U^b$ encountered in the polarizability below.
+
+\subsection{Canonical Perturbed Orbitals}
+\label{sec:2nd-canon}
+
+The {\em canonical} choice (\S\ref{sec:canon-mo}) instead retains the occupied--occupied and
+virtual--virtual orbital-response terms rather than folding them into overlap
+derivatives; their rotations are supplied in closed form by the canonical
+conditions \eqref{eq:canon-oo}--\eqref{eq:canon-vv}, now written for the
+perturbation $y$.  In direct analogy to the canonical first-derivative gradient
+\eqref{eq:grad-canon}, the mixed second derivative reads
+\begin{align}
+\frac{\partial^2 E}{\partial x\,\partial y}
+&= \sum_{pq}\tilde D_{pq} f^{(xy)}_{pq}
++ \sum_{pqrs}\Gamma_{pqrs}\adb{pq}{rs}^{(xy)}
++ \sum_{pq} I_{pq} S^{(xy)}_{pq}
+\nonumber\\
+&\quad
+- \sum_{ij} U^y_{ij} X^{(x)}_{ij}
+- \sum_{ab} U^y_{ab} X^{(x)}_{ab}
++ 2\sum_{a}^{\vir}\sum_{i}^{\occ} U^y_{ai} X^{(x)}_{ai}
++ \sum_{pq} S^{(y)}_{pq} I''^{(x)}_{pq}
+\nonumber\\
+&\quad
++ \sum_{pq}\frac{\partial \tilde D_{pq}}{\partial y} f^{(x)}_{pq}
++ \sum_{pqrs}\frac{\partial \Gamma_{pqrs}}{\partial y}\adb{pq}{rs}^{(x)}
++ \sum_{pq}\frac{\partial I_{pq}}{\partial y} S^{(x)}_{pq},
+\label{eq:d2E-canon}
+\end{align}
+with $X^{(x)}_{ij}=I'^{(x)}_{ij}-I'^{(x)}_{ji}$ and
+$X^{(x)}_{ab}=I'^{(x)}_{ab}-I'^{(x)}_{ba}$ joining the $X^{(x)}_{ai}$ and
+$I''^{(x)}_{pq}$ of Eq.~\eqref{eq:d2E-noncanon}.  The occupied--occupied and
+virtual--virtual coefficients $U^y_{ij}$, $U^y_{ab}$ are now evaluated in closed
+form from Eqs.~\eqref{eq:canon-oo}--\eqref{eq:canon-vv} (in terms of $f^{(y)}$,
+$S^{(y)}$, and the occupied--virtual $U^y_{cm}$ that the CPHF solve supplies),
+while $U^y_{ai}$ is the same CPHF solution required in the non-canonical case.
+
+As in \S\ref{sec:cphf-z-canon}, the explicit $U^y_{ij}$ and $U^y_{ab}$ may be eliminated in favor of
+dependent pairs.  Substituting the canonical conditions \eqref{eq:canon-oo}--\eqref{eq:canon-vv}
+for $U^y_{ij}$ and introducing the occupied--occupied dependent pair
+$P^{(x)}_{ij}=X^{(x)}_{ij}/(\varepsilon_i-\varepsilon_j)$ [cf.\ Eq.~\eqref{eq:Poo}],
+the occupied--occupied orbital-response term becomes
+\begin{align}
+-\sum_{ij}U^y_{ij}X^{(x)}_{ij}
+&= \sum_{ij}P^{(x)}_{ij}f^{(y)}_{ij}
+- \sum_{ij}P^{(x)}_{ij}S^{(y)}_{ij}\varepsilon_j
+\nonumber\\
+&\quad
+- \tfrac12\sum_{ij}\sum_{nm}^{\occ}P^{(x)}_{ij}S^{(y)}_{nm}A_{injm}
++ \sum_{ij}\sum_{c}^{\vir}\sum_{m}^{\occ}P^{(x)}_{ij}U^y_{cm}A_{icjm},
+\label{eq:oo-sub-2}
+\end{align}
+and the virtual block follows identically with
+$P^{(x)}_{ab}=X^{(x)}_{ab}/(\varepsilon_a-\varepsilon_b)$.  Three of the four
+groups go where their \S\ref{sec:cphf-z-canon} counterparts did, now driven by $P^{(x)}$ and by the
+overlap and rotation coefficients of the {\em second} perturbation: the
+overlap-derivative terms (second and third) augment $I''^{(x)}$ to
+$\tilde I''^{(x)}$ [the analog of Eq.~\eqref{eq:Idouble-tilde}], and the term
+carrying $U^y_{cm}$ augments $X^{(x)}_{ai}$ to $\tilde X^{(x)}_{ai}$ [the analog
+of Eq.~\eqref{eq:Xtilde}], which the CPHF solution $U^y_{ai}$ then multiplies.
+The leading group, however, has no first-derivative counterpart:
+$\sum_{ij}P^{(x)}_{ij}f^{(y)}_{ij}+\sum_{ab}P^{(x)}_{ab}f^{(y)}_{ab}$ contracts the
+{\em second}-perturbation skeleton Fock derivative $f^{(y)}$ (in \S\ref{sec:cphf-z-canon} the analogous
+term contracted $f^{(x)}$ and was absorbed into $\tilde D$; here it cannot be,
+since $f^{(y)}$ appears nowhere else), and survives as a distinct term -- the
+response of the canonical dependent pairs to the first perturbation, contracted
+with the second-perturbation integral.  Collecting everything, the canonical
+mixed second derivative is
+\begin{align}
+\frac{\partial^2 E}{\partial x\,\partial y}
+&= \sum_{pq}\tilde D_{pq} f^{(xy)}_{pq}
++ \sum_{pqrs}\Gamma_{pqrs}\adb{pq}{rs}^{(xy)}
++ \sum_{pq} I_{pq} S^{(xy)}_{pq}
+\nonumber\\
+&\quad
++ \sum_{ij}P^{(x)}_{ij}f^{(y)}_{ij}
++ \sum_{ab}P^{(x)}_{ab}f^{(y)}_{ab}
++ 2\sum_{a}^{\vir}\sum_{i}^{\occ} U^y_{ai}\,\tilde X^{(x)}_{ai}
++ \sum_{pq} S^{(y)}_{pq}\,\tilde I''^{(x)}_{pq}
+\nonumber\\
+&\quad
++ \sum_{pq}\frac{\partial \tilde D_{pq}}{\partial y} f^{(x)}_{pq}
++ \sum_{pqrs}\frac{\partial \Gamma_{pqrs}}{\partial y}\adb{pq}{rs}^{(x)}
++ \sum_{pq}\frac{\partial I_{pq}}{\partial y} S^{(x)}_{pq},
+\label{eq:d2E-canon-final}
+\end{align}
+with $\tilde X^{(x)}$ and $\tilde I''^{(x)}$ the second-derivative counterparts of
+Eqs.~\eqref{eq:Xtilde} and \eqref{eq:Idouble-tilde} ($P\to P^{(x)}$, and the
+overlap/rotation coefficients those of $y$).
+
+\subsection{Response of the Relaxed Densities}
+\label{sec:2nd-density-response}
+
+The reductions of \S\ref{sec:2nd-noncanon} and \S\ref{sec:2nd-canon} dispose of
+the first three terms of Eq.~\eqref{eq:d2E}.  The last three,
+\begin{equation*}
+\sum_{pq}\frac{\partial\tilde D_{pq}}{\partial y}\,f^{(x)}_{pq}
++ \sum_{pqrs}\frac{\partial\Gamma_{pqrs}}{\partial y}\,\adb{pq}{rs}^{(x)}
++ \sum_{pq}\frac{\partial I_{pq}}{\partial y}\,S^{(x)}_{pq},
+\end{equation*}
+contract the first-order responses of the relaxed one-particle density $\tilde
+D$, the two-particle density $\Gamma$, and the energy-weighted density $I$ with
+the ordinary skeleton first-derivative integrals of \S\ref{sec:first-derivs}.
+
+The two-particle response $\partial\Gamma/\partial y$ is {\em unrelaxed}: the
+orbital relaxation resides entirely in the one-particle density (through the
+Z-vector), so $\partial\Gamma/\partial y$ is the perturbed unrelaxed
+two-particle density of Appendix~\ref{sec:deriv-densities}, built from the
+once-perturbed amplitudes and multipliers.
+
+The one-particle response $\partial\tilde D/\partial y$ combines the unrelaxed
+response $\partial D/\partial y$ (also Appendix~\ref{sec:deriv-densities}) with
+the response of the orbital relaxation that \S\ref{sec:total-grad} folded into
+$\tilde D$.  Differentiating those assignments, the occupied--virtual block
+carries the perturbed Z-vector,
+\begin{equation}
+\frac{\partial\tilde D_{ai}}{\partial y} = \frac{\partial D_{ai}}{\partial y} - \frac{\partial Z_{ai}}{\partial y},
+\qquad
+\frac{\partial\tilde D_{ia}}{\partial y} = \frac{\partial D_{ia}}{\partial y} - \frac{\partial Z_{ai}}{\partial y},
+\label{eq:dDtilde-ov}
+\end{equation}
+while the occupied--occupied and virtual--virtual blocks are unchanged for
+non-canonical perturbed orbitals and acquire the perturbed dependent pairs
+$\partial P_{ij}/\partial y$, $\partial P_{ab}/\partial y$ for canonical ones
+(the response of Eq.~\eqref{eq:Dtilde}).
+
+\noindent
+Differentiating the dependent pairs of Eq.~\eqref{eq:Poo} by the quotient rule --
+with the canonical orbital energies responding through
+$\partial\varepsilon_i/\partial y$, the diagonal of the perturbed Fock
+[Eq.~\eqref{eq:dfpq}] -- gives the {\em total} derivatives
+\begin{align}
+\frac{\partial P_{ij}}{\partial y}
+&= \frac{1}{\varepsilon_i-\varepsilon_j}\left[
+\frac{\partial I'_{ij}}{\partial y}-\frac{\partial I'_{ji}}{\partial y}
+- P_{ij}\left(\frac{\partial\varepsilon_i}{\partial y}
+             -\frac{\partial\varepsilon_j}{\partial y}\right)\right],
+\label{eq:dPoo}\\
+\frac{\partial P_{ab}}{\partial y}
+&= \frac{1}{\varepsilon_a-\varepsilon_b}\left[
+\frac{\partial I'_{ab}}{\partial y}-\frac{\partial I'_{ba}}{\partial y}
+- P_{ab}\left(\frac{\partial\varepsilon_a}{\partial y}
+             -\frac{\partial\varepsilon_b}{\partial y}\right)\right],
+\label{eq:dPvv}
+\end{align}
+with $\partial I'/\partial y$ given below by Eq.~\eqref{eq:dIprime}.  They complete
+the relaxed one-particle response in these blocks,
+$\partial\tilde D_{ij}/\partial y=\partial D_{ij}/\partial y+\partial P_{ij}/\partial y$
+and $\partial\tilde D_{ab}/\partial y=\partial D_{ab}/\partial y+\partial P_{ab}/\partial y$.
+Equations~\eqref{eq:dPoo}--\eqref{eq:dPvv} are {\em total} derivatives of the
+dependent pairs and are not the intermediate $P^{(x)}$ of \S\ref{sec:2nd-canon}:
+$P^{(x)}$ carries the perturbed numerator over the fixed unperturbed gap, whereas
+the total derivative adds the denominator-response term (the second term in each
+bracket), nonzero only in the non-invariant case where the dependent pairs
+survive.
+
+The perturbed Z-vector $\partial Z/\partial y$ follows by differentiating the
+Z-vector equation $\mathbf{G}^{T}\mathbf{Z}=\mathbf{X}$ of \S\ref{sec:cphf-z},
+\begin{equation}
+\mathbf{G}^{T}\frac{\partial\mathbf{Z}}{\partial y}
+= \frac{\partial\mathbf{X}}{\partial y} - \frac{\partial\mathbf{G}^{T}}{\partial y}\,\mathbf{Z},
+\label{eq:perturbed-zvector}
+\end{equation}
+a single linear solve per perturbation $y$ with the {\em unperturbed} orbital
+Hessian $\mathbf{G}$.  Its right-hand side is the response of the same
+orbital-gradient source that drove the first-derivative Z-vector, and so depends
+on the perturbed-orbital choice.  For non-canonical orbitals
+(\S\ref{sec:2nd-noncanon}) the source is the bare $X_{ai}=I'_{ia}-I'_{ai}$,
+\begin{equation}
+\frac{\partial X_{ai}}{\partial y}
+= \frac{\partial I'_{ia}}{\partial y}-\frac{\partial I'_{ai}}{\partial y};
+\label{eq:dX-noncanon}
+\end{equation}
+for canonical orbitals (\S\ref{sec:2nd-canon}) it is the dependent-pair-augmented
+$\tilde X_{ai}$ of Eq.~\eqref{eq:Xtilde}, whose response adds the dependent-pair
+terms
+\begin{align}
+\frac{\partial\tilde X_{ai}}{\partial y}
+&= \frac{\partial X_{ai}}{\partial y}
++ \tfrac12\sum_{kl}^{\occ}\left(\frac{\partial P_{kl}}{\partial y}A_{kali}
+   + P_{kl}\frac{\partial A_{kali}}{\partial y}\right)
+\nonumber\\
+&\quad
++ \tfrac12\sum_{de}^{\vir}\left(\frac{\partial P_{de}}{\partial y}A_{daei}
+   + P_{de}\frac{\partial A_{daei}}{\partial y}\right),
+\label{eq:dXtilde}
+\end{align}
+with $\partial P/\partial y$ from Eqs.~\eqref{eq:dPoo}--\eqref{eq:dPvv} and
+$\partial A_{pqrs}/\partial y=\partial\adb{pq}{rs}/\partial y
++\partial\adb{ps}{rq}/\partial y$ the pair combination of the full two-electron
+integral derivatives [Eq.~\eqref{eq:deri}].  Either choice requires the perturbed
+generalized Fock $\partial I'/\partial y$ and the orbital-Hessian response
+$\partial\mathbf{G}/\partial y$.  The perturbed
+generalized Fock is the product-rule derivative of Eq.~\eqref{eq:Iprime},
+\begin{align}
+\frac{\partial I'_{pq}}{\partial y} = -\tfrac12\Big[
+&\sum_r\frac{\partial f_{pr}}{\partial y}\big(D_{rq}+D_{qr}\big)
++ \varepsilon_p\Big(\frac{\partial D_{pq}}{\partial y}+\frac{\partial D_{qp}}{\partial y}\Big)
+\nonumber\\
+&+ \delta_{q,\occ}\sum_{rs}\Big(\frac{\partial D_{rs}}{\partial y}\,A_{rpsq}
+   + D_{rs}\,\frac{\partial A_{rpsq}}{\partial y}\Big)
+\nonumber\\
+&+ 4\sum_{rst}\Big(\frac{\partial\adb{pr}{st}}{\partial y}\,\Gamma_{qrst}
+   + \adb{pr}{st}\,\frac{\partial\Gamma_{qrst}}{\partial y}\Big)\Big],
+\label{eq:dIprime}
+\end{align}
+where the density responses $\partial D/\partial y$, $\partial\Gamma/\partial y$
+are the unrelaxed derivative densities of Appendix~\ref{sec:deriv-densities}, and
+the full MO integral derivatives $\partial f/\partial y$,
+$\partial\adb{}{}/\partial y$ (hence $\partial A/\partial y$) together with the
+orbital-Hessian response $\partial\mathbf{G}/\partial y$ follow from the skeleton
+derivatives and the CPHF coefficients $U^y$ through
+Eqs.~\eqref{eq:dfpq}--\eqref{eq:deri}.  The Fock term keeps the {\em full}
+$\partial f/\partial y$ summed over $r$: Eq.~\eqref{eq:Iprime} wrote it in the
+canonical, diagonal-$f$ form $f_{pp}(D_{pq}+D_{qp})$, but the derivative
+reactivates the off-diagonal $\partial f_{pr}/\partial y$ ($r\neq p$), nonzero
+because the one-particle density carries occupied--virtual blocks.
+
+\noindent
+Equation~\eqref{eq:dIprime} is distinct from the perturbed generalized Fock
+$I'^{(x)}$ of Eq.~\eqref{eq:Iprime-x}, despite the similar name.  Here
+$\partial I'/\partial y$ is the total $y$-derivative of the {\em first-derivative}
+generalized Fock $I'$ [Eq.~\eqref{eq:Iprime}]: it is built from the {\em unrelaxed}
+one-particle density $D$ and its response $\partial D/\partial y$, uses the full MO
+integral derivatives $\partial f/\partial y$ and $\partial\adb{}{}/\partial y$, and
+carries no overlap-derivative term; it supplies the Z-vector source
+$\partial X/\partial y$.  By contrast $I'^{(x)}$ [Eq.~\eqref{eq:Iprime-x}] is an
+$x$-{\em skeleton} generalized Fock built from the {\em relaxed} density $\tilde D$
+and the $x$-skeleton integrals $f^{(x)}$, $\adb{pq}{rs}^{(x)}$, $S^{(x)}$
+(including the overlap-derivative term the relaxed gradient carries); it supplies
+the orbital-response term $-2\sum_{pq}U^y_{pq}I'^{(x)}_{pq}$ of
+Eq.~\eqref{eq:d2E-grouped}.
+
+Finally, the energy-weighted density response $\partial I/\partial y$ is the
+product-rule derivative of the $I$ blocks assembled after
+Eq.~\eqref{eq:grad-final}: it combines $\partial I''/\partial y$ (the
+$(a,i)$-swap of $\partial I'/\partial y$, Eq.~\eqref{eq:Idouble}; in the canonical
+route $\tilde I''$ of Eq.~\eqref{eq:Idouble-tilde} replaces $I''$, its response
+carrying the perturbed dependent pairs) with the responses of the Z-vector
+terms, e.g.
+\begin{equation*}
+\frac{\partial I_{ai}}{\partial y} = \frac{\partial I''_{ai}}{\partial y}
++ \frac{\partial Z_{ai}}{\partial y}\,\varepsilon_i
++ Z_{ai}\,\frac{\partial\varepsilon_i}{\partial y},
+\end{equation*}
+the perturbed orbital energy $\partial\varepsilon_i/\partial y$ being the
+diagonal of the perturbed Fock.  With $\partial\tilde D/\partial y$,
+$\partial\Gamma/\partial y$, and $\partial I/\partial y$ in hand, the last three
+terms of Eq.~\eqref{eq:d2E} are evaluated directly.
+
+\subsection{Computational Summary}
+\label{sec:comp-summary-2}
+
+Unlike the gradient, the mixed second derivative does not collapse to a single
+compact expression.  The Z-vector interchange that removed the occupied--virtual
+orbital response from Eq.~\eqref{eq:grad-final} is unavailable (the contracting
+quantity now carries the first perturbation), so the occupied--virtual
+coefficients $U^y_{ai}$ remain explicit, and the first-order density responses
+$\partial\tilde D/\partial y$, $\partial\Gamma/\partial y$, $\partial I/\partial y$
+must be formed.  Both perturbed-orbital choices produce the same mixed second
+derivative through the common form
+\begin{align*}
+\frac{\partial^2 E}{\partial x\,\partial y}
+&= \sum_{pq}\tilde D_{pq}f^{(xy)}_{pq}
++ \sum_{pqrs}\Gamma_{pqrs}\adb{pq}{rs}^{(xy)}
++ \sum_{pq}I_{pq}S^{(xy)}_{pq}
++ (\text{orbital response})
+\\
+&\quad
++ \sum_{pq}\frac{\partial\tilde D_{pq}}{\partial y}f^{(x)}_{pq}
++ \sum_{pqrs}\frac{\partial\Gamma_{pqrs}}{\partial y}\adb{pq}{rs}^{(x)}
++ \sum_{pq}\frac{\partial I_{pq}}{\partial y}S^{(x)}_{pq},
+\end{align*}
+in which the doubly-skeleton integrals and the {\em unrelaxed} two-particle
+density and its response ($\Gamma$, $\partial\Gamma/\partial y$) are
+route-independent.  As for the gradient (\S\ref{sec:comp-summary-1}), the two
+choices differ in how the occupied--occupied and virtual--virtual orbital response
+is carried into the relaxed one-particle density $\tilde D$, the energy-weighted
+density $I$, and their responses $\partial\tilde D/\partial y$, $\partial
+I/\partial y$ -- and hence in the explicit orbital-response term and in the source
+of the perturbed Z-vector.  These route-specific pieces are given in the
+subsections below.
+
+The following ingredients enter both perturbed-orbital choices:
+\begin{enumerate}
+\item The {\em undifferentiated} densities $\tilde D_{pq}$, $\Gamma_{pqrs}$,
+$I_{pq}$, assembled exactly as in the first-derivative summary
+(\S\ref{sec:comp-summary-1}) for the chosen route (only the two-particle $\Gamma$
+is route-independent); they carry the first perturbation $x$ implicitly.
+\item The skeleton first-derivative integrals of both perturbations
+($f^{(x)}$, $\adb{pq}{rs}^{(x)}$, $S^{(x)}$ and $f^{(y)}$, $S^{(y)}$) and the
+doubly-skeleton integrals $f^{(xy)}_{pq}$, $\adb{pq}{rs}^{(xy)}$, $S^{(xy)}_{pq}$
+(the last nonzero only when the atomic-orbital basis depends on the perturbation).
+\item The occupied--virtual response $U^y_{ai}$, from a CPHF solve for the second
+perturbation $y$; there is no Z-vector shortcut at second order.
+\item The first-order density responses $\partial\tilde D_{pq}/\partial y$,
+$\partial\Gamma_{pqrs}/\partial y$, $\partial I_{pq}/\partial y$ (the $(2n+1)$ rule;
+no second-order wave-function response is needed).  The two-particle response
+$\partial\Gamma/\partial y$ is the unrelaxed perturbed density of
+Appendix~\ref{sec:deriv-densities}; the one-particle response
+$\partial\tilde D/\partial y$ and the perturbed Z-vector that supplies its
+occupied--virtual block depend on the perturbed-orbital choice and are written out
+in the subsections below (derived in \S\ref{sec:2nd-density-response}).
+\end{enumerate}
+The perturbed generalized Fock is
+\begin{align*}
+I'^{(x)}_{pq} = -\tfrac12\Big[
+&\sum_r\big(\tilde D_{qr}f^{(x)}_{pr}+\tilde D_{rq}f^{(x)}_{rp}\big)
++ \delta_{q,\occ}\sum_{rs}\tilde D_{rs}A^{(x)}_{rpsq}
+\\
+&+ 4\sum_{rst}\adb{pr}{st}^{(x)}\Gamma_{qrst}
++ \sum_r\big(I_{qr}S^{(x)}_{pr}+I_{rq}S^{(x)}_{rp}\big)\Big],
+\end{align*}
+with $A^{(x)}_{pqrs}=\adb{pq}{rs}^{(x)}+\adb{ps}{rq}^{(x)}$, and its
+occupied--virtual combination and $(a,i)$-swapped form are
+\begin{equation*}
+X^{(x)}_{ai}=I'^{(x)}_{ia}-I'^{(x)}_{ai},
+\qquad
+I''^{(x)}_{ai}=I'^{(x)}_{ia},\quad
+I''^{(x)}_{pq}=I'^{(x)}_{pq}\ \text{(otherwise)}.
+\end{equation*}
+
+\subsubsection{Non-Canonical Perturbed Orbitals}
+Take $U^y_{ij}=-\tfrac12 S^{(y)}_{ij}$ and $U^y_{ab}=-\tfrac12 S^{(y)}_{ab}$.
+\begin{enumerate}
+\item The orbital-response term is
+\begin{equation*}
+(\text{orbital response}) =
+2\sum_{a}^{\vir}\sum_{i}^{\occ}U^y_{ai}\,X^{(x)}_{ai}
++ \sum_{pq}S^{(y)}_{pq}\,I''^{(x)}_{pq}.
+\end{equation*}
+\item Solve the perturbed Z-vector
+$\mathbf{G}^{T}\,\partial\mathbf{Z}/\partial y
+=\partial\mathbf{X}/\partial y-(\partial\mathbf{G}^{T}/\partial y)\,\mathbf{Z}$
+with the bare source
+\begin{equation*}
+\frac{\partial X_{ai}}{\partial y}
+=\frac{\partial I'_{ia}}{\partial y}-\frac{\partial I'_{ai}}{\partial y},
+\end{equation*}
+$\partial I'/\partial y$ from Eq.~\eqref{eq:dIprime}.
+\item Assemble the one-particle response; the occupied--occupied and
+virtual--virtual blocks are unchanged,
+\begin{equation*}
+\frac{\partial\tilde D_{ij}}{\partial y}=\frac{\partial D_{ij}}{\partial y},\qquad
+\frac{\partial\tilde D_{ab}}{\partial y}=\frac{\partial D_{ab}}{\partial y},
+\end{equation*}
+while the occupied--virtual blocks carry the perturbed Z-vector,
+\begin{equation*}
+\frac{\partial\tilde D_{ai}}{\partial y}=\frac{\partial D_{ai}}{\partial y}-\frac{\partial Z_{ai}}{\partial y},\qquad
+\frac{\partial\tilde D_{ia}}{\partial y}=\frac{\partial D_{ia}}{\partial y}-\frac{\partial Z_{ai}}{\partial y}.
+\end{equation*}
+The two-particle response $\partial\Gamma/\partial y$ is the unrelaxed perturbed
+density of Appendix~\ref{sec:deriv-densities}, and $\partial I/\partial y$ is the
+product-rule derivative of the $I$ blocks.
+\end{enumerate}
+
+\subsubsection{Canonical Perturbed Orbitals}
+\begin{enumerate}
+\item Form the occupied--occupied and virtual--virtual combinations
+\begin{equation*}
+X^{(x)}_{ij}=I'^{(x)}_{ij}-I'^{(x)}_{ji},
+\qquad
+X^{(x)}_{ab}=I'^{(x)}_{ab}-I'^{(x)}_{ba},
+\end{equation*}
+and the (numerator-only) dependent pairs
+\begin{equation*}
+P^{(x)}_{ij}=\frac{X^{(x)}_{ij}}{\varepsilon_i-\varepsilon_j},
+\qquad
+P^{(x)}_{ab}=\frac{X^{(x)}_{ab}}{\varepsilon_a-\varepsilon_b};
+\end{equation*}
+fold them into the energy-weighted density,
+\begin{equation*}
+\tilde I''^{(x)}_{ij} = I''^{(x)}_{ij} - P^{(x)}_{ij}\varepsilon_j
+- \tfrac12\sum_{kl}^{\occ}P^{(x)}_{kl}A_{kilj}
+- \tfrac12\sum_{cd}^{\vir}P^{(x)}_{cd}A_{cidj},
+\qquad
+\tilde I''^{(x)}_{ab} = I''^{(x)}_{ab} - P^{(x)}_{ab}\varepsilon_b,
+\end{equation*}
+and into the occupied--virtual combination,
+\begin{equation*}
+\tilde X^{(x)}_{ai} = X^{(x)}_{ai}
++ \tfrac12\sum_{kl}^{\occ}P^{(x)}_{kl}A_{kali}
++ \tfrac12\sum_{de}^{\vir}P^{(x)}_{de}A_{daei}.
+\end{equation*}
+\item The orbital-response term is
+\begin{equation*}
+\begin{split}
+(\text{orbital response}) = {}&
+\sum_{ij}P^{(x)}_{ij}f^{(y)}_{ij}
++ \sum_{ab}P^{(x)}_{ab}f^{(y)}_{ab} \\
+&+ 2\sum_{a}^{\vir}\sum_{i}^{\occ}U^y_{ai}\,\tilde X^{(x)}_{ai}
++ \sum_{pq}S^{(y)}_{pq}\,\tilde I''^{(x)}_{pq}.
+\end{split}
+\end{equation*}
+\item For the density response, form the {\em total} derivatives of the dependent
+pairs (distinct from the numerator-only $P^{(x)}$ of step~1),
+\begin{align*}
+\frac{\partial P_{ij}}{\partial y}&=\frac{1}{\varepsilon_i-\varepsilon_j}\Big[
+\frac{\partial I'_{ij}}{\partial y}-\frac{\partial I'_{ji}}{\partial y}
+- P_{ij}\Big(\frac{\partial\varepsilon_i}{\partial y}-\frac{\partial\varepsilon_j}{\partial y}\Big)\Big],\\
+\frac{\partial P_{ab}}{\partial y}&=\frac{1}{\varepsilon_a-\varepsilon_b}\Big[
+\frac{\partial I'_{ab}}{\partial y}-\frac{\partial I'_{ba}}{\partial y}
+- P_{ab}\Big(\frac{\partial\varepsilon_a}{\partial y}-\frac{\partial\varepsilon_b}{\partial y}\Big)\Big].
+\end{align*}
+\item Solve the perturbed Z-vector
+$\mathbf{G}^{T}\,\partial\mathbf{Z}/\partial y
+=\partial\tilde{\mathbf{X}}/\partial y-(\partial\mathbf{G}^{T}/\partial y)\,\mathbf{Z}$
+with the dependent-pair-augmented source
+\begin{align*}
+\frac{\partial\tilde X_{ai}}{\partial y}=\frac{\partial X_{ai}}{\partial y}
+&+ \tfrac12\sum_{kl}^{\occ}\Big(\frac{\partial P_{kl}}{\partial y}A_{kali}
+   + P_{kl}\frac{\partial A_{kali}}{\partial y}\Big)\\
+&+ \tfrac12\sum_{de}^{\vir}\Big(\frac{\partial P_{de}}{\partial y}A_{daei}
+   + P_{de}\frac{\partial A_{daei}}{\partial y}\Big),
+\end{align*}
+with $\partial X_{ai}/\partial y=\partial I'_{ia}/\partial y-\partial I'_{ai}/\partial y$.
+\item Assemble the one-particle response; the occupied--occupied and
+virtual--virtual blocks now carry the dependent-pair response,
+\begin{equation*}
+\frac{\partial\tilde D_{ij}}{\partial y}=\frac{\partial D_{ij}}{\partial y}+\frac{\partial P_{ij}}{\partial y},\qquad
+\frac{\partial\tilde D_{ab}}{\partial y}=\frac{\partial D_{ab}}{\partial y}+\frac{\partial P_{ab}}{\partial y},
+\end{equation*}
+while the occupied--virtual blocks carry the perturbed Z-vector,
+\begin{equation*}
+\frac{\partial\tilde D_{ai}}{\partial y}=\frac{\partial D_{ai}}{\partial y}-\frac{\partial Z_{ai}}{\partial y},\qquad
+\frac{\partial\tilde D_{ia}}{\partial y}=\frac{\partial D_{ia}}{\partial y}-\frac{\partial Z_{ai}}{\partial y}.
+\end{equation*}
+As in the non-canonical case, $\partial\Gamma/\partial y$ is the unrelaxed
+perturbed two-particle density (Appendix~\ref{sec:deriv-densities}), and $\partial
+I/\partial y$ is the product-rule derivative of the canonical energy-weighted
+density of \S\ref{sec:comp-summary-1} (its $\tilde I''$ blocks and Z-vector terms),
+carrying the total dependent-pair derivatives $\partial P/\partial y$.
+\end{enumerate}
+
+The two recipes yield the same mixed derivative whenever the correlation energy
+is invariant to occupied--occupied and virtual--virtual rotations, as for the
+gradient (\S\ref{sec:comp-summary-1}).  The essential difference from the gradient is that neither
+removes the explicit occupied--virtual response: a CPHF solve for each second
+perturbation $y$ is unavoidable.
+
+\subsection{Second-Derivative Properties}
+\label{sec:2nd-props}
+
+Equation~\eqref{eq:d2E} holds for any pair of real perturbations, but its two
+families of terms are populated very differently, according to the same
+geometric-versus-field distinction drawn for the first derivative in
+\S\ref{sec:first-deriv-props}.  For a geometric perturbation the skeleton
+integrals $f^{(x)}$, $S^{(x)}$, $\adb{pq}{rs}^{(x)}$ are all nonzero, and so are
+their $y$-derivatives: these carry the {\em doubly}-skeleton integrals
+$f^{(xy)}$, $S^{(xy)}$, $\adb{pq}{rs}^{(xy)}$ (the second atomic-orbital
+derivative transformed into the unperturbed molecular-orbital basis) alongside
+the $U^y$ response.  For a static electric field the overlap and two-electron
+skeleton derivatives vanish, the one-electron skeleton derivative reduces to the
+field-independent dipole integral, and every doubly-skeleton integral vanishes
+as well (the field is linear in the Hamiltonian).  Equation~\eqref{eq:d2E} then
+collapses to a compact form built from the dipole integral and the first-order
+density response, which we develop first as the static dipole polarizability,
+the simplest case.
+
+\subsubsection{Static Dipole Polarizability}
+
+The static dipole polarizability is the derivative of the dipole moment
+\eqref{eq:dipole} with respect to a second field,
+$\alpha_{ab}=\partial\mu_a/\partial F_b=-\partial^2 E/\partial F_a\,\partial F_b$.
+Identifying the two perturbations of Eq.~\eqref{eq:d2E} as $x\to F_a$ and
+$y\to F_b$, we recall the field skeleton first-derivative integrals of
+\S\ref{sec:first-deriv-props},
+\begin{equation}
+f^{(F_a)}_{pq} = -\mu^a_{pq}, \qquad
+S^{(F_a)}_{pq} = 0, \qquad
+\adb{pq}{rs}^{(F_a)} = 0,
+\label{eq:field-skeleton}
+\end{equation}
+and note that, because the field is linear in the Hamiltonian, every {\em
+doubly}-skeleton integral vanishes as well ($f^{(F_aF_b)}_{pq}=0$).  Moreover the
+field skeleton derivative
+\eqref{eq:field-skeleton} is a purely one-electron integral (unlike a geometric
+$f^{(x)}$, it has no occupied-sum two-electron part), so its response to the
+second field reduces to the orbital rotation of the dipole integral alone,
+\begin{equation}
+\frac{\partial f^{(F_a)}_{pq}}{\partial F_b}
+= -\sum_t\left(U^b_{tp}\,\mu^a_{tq} + U^b_{tq}\,\mu^a_{pt}\right),
+\qquad U^b \equiv U^{F_b},
+\label{eq:dfield}
+\end{equation}
+with no doubly-skeleton or two-electron contribution.
+
+In Eq.~\eqref{eq:d2E} the two first-line terms carrying $\adb{}{}^{(F_a)}$ or
+$S^{(F_a)}$ vanish, as do the two second-line terms carrying them; only the
+first term of each line survives.  Using \eqref{eq:field-skeleton} and
+\eqref{eq:dfield}, the mixed second derivative collapses to
+\begin{equation}
+\frac{\partial^2 E}{\partial F_a\,\partial F_b}
+= -\sum_{pq}\frac{\partial \tilde D_{pq}}{\partial F_b}\,\mu^a_{pq}
+  -\sum_{pq}\tilde D_{pq}\sum_t\left(U^b_{tp}\,\mu^a_{tq}+U^b_{tq}\,\mu^a_{pt}\right),
+\end{equation}
+and the static dipole polarizability
+$\alpha_{ab}=-\partial^2 E/\partial F_a\,\partial F_b$ is
+\begin{equation}
+\alpha_{ab}
+= \sum_{pq}\frac{\partial \tilde D_{pq}}{\partial F_b}\,\mu^a_{pq}
++ \sum_{pq}\tilde D_{pq}\sum_t\left(U^b_{tp}\,\mu^a_{tq}+U^b_{tq}\,\mu^a_{pt}\right).
+\label{eq:polarizability}
+\end{equation}
+
+The two contributions have a clear physical reading.  The first is the {\em
+density response}: the field-$b$ response of the relaxed one-particle density,
+contracted with the dipole integrals along $a$.  The second is the {\em dipole
+relaxation}: the unperturbed relaxed density contracted with the change in
+$\mu^a$ induced by the field-$b$ rotation of the molecular orbitals.  The
+two-particle density $\Gamma$ and the energy-weighted density $I$ do not appear
+explicitly (their skeleton integrals $\adb{}{}^{(F_a)}$ and $S^{(F_a)}$ vanish);
+they re-enter only implicitly, through $\partial\tilde D/\partial F_b$.
+
+Two ingredients complete Eq.~\eqref{eq:polarizability}, both instances of the
+general second-derivative recipe of \S\ref{sec:comp-summary-2}.  The orbital
+response $U^b$ is the coupled-perturbed Hartree--Fock solution for the field
+perturbation, obtained as in \S\ref{sec:cphf-z}; because $S^{(F_b)}=0$, its
+right-hand side carries no overlap-derivative terms.  The density response
+$\partial\tilde D/\partial F_b$ is the first-order field response of the relaxed
+one-particle density, built from the once-perturbed wave-function and Z-vector
+equations (the $(2n+1)$ rule); its explicit construction is specific to the
+correlation method.
+
 \appendix
+
+\section{Densities for Specific Methods}
+\label{sec:densities}
+
+The presentation given in \S\ref{sec:first-derivs} and \S\ref{sec:second-derivs}
+is general for any correlated method,
+provided the one-particle density $D_{pq}$ and two-particle density
+$\Gamma_{pqrs}$ that enter Eq.~\eqref{eq:dE} are available.  In this appendix
+we provide spin-orbital expressions for three major quantum chemical electron
+correlation methods: CCSD, CCSD(T), and MP2.  Note that these are the {\em
+unrelaxed} densities (the orbital relaxation is added separately through the
+Z-vector of \S\ref{sec:cphf-z}).  $\Gamma_{pqrs}$ is fully antisymmetric, $\Gamma_{pqrs} =
+-\Gamma_{qprs} = -\Gamma_{pqsr} = \Gamma_{qpsr}$, but (unlike the two-electron
+integrals) it is not in general bra-ket symmetric, $\Gamma_{pqrs} \neq
+\Gamma_{rspq}$, because the coupled-cluster density is non-Hermitian
+($\Lambda \neq T^\dagger$).  Finally, the two-particle expressions tabulated
+below are the {\em diagrammatic} density blocks (as obtained from Wick's theorem
+or the diagrammatic rules); to use them in Eq.~\eqref{eq:dE}, which carries no
+explicit prefactor, each $\Gamma_{pqrs}$ must be multiplied by an overall factor
+of $\frac14$ (the antisymmetric double-sum factor of the spin-orbital
+two-electron energy).  The one-particle density $D_{pq}$ needs no such factor.
+
+\subsection{Coupled Cluster Singles and Doubles (CCSD)}
+\label{sec:ccsd_pdms}
+
+This subsection collects the spin-orbital CCSD expressions in terms of the
+cluster amplitudes $t_i^a$, $t_{ij}^{ab}$ and the de-excitation
+(Lagrange-multiplier) amplitudes $\lambda^i_a$, $\lambda^{ij}_{ab}$.  The
+effective double-excitation operator is
+\begin{equation}
+\tau_{ij}^{ab} = t_{ij}^{ab} + \tfrac12\,P(ij)\,P(ab)\, t_i^a t_j^b,
+\label{eq:tau}
+\end{equation}
+with the antisymmetrizer defined as $P(pq)Y_{pq} = Y_{pq} - Y_{qp}$.
+Tables~\ref{Table:ccsd_1pdm} and \ref{Table:ccsd_2pdm} give the expressions
+for the one- and two-electron densities, respectively.  For $\Gamma_{pqrs}$,
+Table~\ref{Table:ccsd_2pdm} lists one representative block of each occupation
+block, and the remaining blocks follow from antisymmetry.
+
+\begin{table}[H]
+\caption{Spin-orbital CCSD one-electron density $D_{pq}$ entering Eq.~\eqref{eq:dE}.  The one-electron term of Eq.~\eqref{eq:dE} carries no prefactor, so these blocks are used as tabulated.}
+\label{Table:ccsd_1pdm}
+\renewcommand{\arraystretch}{1.6}
+\begin{center}
+\begin{tabular}{ll}
+\hline\hline
+Block & Algebraic expression \\
+\hline
+$D_{ij}$ & $\displaystyle -\sum_e \lambda^j_e t_i^e - \frac12 \sum_{mef}\lambda^{jm}_{ef} t_{im}^{ef}$ \\
+$D_{ab}$ & $\displaystyle \sum_m \lambda^m_a t_m^b + \frac12 \sum_{mne}\lambda^{mn}_{ae} t_{mn}^{be}$ \\
+$D_{ia}$ & $\displaystyle t_i^a + \sum_{me}\lambda^m_e t_{im}^{ae} - \sum_{me}\lambda^m_e t_i^e t_m^a - \frac12\sum_{mnef}\lambda^{mn}_{ef}\left(t_i^e t_{mn}^{af} + t_m^a t_{in}^{ef}\right)$ \\
+$D_{ai}$ & $\displaystyle \lambda^i_a$ \\
+\hline\hline
+\end{tabular}
+\end{center}
+\end{table}
+
+\begin{table}[H]
+\caption{Spin-orbital CCSD two-electron density $\Gamma_{pqrs}$ (diagrammatic
+blocks; each must be multiplied by an overall $\frac14$ to enter
+Eq.~\eqref{eq:dE}, per the appendix introduction).  The $\tau$ tensor is given by
+Eq.~\eqref{eq:tau}.}
+\label{Table:ccsd_2pdm}
+\renewcommand{\arraystretch}{1.5}
+\begin{center}
+\begin{tabular}{ll}
+\hline\hline
+Block & Algebraic expression \\
+\hline
+\hline
+ \\
+$\Gamma_{ijkl}$ & $\displaystyle \frac12 \sum_{ef}\lambda^{kl}_{ef}\,\tau_{ij}^{ef}$ \\
+$\Gamma_{abcd}$ & $\displaystyle \frac12 \sum_{mn}\lambda^{mn}_{ab}\,\tau_{mn}^{cd}$ \\
+$\Gamma_{ijka}$ & $\displaystyle -\sum_e\lambda^k_e\tau_{ij}^{ea} + \frac12\sum_{mef}\lambda^{km}_{ef}\tau_{ij}^{ef}t_m^a + P(ij)\sum_{mef}\lambda^{mk}_{ef}t_{im}^{ae}t_j^f - \frac12 P(ij)\sum_{mef}\lambda^{km}_{ef}t_{im}^{ef}t_j^a$ \\
+$\Gamma_{ciab}$ & $\displaystyle \sum_m\lambda^m_c\tau_{mi}^{ab} - \frac12\sum_{mne}\lambda^{mn}_{ce}\tau_{mn}^{ab}t_i^e - P(ab)\sum_{mne}\lambda^{mn}_{ce}t_{in}^{ae}t_m^b + \frac12 P(ab)\sum_{mne}\lambda^{mn}_{ce}t_{mn}^{ae}t_i^b$ \\
+$\Gamma_{abci}$ & $\displaystyle \sum_m\lambda^{mi}_{ab}t_m^c$ \\
+$\Gamma_{kaij}$ & $\displaystyle -\sum_e\lambda^{ij}_{ea}t_k^e$ \\
+$\Gamma_{ibaj}$ & $\displaystyle t_i^a\lambda^j_b + \sum_{me}\lambda^{jm}_{be}\big(t_{mi}^{ea} - t_m^a t_i^e\big)$ \\
+$\Gamma_{ijab}$ & $\displaystyle \tau_{ij}^{ab} + \frac14 \sum_{mnef}\lambda^{mn}_{ef}\tau_{ij}^{ef}\tau_{mn}^{ab}$ \\
+ & $\displaystyle -\frac12 P(ij)\sum_{mnef}\lambda^{mn}_{ef}t_{in}^{ef}\tau_{mj}^{ab} - P(ij)\sum_{me}\lambda^m_e\tau_{mj}^{ab}t_i^e$ \\
+ & $\displaystyle -\frac12 P(ab)\sum_{mnef}\lambda^{mn}_{ef}t_{mn}^{af}\tau_{ij}^{eb} - P(ab)\sum_{me}\lambda^m_e\tau_{ij}^{eb}t_m^a$ \\
+ & $\displaystyle -\frac12 P(ij)P(ab)\sum_{mnef}\big(t_{mi}^{ae}+2t_i^e t_m^a\big)\lambda^{mn}_{ef}t_{jn}^{bf}$ \\
+ & $\displaystyle - P(ij)P(ab)\sum_{me}\big(t_{mi}^{ae}+2t_i^e t_m^a\big)\lambda^m_e t_j^b + 3 P(ij)P(ab)\sum_{me}\lambda^m_e t_i^a t_j^e t_m^b$ \\
+$\Gamma_{abij}$ & $\displaystyle \lambda^{ij}_{ab}$ \\
+ \\
+\hline\hline
+\end{tabular}
+\end{center}
+\end{table}
+
+\subsection{Perturbative Triples [CCSD(T)]}
+\label{sec:ccsdt_pdms}
+
+The CCSD(T) method adds a perturbative estimate of the connected-triples
+contribution on top of the converged CCSD wavefunction.  Its density is most
+cleanly organized as the CCSD density of Tables~\ref{Table:ccsd_1pdm} and
+\ref{Table:ccsd_2pdm} \emph{plus} a set of {\em (T) increments}
+$D^{(T)}_{pq}$, $\Gamma^{(T)}_{pqrs}$.  These follow from the CCSD(T) Lagrangian
+(written here with no orbital rotations),
+\begin{equation}
+\mathcal{L}_{\mathrm{CCSD(T)}}
+  = \langle 0|(1+\Lambda_1+\Lambda_2)\bar{H}|0\rangle
+  + \langle 0|(T_1^{\dagger}+T_2^{\dagger})[H,T_3]|0\rangle
+  + \langle 0|\Lambda_3\big([F,T_3]+[H,T_2]\big)|0\rangle,
+\label{eq:ccsdt_lag}
+\end{equation}
+where $\bar{H}=e^{-T}He^{T}$ is the CCSD similarity-transformed Hamiltonian and
+$T_3$, $\Lambda_3$ are the triples cluster and de-excitation operators.  Making
+$\mathcal{L}$ stationary with respect to the triples amplitudes and multipliers
+shows that, at the order retained in (T), the triples multiplier is simply the
+sum of the connected and disconnected triples amplitudes,
+\begin{equation}
+\lambda^{ijk}_{abc} = t^{(c)\,abc}_{ijk} + t^{(d)\,abc}_{ijk},
+\label{eq:lam3}
+\end{equation}
+so no separate triples equation need be solved for the density (compare the MP2
+identity $\lambda^{ij}_{ab}=t^{ab}_{ij}$).  The connected and disconnected pieces
+are
+\begin{align}
+t^{(c)\,abc}_{ijk} &= \left(D^{abc}_{ijk}\right)^{-1} P(i/jk)\,P(a/bc)
+   \left( \sum_e t^{ae}_{jk}\,\langle bc\|ei\rangle
+        - \sum_m t^{bc}_{im}\,\langle ma\|jk\rangle \right),
+\label{eq:t3c}\\[3pt]
+t^{(d)\,abc}_{ijk} &= \left(D^{abc}_{ijk}\right)^{-1} P(i/jk)\,P(a/bc)\,
+   t^a_i\,\langle jk\|bc\rangle,
+\label{eq:t3d}
+\end{align}
+with the orbital-energy denominator $D^{abc}_{ijk}=\varepsilon_i+\varepsilon_j
++\varepsilon_k-\varepsilon_a-\varepsilon_b-\varepsilon_c$ and the three-index
+antisymmetrizer $P(p/qr)=1-P_{pq}-P_{pr}$.  For canonical Hartree--Fock orbitals
+the occupied--virtual Fock block vanishes; a general (semicanonical) reference
+adds a term $F_{ia}\,t^{bc}_{jk}$ to the disconnected amplitude \eqref{eq:t3d}.
+
+Because $T_3$ enters the Lagrangian \eqref{eq:ccsdt_lag}, the CCSD $\Lambda_1$ and
+$\Lambda_2$ equations acquire (T) source terms.  The de-excitation amplitudes
+$\lambda^i_a$, $\lambda^{ij}_{ab}$ that enter Tables~\ref{Table:ccsd_1pdm} and
+\ref{Table:ccsd_2pdm} for CCSD(T) are therefore the {\em (T)-relaxed} solutions of
+the CCSD $\Lambda$ equations augmented by
+\begin{align}
+S^a_i    &= \tfrac14 \sum_{lm,ef} t^{(c)\,aef}_{ilm}\,\langle lm\|ef\rangle,
+\label{eq:S1}\\[3pt]
+S^{ab}_{ij} &= \tfrac12 P(ab)\!\sum_{m,ef}\!\big(2t^{(c)}+t^{(d)}\big)^{aef}_{ijm}\langle bm\|ef\rangle
+             - \tfrac12 P(ij)\!\sum_{lm,e}\!\big(2t^{(c)}+t^{(d)}\big)^{abe}_{ilm}\langle lm\|je\rangle.
+\label{eq:S2}
+\end{align}
+
+The (T) increments themselves are collected in Tables~\ref{Table:ccsdt_1pdm}
+(one-electron) and \ref{Table:ccsdt_2pdm} (two-electron).  As with CCSD, the
+one-electron increments carry no prefactor while the two-electron increments are
+diagrammatic blocks to be multiplied by the overall $\frac14$ of the appendix
+introduction.  The blocks originating in the $(T_1^{\dagger}+T_2^{\dagger})[H,T_3]$
+term of \eqref{eq:ccsdt_lag} contract the connected amplitude $t^{(c)}$ alone,
+while those originating in the $\Lambda_3([F,T_3]+[H,T_2])$ term contract the full
+multiplier $t^{(c)}+t^{(d)}$ of \eqref{eq:lam3}.
+
+\begin{table}[H]
+\caption{Spin-orbital (T) increments to the one-electron density, added to the
+CCSD blocks of Table~\ref{Table:ccsd_1pdm}.  As one-electron blocks they carry no
+prefactor.  Only the {\em diagonal} of the $oo$ and $vv$ increments is a genuine
+density term; the off-diagonal $\langle 0|\Lambda_3[E_{pq},T_3]|0\rangle$ blocks
+are the $oo$/$vv$ orbital response carried by the dependent-pair rotations of
+\S\ref{sec:canon-mo}--\S\ref{sec:cphf-z-canon}, not the density.}
+\label{Table:ccsdt_1pdm}
+\renewcommand{\arraystretch}{1.6}
+\begin{center}
+\begin{tabular}{ll}
+\hline\hline
+Block & Algebraic expression \\
+\hline
+$D^{(T)}_{ia}$ & $\displaystyle \frac14 \sum_{lm,ef} t^{(c)\,aef}_{ilm}\, t^{ef}_{lm}$ \\
+$D^{(T)}_{ij}$ (diagonal) & $\displaystyle -\frac{1}{12} \sum_{lm,efg} t^{(c)\,efg}_{lmi}\,\big(t^{(c)}+t^{(d)}\big)^{efg}_{lmj}$ \\
+$D^{(T)}_{ab}$ (diagonal) & $\displaystyle +\frac{1}{12} \sum_{lmn,ef} t^{(c)\,efb}_{lmn}\,\big(t^{(c)}+t^{(d)}\big)^{efa}_{lmn}$ \\
+\hline\hline
+\end{tabular}
+\end{center}
+\end{table}
+
+\begin{table}[H]
+\caption{Spin-orbital (T) increments to the two-electron density, added to the
+CCSD blocks of Table~\ref{Table:ccsd_2pdm} (diagrammatic blocks; each must be
+multiplied by an overall $\frac14$ to enter Eq.~\eqref{eq:dE}, per the appendix
+introduction).}
+\label{Table:ccsdt_2pdm}
+\renewcommand{\arraystretch}{1.6}
+\begin{center}
+\begin{tabular}{ll}
+\hline\hline
+Block & Algebraic expression \\
+\hline
+$\Gamma^{(T)}_{ijab}$ & $\displaystyle \sum_{me} t^{(c)\,eab}_{mij}\, t^e_m$ \\
+$\Gamma^{(T)}_{ijka}$ & $\displaystyle -\frac12 \sum_{mef} t^{(c)\,efa}_{mij}\, t^{ef}_{mk}$ \\
+$\Gamma^{(T)}_{ciab}$ & $\displaystyle +\frac12 \sum_{mne} t^{(c)\,eab}_{mni}\, t^{ec}_{mn}$ \\
+$\Gamma^{(T)}_{kaij}$ & $\displaystyle -\frac12 \sum_{mef} \big(t^{(c)}+t^{(d)}\big)^{efa}_{mij}\, t^{ef}_{mk}$ \\
+$\Gamma^{(T)}_{abci}$ & $\displaystyle +\frac12 \sum_{mne} \big(t^{(c)}+t^{(d)}\big)^{eab}_{mni}\, t^{ec}_{mn}$ \\
+\hline\hline
+\end{tabular}
+\end{center}
+\end{table}
+
+\subsection{Second-Order M{\o}ller-Plesset Perturbation Theory (MP2)}
+
+The MP2 densities are the first-order limit of the CCSD expressions of Appendix~\ref{sec:ccsd_pdms}
+($t_i^a\to0$, $\lambda^{ij}_{ab}\to t_{ij}^{ab}$, $\lambda^i_a\to0$, so $\tau\to t$).
+Only the occupied--occupied ($oo$) and virtual--virtual ($vv$) one-particle blocks and the
+$oovv$/$vvoo$ two-particle blocks survive,
+\begin{align}
+D_{ij} &= -\tfrac12\sum_{mef} t_{im}^{ef} t_{jm}^{ef}, &
+D_{ab} &= \tfrac12\sum_{mne} t_{mn}^{be} t_{mn}^{ae}, \\
+\Gamma_{ijab} &= t_{ij}^{ab}, &
+\Gamma_{abij} &= t_{ij}^{ab},
+\end{align}
+with $D_{ia}=D_{ai}=0$ and all other $\Gamma$ blocks vanishing.  As in the CCSD
+case, the $\Gamma$ expressions are diagrammatic blocks and must be multiplied by
+an overall $\frac14$ for use in Eq.~\eqref{eq:dE}; $D$ enters with no prefactor.
+
+\section{Derivative Densities for Specific Methods}
+\label{sec:deriv-densities}
+
+The second derivatives of \S\ref{sec:second-derivs} require the first-order
+responses $\partial_x D_{pq}$ and $\partial_x\Gamma_{pqrs}$ of the unrelaxed
+densities of Appendix~\ref{sec:densities}.  Every density block there is
+multilinear in the cluster amplitudes and their de-excitation
+(Lagrange-multiplier) counterparts, so its response follows by the product rule:
+the derivative of a block is the sum, over the amplitude factors of each of its
+terms, of that term with the one factor replaced by its first-order response.  We
+write the first-order responses of the amplitudes as
+\begin{equation*}
+t^{a,x}_i\equiv\partial_x t^a_i,\quad
+t^{ab,x}_{ij}\equiv\partial_x t^{ab}_{ij},\quad
+\lambda^{i,x}_a\equiv\partial_x\lambda^i_a,\quad
+\lambda^{ij,x}_{ab}\equiv\partial_x\lambda^{ij}_{ab},
+\end{equation*}
+and the response of the effective double-excitation operator \eqref{eq:tau} as
+\begin{equation}
+\tau^{ab,x}_{ij} \equiv \partial_x\tau^{ab}_{ij}
+= t^{ab,x}_{ij} + \tfrac12 P(ij)P(ab)\big(t^{a,x}_i t^b_j + t^a_i t^{b,x}_j\big).
+\label{eq:tau-x}
+\end{equation}
+Each two-particle response carries the same overall $\frac14$ as its parent block
+(Appendix~\ref{sec:densities}).  The construction of the perturbed amplitudes
+themselves, and the evaluation of the several quantities that enter in terms of
+the skeleton derivative integrals, are taken up separately; here we give only the
+product-rule expansions of the densities.
+
+\subsection{Coupled Cluster Singles and Doubles (CCSD)}
+\label{sec:ccsd_deriv_pdms}
+
+The product-rule responses of Tables~\ref{Table:ccsd_1pdm} and
+\ref{Table:ccsd_2pdm} are collected in Tables~\ref{Table:ccsd_deriv_1pdm} and
+\ref{Table:ccsd_deriv_2pdm}; each two-particle response inherits the overall
+$\frac14$ of its parent, and $\tau^{ab,x}_{ij}$ is given by Eq.~\eqref{eq:tau-x}.
+
+\begin{table}[H]
+\caption{Spin-orbital CCSD one-electron derivative density $\partial_x D_{pq}$,
+the product-rule response of Table~\ref{Table:ccsd_1pdm}.}
+\label{Table:ccsd_deriv_1pdm}
+\renewcommand{\arraystretch}{1.6}
+\begin{center}
+\begin{tabular}{ll}
+\hline\hline
+Block & Algebraic expression \\
+\hline
+$\partial_x D_{ij}$ & $\displaystyle -\sum_e\big(\lambda^{j,x}_e t^e_i + \lambda^j_e t^{e,x}_i\big) - \frac12\sum_{mef}\big(\lambda^{jm,x}_{ef} t^{ef}_{im} + \lambda^{jm}_{ef} t^{ef,x}_{im}\big)$ \\
+$\partial_x D_{ab}$ & $\displaystyle \sum_m\big(\lambda^{m,x}_a t^b_m + \lambda^m_a t^{b,x}_m\big) + \frac12\sum_{mne}\big(\lambda^{mn,x}_{ae} t^{be}_{mn} + \lambda^{mn}_{ae} t^{be,x}_{mn}\big)$ \\
+$\partial_x D_{ia}$ & $\displaystyle t^{a,x}_i + \sum_{me}\big(\lambda^{m,x}_e t^{ae}_{im} + \lambda^m_e t^{ae,x}_{im}\big) - \sum_{me}\big(\lambda^{m,x}_e t^e_i t^a_m + \lambda^m_e t^{e,x}_i t^a_m + \lambda^m_e t^e_i t^{a,x}_m\big)$ \\
+ & $\displaystyle - \frac12\sum_{mnef}\lambda^{mn,x}_{ef}\big(t^e_i t^{af}_{mn} + t^a_m t^{ef}_{in}\big) - \frac12\sum_{mnef}\lambda^{mn}_{ef}\big(t^{e,x}_i t^{af}_{mn} + t^e_i t^{af,x}_{mn} + t^{a,x}_m t^{ef}_{in} + t^a_m t^{ef,x}_{in}\big)$ \\
+$\partial_x D_{ai}$ & $\displaystyle \lambda^{i,x}_a$ \\
+\hline\hline
+\end{tabular}
+\end{center}
+\end{table}
+
+{\renewcommand{\arraystretch}{1.5}\setlength{\LTcapwidth}{\textwidth}
+\begin{longtable}{ll}
+\caption{Spin-orbital CCSD two-electron derivative density
+$\partial_x\Gamma_{pqrs}$, the product-rule response of
+Table~\ref{Table:ccsd_2pdm} (each block to be multiplied by the overall
+$\frac14$).  Long blocks are broken by parent term, one continuation row each.}
+\label{Table:ccsd_deriv_2pdm}\\
+\hline\hline
+Block & Algebraic expression \\
+\hline
+\endfirsthead
+\multicolumn{2}{c}{\small\emph{Table~\ref{Table:ccsd_deriv_2pdm}, continued}}\\
+\hline\hline
+Block & Algebraic expression \\
+\hline
+\endhead
+\hline
+\multicolumn{2}{r}{\small\emph{continued on next page}}\\
+\endfoot
+\hline\hline
+\endlastfoot
+$\partial_x\Gamma_{ijkl}$ & $\displaystyle \frac12\sum_{ef}\big(\lambda^{kl,x}_{ef}\tau^{ef}_{ij} + \lambda^{kl}_{ef}\tau^{ef,x}_{ij}\big)$ \\
+$\partial_x\Gamma_{abcd}$ & $\displaystyle \frac12\sum_{mn}\big(\lambda^{mn,x}_{ab}\tau^{cd}_{mn} + \lambda^{mn}_{ab}\tau^{cd,x}_{mn}\big)$ \\
+$\partial_x\Gamma_{ijka}$ & $\displaystyle -\sum_e\big(\lambda^{k,x}_e\tau^{ea}_{ij} + \lambda^k_e\tau^{ea,x}_{ij}\big)$ \\
+ & $\displaystyle + \frac12\sum_{mef}\big(\lambda^{km,x}_{ef}\tau^{ef}_{ij}t^a_m + \lambda^{km}_{ef}\tau^{ef,x}_{ij}t^a_m + \lambda^{km}_{ef}\tau^{ef}_{ij}t^{a,x}_m\big)$ \\
+ & $\displaystyle + P(ij)\sum_{mef}\big(\lambda^{mk,x}_{ef}t^{ae}_{im}t^f_j + \lambda^{mk}_{ef}t^{ae,x}_{im}t^f_j + \lambda^{mk}_{ef}t^{ae}_{im}t^{f,x}_j\big)$ \\
+ & $\displaystyle - \frac12 P(ij)\sum_{mef}\big(\lambda^{km,x}_{ef}t^{ef}_{im}t^a_j + \lambda^{km}_{ef}t^{ef,x}_{im}t^a_j + \lambda^{km}_{ef}t^{ef}_{im}t^{a,x}_j\big)$ \\
+$\partial_x\Gamma_{ciab}$ & $\displaystyle \sum_m\big(\lambda^{m,x}_c\tau^{ab}_{mi} + \lambda^m_c\tau^{ab,x}_{mi}\big)$ \\
+ & $\displaystyle - \frac12\sum_{mne}\big(\lambda^{mn,x}_{ce}\tau^{ab}_{mn}t^e_i + \lambda^{mn}_{ce}\tau^{ab,x}_{mn}t^e_i + \lambda^{mn}_{ce}\tau^{ab}_{mn}t^{e,x}_i\big)$ \\
+ & $\displaystyle - P(ab)\sum_{mne}\big(\lambda^{mn,x}_{ce}t^{ae}_{in}t^b_m + \lambda^{mn}_{ce}t^{ae,x}_{in}t^b_m + \lambda^{mn}_{ce}t^{ae}_{in}t^{b,x}_m\big)$ \\
+ & $\displaystyle + \frac12 P(ab)\sum_{mne}\big(\lambda^{mn,x}_{ce}t^{ae}_{mn}t^b_i + \lambda^{mn}_{ce}t^{ae,x}_{mn}t^b_i + \lambda^{mn}_{ce}t^{ae}_{mn}t^{b,x}_i\big)$ \\
+$\partial_x\Gamma_{abci}$ & $\displaystyle \sum_m\big(\lambda^{mi,x}_{ab}t^c_m + \lambda^{mi}_{ab}t^{c,x}_m\big)$ \\
+$\partial_x\Gamma_{kaij}$ & $\displaystyle -\sum_e\big(\lambda^{ij,x}_{ea}t^e_k + \lambda^{ij}_{ea}t^{e,x}_k\big)$ \\
+$\partial_x\Gamma_{ibaj}$ & $\displaystyle t^{a,x}_i\lambda^j_b + t^a_i\lambda^{j,x}_b$ \\
+ & $\displaystyle + \sum_{me}\Big[\lambda^{jm,x}_{be}\big(t^{ea}_{mi} - t^a_m t^e_i\big) + \lambda^{jm}_{be}\big(t^{ea,x}_{mi} - t^{a,x}_m t^e_i - t^a_m t^{e,x}_i\big)\Big]$ \\
+$\partial_x\Gamma_{ijab}$ & $\displaystyle \tau^{ab,x}_{ij} + \frac14\sum_{mnef}\big(\lambda^{mn,x}_{ef}\tau^{ef}_{ij}\tau^{ab}_{mn} + \lambda^{mn}_{ef}\tau^{ef,x}_{ij}\tau^{ab}_{mn} + \lambda^{mn}_{ef}\tau^{ef}_{ij}\tau^{ab,x}_{mn}\big)$ \\
+ & $\displaystyle - \frac12 P(ij)\sum_{mnef}\big(\lambda^{mn,x}_{ef}t^{ef}_{in}\tau^{ab}_{mj} + \lambda^{mn}_{ef}t^{ef,x}_{in}\tau^{ab}_{mj} + \lambda^{mn}_{ef}t^{ef}_{in}\tau^{ab,x}_{mj}\big)$ \\
+ & $\displaystyle - P(ij)\sum_{me}\big(\lambda^{m,x}_e\tau^{ab}_{mj}t^e_i + \lambda^m_e\tau^{ab,x}_{mj}t^e_i + \lambda^m_e\tau^{ab}_{mj}t^{e,x}_i\big)$ \\
+ & $\displaystyle - \frac12 P(ab)\sum_{mnef}\big(\lambda^{mn,x}_{ef}t^{af}_{mn}\tau^{eb}_{ij} + \lambda^{mn}_{ef}t^{af,x}_{mn}\tau^{eb}_{ij} + \lambda^{mn}_{ef}t^{af}_{mn}\tau^{eb,x}_{ij}\big)$ \\
+ & $\displaystyle - P(ab)\sum_{me}\big(\lambda^{m,x}_e\tau^{eb}_{ij}t^a_m + \lambda^m_e\tau^{eb,x}_{ij}t^a_m + \lambda^m_e\tau^{eb}_{ij}t^{a,x}_m\big)$ \\
+ & $\displaystyle - \frac12 P(ij)P(ab)\sum_{mnef}\big(t^{ae,x}_{mi} + 2t^{e,x}_i t^a_m + 2t^e_i t^{a,x}_m\big)\lambda^{mn}_{ef}t^{bf}_{jn}$ \\
+ & $\displaystyle - \frac12 P(ij)P(ab)\sum_{mnef}\big(t^{ae}_{mi} + 2t^e_i t^a_m\big)\big(\lambda^{mn,x}_{ef}t^{bf}_{jn} + \lambda^{mn}_{ef}t^{bf,x}_{jn}\big)$ \\
+ & $\displaystyle - P(ij)P(ab)\sum_{me}\big(t^{ae,x}_{mi} + 2t^{e,x}_i t^a_m + 2t^e_i t^{a,x}_m\big)\lambda^m_e t^b_j$ \\
+ & $\displaystyle - P(ij)P(ab)\sum_{me}\big(t^{ae}_{mi} + 2t^e_i t^a_m\big)\big(\lambda^{m,x}_e t^b_j + \lambda^m_e t^{b,x}_j\big)$ \\
+ & $\displaystyle + 3P(ij)P(ab)\sum_{me}\big(\lambda^{m,x}_e t^a_i t^e_j t^b_m + \lambda^m_e t^{a,x}_i t^e_j t^b_m + \lambda^m_e t^a_i t^{e,x}_j t^b_m + \lambda^m_e t^a_i t^e_j t^{b,x}_m\big)$ \\
+$\partial_x\Gamma_{abij}$ & $\displaystyle \lambda^{ij,x}_{ab}$ \\
+\end{longtable}
+}
+
+\subsection{Perturbative Triples [CCSD(T)]}
+\label{sec:ccsdt_deriv_pdms}
+
+For CCSD(T) the derivative density is the sum of the CCSD-block responses of
+Tables~\ref{Table:ccsd_deriv_1pdm} and \ref{Table:ccsd_deriv_2pdm} (now evaluated
+with the (T)-relaxed multipliers $\lambda$ and their responses $\lambda^x$) and
+the responses of the (T) increments below.  Writing the first-order responses of
+the connected and disconnected triples as
+$t^{(c)\,abc,x}_{ijk}\equiv\partial_x t^{(c)\,abc}_{ijk}$ and
+$t^{(d)\,abc,x}_{ijk}\equiv\partial_x t^{(d)\,abc}_{ijk}$, with the shorthand
+$(t^{(c)}+t^{(d)})^{abc,x}_{ijk}\equiv t^{(c)\,abc,x}_{ijk}+t^{(d)\,abc,x}_{ijk}$,
+the product rule applied to the increments of Tables~\ref{Table:ccsdt_1pdm} and
+\ref{Table:ccsdt_2pdm} gives Tables~\ref{Table:ccsdt_deriv_1pdm} and
+\ref{Table:ccsdt_deriv_2pdm}.  Only the diagonal of the $oo$/$vv$ one-electron
+responses is retained, as for the parent increments.
+
+\begin{table}[H]
+\caption{Spin-orbital (T) increments to the one-electron derivative density
+$\partial_x D^{(T)}_{pq}$, the product-rule response of
+Table~\ref{Table:ccsdt_1pdm}.}
+\label{Table:ccsdt_deriv_1pdm}
+\renewcommand{\arraystretch}{1.6}
+\begin{center}
+\begin{tabular}{ll}
+\hline\hline
+Block & Algebraic expression \\
+\hline
+$\partial_x D^{(T)}_{ia}$ & $\displaystyle \frac14 \sum_{lm,ef}\big(t^{(c)\,aef,x}_{ilm} t^{ef}_{lm} + t^{(c)\,aef}_{ilm} t^{ef,x}_{lm}\big)$ \\
+$\partial_x D^{(T)}_{ij}$ (diag) & $\displaystyle -\frac{1}{12} \sum_{lm,efg}\big[t^{(c)\,efg,x}_{lmi}(t^{(c)}+t^{(d)})^{efg}_{lmj} + t^{(c)\,efg}_{lmi}(t^{(c)}+t^{(d)})^{efg,x}_{lmj}\big]$ \\
+$\partial_x D^{(T)}_{ab}$ (diag) & $\displaystyle +\frac{1}{12} \sum_{lmn,ef}\big[t^{(c)\,efb,x}_{lmn}(t^{(c)}+t^{(d)})^{efa}_{lmn} + t^{(c)\,efb}_{lmn}(t^{(c)}+t^{(d)})^{efa,x}_{lmn}\big]$ \\
+\hline\hline
+\end{tabular}
+\end{center}
+\end{table}
+
+\begin{table}[H]
+\caption{Spin-orbital (T) increments to the two-electron derivative density
+$\partial_x\Gamma^{(T)}_{pqrs}$, the product-rule response of
+Table~\ref{Table:ccsdt_2pdm} (each block to be multiplied by the overall
+$\frac14$).}
+\label{Table:ccsdt_deriv_2pdm}
+\renewcommand{\arraystretch}{1.6}
+\begin{center}
+\begin{tabular}{ll}
+\hline\hline
+Block & Algebraic expression \\
+\hline
+$\partial_x\Gamma^{(T)}_{ijab}$ & $\displaystyle \sum_{me}\big(t^{(c)\,eab,x}_{mij} t^e_m + t^{(c)\,eab}_{mij} t^{e,x}_m\big)$ \\
+$\partial_x\Gamma^{(T)}_{ijka}$ & $\displaystyle -\frac12 \sum_{mef}\big(t^{(c)\,efa,x}_{mij} t^{ef}_{mk} + t^{(c)\,efa}_{mij} t^{ef,x}_{mk}\big)$ \\
+$\partial_x\Gamma^{(T)}_{ciab}$ & $\displaystyle +\frac12 \sum_{mne}\big(t^{(c)\,eab,x}_{mni} t^{ec}_{mn} + t^{(c)\,eab}_{mni} t^{ec,x}_{mn}\big)$ \\
+$\partial_x\Gamma^{(T)}_{kaij}$ & $\displaystyle -\frac12 \sum_{mef}\big[(t^{(c)}+t^{(d)})^{efa,x}_{mij} t^{ef}_{mk} + (t^{(c)}+t^{(d)})^{efa}_{mij} t^{ef,x}_{mk}\big]$ \\
+$\partial_x\Gamma^{(T)}_{abci}$ & $\displaystyle +\frac12 \sum_{mne}\big[(t^{(c)}+t^{(d)})^{eab,x}_{mni} t^{ec}_{mn} + (t^{(c)}+t^{(d)})^{eab}_{mni} t^{ec,x}_{mn}\big]$ \\
+\hline\hline
+\end{tabular}
+\end{center}
+\end{table}
+
+\subsection{Second-Order M{\o}ller-Plesset Perturbation Theory (MP2)}
+
+The MP2 derivative densities are the first-order limit of the CCSD responses
+($t_i^a\to0$, $\lambda^{ij}_{ab}\to t^{ab}_{ij}$, so $\lambda^{ij,x}_{ab}\to
+t^{ab,x}_{ij}$); only the surviving blocks contribute,
+\begin{align*}
+\partial_x D_{ij} &= -\tfrac12\sum_{mef}\big(t^{ef,x}_{im} t^{ef}_{jm} + t^{ef}_{im} t^{ef,x}_{jm}\big),
+&
+\partial_x D_{ab} &= \tfrac12\sum_{mne}\big(t^{be,x}_{mn} t^{ae}_{mn} + t^{be}_{mn} t^{ae,x}_{mn}\big),
+\\
+\partial_x\Gamma_{ijab} &= t^{ab,x}_{ij}, &
+\partial_x\Gamma_{abij} &= t^{ab,x}_{ij},
+\end{align*}
+with $\partial_x D_{ia}=\partial_x D_{ai}=0$ and all other $\partial_x\Gamma$
+blocks vanishing.  As in the CCSD case the $\Gamma$ responses carry the overall
+$\frac14$; $\partial_x D$ needs no prefactor.
 
 \section{Frozen Core}
 
@@ -588,15 +1721,15 @@ rotations, and to core$\leftrightarrow$core rotations.  It is {\em not}
 invariant to core$\leftrightarrow$active-occupied rotations, however, since
 mixing a frozen core orbital into the active space changes the set of
 correlated excitations.  That block of the MO response therefore requires the
-canonical perturbed-MO treatment of \S5 and \S6.
+canonical perturbed-MO treatment of \S\ref{sec:canon-mo} and \S\ref{sec:cphf-z-canon}.
 
-If one chooses to use canonical perturbed MOs (\S5 and \S6), then the extension
+If one chooses to use canonical perturbed MOs (\S\ref{sec:canon-mo} and \S\ref{sec:cphf-z-canon}), then the extension
 of the gradient expressions above to incorporate the MO response remains unchanged.
 However, if one is using the non-canonical perturbed MO choice of 
 $U^x=-\tfrac12 S^{(x)}$ for the active occ-occ and vir-vir blocks, then one must 
 apply the canonical condition \eqref{eq:canon} to the
 core$\leftrightarrow$active-occupied block using the corresponding
-dependent-pair expression from \S6,
+dependent-pair expression from \S\ref{sec:cphf-z-canon},
 \begin{equation}
 P_{ci} = \frac{X_{ci}}{\varepsilon_c-\varepsilon_i}
 = \frac{I'_{ci}-I'_{ic}}{\varepsilon_c-\varepsilon_i}
@@ -604,7 +1737,7 @@ P_{ci} = \frac{X_{ci}}{\varepsilon_c-\varepsilon_i}
 \label{eq:Pco}
 \end{equation}
 the restriction of Eq.~\eqref{eq:canon-oo} to $(c,i)$ pairs.  It enters the
-relaxed density as the occupied dependent-pair of \S6 does,
+relaxed density as the occupied dependent pair of \S\ref{sec:cphf-z-canon} does,
 \begin{equation}
 \tilde{D}_{ci}=\tilde{D}_{ic}=P_{ci},
 \end{equation}
@@ -617,9 +1750,9 @@ to the core-core block; and (2) the occupied$\leftrightarrow$virtual orbital
 response (the Z-vector) now spans the {\em full} occupied space, core plus active,
 because the core orbitals relax against the virtuals.
 
-Nothing in \S5--\S6 is specific to a particular method or to the all-electron
-case.  The occupied dependent-pair is defined over the entire occupied space and
-the virtual dependent-pair over the entire virtual space, and each block is
+Nothing in \S\ref{sec:canon-mo}--\S\ref{sec:cphf-z-canon} is specific to a particular method or to the all-electron
+case.  The occupied dependent pair is defined over the entire occupied space and
+the virtual dependent pair over the entire virtual space, and each block is
 populated only where the energy fails to be invariant, its antisymmetric
 numerator $X_{pq}=I'_{pq}-I'_{qp}$ vanishing elsewhere.  
 
@@ -659,6 +1792,12 @@ K. Hald, A. Halkier, P. J{\o}rgensen, S. Coriani, and T. Helgaker, \textit{J.
   Chem. Phys.}, {\bf 118},  2985-2998  (2003).
 A Lagrangian, integral-density direct formulation and implementation of the
   analytic CCSD and CCSD(T) gradients.
+
+\bibitem{Stanton97}
+J. F. Stanton and J. Gauss in
+\textit{Recent Advances in Coupled-Cluster Methods}, R. J. Bartlett, ed. World Scientific Publishing, Singapore,
+1997, pp. 49-79.
+Analytic evaluation of second derivatives of the energy: Computational strategies for the CCSD and CCSD(T) approximations.
 
 \end{thebibliography}
 

--- a/docs/cc_gradients_orbital_response.tex
+++ b/docs/cc_gradients_orbital_response.tex
@@ -1462,6 +1462,25 @@ S^{ab}_{ij} &= \tfrac12 P(ab)\!\sum_{m,ef}\!\big(2t^{(c)}+t^{(d)}\big)^{aef}_{ij
 \label{eq:S2}
 \end{align}
 
+For a second derivative (\S\ref{sec:second-derivs}) the perturbed multipliers
+$\lambda^{i,x}_a$, $\lambda^{ij,x}_{ab}$ solve the perturbed $\Lambda$ equations,
+whose inhomogeneity carries the field derivatives $\partial_x S^a_i$,
+$\partial_x S^{ab}_{ij}$ of these sources (Eqs.~\eqref{eq:S1}--\eqref{eq:S2} with the
+triples amplitudes and integrals replaced by their first-order responses).  The
+perturbed sources must enter the perturbed $\Lambda$ residual in \emph{exactly} the
+same way as $S^a_i$, $S^{ab}_{ij}$ enter the unperturbed one.  This is subtle in the
+spin-adapted (closed-shell) formulation, where the doubles residual is evaluated in a
+half-permuted form and completed by a final $\lambda^{ij}_{ab}\!\leftarrow\!
+\lambda^{ij}_{ab}+\lambda^{ji}_{ba}$ symmetrization: because $S^{ab}_{ij}$ is added
+\emph{before} that step, its perturbed counterpart $\partial_x S^{ab}_{ij}$ must be
+symmetrized identically.  Adding it afterward leaves the perturbed $\Lambda_2$
+carrying the \emph{unperturbed} permuted source, $P(ij)P(ab)\,S^{ab}_{ij}$ instead of
+$P(ij)P(ab)\,\partial_x S^{ab}_{ij}$; the error is invisible to the gradient but
+corrupts the near-degenerate $vv$/$oo$ dependent-pair rotations of the perturbed
+relaxed density (and hence the polarizability).  In the implementation the (T) source
+is therefore passed into the one Lambda-residual routine that both the unperturbed and
+perturbed solves share, so the half-permutation is applied once, consistently.
+
 The (T) increments themselves are collected in Tables~\ref{Table:ccsdt_1pdm}
 (one-electron) and \ref{Table:ccsdt_2pdm} (two-electron).  As with CCSD, the
 one-electron increments carry no prefactor while the two-electron increments are

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -391,25 +391,21 @@ class CCderiv:
         The reference (SCF) polarizability is kept separate (:meth:`HFwfn.polarizability`); the
         :func:`pycc.polarizability` facade sums nuclear (zero) + reference + this correlation part.
 
-        Spatial closed-shell RHF and spin-orbital UHF CCSD (all-electron and frozen core), and
-        spin-orbital CCSD(T) (all-electron and frozen core); spatial CCSD(T) to follow.  CCSD is
-        validated against a tight finite field of :meth:`relaxed_dipole` and the SO == spatial
-        keystone; CCSD(T) against the energy second-derivative finite field."""
+        Spatial closed-shell RHF and spin-orbital UHF, CCSD and CCSD(T), all-electron and frozen
+        core.  CCSD is validated against a tight finite field of :meth:`relaxed_dipole` and the
+        SO == spatial keystone; CCSD(T) against the energy second-derivative finite field and the
+        SO == spatial keystone (SO CCSD(T) itself matched to CFOUR)."""
         if route != '2n+1':
             raise ValueError(f"CC polarizability supports only the asymmetric '2n+1' route, not {route!r}.")
         cc = self.ccwfn
         if cc.model.upper() not in ('CCSD', 'CCSD(T)'):
             raise NotImplementedError(f"CC polarizability: only CCSD and CCSD(T) are implemented (not {cc.model}).")
         is_t = cc.model.upper() == 'CCSD(T)'
+        if is_t and not hasattr(cc, 'S1'):
+            raise ValueError("CCSD(T) polarizability requires the (T) density intermediates; "
+                             "build the wavefunction with make_t3_density=True.")
         if cc.orbital_basis == 'spinorbital':
-            if is_t and not hasattr(cc, 'S1'):
-                raise ValueError("CCSD(T) polarizability requires the (T) density intermediates; "
-                                 "build the wavefunction with make_t3_density=True.")
             return self._so_polarizability()
-        if is_t:
-            raise NotImplementedError("Spatial CCSD(T) polarizability is not yet available "
-                                      "(the spatial (T) perturbed response is under development); "
-                                      "use orbital_basis='spinorbital'.")
         from .cchbar import cchbar
         from .cclambda import cclambda
         from .ccdensity import ccdensity
@@ -457,7 +453,7 @@ class CCderiv:
         for b in range(3):
             pert = Perturbation('field', b)
             dDrel = self._perturbed_relaxed_density(pert, hbar, lam, D0, Gam0, z, Pco, Poo0, Pvv0)
-            Ub = np.asarray(cphf._full_U(pert, ncore, canonical=(is_t or getattr(self, '_DBG_FORCE_CANON', False))))
+            Ub = np.asarray(cphf._full_U(pert, ncore, canonical=is_t))
             for a in range(3):
                 rot = Ub.T @ mu[a] + mu[a] @ Ub
                 alpha[a, b] = c('pq,pq->', dDrel, mu[a]) + c('pq,pq->', Drel, rot)
@@ -546,7 +542,7 @@ class CCderiv:
         L = np.asarray(cc.H.L)
         eps = np.diag(np.asarray(cc.H.F))
         is_t = cc.model.upper() == 'CCSD(T)'
-        canon = is_t or getattr(self, '_DBG_FORCE_CANON', False)
+        canon = is_t                                    # (T) needs canonical perturbed orbitals
         cphf = cc.mp._full_occ_cphf()
         df = np.asarray(cphf.perturbed_fock(pert, ncore, canonical=canon))
         deri = np.asarray(cphf.perturbed_eri(pert, ncore, canonical=canon))
@@ -570,33 +566,11 @@ class CCderiv:
                        + c('jc,ajic->ia', zjc, dL[v, o, ofull, co]) + c('jc,acij->ia', zjc, dL[v, co, ofull, o]))
         dPoo = dPvv = None
         if is_t:                                        # perturbed (T) oo/vv dependent-pairs
-            dfd = np.zeros(cc.nmo) if getattr(self, '_DBG_NO_DGAP', False) else np.diag(df)
-            thr = getattr(self, '_DBG_GAP_THRESH', 1e-8)
-            dPoo = self._perturbed_dependent_pairs(dIp[o, o], Poo0, eps[o], dfd[o], thr)
-            dPvv = self._perturbed_dependent_pairs(dIp[v, v], Pvv0, eps[v], dfd[v], thr)
-            if getattr(self, '_DBG', False):
-                cc_ = self.ccwfn
-                F0d = np.asarray(cc_.H.F).copy(); ERI0d = np.asarray(cc_.H.ERI).copy(); L0d = np.asarray(cc_.H.L).copy()
-                hh = 1e-3
-                def lag_at(s):
-                    cc_.H.F = F0d + s*hh*df; cc_.H.ERI = ERI0d + s*hh*deri; cc_.H.L = L0d + s*hh*dL
-                    return np.asarray(self._lagrangian(D0 + s*hh*dDg, Gam0 + s*hh*dGam))
-                try:
-                    sdip = (lag_at(-2) - 8*lag_at(-1) + 8*lag_at(1) - lag_at(2)) / (12*hh)
-                finally:
-                    cc_.H.F = F0d; cc_.H.ERI = ERI0d; cc_.H.L = L0d
-                go = eps[o][:, None] - eps[o][None, :]; gv = eps[v][:, None] - eps[v][None, :]
-                print('  dIp[o,o] a-vs-sten %.2e  dIp[v,v] %.2e | max|dPoo| %.2e max|dPvv| %.2e | '
-                      'mingap_oo %.2e mingap_vv %.2e'
-                      % (np.max(np.abs(dIp[o, o]-sdip[o, o])), np.max(np.abs(dIp[v, v]-sdip[v, v])),
-                         np.max(np.abs(dPoo)), np.max(np.abs(dPvv)),
-                         np.min(np.abs(go[~np.eye(go.shape[0], dtype=bool)])),
-                         np.min(np.abs(gv[~np.eye(gv.shape[0], dtype=bool)]))))
-            if getattr(self, '_DBG_NO_DEPPAIR', False):  # DEBUG isolation
-                dPoo = np.zeros_like(dPoo); dPvv = np.zeros_like(dPvv)
-            else:
-                dX = dX + (c('kl,akil->ia', dPoo, L[v, o, ofull, o]) + c('kl,akil->ia', Poo0, dL[v, o, ofull, o])
-                           + c('bc,ibac->ia', dPvv, L[ofull, v, v, v]) + c('bc,ibac->ia', Pvv0, dL[ofull, v, v, v]))
+            dfd = np.diag(df)                           # canonical df diagonal = the perturbed gaps
+            dPoo = self._perturbed_dependent_pairs(dIp[o, o], Poo0, eps[o], dfd[o])
+            dPvv = self._perturbed_dependent_pairs(dIp[v, v], Pvv0, eps[v], dfd[v])
+            dX = dX + (c('kl,akil->ia', dPoo, L[v, o, ofull, o]) + c('kl,akil->ia', Poo0, dL[v, o, ofull, o])
+                       + c('bc,ibac->ia', dPvv, L[ofull, v, v, v]) + c('bc,ibac->ia', Pvv0, dL[ofull, v, v, v]))
         # perturbed orbital-Hessian response (A^x z); reference-only, as in MP2
         Axz = (c('ajib,jb->ia', dL[v, ofull, ofull, v], z) + c('abij,jb->ia', dL[v, v, ofull, ofull], z)
                + c('ab,ib->ia', df[v, v], z) - c('ij,ja->ia', df[ofull, ofull], z))
@@ -633,7 +607,7 @@ class CCderiv:
         ERI = np.asarray(cc.H.ERI)
         eps = np.diag(np.asarray(cc.H.F))
         is_t = cc.model.upper() == 'CCSD(T)'
-        canon = is_t or getattr(self, '_DBG_FORCE_CANON', False)
+        canon = is_t                                    # (T) needs canonical perturbed orbitals
         cphf = cc.mp._full_occ_cphf()
         df = np.asarray(cphf.perturbed_fock(pert, ncore, canonical=canon))
         deri = np.asarray(cphf.perturbed_eri(pert, ncore, canonical=canon))
@@ -655,15 +629,11 @@ class CCderiv:
                        + c('jc,ajic->ia', zjc, deri[v, o, ofull, co]) + c('jc,acij->ia', zjc, deri[v, co, ofull, o]))
         dPoo = dPvv = None
         if is_t:                                        # perturbed (T) oo/vv dependent-pairs
-            dfd = np.zeros(cc.nmo) if getattr(self, '_DBG_NO_DGAP', False) else np.diag(df)
-            thr = getattr(self, '_DBG_GAP_THRESH', 1e-8)
-            dPoo = self._perturbed_dependent_pairs(dIp[o, o], Poo0, eps[o], dfd[o], thr)
-            dPvv = self._perturbed_dependent_pairs(dIp[v, v], Pvv0, eps[v], dfd[v], thr)
-            if getattr(self, '_DBG_NO_DEPPAIR', False):  # DEBUG isolation
-                dPoo = np.zeros_like(dPoo); dPvv = np.zeros_like(dPvv)
-            else:
-                dX = dX + (c('kl,akil->ia', dPoo, ERI[v, o, ofull, o]) + c('kl,akil->ia', Poo0, deri[v, o, ofull, o])
-                           + c('bc,ibac->ia', dPvv, ERI[ofull, v, v, v]) + c('bc,ibac->ia', Pvv0, deri[ofull, v, v, v]))
+            dfd = np.diag(df)                           # canonical df diagonal = the perturbed gaps
+            dPoo = self._perturbed_dependent_pairs(dIp[o, o], Poo0, eps[o], dfd[o])
+            dPvv = self._perturbed_dependent_pairs(dIp[v, v], Pvv0, eps[v], dfd[v])
+            dX = dX + (c('kl,akil->ia', dPoo, ERI[v, o, ofull, o]) + c('kl,akil->ia', Poo0, deri[v, o, ofull, o])
+                       + c('bc,ibac->ia', dPvv, ERI[ofull, v, v, v]) + c('bc,ibac->ia', Pvv0, deri[ofull, v, v, v]))
         Axz = (c('ajib,jb->ia', deri[v, ofull, ofull, v], z) + c('abij,jb->ia', deri[v, v, ofull, ofull], z)
                + c('ab,ib->ia', df[v, v], z) - c('ij,ja->ia', df[ofull, ofull], z))
         zx = np.linalg.solve(G, (dX - Axz).reshape(-1)).reshape(nof, nv)
@@ -790,74 +760,12 @@ class CCderiv:
             X1, X2 = diis.extrapolate(X1, X2)
         return X1, X2
 
-    def _hbar_blocks(self, hbar, F, ERI, L, t1, t2):
-        """All (spatial CCSD) HBAR blocks built from explicit integrals/amplitudes -- the
-        :meth:`cchbar._build` sequence with supplied arguments (no wavefunction-state mutation).
-        Used by :meth:`_perturbed_hbar` for the exact stencil."""
-        o, v = self.ccwfn.o, self.ccwfn.v
-        Hov = hbar.build_Hov(o, v, F, L, t1)
-        Hvv = hbar.build_Hvv(o, v, F, L, t1, t2)
-        Hoo = hbar.build_Hoo(o, v, F, L, t1, t2)
-        Hoooo = hbar.build_Hoooo(o, v, ERI, t1, t2)
-        Hvvvv = hbar.build_Hvvvv(o, v, ERI, t1, t2)
-        Hvovv = hbar.build_Hvovv(o, v, ERI, t1)
-        Hooov = hbar.build_Hooov(o, v, ERI, t1)
-        Hovvo = hbar.build_Hovvo(o, v, ERI, L, t1, t2)
-        Hovov = hbar.build_Hovov(o, v, ERI, t1, t2)
-        Hvvvo = hbar.build_Hvvvo(o, v, ERI, L, Hov, Hvvvv, t1, t2)
-        Hovoo = hbar.build_Hovoo(o, v, ERI, L, Hov, Hoooo, t1, t2)
-        return {'Hov': Hov, 'Hvv': Hvv, 'Hoo': Hoo, 'Hoooo': Hoooo, 'Hvvvv': Hvvvv,
-                'Hvovv': Hvovv, 'Hooov': Hooov, 'Hovvo': Hovvo, 'Hovov': Hovov,
-                'Hvvvo': Hvvvo, 'Hovoo': Hovoo}
-
-    def _so_hbar_blocks(self, hbar, F, ERI, t1, t2):
-        """Spin-orbital HBAR blocks from explicit integrals/amplitudes (the ``cchbar._so_build``
-        sequence -- no Hovov; Hvvvo/Hovoo via the Zovov intermediate)."""
-        o, v = self.ccwfn.o, self.ccwfn.v
-        Hov = hbar._so_build_Hov(o, v, F, ERI, t1)
-        Hvv = hbar._so_build_Hvv(o, v, F, ERI, Hov, t1, t2)
-        Hoo = hbar._so_build_Hoo(o, v, F, ERI, Hov, t1, t2)
-        Hoooo = hbar._so_build_Hoooo(o, v, ERI, t1, t2)
-        Hvvvv = hbar._so_build_Hvvvv(o, v, ERI, t1, t2)
-        Hvovv = hbar._so_build_Hvovv(o, v, ERI, t1)
-        Hooov = hbar._so_build_Hooov(o, v, ERI, t1)
-        Hovvo = hbar._so_build_Hovvo(o, v, ERI, t1, t2)
-        Zovov = hbar._so_build_Zovov(o, v, ERI, t2)
-        Hvvvo = hbar._so_build_Hvvvo(o, v, ERI, Hov, Hvvvv, Zovov, t1, t2)
-        Hovoo = hbar._so_build_Hovoo(o, v, ERI, Hov, Hoooo, Zovov, t1, t2)
-        return {'Hov': Hov, 'Hvv': Hvv, 'Hoo': Hoo, 'Hoooo': Hoooo, 'Hvvvv': Hvvvv,
-                'Hvovv': Hvovv, 'Hooov': Hooov, 'Hovvo': Hovvo, 'Hvvvo': Hvvvo, 'Hovoo': Hovoo}
-
     def _perturbed_hbar(self, df, deri, dL, dt1, dt2, hbar):
-        """Spatial perturbed HBAR ``dHBAR``.  Analytic (product rule of the ``build_H*`` blocks,
-        :meth:`_perturbed_hbar_analytic`) by default; the exact 5-point stencil is kept behind
-        ``_DBG_FORCE_STENCIL_HBAR`` as an oracle.  Both are exact for CCSD (the analytic form was
-        verified to ~1e-15 against a complex-step derivative of :meth:`_hbar_blocks`).  Needed only
-        for the perturbed-Lambda inhomogeneity."""
-        if getattr(self, '_DBG_FORCE_STENCIL_HBAR', False):
-            return self._perturbed_hbar_stencil(df, deri, dL, dt1, dt2, hbar)
-        return self._perturbed_hbar_analytic(df, deri, dL, dt1, dt2, hbar)
-
-    def _perturbed_hbar_stencil(self, df, deri, dL, dt1, dt2, hbar):
-        """Spatial perturbed HBAR via the exact 5-point central stencil of the block builders at
-        ``(F +- h df, ERI +- h deri, L +- h dL, t +- h dt)`` (degree-<=4 blocks)."""
-        cc = self.ccwfn
-        F0 = np.asarray(cc.H.F); ERI0 = np.asarray(cc.H.ERI); L0 = np.asarray(cc.H.L)
-        t01 = np.asarray(cc.t1); t02 = np.asarray(cc.t2)
-        h = 1e-2
-        def at(s):
-            return self._hbar_blocks(hbar, F0 + s*h*df, ERI0 + s*h*deri, L0 + s*h*dL,
-                                     t01 + s*h*dt1, t02 + s*h*dt2)
-        m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
-        return {k: (np.asarray(m2[k]) - 8.0*np.asarray(m1[k]) + 8.0*np.asarray(p1[k])
-                    - np.asarray(p2[k])) / (12.0*h) for k in m2}
-
-    def _perturbed_hbar_analytic(self, df, deri, dL, dt1, dt2, hbar):
-        """Analytic spatial (closed-shell RHF) perturbed HBAR ``dHBAR``: the term-by-term
-        product-rule derivative of the :meth:`cchbar.build_H*` builders along
+        """Spatial (closed-shell RHF) perturbed HBAR ``dHBAR``: the term-by-term product-rule
+        derivative of the :meth:`cchbar.build_H*` builders along
         ``(F+df, ERI+deri, L+dL, t1+dt1, t2+dt2)``.  Computed in dependency order (``Hov``,
-        ``Hvvvv``, ``Hoooo`` feed ``Hvvvo``/``Hovoo``).  Verified to ~1e-15 against a complex-step
-        derivative of :meth:`_hbar_blocks`."""
+        ``Hvvvv``, ``Hoooo`` feed ``Hvvvo``/``Hovoo``).  Needed for the perturbed-Lambda
+        inhomogeneity; verified to ~1e-15 against a complex-step derivative of the HBAR builders."""
         cc = self.ccwfn
         o, v = cc.o, cc.v
         c = self.contract
@@ -927,32 +835,11 @@ class CCderiv:
         return d
 
     def _so_perturbed_hbar(self, df, deri, dt1, dt2, hbar):
-        """Spin-orbital perturbed HBAR ``dHBAR``.  Analytic (product rule of the ``_so_build_*``
-        blocks, :meth:`_so_perturbed_hbar_analytic`) by default; the exact 5-point stencil is kept
-        behind ``_DBG_FORCE_STENCIL_HBAR`` as an oracle.  Both are exact for CCSD (the analytic form
-        was verified to ~1e-15 against a complex-step derivative of :meth:`_so_hbar_blocks`)."""
-        if getattr(self, '_DBG_FORCE_STENCIL_HBAR', False):
-            return self._so_perturbed_hbar_stencil(df, deri, dt1, dt2, hbar)
-        return self._so_perturbed_hbar_analytic(df, deri, dt1, dt2, hbar)
-
-    def _so_perturbed_hbar_stencil(self, df, deri, dt1, dt2, hbar):
-        """Spin-orbital perturbed HBAR via the exact 5-point stencil (degree-<=4 blocks)."""
-        cc = self.ccwfn
-        F0 = np.asarray(cc.H.F); ERI0 = np.asarray(cc.H.ERI)
-        t01 = np.asarray(cc.t1); t02 = np.asarray(cc.t2)
-        h = 1e-2
-        def at(s):
-            return self._so_hbar_blocks(hbar, F0 + s*h*df, ERI0 + s*h*deri, t01 + s*h*dt1, t02 + s*h*dt2)
-        m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
-        return {k: (np.asarray(m2[k]) - 8.0*np.asarray(m1[k]) + 8.0*np.asarray(p1[k])
-                    - np.asarray(p2[k])) / (12.0*h) for k in m2}
-
-    def _so_perturbed_hbar_analytic(self, df, deri, dt1, dt2, hbar):
-        """Analytic spin-orbital perturbed HBAR ``dHBAR``: the term-by-term product-rule derivative
+        """Spin-orbital perturbed HBAR ``dHBAR``: the term-by-term product-rule derivative
         of the :meth:`cchbar._so_build_*` block builders along ``(F+df, ERI+deri, t1+dt1, t2+dt2)``.
         Blocks are computed in dependency order (``Hov`` first; ``Hvvvo``/``Hovoo`` last, reusing the
         unperturbed ``Hov``/``Hvvvv``/``Hoooo``/``Zovov`` intermediates).  Verified to ~1e-15 against
-        a complex-step derivative of :meth:`_so_hbar_blocks`."""
+        a complex-step derivative of the ``_so_build_*`` builders."""
         cc = self.ccwfn
         o, v = cc.o, cc.v
         c = self.contract
@@ -1022,50 +909,29 @@ class CCderiv:
                - c('je,mbie->mbij', dt1, Zovov0) - c('je,mbie->mbij', t1, dZovov)))
         return d
 
-    def _perturbed_t3_intermediates(self, df, deri, dL, dt1, dt2, h=1e-3):
-        """Field response of the (T) intermediates ``d{Doo,Dvv,Dov,Goovv,Gooov,Gvvvo,S1,S2}/dF``
-        via a 5-point central stencil of :func:`cctriples.t3_density` along the **canonical** field
-        path ``(t1 +- h dt1, t2 +- h dt2, F0 +- h df, ERI +- h deri, L +- h dL)``.  ``df`` MUST be
-        the canonical perturbed Fock (``perturbed_fock(..., canonical=True)``, diagonal in oo/vv), so
-        the batched diagonal-denominator (T) formula stays valid at every displacement.
-
-        Unlike the HBAR stencil (:meth:`_perturbed_hbar`, polynomial -> algebraically exact), the (T)
-        intermediates are *rational* in the step (the ``1/D`` energy denominator), so this is only
-        ``O(h^4)`` -- the stencil-first validation crutch; the analytic ``dt3 = (dN - t3 dD)/D`` route
-        (batched ``t3c_ijk`` etc.) replaces it for production."""
+    def _perturbed_t3_intermediates(self, df, deri, dL, dt1, dt2):
+        """Field response of the (T) intermediates ``d{Doo,Dvv,Dov,Goovv,Gooov,Gvvvo,S1,S2}/dF``: the
+        analytic product-rule derivative ``dt3 = (dN - t3 dD)/D`` (:func:`cctriples.dt3_density`) along
+        the **canonical** field path ``(t1+dt1, t2+dt2, F+df, ERI+deri, L+dL)``.  ``df`` MUST be the
+        canonical perturbed Fock (``perturbed_fock(..., canonical=True)``, diagonal in oo/vv) so the
+        batched diagonal-denominator (T) formula stays valid."""
         from . import cctriples
         cc = self.ccwfn
         o, v, no, nv = cc.o, cc.v, cc.no, cc.nv
         F0 = np.asarray(cc.H.F); ERI0 = np.asarray(cc.H.ERI); L0 = np.asarray(cc.H.L)
         t01 = np.asarray(cc.t1); t02 = np.asarray(cc.t2)
-        if not getattr(self, '_DBG_FORCE_STENCIL_T3', False):   # analytic (product rule); no stencil
-            return cctriples.dt3_density(o, v, no, nv, t01, t02, dt1, dt2, F0, df, ERI0, deri, L0, dL, self.contract)
-        def at(s):
-            _, d = cctriples.t3_density(o, v, no, nv, t01 + s*h*dt1, t02 + s*h*dt2,
-                                        F0 + s*h*df, ERI0 + s*h*deri, L0 + s*h*dL, self.contract)
-            return d
-        m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
-        return {k: (np.asarray(m2[k]) - 8.0*np.asarray(m1[k]) + 8.0*np.asarray(p1[k])
-                    - np.asarray(p2[k])) / (12.0*h) for k in m2}
+        return cctriples.dt3_density(o, v, no, nv, t01, t02, dt1, dt2, F0, df, ERI0, deri, L0, dL, self.contract)
 
-    def _so_perturbed_t3_intermediates(self, df, deri, dt1, dt2, h=1e-3):
-        """Spin-orbital field response of the (T) intermediates via the 5-point stencil of
-        :func:`cctriples.so_t3_density` along the canonical path (no ``L``).  O(h^4); see
+    def _so_perturbed_t3_intermediates(self, df, deri, dt1, dt2):
+        """Spin-orbital field response of the (T) intermediates: the analytic product-rule derivative
+        :func:`cctriples.so_dt3_density` along the canonical path (no ``L``); see
         :meth:`_perturbed_t3_intermediates`."""
         from . import cctriples
         cc = self.ccwfn
         o, v, no, nv = cc.o, cc.v, cc.no, cc.nv
         F0 = np.asarray(cc.H.F); ERI0 = np.asarray(cc.H.ERI)
         t01 = np.asarray(cc.t1); t02 = np.asarray(cc.t2)
-        if not getattr(self, '_DBG_FORCE_STENCIL_T3', False):   # analytic (product rule); no stencil
-            return cctriples.so_dt3_density(o, v, no, nv, t01, t02, dt1, dt2, F0, df, ERI0, deri, self.contract)
-        def at(s):
-            _, d = cctriples.so_t3_density(o, v, no, nv, t01 + s*h*dt1, t02 + s*h*dt2,
-                                           F0 + s*h*df, ERI0 + s*h*deri, self.contract)
-            return d
-        m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
-        return {k: (np.asarray(m2[k]) - 8.0*np.asarray(m1[k]) + 8.0*np.asarray(p1[k])
-                    - np.asarray(p2[k])) / (12.0*h) for k in m2}
+        return cctriples.so_dt3_density(o, v, no, nv, t01, t02, dt1, dt2, F0, df, ERI0, deri, self.contract)
 
     def _perturbed_lambda(self, df, deri, dL, dt1, dt2, hbar, lam, dS1=None, dS2=None, maxiter=200, rconv=1e-13):
         """Perturbed Lambda ``dLambda/dF`` (iterative, linear), staying in ``cclambda`` (no
@@ -1074,9 +940,10 @@ class CCderiv:
         action is ``r_L(dLambda) - r_L(0)`` (``r_L`` is affine in Lambda).  Iterate
         ``dLambda += (B + Jacobian)/D`` like :meth:`cclambda.solve_lambda`.
 
-        CCSD(T): ``r_L1``/``r_L2`` add the cached (T) source ``cc.S1``/``0.5 cc.S2`` (constants in
-        Lambda), so the inhomogeneity ``B`` picks up the *unperturbed* ``S1``/``0.5 S2`` -- replace
-        them with the perturbed ``dS1``/``0.5 dS2`` (from :meth:`_perturbed_t3_intermediates`)."""
+        CCSD(T): the perturbed (T) sources ``dS1``/``dS2`` (from :meth:`_perturbed_t3_intermediates`)
+        are passed straight into ``r_L1``/``r_L2`` via their ``s1``/``s2`` arguments, so they thread
+        through the same residual construction and P_ij^ab symmetrization as the unperturbed
+        ``cc.S1``/``cc.S2`` do in :meth:`cclambda.solve_lambda` -- no separate correction needed."""
         from .utils import helper_diis
         cc = self.ccwfn
         o, v = cc.o, cc.v
@@ -1086,29 +953,26 @@ class CCderiv:
         t2 = np.asarray(cc.t2)
         L0 = np.asarray(cc.H.L)
 
-        def rL1(La, Lb, H, Gvv, Goo):
+        def rL1(La, Lb, H, Gvv, Goo, s1=None):
             return np.asarray(lam.r_L1(o, v, La, Lb, H['Hov'], H['Hvv'], H['Hoo'], H['Hovvo'],
-                                       H['Hovov'], H['Hvvvo'], H['Hovoo'], H['Hvovv'], H['Hooov'], Gvv, Goo))
-        def rL2(La, Lb, Ld, H, Gvv, Goo):
+                                       H['Hovov'], H['Hvvvo'], H['Hovoo'], H['Hvovv'], H['Hooov'], Gvv, Goo, s1=s1))
+        def rL2(La, Lb, Ld, H, Gvv, Goo, s2=None):
             return np.asarray(lam.r_L2(o, v, La, Lb, Ld, H['Hov'], H['Hvv'], H['Hoo'], H['Hoooo'],
                                        H['Hvvvv'], H['Hovvo'], H['Hovov'], H['Hvvvo'], H['Hovoo'],
-                                       H['Hvovv'], H['Hooov'], Gvv, Goo))
+                                       H['Hvovv'], H['Hooov'], Gvv, Goo, s2=s2))
 
         dH = self._perturbed_hbar(df, deri, dL, dt1, dt2, hbar)
         H0 = {b: np.asarray(getattr(hbar, b)) for b in self._HBAR_BLOCKS}
         Goo0 = np.asarray(lam.build_Goo(t2, l2)); Gvv0 = np.asarray(lam.build_Gvv(t2, l2))
         dGoo = np.asarray(lam.build_Goo(dt2, l2)); dGvv = np.asarray(lam.build_Gvv(dt2, l2))  # l2 fixed
-        B1 = rL1(l1, l2, dH, Gvv0, Goo0)
-        B2 = rL2(l1, l2, dL, dH, Gvv0, Goo0)
+        B1 = rL1(l1, l2, dH, Gvv0, Goo0, s1=dS1)        # (T): dS1/dS2 thread through r_L1/r_L2 exactly
+        B2 = rL2(l1, l2, dL, dH, Gvv0, Goo0, s2=dS2)    # as cc.S1/cc.S2 do unperturbed (None for CCSD)
         Hvovv0, Hooov0 = H0['Hvovv'], H0['Hooov']
         c1 = -2.0*c('ef,eifa->ia', dGvv, Hvovv0) + c('ef,eiaf->ia', dGvv, Hvovv0)
         c1 += -2.0*c('mn,mina->ia', dGoo, Hooov0) + c('mn,imna->ia', dGoo, Hooov0)
         c2p = c('ae,ijeb->ijab', dGvv, L0[o, o, v, v]) - c('mi,mjab->ijab', dGoo, L0[o, o, v, v])
         B1 = B1 + c1
         B2 = B2 + (c2p + c2p.swapaxes(0, 1).swapaxes(2, 3))
-        if dS1 is not None:                             # (T): swap the cached S1/0.5 S2 for dS1/0.5 dS2
-            B1 = B1 + (dS1 - np.asarray(cc.S1))
-            B2 = B2 + 0.5 * (dS2 - np.asarray(cc.S2))
         zl1 = np.zeros_like(l1); zl2 = np.zeros_like(l2)
         zGvv = np.zeros_like(Gvv0); zGoo = np.zeros_like(Goo0)
         rL1_0 = rL1(zl1, zl2, H0, zGvv, zGoo)           # = 2*Hov (the Lambda-independent constant)
@@ -1133,8 +997,10 @@ class CCderiv:
         """Spin-orbital perturbed Lambda ``dLambda/dF`` (SO r_L; inhomogeneity = r_L with perturbed
         HBAR + perturbed ERI, unperturbed G, plus the dG.H / dG.<pq||rs> product-rule halves).
 
-        CCSD(T): the SO ``r_L1``/``r_L2`` add ``cc.S1``/``cc.S2`` (no 1/2 on S2, unlike the spatial
-        path), so replace the cached ``S1``/``S2`` in ``B`` with the perturbed ``dS1``/``dS2``."""
+        CCSD(T): the perturbed (T) sources ``dS1``/``dS2`` are passed straight into the SO
+        ``_so_r_L1``/``_so_r_L2`` via their ``s1``/``s2`` arguments (no 1/2 on S2, unlike the spatial
+        path), so they thread through the same residual construction as ``cc.S1``/``cc.S2`` do
+        unperturbed -- no separate correction needed."""
         from .utils import helper_diis
         cc = self.ccwfn
         o, v = cc.o, cc.v
@@ -1144,28 +1010,25 @@ class CCderiv:
         t2 = np.asarray(cc.t2)
         ERI0 = np.asarray(cc.H.ERI)
 
-        def rL1(La, Lb, H, Gvv, Goo):
+        def rL1(La, Lb, H, Gvv, Goo, s1=None):
             return np.asarray(lam._so_r_L1(o, v, La, Lb, H['Hov'], H['Hvv'], H['Hoo'], H['Hovvo'],
-                                           H['Hvvvo'], H['Hovoo'], H['Hvovv'], H['Hooov'], Gvv, Goo))
-        def rL2(La, Lb, E, H, Gvv, Goo):
+                                           H['Hvvvo'], H['Hovoo'], H['Hvovv'], H['Hooov'], Gvv, Goo, s1=s1))
+        def rL2(La, Lb, E, H, Gvv, Goo, s2=None):
             return np.asarray(lam._so_r_L2(o, v, La, Lb, E, H['Hov'], H['Hvv'], H['Hoo'], H['Hoooo'],
                                            H['Hvvvv'], H['Hovvo'], H['Hvvvo'], H['Hovoo'], H['Hvovv'],
-                                           H['Hooov'], Gvv, Goo))
+                                           H['Hooov'], Gvv, Goo, s2=s2))
 
         dH = self._so_perturbed_hbar(df, deri, dt1, dt2, hbar)
         H0 = {b: np.asarray(getattr(hbar, b)) for b in self._SO_HBAR_BLOCKS}
         Goo0 = np.asarray(lam.build_Goo(t2, l2)); Gvv0 = np.asarray(lam.build_Gvv(t2, l2))
         dGoo = np.asarray(lam.build_Goo(dt2, l2)); dGvv = np.asarray(lam.build_Gvv(dt2, l2))  # l2 fixed
-        B1 = rL1(l1, l2, dH, Gvv0, Goo0)
-        B2 = rL2(l1, l2, deri, dH, Gvv0, Goo0)
+        B1 = rL1(l1, l2, dH, Gvv0, Goo0, s1=dS1)        # (T): dS1/dS2 thread through _so_r_L1/_so_r_L2
+        B2 = rL2(l1, l2, deri, dH, Gvv0, Goo0, s2=dS2)  # exactly as cc.S1/cc.S2 do (None for CCSD)
         Hvovv0, Hooov0 = H0['Hvovv'], H0['Hooov']
         B1 = B1 - c('ef,eifa->ia', dGvv, Hvovv0) - c('mn,mina->ia', dGoo, Hooov0)
         oovv = ERI0[o, o, v, v]
         B2 = B2 + (c('be,ijae->ijab', dGvv, oovv) - c('ae,ijbe->ijab', dGvv, oovv)) \
                 - (c('mj,imab->ijab', dGoo, oovv) - c('mi,jmab->ijab', dGoo, oovv))
-        if dS1 is not None:                             # (T): swap the cached S1/S2 for dS1/dS2 (SO: no 1/2)
-            B1 = B1 + (dS1 - np.asarray(cc.S1))
-            B2 = B2 + (dS2 - np.asarray(cc.S2))
         zl1 = np.zeros_like(l1); zl2 = np.zeros_like(l2)
         zGvv = np.zeros_like(Gvv0); zGoo = np.zeros_like(Goo0)
         rL1_0 = rL1(zl1, zl2, H0, zGvv, zGoo)
@@ -1185,58 +1048,17 @@ class CCderiv:
             dl1, dl2 = diis.extrapolate(dl1, dl2)
         return dl1, dl2
 
-    _T3_DENS_KEYS = ('Doo', 'Dvv', 'Dov', 'Goovv', 'Gooov', 'Gvvvo')
-
     def _perturbed_correlation_densities(self, dt1, dt2, dl1, dl2, lam, dt3=None):
-        """Field response ``(dD, dGamma)`` of the unrelaxed CC correlation densities via a 5-point
-        stencil of :meth:`ccdensity.gradient_densities` in the amplitudes/multipliers (the densities
-        are pure polynomials in ``t``/``lambda`` -- exact).  Temporarily sets ``cc.t1/t2`` and
-        ``lam.l1/l2`` to the stepped values (restored).
-
-        For CCSD(T), ``dt3`` is the dict of perturbed (T) intermediates
-        (:meth:`_perturbed_t3_intermediates`); the cached (T) intermediates on the wfn
-        (``cc.Doo/Dvv/Dov/Goovv/Gooov/Gvvvo``) are stepped alongside ``t``/``lambda``, so the reused
-        ``gradient_densities`` places the perturbed (T) 1-/2-PDM contribution with the correct
-        blocks/symmetrization automatically (it is linear in those cached intermediates, so the
-        stencil captures them exactly).
-
-        Analytic by default for both CCSD and CCSD(T), on both spin paths
-        (:meth:`_so_perturbed_correlation_densities` / :meth:`_spatial_perturbed_correlation_densities`,
-        which add the ``dt3`` (T)-increment response when given); the 5-point stencil is kept behind
-        ``_DBG_FORCE_STENCIL_DENS`` as an oracle.  The stencil steps the cached (T) *density* blocks
-        (``dt3`` keys other than the Lambda sources ``S1``/``S2``) alongside ``t``/``lambda`` -- for
-        SO that includes ``Gvovv``/``Govoo``, so the stencil is a complete oracle for the analytic
-        path."""
+        """Field response ``(dD, dGamma)`` of the unrelaxed CC correlation densities: the analytic
+        product-rule derivative of the density builders, dispatched by orbital basis to
+        :meth:`_so_perturbed_correlation_densities` or
+        :meth:`_spatial_perturbed_correlation_densities`.  For CCSD(T), ``dt3`` (from
+        :meth:`_perturbed_t3_intermediates`) supplies the perturbed (T) 1-/2-PDM increments, added
+        with the same blocks and symmetrization the unperturbed builders use."""
         cc = self.ccwfn
-        if not getattr(self, '_DBG_FORCE_STENCIL_DENS', False):   # analytic CCSD/(T); no stencil
-            if cc.orbital_basis == 'spinorbital':
-                return self._so_perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam, dt3)
-            return self._spatial_perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam, dt3)
-        from .ccdensity import ccdensity
-        t01, t02 = np.asarray(cc.t1).copy(), np.asarray(cc.t2).copy()
-        l01, l02 = np.asarray(lam.l1).copy(), np.asarray(lam.l2).copy()
-        t3keys = [k for k in dt3 if k not in ('S1', 'S2')] if dt3 is not None else None  # (T) density blocks
-        t3_0 = ({k: np.asarray(getattr(cc, k)).copy() for k in t3keys} if dt3 is not None else None)
-        h = 1e-2
-        def at(s):
-            cc.t1 = t01 + s*h*dt1; cc.t2 = t02 + s*h*dt2
-            lam.l1 = l01 + s*h*dl1; lam.l2 = l02 + s*h*dl2
-            if dt3 is not None:
-                for k in t3keys:
-                    setattr(cc, k, t3_0[k] + s*h*np.asarray(dt3[k]))
-            D_s, Gam_s = ccdensity(cc, lam).gradient_densities()
-            return np.asarray(D_s), np.asarray(Gam_s)
-        try:
-            m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
-        finally:
-            cc.t1, cc.t2 = t01, t02
-            lam.l1, lam.l2 = l01, l02
-            if dt3 is not None:
-                for k in t3keys:
-                    setattr(cc, k, t3_0[k])
-        dDg = (m2[0] - 8.0*m1[0] + 8.0*p1[0] - p2[0]) / (12.0*h)
-        dGam = (m2[1] - 8.0*m1[1] + 8.0*p1[1] - p2[1]) / (12.0*h)
-        return dDg, dGam
+        if cc.orbital_basis == 'spinorbital':
+            return self._so_perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam, dt3)
+        return self._spatial_perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam, dt3)
 
     def _so_perturbed_correlation_densities(self, dt1, dt2, dl1, dl2, lam, dt3=None):
         """Analytic field response ``(dD, dGamma)`` of the unrelaxed **spin-orbital CCSD**

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -95,6 +95,23 @@ class CCderiv:
         P[m] = num[m] / den[m]
         return P
 
+    @staticmethod
+    def _perturbed_dependent_pairs(dIblock, Pblock0, eps_block, dfdiag_block, thresh=1e-8):
+        """Field derivative ``dP`` of the canonical dependent-pair rotation
+        ``P = (I'_mn - I'_nm)/(eps_m - eps_n)`` for an occ-occ or virt-virt block.  Quotient rule,
+        ``dP_mn = (dI'_mn - dI'_nm)/(eps_m - eps_n) - P0_mn (df_mm - df_nn)/(eps_m - eps_n)`` -- the
+        second term is the denominator derivative ``d(eps_m - eps_n) = df_mm - df_nn`` (the canonical
+        ``df`` diagonal), using the unperturbed ``Pblock0``.  Gated on ``|eps_m - eps_n| > thresh``
+        (diagonal + near-degenerate pairs -> 0, matching :meth:`_dependent_pairs` for a non-degenerate
+        spectrum; near-degeneracy is the standard caveat of the canonical route)."""
+        dnum = np.asarray(dIblock) - np.asarray(dIblock).T
+        gap = eps_block[:, None] - eps_block[None, :]
+        dgap = dfdiag_block[:, None] - dfdiag_block[None, :]
+        dP = np.zeros_like(dnum)
+        m = np.abs(gap) > thresh
+        dP[m] = (dnum[m] - np.asarray(Pblock0)[m] * dgap[m]) / gap[m]
+        return dP
+
     def _relaxed_density(self):
         """The relaxed correlation 1-PDM ``Drel`` and the symmetrized 2-PDM ``Gam`` (spatial
         closed-shell RHF).  ``Drel`` is the Lambda-response 1-PDM ``D`` plus the orbital-relaxation
@@ -380,8 +397,9 @@ class CCderiv:
         if route != '2n+1':
             raise ValueError(f"CC polarizability supports only the asymmetric '2n+1' route, not {route!r}.")
         cc = self.ccwfn
-        if cc.model.upper() != 'CCSD':
-            raise NotImplementedError(f"CC polarizability: only CCSD is implemented (not {cc.model}).")
+        if cc.model.upper() not in ('CCSD', 'CCSD(T)'):
+            raise NotImplementedError(f"CC polarizability: only CCSD and CCSD(T) are implemented (not {cc.model}).")
+        is_t = cc.model.upper() == 'CCSD(T)'
         if cc.orbital_basis == 'spinorbital':
             return self._so_polarizability()
         from .cchbar import cchbar
@@ -414,6 +432,13 @@ class CCderiv:
         if cc.nfzc:                                      # couple P_co into the Z-vector RHS
             zjc = -Pco.T
             X0 = X0 - (c('jc,ajic->ia', zjc, L[v, o, ofull, co]) + c('jc,acij->ia', zjc, L[v, co, ofull, o]))
+        Poo0 = Pvv0 = None
+        if cc.model.upper() == 'CCSD(T)':                # (T) oo/vv dependent-pairs (as in _relaxed_density)
+            Poo0 = self._dependent_pairs(Ip0[o, o], eps[o])
+            Pvv0 = self._dependent_pairs(Ip0[v, v], eps[v])
+            Drel[o, o] += Poo0
+            Drel[v, v] += Pvv0
+            X0 = X0 + (c('kl,akil->ia', Poo0, L[v, o, ofull, o]) + c('bc,ibac->ia', Pvv0, L[ofull, v, v, v]))
         z = np.asarray(hf.cphf.solve(X0))
         Drel[v, ofull] += -z.T
         Drel[ofull, v] += -z
@@ -423,8 +448,8 @@ class CCderiv:
         alpha = np.zeros((3, 3))
         for b in range(3):
             pert = Perturbation('field', b)
-            dDrel = self._perturbed_relaxed_density(pert, hbar, lam, D0, Gam0, z, Pco)
-            Ub = np.asarray(cphf._full_U(pert, ncore))
+            dDrel = self._perturbed_relaxed_density(pert, hbar, lam, D0, Gam0, z, Pco, Poo0, Pvv0)
+            Ub = np.asarray(cphf._full_U(pert, ncore, canonical=(is_t or getattr(self, '_DBG_FORCE_CANON', False))))
             for a in range(3):
                 rot = Ub.T @ mu[a] + mu[a] @ Ub
                 alpha[a, b] = c('pq,pq->', dDrel, mu[a]) + c('pq,pq->', Drel, rot)
@@ -464,6 +489,13 @@ class CCderiv:
         if cc.nfzc:
             zjc = -Pco.T
             X0 = X0 - (c('jc,ajic->ia', zjc, ERI[v, o, ofull, co]) + c('jc,acij->ia', zjc, ERI[v, co, ofull, o]))
+        Poo0 = Pvv0 = None
+        if cc.model.upper() == 'CCSD(T)':                 # (T) oo/vv dependent-pairs (as in _so_relaxed_density)
+            Poo0 = self._dependent_pairs(Ip0[o, o], eps[o])
+            Pvv0 = self._dependent_pairs(Ip0[v, v], eps[v])
+            Drel[o, o] += Poo0
+            Drel[v, v] += Pvv0
+            X0 = X0 + (c('kl,akil->ia', Poo0, ERI[v, o, ofull, o]) + c('bc,ibac->ia', Pvv0, ERI[ofull, v, v, v]))
         G = (c('ajib->iajb', ERI[v, ofull, ofull, v]) + c('abij->iajb', ERI[v, v, ofull, ofull])).reshape(nof*nv, nof*nv)
         G[np.diag_indices(nof*nv)] += (eps[v][None, :] - eps[ofull][:, None]).reshape(-1)
         z = np.linalg.solve(G, X0.reshape(-1)).reshape(nof, nv)
@@ -482,13 +514,21 @@ class CCderiv:
                 alpha[a, b] = c('pq,pq->', dDrel, mu[a]) + c('pq,pq->', Drel, rot)
         return alpha
 
-    def _perturbed_relaxed_density(self, pert, hbar, lam, D0, Gam0, z, Pco=None) -> np.ndarray:
+    def _perturbed_relaxed_density(self, pert, hbar, lam, D0, Gam0, z, Pco=None,
+                                   Poo0=None, Pvv0=None) -> np.ndarray:
         """Field response ``dD_rel`` of the CC relaxed 1-PDM (spatial; all-electron or frozen core).
         Mirrors :meth:`MPwfn._perturbed_relaxed_opdm` with the CC densities, but (i) keeps the CC
         *unrelaxed* ov/vo blocks (``D_ai != D_ia`` for CC; MP2 has none) and (ii) builds the perturbed
         Lagrangian with the FULL-df Fock term (see :meth:`_cc_perturbed_lagrangian`).  For frozen core
         the perturbed core<->active Sylvester divide ``dP_co`` is added and coupled into the perturbed
-        Z-vector RHS, exactly as in the MP2 template / the unperturbed :meth:`_relaxed_density`."""
+        Z-vector RHS, exactly as in the MP2 template / the unperturbed :meth:`_relaxed_density`.
+
+        CCSD(T): uses the **canonical** perturbed orbitals (``df``/``deri`` with ``canonical=True``, so
+        ``df`` is diagonal in oo/vv -- the non-invariant (T) kernels require it), threads the perturbed
+        (T) intermediates ``dt3`` into the density and the Lambda source, and adds the perturbed
+        active-oo/vv dependent-pairs ``dPoo``/``dPvv`` (the field-derivative of the unperturbed
+        ``Poo0``/``Pvv0``, including the ``d(eps_i-eps_j) = df_ii - df_jj`` denominator term) to
+        ``dD_rel`` + the perturbed Z-vector RHS."""
         cc = self.ccwfn
         o, v = cc.o, cc.v
         co = slice(0, cc.nfzc)
@@ -497,15 +537,20 @@ class CCderiv:
         ncore = o.stop - cc.no
         L = np.asarray(cc.H.L)
         eps = np.diag(np.asarray(cc.H.F))
+        is_t = cc.model.upper() == 'CCSD(T)'
+        canon = is_t or getattr(self, '_DBG_FORCE_CANON', False)
         cphf = cc.mp._full_occ_cphf()
-        df = np.asarray(cphf.perturbed_fock(pert, ncore))
-        deri = np.asarray(cphf.perturbed_eri(pert, ncore))
+        df = np.asarray(cphf.perturbed_fock(pert, ncore, canonical=canon))
+        deri = np.asarray(cphf.perturbed_eri(pert, ncore, canonical=canon))
         dL = 2.0 * deri - deri.swapaxes(2, 3)
         hf = self._reference_hf()
 
         dt1, dt2 = self._perturbed_amplitudes(df, deri, dL, hbar)
-        dl1, dl2 = self._perturbed_lambda(df, deri, dL, dt1, dt2, hbar, lam)
-        dDg, dGam = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam)
+        dt3 = self._perturbed_t3_intermediates(df, deri, dL, dt1, dt2) if is_t else None
+        dl1, dl2 = self._perturbed_lambda(df, deri, dL, dt1, dt2, hbar, lam,
+                                          dS1=(dt3['S1'] if is_t else None),
+                                          dS2=(dt3['S2'] if is_t else None))
+        dDg, dGam = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam, dt3=dt3)
         dIp = self._cc_perturbed_lagrangian(df, deri, dL, D0, dDg, Gam0, dGam)
         dX = dIp[ofull, v] - dIp[v, ofull].T
         dPco = None
@@ -515,6 +560,35 @@ class CCderiv:
             zjc, dzjc = -Pco.T, -dPco.T
             dX = dX - (c('jc,ajic->ia', dzjc, L[v, o, ofull, co]) + c('jc,acij->ia', dzjc, L[v, co, ofull, o])
                        + c('jc,ajic->ia', zjc, dL[v, o, ofull, co]) + c('jc,acij->ia', zjc, dL[v, co, ofull, o]))
+        dPoo = dPvv = None
+        if is_t:                                        # perturbed (T) oo/vv dependent-pairs
+            dfd = np.zeros(cc.nmo) if getattr(self, '_DBG_NO_DGAP', False) else np.diag(df)
+            thr = getattr(self, '_DBG_GAP_THRESH', 1e-8)
+            dPoo = self._perturbed_dependent_pairs(dIp[o, o], Poo0, eps[o], dfd[o], thr)
+            dPvv = self._perturbed_dependent_pairs(dIp[v, v], Pvv0, eps[v], dfd[v], thr)
+            if getattr(self, '_DBG', False):
+                cc_ = self.ccwfn
+                F0d = np.asarray(cc_.H.F).copy(); ERI0d = np.asarray(cc_.H.ERI).copy(); L0d = np.asarray(cc_.H.L).copy()
+                hh = 1e-3
+                def lag_at(s):
+                    cc_.H.F = F0d + s*hh*df; cc_.H.ERI = ERI0d + s*hh*deri; cc_.H.L = L0d + s*hh*dL
+                    return np.asarray(self._lagrangian(D0 + s*hh*dDg, Gam0 + s*hh*dGam))
+                try:
+                    sdip = (lag_at(-2) - 8*lag_at(-1) + 8*lag_at(1) - lag_at(2)) / (12*hh)
+                finally:
+                    cc_.H.F = F0d; cc_.H.ERI = ERI0d; cc_.H.L = L0d
+                go = eps[o][:, None] - eps[o][None, :]; gv = eps[v][:, None] - eps[v][None, :]
+                print('  dIp[o,o] a-vs-sten %.2e  dIp[v,v] %.2e | max|dPoo| %.2e max|dPvv| %.2e | '
+                      'mingap_oo %.2e mingap_vv %.2e'
+                      % (np.max(np.abs(dIp[o, o]-sdip[o, o])), np.max(np.abs(dIp[v, v]-sdip[v, v])),
+                         np.max(np.abs(dPoo)), np.max(np.abs(dPvv)),
+                         np.min(np.abs(go[~np.eye(go.shape[0], dtype=bool)])),
+                         np.min(np.abs(gv[~np.eye(gv.shape[0], dtype=bool)]))))
+            if getattr(self, '_DBG_NO_DEPPAIR', False):  # DEBUG isolation
+                dPoo = np.zeros_like(dPoo); dPvv = np.zeros_like(dPvv)
+            else:
+                dX = dX + (c('kl,akil->ia', dPoo, L[v, o, ofull, o]) + c('kl,akil->ia', Poo0, dL[v, o, ofull, o])
+                           + c('bc,ibac->ia', dPvv, L[ofull, v, v, v]) + c('bc,ibac->ia', Pvv0, dL[ofull, v, v, v]))
         # perturbed orbital-Hessian response (A^x z); reference-only, as in MP2
         Axz = (c('ajib,jb->ia', dL[v, ofull, ofull, v], z) + c('abij,jb->ia', dL[v, v, ofull, ofull], z)
                + c('ab,ib->ia', df[v, v], z) - c('ij,ja->ia', df[ofull, ofull], z))
@@ -523,6 +597,9 @@ class CCderiv:
         if cc.nfzc:
             dDrel[co, o] += dPco
             dDrel[o, co] += dPco.T
+        if is_t:
+            dDrel[o, o] += dPoo
+            dDrel[v, v] += dPvv
         dDrel[v, ofull] += -zx.T
         dDrel[ofull, v] += -zx
         return dDrel
@@ -910,12 +987,61 @@ class CCderiv:
                - c('je,mbie->mbij', dt1, Zovov0) - c('je,mbie->mbij', t1, dZovov)))
         return d
 
-    def _perturbed_lambda(self, df, deri, dL, dt1, dt2, hbar, lam, maxiter=200, rconv=1e-13):
+    def _perturbed_t3_intermediates(self, df, deri, dL, dt1, dt2, h=1e-3):
+        """Field response of the (T) intermediates ``d{Doo,Dvv,Dov,Goovv,Gooov,Gvvvo,S1,S2}/dF``
+        via a 5-point central stencil of :func:`cctriples.t3_density` along the **canonical** field
+        path ``(t1 +- h dt1, t2 +- h dt2, F0 +- h df, ERI +- h deri, L +- h dL)``.  ``df`` MUST be
+        the canonical perturbed Fock (``perturbed_fock(..., canonical=True)``, diagonal in oo/vv), so
+        the batched diagonal-denominator (T) formula stays valid at every displacement.
+
+        Unlike the HBAR stencil (:meth:`_perturbed_hbar`, polynomial -> algebraically exact), the (T)
+        intermediates are *rational* in the step (the ``1/D`` energy denominator), so this is only
+        ``O(h^4)`` -- the stencil-first validation crutch; the analytic ``dt3 = (dN - t3 dD)/D`` route
+        (batched ``t3c_ijk`` etc.) replaces it for production."""
+        from . import cctriples
+        cc = self.ccwfn
+        o, v, no, nv = cc.o, cc.v, cc.no, cc.nv
+        F0 = np.asarray(cc.H.F); ERI0 = np.asarray(cc.H.ERI); L0 = np.asarray(cc.H.L)
+        t01 = np.asarray(cc.t1); t02 = np.asarray(cc.t2)
+        if not getattr(self, '_DBG_FORCE_STENCIL_T3', False):   # analytic (product rule); no stencil
+            return cctriples.dt3_density(o, v, no, nv, t01, t02, dt1, dt2, F0, df, ERI0, deri, L0, dL, self.contract)
+        def at(s):
+            _, d = cctriples.t3_density(o, v, no, nv, t01 + s*h*dt1, t02 + s*h*dt2,
+                                        F0 + s*h*df, ERI0 + s*h*deri, L0 + s*h*dL, self.contract)
+            return d
+        m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
+        return {k: (np.asarray(m2[k]) - 8.0*np.asarray(m1[k]) + 8.0*np.asarray(p1[k])
+                    - np.asarray(p2[k])) / (12.0*h) for k in m2}
+
+    def _so_perturbed_t3_intermediates(self, df, deri, dt1, dt2, h=1e-3):
+        """Spin-orbital field response of the (T) intermediates via the 5-point stencil of
+        :func:`cctriples.so_t3_density` along the canonical path (no ``L``).  O(h^4); see
+        :meth:`_perturbed_t3_intermediates`."""
+        from . import cctriples
+        cc = self.ccwfn
+        o, v, no, nv = cc.o, cc.v, cc.no, cc.nv
+        F0 = np.asarray(cc.H.F); ERI0 = np.asarray(cc.H.ERI)
+        t01 = np.asarray(cc.t1); t02 = np.asarray(cc.t2)
+        if not getattr(self, '_DBG_FORCE_STENCIL_T3', False):   # analytic (product rule); no stencil
+            return cctriples.so_dt3_density(o, v, no, nv, t01, t02, dt1, dt2, F0, df, ERI0, deri, self.contract)
+        def at(s):
+            _, d = cctriples.so_t3_density(o, v, no, nv, t01 + s*h*dt1, t02 + s*h*dt2,
+                                           F0 + s*h*df, ERI0 + s*h*deri, self.contract)
+            return d
+        m2, m1, p1, p2 = at(-2), at(-1), at(1), at(2)
+        return {k: (np.asarray(m2[k]) - 8.0*np.asarray(m1[k]) + 8.0*np.asarray(p1[k])
+                    - np.asarray(p2[k])) / (12.0*h) for k in m2}
+
+    def _perturbed_lambda(self, df, deri, dL, dt1, dt2, hbar, lam, dS1=None, dS2=None, maxiter=200, rconv=1e-13):
         """Perturbed Lambda ``dLambda/dF`` (iterative, linear), staying in ``cclambda`` (no
         ``Y1/Y2``).  The inhomogeneity is ``r_L`` evaluated with the perturbed HBAR + ``dL``
         (unperturbed G) plus the explicit ``dG.H``/``dG.L`` product-rule halves; the Lambda-Jacobian
         action is ``r_L(dLambda) - r_L(0)`` (``r_L`` is affine in Lambda).  Iterate
-        ``dLambda += (B + Jacobian)/D`` like :meth:`cclambda.solve_lambda`."""
+        ``dLambda += (B + Jacobian)/D`` like :meth:`cclambda.solve_lambda`.
+
+        CCSD(T): ``r_L1``/``r_L2`` add the cached (T) source ``cc.S1``/``0.5 cc.S2`` (constants in
+        Lambda), so the inhomogeneity ``B`` picks up the *unperturbed* ``S1``/``0.5 S2`` -- replace
+        them with the perturbed ``dS1``/``0.5 dS2`` (from :meth:`_perturbed_t3_intermediates`)."""
         from .utils import helper_diis
         cc = self.ccwfn
         o, v = cc.o, cc.v
@@ -945,6 +1071,9 @@ class CCderiv:
         c2p = c('ae,ijeb->ijab', dGvv, L0[o, o, v, v]) - c('mi,mjab->ijab', dGoo, L0[o, o, v, v])
         B1 = B1 + c1
         B2 = B2 + (c2p + c2p.swapaxes(0, 1).swapaxes(2, 3))
+        if dS1 is not None:                             # (T): swap the cached S1/0.5 S2 for dS1/0.5 dS2
+            B1 = B1 + (dS1 - np.asarray(cc.S1))
+            B2 = B2 + 0.5 * (dS2 - np.asarray(cc.S2))
         zl1 = np.zeros_like(l1); zl2 = np.zeros_like(l2)
         zGvv = np.zeros_like(Gvv0); zGoo = np.zeros_like(Goo0)
         rL1_0 = rL1(zl1, zl2, H0, zGvv, zGoo)           # = 2*Hov (the Lambda-independent constant)
@@ -965,9 +1094,12 @@ class CCderiv:
             dl1, dl2 = diis.extrapolate(dl1, dl2)
         return dl1, dl2
 
-    def _so_perturbed_lambda(self, df, deri, dt1, dt2, hbar, lam, maxiter=200, rconv=1e-13):
+    def _so_perturbed_lambda(self, df, deri, dt1, dt2, hbar, lam, dS1=None, dS2=None, maxiter=200, rconv=1e-13):
         """Spin-orbital perturbed Lambda ``dLambda/dF`` (SO r_L; inhomogeneity = r_L with perturbed
-        HBAR + perturbed ERI, unperturbed G, plus the dG.H / dG.<pq||rs> product-rule halves)."""
+        HBAR + perturbed ERI, unperturbed G, plus the dG.H / dG.<pq||rs> product-rule halves).
+
+        CCSD(T): the SO ``r_L1``/``r_L2`` add ``cc.S1``/``cc.S2`` (no 1/2 on S2, unlike the spatial
+        path), so replace the cached ``S1``/``S2`` in ``B`` with the perturbed ``dS1``/``dS2``."""
         from .utils import helper_diis
         cc = self.ccwfn
         o, v = cc.o, cc.v
@@ -996,6 +1128,9 @@ class CCderiv:
         oovv = ERI0[o, o, v, v]
         B2 = B2 + (c('be,ijae->ijab', dGvv, oovv) - c('ae,ijbe->ijab', dGvv, oovv)) \
                 - (c('mj,imab->ijab', dGoo, oovv) - c('mi,jmab->ijab', dGoo, oovv))
+        if dS1 is not None:                             # (T): swap the cached S1/S2 for dS1/dS2 (SO: no 1/2)
+            B1 = B1 + (dS1 - np.asarray(cc.S1))
+            B2 = B2 + (dS2 - np.asarray(cc.S2))
         zl1 = np.zeros_like(l1); zl2 = np.zeros_like(l2)
         zGvv = np.zeros_like(Gvv0); zGoo = np.zeros_like(Goo0)
         rL1_0 = rL1(zl1, zl2, H0, zGvv, zGoo)
@@ -1015,27 +1150,45 @@ class CCderiv:
             dl1, dl2 = diis.extrapolate(dl1, dl2)
         return dl1, dl2
 
-    def _perturbed_correlation_densities(self, dt1, dt2, dl1, dl2, lam):
+    _T3_DENS_KEYS = ('Doo', 'Dvv', 'Dov', 'Goovv', 'Gooov', 'Gvvvo')
+
+    def _perturbed_correlation_densities(self, dt1, dt2, dl1, dl2, lam, dt3=None):
         """Field response ``(dD, dGamma)`` of the unrelaxed CC correlation densities via a 5-point
         stencil of :meth:`ccdensity.gradient_densities` in the amplitudes/multipliers (the densities
         are pure polynomials in ``t``/``lambda`` -- exact).  Temporarily sets ``cc.t1/t2`` and
         ``lam.l1/l2`` to the stepped values (restored).
 
-        Analytic by default (:meth:`_so_perturbed_correlation_densities` /
-        :meth:`_spatial_perturbed_correlation_densities`, the product-rule derivative of the density
-        builders); the stencil is kept behind ``_DBG_FORCE_STENCIL_DENS`` as an oracle."""
+        For CCSD(T), ``dt3`` is the dict of perturbed (T) intermediates
+        (:meth:`_perturbed_t3_intermediates`); the cached (T) intermediates on the wfn
+        (``cc.Doo/Dvv/Dov/Goovv/Gooov/Gvvvo``) are stepped alongside ``t``/``lambda``, so the reused
+        ``gradient_densities`` places the perturbed (T) 1-/2-PDM contribution with the correct
+        blocks/symmetrization automatically (it is linear in those cached intermediates, so the
+        stencil captures them exactly).
+
+        Analytic by default for both CCSD and CCSD(T), on both spin paths
+        (:meth:`_so_perturbed_correlation_densities` / :meth:`_spatial_perturbed_correlation_densities`,
+        which add the ``dt3`` (T)-increment response when given); the 5-point stencil is kept behind
+        ``_DBG_FORCE_STENCIL_DENS`` as an oracle.  The stencil steps the cached (T) *density* blocks
+        (``dt3`` keys other than the Lambda sources ``S1``/``S2``) alongside ``t``/``lambda`` -- for
+        SO that includes ``Gvovv``/``Govoo``, so the stencil is a complete oracle for the analytic
+        path."""
         cc = self.ccwfn
-        if not getattr(self, '_DBG_FORCE_STENCIL_DENS', False):   # analytic CCSD; no stencil
+        if not getattr(self, '_DBG_FORCE_STENCIL_DENS', False):   # analytic CCSD/(T); no stencil
             if cc.orbital_basis == 'spinorbital':
-                return self._so_perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam)
-            return self._spatial_perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam)
+                return self._so_perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam, dt3)
+            return self._spatial_perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam, dt3)
         from .ccdensity import ccdensity
         t01, t02 = np.asarray(cc.t1).copy(), np.asarray(cc.t2).copy()
         l01, l02 = np.asarray(lam.l1).copy(), np.asarray(lam.l2).copy()
+        t3keys = [k for k in dt3 if k not in ('S1', 'S2')] if dt3 is not None else None  # (T) density blocks
+        t3_0 = ({k: np.asarray(getattr(cc, k)).copy() for k in t3keys} if dt3 is not None else None)
         h = 1e-2
         def at(s):
             cc.t1 = t01 + s*h*dt1; cc.t2 = t02 + s*h*dt2
             lam.l1 = l01 + s*h*dl1; lam.l2 = l02 + s*h*dl2
+            if dt3 is not None:
+                for k in t3keys:
+                    setattr(cc, k, t3_0[k] + s*h*np.asarray(dt3[k]))
             D_s, Gam_s = ccdensity(cc, lam).gradient_densities()
             return np.asarray(D_s), np.asarray(Gam_s)
         try:
@@ -1043,11 +1196,14 @@ class CCderiv:
         finally:
             cc.t1, cc.t2 = t01, t02
             lam.l1, lam.l2 = l01, l02
+            if dt3 is not None:
+                for k in t3keys:
+                    setattr(cc, k, t3_0[k])
         dDg = (m2[0] - 8.0*m1[0] + 8.0*p1[0] - p2[0]) / (12.0*h)
         dGam = (m2[1] - 8.0*m1[1] + 8.0*p1[1] - p2[1]) / (12.0*h)
         return dDg, dGam
 
-    def _so_perturbed_correlation_densities(self, dt1, dt2, dl1, dl2, lam):
+    def _so_perturbed_correlation_densities(self, dt1, dt2, dl1, dl2, lam, dt3=None):
         """Analytic field response ``(dD, dGamma)`` of the unrelaxed **spin-orbital CCSD**
         correlation densities: the product-rule derivative of the raw density builders
         (:meth:`ccdensity.build_Doo`/``Dvv``/``Dvo``/``Dov`` and :meth:`ccdensity.build_so_twopdm`),
@@ -1057,7 +1213,12 @@ class CCderiv:
         The nine two-particle block derivatives are placed into the full ``nmo^4`` array and bra-ket
         symmetrized exactly as :meth:`ccdensity.gradient_densities` / :meth:`ccdensity._so_full_twopdm`
         do (overall ``1/4``, ``1/2 (Gamma + Gamma_rspq)``), so the result matches the stenciled
-        convention block for block.  Frozen-core rows/columns stay zero (active ``o``/``v`` slices)."""
+        convention block for block.  Frozen-core rows/columns stay zero (active ``o``/``v`` slices).
+
+        For CCSD(T), ``dt3`` (from :meth:`_so_perturbed_t3_intermediates`) supplies the perturbed
+        (T) increments, which enter the density builders additively; they are added to the matching
+        derivative blocks before placement (``Goovv->ijab``, ``Gooov->ijka``, ``Gvovv->ciab``,
+        ``Govoo->kaij``, ``Gvvvo->abci``, and ``Doo``/``Dvv``/``Dov`` on the 1-PDM)."""
         cc = self.ccwfn
         o, v, nmo = cc.o, cc.v, cc.nmo
         c = self.contract
@@ -1130,6 +1291,13 @@ class CCderiv:
             + 3.0*Pijab(c('me,ia,je,mb->ijab', dl1, t1, t1, t1) + c('me,ia,je,mb->ijab', l1, dt1, t1, t1)
                         + c('me,ia,je,mb->ijab', l1, t1, dt1, t1) + c('me,ia,je,mb->ijab', l1, t1, t1, dt1)))
         dG['abij'] = dl2.transpose(2, 3, 0, 1)
+        if dt3 is not None:                              # (T) increments (additive; see build_so_twopdm)
+            dDoo = dDoo + dt3['Doo']; dDvv = dDvv + dt3['Dvv']; dDov = dDov + dt3['Dov']
+            dG['ijab'] = dG['ijab'] + dt3['Goovv']
+            dG['ijka'] = dG['ijka'] + dt3['Gooov']
+            dG['ciab'] = dG['ciab'] + dt3['Gvovv']
+            dG['kaij'] = dG['kaij'] + dt3['Govoo']
+            dG['abci'] = dG['abci'] + dt3['Gvvvo']
         # ---- placement + symmetrization (mirrors ccdensity._so_full_twopdm + gradient_densities) ----
         dGam = np.zeros((nmo, nmo, nmo, nmo))
         dGam[o, o, o, o] = dG['ijkl']
@@ -1149,7 +1317,7 @@ class CCderiv:
         dD[o, o] = dDoo; dD[v, v] = dDvv; dD[o, v] = dDov; dD[v, o] = dDvo
         return dD, 0.25 * dGam
 
-    def _spatial_perturbed_correlation_densities(self, dt1, dt2, dl1, dl2, lam):
+    def _spatial_perturbed_correlation_densities(self, dt1, dt2, dl1, dl2, lam, dt3=None):
         """Analytic field response ``(dD, dGamma)`` of the unrelaxed **spatial (closed-shell RHF)
         CCSD** correlation densities: the product-rule derivative of the ccdensity builders
         (:meth:`ccdensity.build_Doo`/``Dvv``/``Dvo``/``Dov`` and ``Doooo``/``Dvvvv``/``Dooov``/
@@ -1157,7 +1325,12 @@ class CCderiv:
         :meth:`ccdensity.gradient_densities` (blocks with the same per-block factors, then the
         four-fold ``1/4(G + G_qpsr + G_rspq + G_srqp)``).  Replaces the 5-point stencil for this
         path; verified to ~1e-15 against a complex-step derivative of the builders.  Frozen-core
-        rows/columns stay zero (active ``o``/``v`` slices)."""
+        rows/columns stay zero (active ``o``/``v`` slices).
+
+        For CCSD(T), ``dt3`` (from :meth:`_perturbed_t3_intermediates`) supplies the perturbed (T)
+        increments, added to the matching derivative blocks before placement (``Gooov->Dooov``,
+        ``Gvvvo->Dvvvo``, ``Goovv->Doovv``, and ``Doo``/``Dvv``/``Dov`` on the 1-PDM); the spatial
+        route has no ``Gvovv``/``Govoo``."""
         cc = self.ccwfn
         o, v, nmo = cc.o, cc.v, cc.nmo
         c = self.contract
@@ -1272,6 +1445,11 @@ class CCderiv:
         g2, dg2 = c('ie,mnej->mnij', t1, g1), p2('ie,mnej->mnij', t1, dt1, g1, dg1)
         g3, dg3 = c('nb,mnij->mbij', t1, g2), p2('nb,mnij->mbij', t1, dt1, g2, dg2)
         dDoovv = dDoovv + p2('ma,mbij->ijab', t1, dt1, g3, dg3)
+        if dt3 is not None:                              # (T) increments (additive; see build_Dooov/Dvvvo/Doovv)
+            dDoo = dDoo + dt3['Doo']; dDvv = dDvv + dt3['Dvv']; dDov = dDov + dt3['Dov']
+            dDooov = dDooov + dt3['Gooov']
+            dDvvvo = dDvvvo + dt3['Gvvvo']
+            dDoovv = dDoovv + dt3['Goovv']
         # ---- placement + four-fold symmetrization (mirrors gradient_densities spatial path) ----
         dD = np.zeros((nmo, nmo))
         dD[o, o] = dDoo; dD[v, v] = dDvv; dD[o, v] = dDov; dD[v, o] = dDvo

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -391,9 +391,10 @@ class CCderiv:
         The reference (SCF) polarizability is kept separate (:meth:`HFwfn.polarizability`); the
         :func:`pycc.polarizability` facade sums nuclear (zero) + reference + this correlation part.
 
-        Spatial closed-shell RHF and spin-orbital UHF (both all-electron and frozen core); (T) to
-        follow.  Validated against a tight finite field of :meth:`relaxed_dipole` and the SO ==
-        spatial keystone."""
+        Spatial closed-shell RHF and spin-orbital UHF CCSD (all-electron and frozen core), and
+        spin-orbital CCSD(T) (all-electron and frozen core); spatial CCSD(T) to follow.  CCSD is
+        validated against a tight finite field of :meth:`relaxed_dipole` and the SO == spatial
+        keystone; CCSD(T) against the energy second-derivative finite field."""
         if route != '2n+1':
             raise ValueError(f"CC polarizability supports only the asymmetric '2n+1' route, not {route!r}.")
         cc = self.ccwfn
@@ -401,7 +402,14 @@ class CCderiv:
             raise NotImplementedError(f"CC polarizability: only CCSD and CCSD(T) are implemented (not {cc.model}).")
         is_t = cc.model.upper() == 'CCSD(T)'
         if cc.orbital_basis == 'spinorbital':
+            if is_t and not hasattr(cc, 'S1'):
+                raise ValueError("CCSD(T) polarizability requires the (T) density intermediates; "
+                                 "build the wavefunction with make_t3_density=True.")
             return self._so_polarizability()
+        if is_t:
+            raise NotImplementedError("Spatial CCSD(T) polarizability is not yet available "
+                                      "(the spatial (T) perturbed response is under development); "
+                                      "use orbital_basis='spinorbital'.")
         from .cchbar import cchbar
         from .cclambda import cclambda
         from .ccdensity import ccdensity
@@ -507,8 +515,8 @@ class CCderiv:
         alpha = np.zeros((3, 3))
         for b in range(3):
             pert = Perturbation('field', b)
-            dDrel = self._so_perturbed_relaxed_density(pert, hbar, lam, D0, Gam0, z, G, Pco)
-            Ub = np.asarray(cphf._full_U(pert, ncore))
+            dDrel = self._so_perturbed_relaxed_density(pert, hbar, lam, D0, Gam0, z, G, Pco, Poo0, Pvv0)
+            Ub = np.asarray(cphf._full_U(pert, ncore, canonical=(cc.model.upper() == 'CCSD(T)')))
             for a in range(3):
                 rot = Ub.T @ mu[a] + mu[a] @ Ub
                 alpha[a, b] = c('pq,pq->', dDrel, mu[a]) + c('pq,pq->', Drel, rot)
@@ -604,9 +612,17 @@ class CCderiv:
         dDrel[ofull, v] += -zx
         return dDrel
 
-    def _so_perturbed_relaxed_density(self, pert, hbar, lam, D0, Gam0, z, G, Pco):
+    def _so_perturbed_relaxed_density(self, pert, hbar, lam, D0, Gam0, z, G, Pco,
+                                      Poo0=None, Pvv0=None):
         """Spin-orbital field response ``dD_rel``; the SO analog of
-        :meth:`_perturbed_relaxed_density` (inline Hessian ``G``, antisymmetrized ERI)."""
+        :meth:`_perturbed_relaxed_density` (inline Hessian ``G``, antisymmetrized ERI).
+
+        CCSD(T): uses the **canonical** perturbed orbitals (``df``/``deri`` with ``canonical=True``,
+        so ``df`` is diagonal in oo/vv -- the non-invariant (T) kernels require it), threads the
+        perturbed (T) intermediates ``dt3`` into the density and the Lambda source, and adds the
+        perturbed active-oo/vv dependent-pairs ``dPoo``/``dPvv`` (the field derivative of the
+        unperturbed ``Poo0``/``Pvv0``, including the ``d(eps_i-eps_j) = df_ii - df_jj`` denominator
+        term) to ``dD_rel`` and the perturbed Z-vector RHS -- mirroring the spatial template."""
         cc = self.ccwfn
         o, v, nv = cc.o, cc.v, cc.nv
         co = slice(0, o.start)
@@ -616,13 +632,18 @@ class CCderiv:
         ncore = o.stop - cc.no
         ERI = np.asarray(cc.H.ERI)
         eps = np.diag(np.asarray(cc.H.F))
+        is_t = cc.model.upper() == 'CCSD(T)'
+        canon = is_t or getattr(self, '_DBG_FORCE_CANON', False)
         cphf = cc.mp._full_occ_cphf()
-        df = np.asarray(cphf.perturbed_fock(pert, ncore))
-        deri = np.asarray(cphf.perturbed_eri(pert, ncore))
+        df = np.asarray(cphf.perturbed_fock(pert, ncore, canonical=canon))
+        deri = np.asarray(cphf.perturbed_eri(pert, ncore, canonical=canon))
 
         dt1, dt2 = self._so_perturbed_amplitudes(df, deri, hbar)
-        dl1, dl2 = self._so_perturbed_lambda(df, deri, dt1, dt2, hbar, lam)
-        dDg, dGam = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam)
+        dt3 = self._so_perturbed_t3_intermediates(df, deri, dt1, dt2) if is_t else None
+        dl1, dl2 = self._so_perturbed_lambda(df, deri, dt1, dt2, hbar, lam,
+                                             dS1=(dt3['S1'] if is_t else None),
+                                             dS2=(dt3['S2'] if is_t else None))
+        dDg, dGam = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam, dt3=dt3)
         dIp = self._so_cc_perturbed_lagrangian(df, deri, D0, dDg, Gam0, dGam)
         dX = dIp[ofull, v] - dIp[v, ofull].T
         dPco = None
@@ -632,6 +653,17 @@ class CCderiv:
             zjc, dzjc = -Pco.T, -dPco.T
             dX = dX - (c('jc,ajic->ia', dzjc, ERI[v, o, ofull, co]) + c('jc,acij->ia', dzjc, ERI[v, co, ofull, o])
                        + c('jc,ajic->ia', zjc, deri[v, o, ofull, co]) + c('jc,acij->ia', zjc, deri[v, co, ofull, o]))
+        dPoo = dPvv = None
+        if is_t:                                        # perturbed (T) oo/vv dependent-pairs
+            dfd = np.zeros(cc.nmo) if getattr(self, '_DBG_NO_DGAP', False) else np.diag(df)
+            thr = getattr(self, '_DBG_GAP_THRESH', 1e-8)
+            dPoo = self._perturbed_dependent_pairs(dIp[o, o], Poo0, eps[o], dfd[o], thr)
+            dPvv = self._perturbed_dependent_pairs(dIp[v, v], Pvv0, eps[v], dfd[v], thr)
+            if getattr(self, '_DBG_NO_DEPPAIR', False):  # DEBUG isolation
+                dPoo = np.zeros_like(dPoo); dPvv = np.zeros_like(dPvv)
+            else:
+                dX = dX + (c('kl,akil->ia', dPoo, ERI[v, o, ofull, o]) + c('kl,akil->ia', Poo0, deri[v, o, ofull, o])
+                           + c('bc,ibac->ia', dPvv, ERI[ofull, v, v, v]) + c('bc,ibac->ia', Pvv0, deri[ofull, v, v, v]))
         Axz = (c('ajib,jb->ia', deri[v, ofull, ofull, v], z) + c('abij,jb->ia', deri[v, v, ofull, ofull], z)
                + c('ab,ib->ia', df[v, v], z) - c('ij,ja->ia', df[ofull, ofull], z))
         zx = np.linalg.solve(G, (dX - Axz).reshape(-1)).reshape(nof, nv)
@@ -639,6 +671,9 @@ class CCderiv:
         if cc.nfzc:
             dDrel[co, o] += dPco
             dDrel[o, co] += dPco.T
+        if is_t:
+            dDrel[o, o] += dPoo
+            dDrel[v, v] += dPvv
         dDrel[v, ofull] += -zx.T
         dDrel[ofull, v] += -zx
         return dDrel

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -147,8 +147,10 @@ class cclambda(object):
 
             Goo = self.build_Goo(t2, l2)
             Gvv = self.build_Gvv(t2, l2)
-            r1 = self.r_L1(o, v, l1, l2, Hov, Hvv, Hoo, Hovvo, Hovov, Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo)
-            r2 = self.r_L2(o, v, l1, l2, L, Hov, Hvv, Hoo, Hoooo, Hvvvv, Hovvo, Hovov, Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo)
+            s1 = self.ccwfn.S1 if self.ccwfn.model == 'CCSD(T)' else None    # (T) sources, else None
+            s2 = self.ccwfn.S2 if self.ccwfn.model == 'CCSD(T)' else None
+            r1 = self.r_L1(o, v, l1, l2, Hov, Hvv, Hoo, Hovvo, Hovov, Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo, s1=s1)
+            r2 = self.r_L2(o, v, l1, l2, L, Hov, Hvv, Hoo, Hoooo, Hvvvv, Hovvo, Hovov, Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo, s2=s2)
    
             if self.ccwfn.model == 'CC3':
                 if self.ccwfn.orbital_basis == 'spinorbital':
@@ -638,7 +640,7 @@ class cclambda(object):
         return -1.0 * contract('ijeb,ijab->ae', t2, l2)
 
 
-    def r_L1(self, o, v, l1, l2, Hov, Hvv, Hoo, Hovvo, Hovov, Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo):
+    def r_L1(self, o, v, l1, l2, Hov, Hvv, Hoo, Hovvo, Hovov, Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo, s1=None):
         """Compute the L1 (lambda singles) residual.
 
         The lambda equations are linear; solve_lambda drives this residual to
@@ -664,15 +666,15 @@ class cclambda(object):
         contract = self.contract
         if self.ccwfn.orbital_basis == 'spinorbital':
             return self._so_r_L1(o, v, l1, l2, Hov, Hvv, Hoo, Hovvo, Hvvvo,
-                                          Hovoo, Hvovv, Hooov, Gvv, Goo)
+                                          Hovoo, Hvovv, Hooov, Gvv, Goo, s1=s1)
         if self.ccwfn.model == 'CCD':
             r_l1 = zeros_like(l1)
         else:
             r_l1 = 2.0 * clone(Hov)
 
-            # Add (T) contributions to L1
-            if self.ccwfn.model == 'CCSD(T)':
-                r_l1 = r_l1 + self.ccwfn.S1
+            # (T) source, supplied by the caller (cc.S1 unperturbed / dS1 perturbed); None => omit
+            if s1 is not None:
+                r_l1 = r_l1 + s1
 
             r_l1 = r_l1 + contract('ie,ea->ia', l1, Hvv)
             r_l1 = r_l1 - contract('ma,im->ia', l1, Hoo)          
@@ -692,7 +694,7 @@ class cclambda(object):
                 r_l1 = r_l1 + contract('mn,imna->ia', Goo, Hooov)
         return r_l1
 
-    def r_L2(self, o, v, l1, l2, L, Hov, Hvv, Hoo, Hoooo, Hvvvv, Hovvo, Hovov, Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo):
+    def r_L2(self, o, v, l1, l2, L, Hov, Hvv, Hoo, Hoooo, Hvvvv, Hovvo, Hovov, Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo, s2=None):
         """Compute the L2 (lambda doubles) residual.
 
         The lambda equations are linear; solve_lambda drives this residual to
@@ -724,7 +726,7 @@ class cclambda(object):
         if self.ccwfn.orbital_basis == 'spinorbital':
             return self._so_r_L2(o, v, l1, l2, self.ccwfn.H.ERI, Hov, Hvv, Hoo,
                                           Hoooo, Hvvvv, Hovvo, Hvvvo, Hovoo, Hvovv, Hooov,
-                                          Gvv, Goo)
+                                          Gvv, Goo, s2=s2)
         if self.ccwfn.model == 'CCD':
             r_l2 = clone(L[o,o,v,v], device=self.ccwfn.device1)
 
@@ -740,9 +742,11 @@ class cclambda(object):
         else:
             r_l2 = clone(L[o,o,v,v], device=self.ccwfn.device1)
 
-            # Add (T) contributions to L2
-            if self.ccwfn.model == 'CCSD(T)':
-                r_l2 = r_l2 + 0.5 * self.ccwfn.S2
+            # (T) source, supplied by the caller (cc.S2 unperturbed / dS2 perturbed); None => omit.
+            # Added before the final P_ij^ab symmetrization (r_l2 += r_l2.T) so the source is
+            # symmetrized identically in the unperturbed and perturbed paths.
+            if s2 is not None:
+                r_l2 = r_l2 + 0.5 * s2
 
             r_l2 = r_l2 + 2.0 * contract('ia,jb->ijab', l1, Hov)
             r_l2 = r_l2 - contract('ja,ib->ijab', l1, Hov)
@@ -835,13 +839,13 @@ class cclambda(object):
         return W
                                          
     def _so_r_L1(self, o, v, l1, l2, Hov, Hvv, Hoo, Hovvo, Hvvvo, Hovoo,
-                          Hvovv, Hooov, Gvv, Goo):
+                          Hvovv, Hooov, Gvv, Goo, s1=None):
         """Spin-orbital L1 (lambda singles) residual, built from the antisymmetrized
         spin-orbital HBAR blocks (no Hovov)."""
         contract = self.contract
         r_l1 = clone(Hov)
-        if self.ccwfn.model == 'CCSD(T)':
-            r_l1 = r_l1 + self.ccwfn.S1
+        if s1 is not None:                              # (T) source (cc.S1 / dS1); None => omit
+            r_l1 = r_l1 + s1
         r_l1 = r_l1 + contract('ie,ea->ia', l1, Hvv)
         r_l1 = r_l1 - contract('ma,im->ia', l1, Hoo)
         r_l1 = r_l1 + 0.5 * contract('imef,efam->ia', l2, Hvvvo)
@@ -852,13 +856,13 @@ class cclambda(object):
         return r_l1
 
     def _so_r_L2(self, o, v, l1, l2, ERI, Hov, Hvv, Hoo, Hoooo, Hvvvv, Hovvo,
-                          Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo):
+                          Hvvvo, Hovoo, Hvovv, Hooov, Gvv, Goo, s2=None):
         """Spin-orbital L2 (lambda doubles) residual. Built as the full residual,
         already antisymmetric in i<->j and a<->b (no separate symmetrization)."""
         contract = self.contract
         r_l2 = clone(ERI[o,o,v,v])
-        if self.ccwfn.model == 'CCSD(T)':
-            r_l2 = r_l2 + self.ccwfn.S2
+        if s2 is not None:                              # (T) source (cc.S2 / dS2); None => omit (no 1/2, SO)
+            r_l2 = r_l2 + s2
         r_l2 = r_l2 + (contract('ia,jb->ijab', l1, Hov) - contract('ja,ib->ijab', l1, Hov))
         r_l2 = r_l2 + (contract('jb,ia->ijab', l1, Hov) - contract('ib,ja->ijab', l1, Hov))
         r_l2 = r_l2 + (contract('ijae,eb->ijab', l2, Hvv) - contract('ijbe,ea->ijab', l2, Hvv))

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -941,12 +941,12 @@ def t3_density(o, v, no, nv, t1, t2, F, ERI, L, contract):
     intermediates is a dict of the (T) contributions {Doo, Dvv, Dov, Goovv, Gooov,
     Gvvvo, S1, S2} that the caller caches on the wavefunction.
     """
-    dvv = np.zeros(nv)   # diagonal of the (T) vir-vir 1-PDM (see below)
-    doo = np.zeros(no)   # diagonal of the (T) occ-occ 1-PDM
-    Dov = np.zeros((no,nv))
+    dvv = np.zeros(nv, dtype=t2.dtype)   # diagonal of the (T) vir-vir 1-PDM (see below)
+    doo = np.zeros(no, dtype=t2.dtype)   # diagonal of the (T) occ-occ 1-PDM; dtype-propagating for complex-step
+    Dov = np.zeros((no,nv), dtype=t2.dtype)
     Goovv = np.zeros_like(t2)
-    Gooov = np.zeros((no,no,no,nv))
-    Gvvvo = np.zeros((nv,nv,nv,no))
+    Gooov = np.zeros((no,no,no,nv), dtype=t2.dtype)
+    Gvvvo = np.zeros((nv,nv,nv,no), dtype=t2.dtype)
     S1 = np.zeros_like(t1)
     S2 = np.zeros_like(t2)
     X2 = np.zeros_like(t2)
@@ -1002,6 +1002,68 @@ def t3_density(o, v, no, nv, t1, t2, F, ERI, L, contract):
                 'S1': S1, 'S2': S2}
 
 
+def dt3_density(o, v, no, nv, t1, t2, dt1, dt2, F, df, ERI, deri, L, dL, contract):
+    """Analytic field response of the spatial (closed-shell RHF) (T) intermediates -- the
+    product-rule derivative of :func:`t3_density` along ``(t1+dt1, t2+dt2, F+df, ERI+deri, L+dL)``
+    with **canonical** perturbed orbitals.  Returns ``d{Doo,Dvv,Dov,Goovv,Gooov,Gvvvo,S1,S2}``
+    (the spatial route has no ``Gvovv``/``Govoo``).  Verified to ~1e-16 against a complex-step
+    derivative of :func:`t3_density`."""
+    ddvv = np.zeros(nv, dtype=t2.dtype); ddoo = np.zeros(no, dtype=t2.dtype)
+    dDov = np.zeros((no,nv), dtype=t2.dtype)
+    dGoovv = np.zeros_like(t2); dGooov = np.zeros((no,no,no,nv), dtype=t2.dtype)
+    dGvvvo = np.zeros((nv,nv,nv,no), dtype=t2.dtype); dS1 = np.zeros_like(t1); dS2 = np.zeros_like(t2)
+
+    Wvvvo, Wovoo, Woovv, Fov = ERI[v,v,v,o], ERI[o,v,o,o], ERI[o,o,v,v], F[o,v]
+    dWvvvo, dWovoo, dWoovv, dFov = deri[v,v,v,o], deri[o,v,o,o], deri[o,o,v,v], df[o,v]
+    occ, vir = diag(F)[o], diag(F)[v]
+    docc, dvir = diag(df)[o], diag(df)[v]
+
+    def dNc(i, j, k):   # product rule of the spatial t3c_ijk numerator (12 terms)
+        def T(W, t): return (contract('bae,ce->abc', W[:,:,:,i], t[k,j]) + contract('cae,be->abc', W[:,:,:,i], t[j,k])
+                             + contract('ace,be->abc', W[:,:,:,k], t[j,i]) + contract('bce,ae->abc', W[:,:,:,k], t[i,j])
+                             + contract('cbe,ae->abc', W[:,:,:,j], t[i,k]) + contract('abe,ce->abc', W[:,:,:,j], t[k,i]))
+        def U(W, t): return (contract('mc,mab->abc', W[:,:,j,k], t[i]) + contract('mb,mac->abc', W[:,:,k,j], t[i])
+                             + contract('mb,mca->abc', W[:,:,i,j], t[k]) + contract('ma,mcb->abc', W[:,:,j,i], t[k])
+                             + contract('ma,mbc->abc', W[:,:,k,i], t[j]) + contract('mc,mba->abc', W[:,:,i,k], t[j]))
+        return (T(dWvvvo, t2) + T(Wvvvo, dt2)) - (U(dWovoo, t2) + U(Wovoo, dt2))
+
+    def dNd(i, j, k):   # product rule of the spatial t3d_ijk numerator (6 terms)
+        return (contract('ab,c->abc', dWoovv[i,j], t1[k]) + contract('ac,b->abc', dWoovv[i,k], t1[j]) + contract('bc,a->abc', dWoovv[j,k], t1[i])
+                + contract('ab,c->abc', Woovv[i,j], dt1[k]) + contract('ac,b->abc', Woovv[i,k], dt1[j]) + contract('bc,a->abc', Woovv[j,k], dt1[i])
+                + contract('ab,c->abc', dt2[i,j], Fov[k]) + contract('ac,b->abc', dt2[i,k], Fov[j]) + contract('bc,a->abc', dt2[j,k], Fov[i])
+                + contract('ab,c->abc', t2[i,j], dFov[k]) + contract('ac,b->abc', t2[i,k], dFov[j]) + contract('bc,a->abc', t2[j,k], dFov[i]))
+
+    def sym(A): return 8*A - 4*A.swapaxes(0,1) - 4*A.swapaxes(1,2) - 4*A.swapaxes(0,2) + 2*np.moveaxis(A,0,2) + 2*np.moveaxis(A,2,0)
+
+    for i in range(no):
+        for j in range(no):
+            for k in range(no):
+                M3 = t3c_ijk(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract, True)
+                N3 = t3d_ijk(o, v, i, j, k, t1, t2, Woovv, F, contract, True)
+                denom = occ[i] + occ[j] + occ[k] - (vir.reshape(-1,1,1) + vir.reshape(-1,1) + vir)
+                ddenom = docc[i] + docc[j] + docc[k] - (dvir.reshape(-1,1,1) + dvir.reshape(-1,1) + dvir)
+                dM3 = (dNc(i,j,k) - M3*ddenom) / denom
+                dN3 = (dNd(i,j,k) - N3*ddenom) / denom
+                X3, Y3 = sym(M3), sym(N3); dX3, dY3 = sym(dM3), sym(dN3)
+                ddvv += 0.5 * (contract('acd,acd->a', dM3, (X3+Y3)) + contract('acd,acd->a', M3, (dX3+dY3)))
+                ddoo[i] -= 0.5 * (contract('abc,abc->', dM3, (X3+Y3)) + contract('abc,abc->', M3, (dX3+dY3)))
+                dDov[i] += (contract('abc,bc->a', (dM3 - dM3.swapaxes(0,2)), (4*t2[j,k] - 2*t2[j,k].T))
+                            + contract('abc,bc->a', (M3 - M3.swapaxes(0,2)), (4*dt2[j,k] - 2*dt2[j,k].T)))
+                Z3 = 2*(M3 - M3.swapaxes(1,2)) - (M3.swapaxes(0,1) - np.moveaxis(M3,2,0))
+                dZ3 = 2*(dM3 - dM3.swapaxes(1,2)) - (dM3.swapaxes(0,1) - np.moveaxis(dM3,2,0))
+                dGoovv[i,j] += 4*(contract('c,abc->ab', dt1[k], Z3) + contract('c,abc->ab', t1[k], dZ3))
+                dGooov[j,i] -= contract('abc,lbc->la', (2*dX3+dY3), t2[:,k]) + contract('abc,lbc->la', (2*X3+Y3), dt2[:,k])
+                dGvvvo[:,:,:,j] += contract('abc,cd->abd', (2*dX3+dY3), t2[k,i]) + contract('abc,cd->abd', (2*X3+Y3), dt2[k,i])
+                dS1[i] += (contract('abc,bc->a', 2*(dM3 - dM3.swapaxes(0,1)), L[o,o,v,v][j,k])
+                           + contract('abc,bc->a', 2*(M3 - M3.swapaxes(0,1)), dL[o,o,v,v][j,k]))
+                dS2[i] -= contract('abc,lc->lab', (2*dX3+dY3), ERI[o,o,o,v][j,k]) + contract('abc,lc->lab', (2*X3+Y3), deri[o,o,o,v][j,k])
+                dS2[i,j] += contract('abc,dcb->ad', (2*dX3+dY3), ERI[o,v,v,v][k]) + contract('abc,dcb->ad', (2*X3+Y3), deri[o,v,v,v][k])
+
+    dS2 = dS2 + dS2.swapaxes(0,1).swapaxes(2,3)
+    return {'Doo': np.diag(ddoo), 'Dvv': np.diag(ddvv), 'Dov': dDov,
+            'Goovv': dGoovv, 'Gooov': dGooov, 'Gvvvo': dGvvvo, 'S1': dS1, 'S2': dS2}
+
+
 def so_t3_density(o, v, no, nv, t1, t2, F, ERI, contract):
     """(T) density/Lambda intermediates, spin-orbital (UHF/ROHF references).
 
@@ -1010,14 +1072,14 @@ def so_t3_density(o, v, no, nv, t1, t2, F, ERI, contract):
     Gvovv, Govoo, Gvvvo, S1, S2} that the caller caches on the wavefunction.
     """
     x2 = np.zeros_like(t2)
-    dvv = np.zeros(nv)
-    doo = np.zeros(no)
-    Dov = np.zeros((no,nv))
+    dvv = np.zeros(nv, dtype=t2.dtype)          # dtype-propagating so complex-step works
+    doo = np.zeros(no, dtype=t2.dtype)
+    Dov = np.zeros((no,nv), dtype=t2.dtype)
     Goovv = np.zeros_like(t2)
-    Gooov = np.zeros((no,no,no,nv))
-    Gvovv = np.zeros((nv,no,nv,nv))
-    Govoo = np.zeros((no,nv,no,no))
-    Gvvvo = np.zeros((nv,nv,nv,no))
+    Gooov = np.zeros((no,no,no,nv), dtype=t2.dtype)
+    Gvovv = np.zeros((nv,no,nv,nv), dtype=t2.dtype)
+    Govoo = np.zeros((no,nv,no,no), dtype=t2.dtype)
+    Gvvvo = np.zeros((nv,nv,nv,no), dtype=t2.dtype)
     S1 = np.zeros_like(t1)
     S2 = np.zeros_like(t2)
 
@@ -1077,3 +1139,69 @@ def so_t3_density(o, v, no, nv, t1, t2, F, ERI, contract):
     return ET, {'Doo': np.diag(doo), 'Dvv': np.diag(dvv), 'Dov': Dov,
                 'Goovv': Goovv, 'Gooov': Gooov, 'Gvovv': Gvovv,
                 'Govoo': Govoo, 'Gvvvo': Gvvvo, 'S1': S1, 'S2': S2}
+
+
+def so_dt3_density(o, v, no, nv, t1, t2, dt1, dt2, F, df, ERI, deri, contract):
+    """Analytic field response of the spin-orbital (T) intermediates -- the product-rule
+    derivative of :func:`so_t3_density` along ``(t1+dt1, t2+dt2, F+df, ERI+deri)`` with **canonical**
+    perturbed orbitals (so the batched diagonal denominator's response is ``diag(df)``).  Returns
+    ``d{Doo,Dvv,Dov,Goovv,Gooov,Gvovv,Govoo,Gvvvo,S1,S2}``.  Each per-ijk triple response is
+    ``dt3 = (dN - t3 dD)/D``; every intermediate is then the product rule of its contraction.
+    Verified to ~1e-16 against a complex-step derivative of :func:`so_t3_density`."""
+    ddvv = np.zeros(nv, dtype=t2.dtype); ddoo = np.zeros(no, dtype=t2.dtype)
+    dDov = np.zeros((no,nv), dtype=t2.dtype)
+    dGoovv = np.zeros_like(t2); dGooov = np.zeros((no,no,no,nv), dtype=t2.dtype)
+    dGvovv = np.zeros((nv,no,nv,nv), dtype=t2.dtype); dGovoo = np.zeros((no,nv,no,no), dtype=t2.dtype)
+    dGvvvo = np.zeros((nv,nv,nv,no), dtype=t2.dtype); dS1 = np.zeros_like(t1); dS2 = np.zeros_like(t2)
+
+    Wvvvo, Wovoo, Woovv = ERI[v,v,v,o], ERI[o,v,o,o], ERI[o,o,v,v]
+    Wvovv, Wooov, Fov = ERI[v,o,v,v], ERI[o,o,o,v], F[o,v]
+    dWvvvo, dWovoo, dWoovv = deri[v,v,v,o], deri[o,v,o,o], deri[o,o,v,v]
+    dWvovv, dWooov, dFov = deri[v,o,v,v], deri[o,o,o,v], df[o,v]
+    occ, vir = diag(F)[o], diag(F)[v]
+    docc, dvir = diag(df)[o], diag(df)[v]
+
+    def dNc(i, j, k):   # product-rule derivative of the t3c numerator
+        a = (contract('ad,bcd->abc', dt2[i,j], Wvvvo[:,:,:,k]) + contract('ad,bcd->abc', t2[i,j], dWvvvo[:,:,:,k])
+             - contract('ad,bcd->abc', dt2[k,j], Wvvvo[:,:,:,i]) - contract('ad,bcd->abc', t2[k,j], dWvvvo[:,:,:,i])
+             - contract('ad,bcd->abc', dt2[i,k], Wvvvo[:,:,:,j]) - contract('ad,bcd->abc', t2[i,k], dWvvvo[:,:,:,j]))
+        t3 = a - a.swapaxes(0,1) - a.swapaxes(0,2)
+        a = (contract('lab,lc->abc', dt2[i], Wovoo[:,:,j,k]) + contract('lab,lc->abc', t2[i], dWovoo[:,:,j,k])
+             - contract('lab,lc->abc', dt2[j], Wovoo[:,:,i,k]) - contract('lab,lc->abc', t2[j], dWovoo[:,:,i,k])
+             - contract('lab,lc->abc', dt2[k], Wovoo[:,:,j,i]) - contract('lab,lc->abc', t2[k], dWovoo[:,:,j,i]))
+        return t3 - (a - a.swapaxes(0,2) - a.swapaxes(1,2))
+
+    def dNd(i, j, k):   # product-rule derivative of the t3d numerator
+        a = (contract('a,bc->abc', dt1[i], Woovv[j,k]) + contract('a,bc->abc', t1[i], dWoovv[j,k])
+             - contract('a,bc->abc', dt1[j], Woovv[i,k]) - contract('a,bc->abc', t1[j], dWoovv[i,k])
+             - contract('a,bc->abc', dt1[k], Woovv[j,i]) - contract('a,bc->abc', t1[k], dWoovv[j,i])
+             + contract('a,bc->abc', dFov[i], t2[j,k]) + contract('a,bc->abc', Fov[i], dt2[j,k])
+             - contract('a,bc->abc', dFov[j], t2[i,k]) - contract('a,bc->abc', Fov[j], dt2[i,k])
+             - contract('a,bc->abc', dFov[k], t2[j,i]) - contract('a,bc->abc', Fov[k], dt2[j,i]))
+        return a - a.swapaxes(0,1) - a.swapaxes(0,2)
+
+    for i in range(no):
+        for j in range(no):
+            for k in range(no):
+                t3c = t3c_ijk_so(o, v, i, j, k, t2, Wvvvo, Wovoo, F, contract)
+                t3d = t3d_ijk_so(o, v, i, j, k, t1, t2, Woovv, F, contract)
+                denom = occ[i] + occ[j] + occ[k] - (vir.reshape(-1,1,1) + vir.reshape(-1,1) + vir)
+                ddenom = docc[i] + docc[j] + docc[k] - (dvir.reshape(-1,1,1) + dvir.reshape(-1,1) + dvir)
+                dt3c = (dNc(i,j,k) - t3c*ddenom) / denom
+                dt3d = (dNd(i,j,k) - t3d*ddenom) / denom
+                ddvv += (1/12) * (contract('abc,abc->a', (dt3c+dt3d), t3c) + contract('abc,abc->a', (t3c+t3d), dt3c))
+                ddoo[i] -= (1/12) * (contract('abc,abc->', dt3c, (t3c+t3d)) + contract('abc,abc->', t3c, (dt3c+dt3d)))
+                dDov[i] += (1/4) * (contract('ade,de->a', dt3c, t2[j,k]) + contract('ade,de->a', t3c, dt2[j,k]))
+                dGoovv[i,j] += contract('abc,c->ab', dt3c, t1[k]) + contract('abc,c->ab', t3c, dt1[k])
+                dGooov[i,j] -= (1/2) * (contract('kbc,abc->ka', dt2[k], t3c) + contract('kbc,abc->ka', t2[k], dt3c))
+                dGvovv[:,i] += (1/2) * (contract('ec,abe->cab', dt2[j,k], t3c) + contract('ec,abe->cab', t2[j,k], dt3c))
+                dGovoo[:,:,i,j] -= (1/2) * (contract('kbc,abc->ka', dt2[k], (t3c+t3d)) + contract('kbc,abc->ka', t2[k], (dt3c+dt3d)))
+                dGvvvo[:,:,:,i] += (1/2) * (contract('abe,ec->abc', (dt3c+dt3d), t2[j,k]) + contract('abe,ec->abc', (t3c+t3d), dt2[j,k]))
+                dS1[i] += (1/4) * (contract('abc,bc->a', dt3c, Woovv[j,k]) + contract('abc,bc->a', t3c, dWoovv[j,k]))
+                dS2[i] -= (1/4) * (contract('md,abd->mab', dWooov[j,k], (2*t3c+t3d)) + contract('md,abd->mab', Wooov[j,k], (2*dt3c+dt3d)))
+                dS2[i,j] += (1/4) * (contract('ade,bde->ab', (2*dt3c+dt3d), Wvovv[:,k]) + contract('ade,bde->ab', (2*t3c+t3d), dWvovv[:,k]))
+
+    dS2 = dS2 - dS2.swapaxes(0,1) - dS2.swapaxes(2,3) + dS2.swapaxes(0,1).swapaxes(2,3)
+    return {'Doo': np.diag(ddoo), 'Dvv': np.diag(ddvv), 'Dov': dDov,
+            'Goovv': dGoovv, 'Gooov': dGooov, 'Gvovv': dGvovv,
+            'Govoo': dGovoo, 'Gvvvo': dGvvvo, 'S1': dS1, 'S2': dS2}

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -281,7 +281,7 @@ class CPHF(object):
             return self.solve_nuclear(atom)[cart]
         raise NotImplementedError("ov response wired for 'field'/'nuclear' only.")
 
-    def _full_U(self, pert: "Perturbation", ncore: int = 0) -> np.ndarray:
+    def _full_U(self, pert: "Perturbation", ncore: int = 0, canonical: bool = False) -> np.ndarray:
         """The full ``nmo x nmo`` orbital-rotation matrix ``U^x_pq`` for ``pert``.
 
         The matrix element ``U_qp = <phi_q|d phi_p/dx>`` (the coefficient of orbital ``q`` in
@@ -297,7 +297,15 @@ class CPHF(object):
         move the frozen/active partition), so that block is *not* left at the orthonormality
         value but determined by the canonical Brillouin condition ``d_x f_ij = 0`` -- a direct
         divide by ``(eps_i - eps_j)``, using the already-solved ov response. The redundant
-        core-core, active-active, and vir-vir blocks stay at ``-1/2 S^x``."""
+        core-core, active-active, and vir-vir blocks stay at ``-1/2 S^x``.
+
+        ``canonical=True`` (CCSD(T) derivatives): the (T) energy is *not* invariant to
+        active-occupied or virtual rotations, so the canonical perturbed-orbital condition
+        ``d_x f_pq = 0`` must also fix the active-oo and vv off-diagonal blocks -- the same
+        ``(eps_p - eps_q)`` divide, generalized from the frozen-core core<->active block to the
+        full active-oo/vv space, so that ``d_x f`` is diagonal within oo and vv. Diagonal and
+        (near-)degenerate pairs keep the orthonormality value ``-1/2 S^x`` (the divide is
+        ill-conditioned there -- the standard degeneracy caveat)."""
         o, v, nmo = self.o, self.v, self.wfn.nmo
         fx, Sx, _ = self._skeleton(pert)
         Uia = self._ov_response(pert)                       # (no, nv): U_ai = <phi_a|d phi_i>
@@ -327,9 +335,29 @@ class CPHF(object):
             Uca = -num / (eps[co][:, None] - eps[ao][None, :])
             U[co, ao] = Uca
             U[ao, co] = -(Sx[co, ao] + Uca).T
+        if canonical:
+            # Canonical Brillouin divide d_x f_pq = 0 for the active-oo and vv off-diagonal
+            # blocks (generalizes the frozen-core core<->active block above), so d_x f is
+            # diagonal within oo and vv -- required by the non-invariant (T) kernels.
+            W = (np.asarray(self.wfn.H.ERI) if self.wfn.orbital_basis == 'spinorbital'
+                 else np.asarray(self.wfn.H.L))
+            eps = self.eps
+            ao = slice(o.start + ncore, o.stop)             # active occupied
+            Soo = Sx[o, o]
+            Uvo = U[v, o]
+            for blk in (ao, v):
+                Sblk = Sx[blk, blk]
+                Sterm = 0.5 * (self.contract('nm,pnqm->pq', Soo, W[blk, o, blk, o])
+                               + self.contract('nm,pmqn->pq', Soo, W[blk, o, blk, o]))
+                Uterm = (self.contract('cm,pcqm->pq', Uvo, W[blk, v, blk, o])
+                         + self.contract('cm,pmqc->pq', Uvo, W[blk, o, blk, v]))
+                num = fx[blk, blk] - Sblk * eps[blk][None, :] - Sterm + Uterm
+                gap = eps[blk][:, None] - eps[blk][None, :]
+                offdiag = np.abs(gap) > 1e-8
+                U[blk, blk] = np.where(offdiag, -num / np.where(offdiag, gap, 1.0), -0.5 * Sblk)
         return U
 
-    def perturbed_fock(self, pert: "Perturbation", ncore: int = 0) -> np.ndarray:
+    def perturbed_fock(self, pert: "Perturbation", ncore: int = 0, canonical: bool = False) -> np.ndarray:
         """Full first derivative of the MO Fock matrix ``d_x f_pq`` (``nmo x nmo``) for
         ``pert``, with the CPHF response folded in (derivints.pdf)::
 
@@ -341,8 +369,10 @@ class CPHF(object):
         on the spin-orbital path), ``n,m`` over occupied and ``c`` over virtual. The skeleton
         ``f^(x)``/``S^x`` come from :meth:`_skeleton`; for an electric field ``S^x = 0`` so the
         ``S^x`` term drops. ``ncore`` selects the frozen-core core<->active response in ``U``
-        (see :meth:`_full_U`). Cached per ``(pert, ncore)``."""
-        key = (pert, ncore)
+        (see :meth:`_full_U`). ``canonical`` selects the canonical active-oo/vv perturbed
+        orbitals (CCSD(T); makes ``d_x f`` diagonal within oo and vv). Cached per
+        ``(pert, ncore, canonical)``."""
+        key = (pert, ncore, canonical)
         if key in self._dfock:
             return self._dfock[key]
         o, v = self.o, self.v
@@ -351,7 +381,7 @@ class CPHF(object):
         W = (np.asarray(self.wfn.H.ERI) if self.wfn.orbital_basis == 'spinorbital'
              else np.asarray(self.wfn.H.L))
         fx, Sx, _ = self._skeleton(pert)
-        U = self._full_U(pert, ncore)
+        U = self._full_U(pert, ncore, canonical)
         df = fx + U * eps[:, None] + U.T * eps[None, :]     # f^(x) + U_pq f_pp + U_qp f_qq
         # - 1/2 sum_nm(occ) S^x_nm ( w[p,n,q,m] + w[p,m,q,n] )
         Soo = Sx[o, o]
@@ -364,7 +394,7 @@ class CPHF(object):
         self._dfock[key] = df
         return df
 
-    def perturbed_eri(self, pert: "Perturbation", ncore: int = 0, blocks=None) -> np.ndarray:
+    def perturbed_eri(self, pert: "Perturbation", ncore: int = 0, blocks=None, canonical: bool = False) -> np.ndarray:
         """Full first derivative of the MO two-electron integrals ``d_x <pq|rs>`` for ``pert``
         (derivints.pdf)::
 
@@ -380,13 +410,14 @@ class CPHF(object):
         tensor is built and cached per ``(pert, ncore)`` (geometry-bound, shared across
         properties). ``blocks`` is an optional 4-tuple of block labels ('o'/'v'/'all'), e.g.
         ``('o','o','v','v')`` for the MP2 2PDM; the **default returns the full tensor** (CC
-        consumers need the other blocks)."""
-        key = (pert, ncore)
+        consumers need the other blocks). ``canonical`` selects the canonical active-oo/vv
+        perturbed orbitals (CCSD(T))."""
+        key = (pert, ncore, canonical)
         full = self._deri.get(key)
         if full is None:
             ERI = np.asarray(self.wfn.H.ERI)
             _, _, gx = self._skeleton(pert)
-            U = self._full_U(pert, ncore)
+            U = self._full_U(pert, ncore, canonical)
             full = gx + self._rotate_eri(U, ERI)
             self._deri[key] = full
         if blocks is None:

--- a/pycc/tests/test_034_ccsd_t_density.py
+++ b/pycc/tests/test_034_ccsd_t_density.py
@@ -191,3 +191,57 @@ def test_ccsdt_relaxed_dipole_frozen_core(rhf_wfn):
     mu = np.asarray(pycc.CCderiv(cc).relaxed_dipole())
     assert abs(mu[2] - RELAXED_DIPOLE_Z_REF_FC) < 1e-10, mu[2]
     psi4.core.clean()
+
+
+# Off-axis relaxed CCSD(T) dipole.  The mu_z checks above only probe the totally-symmetric (z)
+# direction of yz-plane water, so the non-totally-symmetric (off-axis) blocks of the (T) relaxed
+# density went untested (mu_x = mu_y = 0 there by symmetry).  Here the molecule is tilted into a
+# general C1 orientation (a fixed rotation of _T_DIPOLE_GEOM) so mu has all three Cartesian
+# components nonzero.  Each reference component was validated (once) against mu_a = -dE_corr/dF_a --
+# a 5-point O(h^4) field-relaxed energy gradient of pycc's own CCSD(T) correlation energy -- to
+# 3.6e-11, all-electron and frozen core.
+_T_DIPOLE_TILTED_GEOM = """
+O  0.074487494137924 -0.055774775873582  0.108878068289408
+H -0.951260432480889 -1.066139182313485 -1.390453518773079
+H -0.230910151065614  1.951325348189316 -0.337520431951801
+symmetry c1
+units bohr
+no_com
+no_reorient
+"""
+RELAXED_DIPOLE_OFFAXIS_REF = np.array([0.0462175718, -0.0346068120, 0.0675560373])      # 6-31G, AE
+RELAXED_DIPOLE_OFFAXIS_REF_FC = np.array([0.0462776809, -0.0346518205, 0.0676438986])   # 6-31G, FC
+
+
+def test_ccsdt_relaxed_dipole_offaxis(rhf_wfn):
+    """The full CCSD(T) relaxed correlation dipole vector (all three Cartesian components) matches its
+    field-gradient-validated reference for a general (tilted) orientation, in BOTH the spin-orbital
+    and spatial bases (SO == spatial keystone).  Unlike the yz-plane mu_z checks above, this probes
+    the off-axis (non-totally-symmetric) blocks of the (T) relaxed density."""
+    wfn = rhf_wfn(_T_DIPOLE_TILTED_GEOM, "6-31G", freeze_core="false")
+    mu = {}
+    for basis in ('spinorbital', 'spatial'):
+        cc = pycc.ccwfn(wfn, model='ccsd(t)', make_t3_density=True, orbital_basis=basis)
+        cc.solve_cc(1e-12, 1e-12, 100)
+        mu[basis] = np.asarray(pycc.CCderiv(cc).relaxed_dipole())
+    assert np.max(np.abs(mu['spatial'] - RELAXED_DIPOLE_OFFAXIS_REF)) < 1e-8, mu['spatial']
+    assert np.max(np.abs(mu['spinorbital'] - RELAXED_DIPOLE_OFFAXIS_REF)) < 1e-8, mu['spinorbital']
+    assert np.max(np.abs(mu['spinorbital'] - mu['spatial'])) < 1e-9, (mu['spinorbital'], mu['spatial'])
+    psi4.core.clean()
+
+
+def test_ccsdt_relaxed_dipole_offaxis_frozen_core(rhf_wfn):
+    """Frozen-core analog of :func:`test_ccsdt_relaxed_dipole_offaxis` (O 1s frozen): the off-axis (T)
+    relaxed dipole with the core<->active P_co divide and the active oo/vv dependent pairs inside
+    D_rel, again in both bases."""
+    wfn = rhf_wfn(_T_DIPOLE_TILTED_GEOM, "6-31G", freeze_core="true")
+    mu = {}
+    for basis in ('spinorbital', 'spatial'):
+        cc = pycc.ccwfn(wfn, model='ccsd(t)', make_t3_density=True, orbital_basis=basis)
+        cc.solve_cc(1e-12, 1e-12, 100)
+        assert cc.nfzc > 0
+        mu[basis] = np.asarray(pycc.CCderiv(cc).relaxed_dipole())
+    assert np.max(np.abs(mu['spatial'] - RELAXED_DIPOLE_OFFAXIS_REF_FC)) < 1e-8, mu['spatial']
+    assert np.max(np.abs(mu['spinorbital'] - RELAXED_DIPOLE_OFFAXIS_REF_FC)) < 1e-8, mu['spinorbital']
+    assert np.max(np.abs(mu['spinorbital'] - mu['spatial'])) < 1e-9, (mu['spinorbital'], mu['spatial'])
+    psi4.core.clean()

--- a/pycc/tests/test_084_cc_polarizability.py
+++ b/pycc/tests/test_084_cc_polarizability.py
@@ -190,15 +190,83 @@ def test_uhf_ccsd_polarizability_nh2(rhf_wfn):
     psi4.core.clean()
 
 
+# ---- CCSD(T): spin-orbital, energy-second-derivative-FD anchored ----
+# The spin-orbital CCSD(T) correlation alpha (H2O/6-31G, WATER), frozen rather than re-run.  Unlike
+# CCSD above, the relaxed-dipole FD is NOT a reliable oracle for (T): the Lee-Rendell dependent-pair
+# numerator gate makes the relaxed dipole non-smooth under an out-of-plane (sigma_h-breaking) field,
+# which poisons the finite difference (the energy is untouched -- it never uses the dependent pairs).
+# So each (T) value was validated once against the ENERGY second-derivative finite field
+# (alpha_aa = -d^2 E_corr/dF_a^2, density-independent) -- diagonals to 2.4e-8 (see _energy_fd_alpha).
+# The deterministic analytic recomputation reproduces the frozen tensor to ~machine precision, so
+# 1e-9 is a tight regression guard.  Spatial CCSD(T) is not yet available.
+WATER_ALPHA_T_DIAG    = np.array([0.0749401988258554, 0.0992910106442475, 0.20111257930800613])   # SO, AE
+WATER_ALPHA_T_DIAG_FC = np.array([0.0752394685506570, 0.1001122215200233, 0.20165562805738180])   # SO, FC
+# frozen external anchor: alpha diagonal from the 5-point energy 2nd-derivative FD (validated once).
+ALPHA_T_ENERGY_FD    = np.array([0.0749401992206078, 0.0992910218359603, 0.20111260312954962])    # AE
+ALPHA_T_ENERGY_FD_FC = np.array([0.0752394689422971, 0.1001122328817920, 0.20165565204760540])    # FC
+
+
+def _energy_fd_alpha(freeze_core='false', F=5e-3):
+    """Regeneration recipe for ALPHA_T_ENERGY_FD[_FC] (not run in the tests): the SO CCSD(T)
+    correlation alpha diagonal from a 5-point O(h^4) finite field of pycc's own correlation energy,
+    alpha_aa = -d^2(E_CCSD(T) - E_SCF)/dF_a^2 -- density-independent, the reliable (T) oracle."""
+    def e(Fvec):
+        psi4.core.clean(); psi4.core.clean_options(); psi4.geometry(WATER)
+        opt = {'basis': '6-31G', 'scf_type': 'pk', 'freeze_core': freeze_core,
+               'e_convergence': 1e-14, 'd_convergence': 1e-14}
+        if Fvec is not None:
+            opt.update({'perturb_h': True, 'perturb_with': 'dipole', 'perturb_dipole': Fvec})
+        psi4.set_options(opt)
+        _, wfn = psi4.energy('scf', return_wfn=True)
+        return pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis='spinorbital').solve_cc(1e-13, 1e-13, 300)
+    E0 = e(None); diag = np.zeros(3)
+    for a in range(3):
+        d = lambda s: e([s * F if i == a else 0.0 for i in range(3)])
+        diag[a] = -(-d(2) + 16 * d(1) - 30 * E0 + 16 * d(-1) - d(-2)) / (12 * F * F)
+    return diag
+
+
+def test_so_ccsdt_polarizability_water_631g(rhf_wfn):
+    """All-electron spin-orbital CCSD(T) correlation alpha (H2O/6-31G) vs the frozen reference and the
+    frozen energy-second-derivative finite field; the tensor is diagonal by symmetry."""
+    wfn = rhf_wfn(WATER, "6-31G", freeze_core="false")
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis='spinorbital', make_t3_density=True)
+    cc.solve_cc(1e-13, 1e-13, 100)
+    a = np.asarray(pycc.CCderiv(cc).polarizability())
+    assert np.max(np.abs(np.diag(a) - WATER_ALPHA_T_DIAG)) < 1e-9, np.diag(a)
+    assert np.max(np.abs(a - np.diag(np.diag(a)))) < 1e-10, a          # diagonal by symmetry
+    assert np.max(np.abs(np.diag(a) - ALPHA_T_ENERGY_FD)) < 1e-7, np.diag(a)
+    psi4.core.clean()
+
+
+def test_fc_so_ccsdt_polarizability_water_631g(rhf_wfn):
+    """Frozen-core spin-orbital CCSD(T) correlation alpha (H2O/6-31G, O 1s frozen) vs the frozen
+    reference and the frozen energy-FD diagonal -- exercises the (T) core<->active and active oo/vv
+    dependent-pair response inside the perturbed relaxed density."""
+    wfn = rhf_wfn(WATER, "6-31G", freeze_core="true")
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis='spinorbital', make_t3_density=True)
+    cc.solve_cc(1e-13, 1e-13, 100)
+    assert cc.nfzc > 0
+    a = np.asarray(pycc.CCderiv(cc).polarizability())
+    assert np.max(np.abs(np.diag(a) - WATER_ALPHA_T_DIAG_FC)) < 1e-9, np.diag(a)
+    assert np.max(np.abs(np.diag(a) - ALPHA_T_ENERGY_FD_FC)) < 1e-7, np.diag(a)
+    psi4.core.clean()
+
+
 def test_ccsd_polarizability_guards(rhf_wfn):
-    """The unimplemented paths raise rather than silently returning a wrong tensor: CCSD(T)
-    (needs the perturbed (T) response), an unknown route, and the spin-orbital basis."""
+    """The unimplemented / misused paths raise rather than silently returning a wrong tensor: spatial
+    CCSD(T) (the spatial (T) perturbed response is not yet available), spin-orbital CCSD(T) built
+    without the (T) density intermediates, and an unknown route."""
     import pytest
     wfn = rhf_wfn(WATER, "6-31G", freeze_core="false")
-    cc = pycc.ccwfn(wfn, model='ccsd(t)')
+    cc = pycc.ccwfn(wfn, model='ccsd(t)')                              # spatial CCSD(T)
     cc.solve_cc(1e-12, 1e-12, 100)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError):                          # spatial (T) not yet available
         pycc.CCderiv(cc).polarizability()
     with pytest.raises(ValueError):
         pycc.CCderiv(cc).polarizability(route='explicit')
+    cc_so = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis='spinorbital')   # no make_t3_density
+    cc_so.solve_cc(1e-12, 1e-12, 100)
+    with pytest.raises(ValueError):                                   # SO (T) needs make_t3_density
+        pycc.CCderiv(cc_so).polarizability()
     psi4.core.clean()

--- a/pycc/tests/test_084_cc_polarizability.py
+++ b/pycc/tests/test_084_cc_polarizability.py
@@ -19,6 +19,7 @@ closed-shell RHF, all-electron (frozen core / spin-orbital / (T) to follow)."""
 import psi4
 import pycc
 import numpy as np
+import pytest
 
 
 # Equilibrium H2O (C2v, molecular plane yz, C2 along z); frame locked for a reproducible tensor.
@@ -253,17 +254,126 @@ def test_fc_so_ccsdt_polarizability_water_631g(rhf_wfn):
     psi4.core.clean()
 
 
+# --- CFOUR-oracle CCSD(T) polarizability tests ----------------------------------------------------
+# Oracles from CFOUR (xcfour, CALC=CCSD(T), PROP=SECOND_ORDER, SCF_CONV=13, CC_CONV=12): the
+# correlation polarizability is POLAR (total) - POLARSCF (HF).  To match CFOUR to all printed digits
+# the AO basis must be identical -- Psi4's "6-31G" differs from CFOUR's by ~4e-8 -- so CFOUR's exact
+# GENBAS "6-31G" is transcribed here; pycc then reproduces CFOUR to ~5e-11 on both routes.
+CFOUR_631G = """cartesian
+****
+H     0
+S   3   1.00
+     18.7311370             0.0334946
+      2.8253944             0.2347270
+      0.6401217             0.8137573
+S   1   1.00
+      0.1612778             1.0000000
+****
+O     0
+S   6   1.00
+   5484.6716600             0.0018311
+    825.2349460             0.0139502
+    188.0469580             0.0684451
+     52.9645000             0.2327143
+     16.8975704             0.4701929
+      5.7996353             0.3585209
+S   3   1.00
+     15.5396162            -0.1107775
+      3.5999336            -0.1480263
+      1.0137618             1.1307670
+S   1   1.00
+      0.2700058             1.0000000
+P   3   1.00
+     15.5396162             0.0708743
+      3.5999336             0.3397528
+      1.0137618             0.7271586
+P   1   1.00
+      0.2700058             1.0000000
+****
+F     0
+S   6   1.00
+   7001.7130900             0.0018196
+   1051.3660900             0.0139161
+    239.2856900             0.0684053
+     67.3974453             0.2331858
+     21.5199573             0.4712674
+      7.4031013             0.3566185
+S   3   1.00
+     20.8479528            -0.1085070
+      4.8083083            -0.1464517
+      1.3440699             1.1286886
+S   1   1.00
+      0.3581514             1.0000000
+P   3   1.00
+     20.8479528             0.0716287
+      4.8083083             0.3459121
+      1.3440699             0.7224700
+P   1   1.00
+      0.3581514             1.0000000
+****
+"""
+
+# CFOUR CCSD(T) correlation polarizability (a.u.), POLAR - POLARSCF, keyed by (molecule, freeze_core).
+CFOUR_ALPHA_T = {
+    ('water', 'false'): np.diag([0.0749401813, 0.0992909720, 0.2011125406]),
+    ('water', 'true'):  np.diag([0.0752394512, 0.1001121832, 0.2016555896]),
+    ('hof', 'false'): np.array([[-2.2114079425, -0.7220009461, 0.0],
+                                [-0.7220009461,  0.1659235582, 0.0],
+                                [ 0.0,           0.0,           0.0651632870]]),
+    ('hof', 'true'):  np.array([[-2.2106648649, -0.7220673958, 0.0],
+                                [-0.7220673958,  0.1661531583, 0.0],
+                                [ 0.0,           0.0,           0.0652603834]]),
+}
+_CFOUR_GEOM = {'water': WATER, 'hof': HOF}
+
+
+def _cfour_wfn(geom, freeze_core):
+    """RHF reference in CFOUR's exact GENBAS 6-31G (via basis_helper), for the CFOUR-oracle tests."""
+    psi4.core.clean(); psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'scf_type': 'pk', 'freeze_core': freeze_core,
+                      'e_convergence': 1e-13, 'd_convergence': 1e-13})
+    psi4.basis_helper(CFOUR_631G, name='cfour631g')
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    return wfn
+
+
+# route x molecule x freeze_core; the spin-orbital HOF cases are the expensive pair (~200 s), so they
+# are marked slow (skipped by default) -- the spatial HOF cases and the SO==spatial keystone still
+# exercise the off-diagonal and SO paths in the default run.
+_CFOUR_CASES = [
+    ('spatial', 'water', 'false'), ('spatial', 'water', 'true'),
+    ('spatial', 'hof', 'false'), ('spatial', 'hof', 'true'),
+    ('spinorbital', 'water', 'false'), ('spinorbital', 'water', 'true'),
+    pytest.param('spinorbital', 'hof', 'false', marks=pytest.mark.slow),
+    pytest.param('spinorbital', 'hof', 'true', marks=pytest.mark.slow),
+]
+
+
+@pytest.mark.parametrize('route,mol,fc', _CFOUR_CASES)
+def test_ccsdt_polarizability_cfour(route, mol, fc):
+    """CCSD(T) correlation polarizability vs the CFOUR oracle (POLAR - POLARSCF), water and HOF,
+    all-electron and frozen core, on both the spatial (closed-shell RHF) and spin-orbital routes, in
+    CFOUR's exact GENBAS 6-31G.  HOF exercises the off-diagonal (Cs) in-plane block; matches to 1e-9."""
+    wfn = _cfour_wfn(_CFOUR_GEOM[mol], fc)
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis=route, make_t3_density=True)
+    cc.solve_cc(1e-13, 1e-13, 100)
+    a = np.asarray(pycc.CCderiv(cc).polarizability())
+    assert np.max(np.abs(a - CFOUR_ALPHA_T[(mol, fc)])) < 1e-9, (mol, fc, route, a)
+    assert np.max(np.abs(a - a.T)) < 1e-9                      # symmetric
+    psi4.core.clean()
+
+
 def test_ccsd_polarizability_guards(rhf_wfn):
-    """The unimplemented / misused paths raise rather than silently returning a wrong tensor: spatial
-    CCSD(T) (the spatial (T) perturbed response is not yet available), spin-orbital CCSD(T) built
-    without the (T) density intermediates, and an unknown route."""
+    """The misused paths raise rather than silently returning a wrong tensor: CCSD(T) (spatial or
+    spin-orbital) built without the (T) density intermediates, and an unknown route."""
     import pytest
     wfn = rhf_wfn(WATER, "6-31G", freeze_core="false")
-    cc = pycc.ccwfn(wfn, model='ccsd(t)')                              # spatial CCSD(T)
+    cc = pycc.ccwfn(wfn, model='ccsd(t)')                              # spatial CCSD(T), no make_t3_density
     cc.solve_cc(1e-12, 1e-12, 100)
-    with pytest.raises(NotImplementedError):                          # spatial (T) not yet available
+    with pytest.raises(ValueError):                                   # (T) needs make_t3_density
         pycc.CCderiv(cc).polarizability()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):                                   # unknown route
         pycc.CCderiv(cc).polarizability(route='explicit')
     cc_so = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis='spinorbital')   # no make_t3_density
     cc_so.solve_cc(1e-12, 1e-12, 100)


### PR DESCRIPTION
# Analytic spatial CCSD(T) polarizability + (T) Lambda-source refactor

## Summary

Completes the CCSD(T) static dipole polarizability: the spatial (closed-shell RHF)
route now matches the CFOUR-validated spin-orbital route to ~1e-12, so both routes are
done for all-electron and frozen core. Last item of DERIVATIVES_PLAN section 8 (phase 4).

## Root cause of the previously-broken spatial (T)

The spatial _perturbed_lambda added the perturbed (T) L2 source dS2 WITHOUT the P_ij^ab
symmetrization that r_L2 applies to the unperturbed cc.S2 (cc.S2 is added before r_L2's
final r_l2 += r_l2.swapaxes(0,1).swapaxes(2,3)), so the perturbed L2 carried P(cc.S2)
instead of P(dS2). The error is invisible to the gradient but corrupts the near-degenerate
vv/oo dependent-pair rotations of the perturbed relaxed density (hence the polarizability).

Diagnosed with the biorthogonal SO<->spatial map of the Lambda amplitudes
(L1(spat) = 2 L1(SO); L2^ab(spat) = 4 L2ab(SO) - 2 L2ba(SO), abab block): the perturbed (T)
sources dS1/dS2 satisfied the map (correct) while the perturbed Lambda dL1/dL2 did not.

## Fix (a refactor that eliminates the bug class)

r_L1/r_L2/_so_r_L1/_so_r_L2 now take an optional (T)-source argument (s1/s2) and add it in
exactly one place (symmetrized once). Both cclambda.solve_lambda (unperturbed,
s = cc.S1/cc.S2) and CCderiv._perturbed_lambda (perturbed, s = dS1/dS2) supply it, so the
unperturbed and perturbed paths are structurally identical -- there is no longer a separate
"correct the source after the fact" step that can drift out of sync.

## Changes

- Enable spatial CCSD(T) in CCderiv.polarizability() (drop the NotImplementedError guard;
  the make_t3_density guard now covers both routes).
- Regression tests: test_ccsdt_polarizability_cfour (spatial + SO x water/HOF x AE/FC,
  tolerance 1e-9), anchored to CFOUR (correlation = POLAR - POLARSCF) in CFOUR's exact
  GENBAS 6-31G basis (Psi4's differs by ~4e-8; matched-basis agreement ~5e-11). The two
  spin-orbital HOF cases are marked slow.
- Doc: note the (T)-source symmetrization requirement after eq:S2 in
  cc_gradients_orbital_response.tex; status updates in DERIVATIVES_PLAN and README.
- Cleanup: strip all _DBG_* debug scaffolding, including the finite-difference stencil
  oracles and the now-dead helpers (_hbar_blocks/_so_hbar_blocks, _T3_DENS_KEYS). The
  perturbed HBAR / t3 / correlation-density methods are now single analytic paths.

## Validation

- Spatial == SO keystone ~1e-12 (water diagonal, HOF off-diagonal), AE and FC.
- vs CFOUR ~5e-11, both routes, AE and FC.
- No regressions: polarizability, (T) gradient, (T) density/relaxed dipole, CCSD Lambda,
  CC3, CC3 response, CCSD and SO-CCSD gradient, EOM-CCSD suites all pass.

## Files

pycc/ccderiv.py, pycc/cclambda.py, pycc/tests/test_084_cc_polarizability.py,
docs/cc_gradients_orbital_response.tex, docs/DERIVATIVES_PLAN_2026-06.md, README.md
