### PR TITLE
refactor(deriv): hoist the generalized-Fock Lagrangian to CorrelatedDerivs (Phase 2a)

### DIFF
--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -281,7 +281,7 @@ class ccdensity(object):
         no-extra-prefactor convention (``contract(D, F) + contract(Gamma, ERI) = E_corr``) the ``1/4``
         is absorbed into the returned ``Gamma`` -- matching :meth:`MPwfn._so_mp2_tpdm` (whose oovv
         block is ``1/4 t2``) and the ``termC = 4 sum <pr||st> Gamma_qrst`` in
-        :meth:`MPwfn._so_mp2_lagrangian`.  (MP2's ``Gamma`` is already bra-ket symmetric --
+        :meth:`CorrelatedDerivs._so_lagrangian`.  (MP2's ``Gamma`` is already bra-ket symmetric --
         ``oovv = t2``, ``vvoo = t2.T`` -- so it needs no symmetrization.)"""
         if self.onlyone:
             raise RuntimeError("gradient_densities needs the two-particle density "

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -54,22 +54,6 @@ class CCderiv(CorrelatedDerivs):
             self._dens = ccdensity(self.ccwfn, lam)
         return self._dens
 
-    def _lagrangian(self, D, Gam):
-        """The generalized-Fock (orbital-gradient) Lagrangian ``I'_pq`` from a full-MO 1-PDM ``D``
-        and 2-PDM ``Gam`` -- reused verbatim from the MP2 gradient machinery (it is generic in the
-        densities: ``-1/2 [ eps_p(D_pq+D_qp) + delta_{q,occ} sum_rs D_rs(<rp|sq>_L + <rq|sp>_L)
-        + 4 sum_rst <pr|st> Gam_qrst ]``).  Its ov-antisymmetric part is the Z-vector RHS; evaluated
-        at the relaxed density it is the energy-weighted density.  ``Gam`` must carry the proper
-        2-PDM permutational symmetry (:meth:`ccdensity.gradient_densities` symmetrizes it), since
-        the three-index ``termC`` is sensitive to it.  Dispatches on the orbital basis: the
-        spin-orbital path uses the antisymmetrized ``_so_mp2_lagrangian`` (``<pq||rs>``), the spatial
-        path the spin-adapted ``_mp2_lagrangian`` (``H.L``).  The shared primitive lives on the MP2
-        derivative driver (``cc.mp.deriv``, an :class:`~pycc.mpderiv.MPderiv`); Phase 2 hoists it
-        into :class:`~pycc.correlatedderivs.CorrelatedDerivs`."""
-        if self.ccwfn.orbital_basis == 'spinorbital':
-            return self.ccwfn.mp.deriv._so_mp2_lagrangian(D, Gam)
-        return self.ccwfn.mp.deriv._mp2_lagrangian(D, Gam)
-
     def _relaxed_density(self):
         """The relaxed correlation 1-PDM ``Drel`` and the symmetrized 2-PDM ``Gam`` (spatial
         closed-shell RHF).  ``Drel`` is the Lambda-response 1-PDM ``D`` plus the orbital-relaxation
@@ -244,7 +228,7 @@ class CCderiv(CorrelatedDerivs):
             dE_corr/dX = sum_pq D~_pq f^X_pq + sum_pqrs Gamma_pqrs <pq||rs>^X + sum_pq W_pq S^X_pq
 
         Differences from the spatial path: the generalized-Fock Lagrangian is the antisymmetrized
-        ``_so_mp2_lagrangian`` (:meth:`_lagrangian` dispatches); the orbital Hessian is built
+        ``_so_lagrangian`` (:meth:`_lagrangian` dispatches); the orbital Hessian is built
         **inline** (``G_ia,jb = <aj||ib> + <ab||ij> + delta (eps_a - eps_i)``) rather than borrowed
         from an all-electron ``HFwfn`` CPHF -- the all-electron spin-orbital ``HFwfn`` orders the
         spins differently from the densities, so there is no CPHF to reuse; and the skeleton
@@ -1245,11 +1229,11 @@ class CCderiv(CorrelatedDerivs):
     def _cc_perturbed_lagrangian(self, df, deri, dL, D, dD, Gam, dGam):
         """Field response ``dI'`` of the generalized-Fock (GSB) Lagrangian, density-generic.  The
         Fock term is the **full matrix product** ``df @ (D + D.T)`` -- NOT the diagonal ``diag(df)``
-        a stencil of :meth:`MPwfn._mp2_lagrangian` (which uses ``eps[:,None]*(D+D.T)``, valid only
-        at the canonical F=0) would give.  The omitted ``df_offdiag @ (D+D.T)`` vanishes for MP2
-        (unrelaxed ``D`` has no ov block) but is nonzero for CC (couples to ``Dov``/``Dvo``); see
-        DERIVATIVES_PLAN sec 8.2.  (Same formula as :meth:`MPwfn._perturbed_lagrangian`; destined to
-        merge with it under ``CorrelatedDerivs``.)"""
+        a stencil of :meth:`CorrelatedDerivs._spatial_lagrangian` (which uses ``eps[:,None]*(D+D.T)``,
+        valid only at the canonical F=0) would give.  The omitted ``df_offdiag @ (D+D.T)`` vanishes
+        for MP2 (unrelaxed ``D`` has no ov block) but is nonzero for CC (couples to ``Dov``/``Dvo``);
+        see DERIVATIVES_PLAN sec 8.2.  (Same formula as :meth:`MPderiv._perturbed_lagrangian`;
+        destined to merge with it under ``CorrelatedDerivs`` in Phase 3.)"""
         cc = self.ccwfn
         o = cc.o
         ofull = slice(0, o.stop)

--- a/pycc/correlatedderivs.py
+++ b/pycc/correlatedderivs.py
@@ -34,6 +34,74 @@ class CorrelatedDerivs:
             self._ref_hf = HFwfn(self.wfn.ref, orbital_basis=self.wfn.orbital_basis)
         return self._ref_hf
 
+    # ---- generalized-Fock orbital Lagrangian I'(D, Gam) ----
+    # The Gauss/Stanton/Bartlett orbital-gradient Lagrangian: a method-agnostic function of a
+    # full-MO 1-PDM ``D`` and cumulant 2-PDM ``Gam`` (both supplied by the leaf) plus the SCF
+    # reference integrals/Fock.  Its occupied-virtual antisymmetric part ``X_ai = I'_ia - I'_ai``
+    # drives the Z-vector; evaluated at the relaxed density it is the energy-weighted density ``W``.
+    # Basis-dispatched: antisymmetrized ``<pq||rs>`` (spin-orbital) vs the spin-adapted ``L``
+    # (closed-shell).  ``Gam`` must carry the proper 2-PDM permutational symmetry (the caller's
+    # densities -- MP2 seeds / :meth:`ccdensity.gradient_densities` -- ensure this).
+
+    def _lagrangian(self, D, Gam) -> np.ndarray:
+        """Generalized-Fock orbital Lagrangian ``I'(D, Gam)`` (``nmo x nmo``)
+
+            I'_pq = -1/2 [ f_pp (D_pq + D_qp)
+                           + delta_{q in ofull} sum_rs D_rs (w_rpsq + w_rqsp)
+                           + 4 sum_rst <pr||st> Gamma_qrst ]
+
+        with the two-electron kernel ``w`` = the antisymmetrized ``<pq||rs>`` (spin-orbital,
+        :meth:`_so_lagrangian`) or the spin-adapted ``L`` (closed-shell, :meth:`_spatial_lagrangian`),
+        dispatched on the orbital basis."""
+        if self.wfn.orbital_basis == 'spinorbital':
+            return self._so_lagrangian(D, Gam)
+        return self._spatial_lagrangian(D, Gam)
+
+    def _so_lagrangian(self, D, Gam) -> np.ndarray:
+        """Spin-orbital generalized-Fock Lagrangian ``I'_pq`` (``nmo x nmo``) from a full-MO
+        1-PDM ``D`` and cumulant 2-PDM ``Gam``
+
+            I'_pq = -1/2 [ f_pp (D_pq + D_qp)
+                           + delta_{q in ofull} sum_rs D_rs (<rp||sq> + <rq||sp>)
+                           + 4 sum_rst <pr||st> Gamma_qrst ]
+
+        The 1-PDM term's column index runs over the full occupied space ``ofull`` (= core +
+        active), so the frozen-core rows/columns are built (for ``nfzc=0`` this is the whole
+        occupied space)."""
+        nmo = self.wfn.nmo
+        ofull = slice(0, self.wfn.o.stop)
+        ERI = np.asarray(self.wfn.H.ERI)
+        eps = np.diag(np.asarray(self.wfn.H.F))
+        termA = eps[:, None] * (D + D.T)                       # f_pp (D_pq + D_qp)
+        termB = np.zeros((nmo, nmo))
+        termB[:, ofull] = (self.contract('rs,rpsq->pq', D, ERI[:, :, :, ofull])
+                           + self.contract('rs,rqsp->pq', D, ERI[:, ofull, :, :]))
+        termC = 4.0 * self.contract('prst,qrst->pq', ERI, Gam)
+        return -0.5 * (termA + termB + termC)
+
+    def _spatial_lagrangian(self, D, Gam) -> np.ndarray:
+        """Spin-adapted (closed-shell) generalized-Fock Lagrangian ``I'_pq`` (``nmo x nmo``) -- the
+        closed-shell analogue of :meth:`_so_lagrangian`
+
+            I'_pq = -1/2 [ f_pp (D_pq + D_qp)
+                           + delta_{q in ofull} sum_rs D_rs (L_rpsq + L_rqsp)
+                           + 4 sum_rst <pr|st> Gamma_qrst ]
+
+        with the spin-adapted ``L_pqrs = 2 <pq|rs> - <pq|sr>`` (= ``H.L``) carrying the closed-shell
+        spin sum in the two-electron 1-PDM term, and the bare ``<pr|st>`` (= ``H.ERI``) with
+        ``Gamma`` in the 2-PDM term.  ``ofull`` is the full occupied space (core + active)."""
+        nmo = self.wfn.nmo
+        ofull = slice(0, self.wfn.nfzc + self.wfn.no)
+        ERI = np.asarray(self.wfn.H.ERI)
+        L = np.asarray(self.wfn.H.L)
+        eps = np.diag(np.asarray(self.wfn.H.F))
+        termA = eps[:, None] * (D + D.T)
+        termB = np.zeros((nmo, nmo))
+        termB[:, ofull] = (self.contract('rs,rpsq->pq', D, L[:, :, :, ofull])
+                           + self.contract('rs,rqsp->pq', D, L[:, ofull, :, :]))
+        termC = 4.0 * self.contract('prst,qrst->pq', ERI, Gam)
+        return -0.5 * (termA + termB + termC)
+
     @staticmethod
     def _dependent_pairs(Iblock, eps_block, thresh=1e-8):
         """Canonical dependent-pair rotation ``P_mn = (I'_mn - I'_nm)/(eps_m - eps_n)`` for a square

--- a/pycc/mpderiv.py
+++ b/pycc/mpderiv.py
@@ -40,29 +40,6 @@ class MPderiv(CorrelatedDerivs):
     # The spin-orbital (_so_) and spin-adapted (closed-shell, unlabeled) paths are paired.
     # W = I'(D_relaxed) is the energy-weighted density.
 
-    def _so_mp2_lagrangian(self, D, Gam) -> np.ndarray:
-        """Spin-orbital generalized-Fock Lagrangian ``I'_pq`` (``nmo x nmo``) from a full-MO
-        1-PDM ``D`` and cumulant 2-PDM ``Gamma``
-
-            I'_pq = -1/2 [ f_pp (D_pq + D_qp)
-                           + delta_{q in ofull} sum_rs D_rs (<rp||sq> + <rq||sp>)
-                           + 4 sum_rst <pr||st> Gamma_qrst ]
-
-        The 1-PDM term's column index runs over the full occupied space ``ofull`` (= core +
-        active), so the frozen-core rows/columns are built (for ``nfzc=0`` this is the whole
-        occupied space). Its occupied-virtual antisymmetric part ``X_ai = I'_ia - I'_ai`` is
-        the Z-vector RHS; evaluated at the relaxed ``D`` it is the energy-weighted density."""
-        nmo = self.mp.nmo
-        ofull = slice(0, self.mp.o.stop)
-        ERI = np.asarray(self.mp.H.ERI)
-        eps = np.diag(np.asarray(self.mp.H.F))
-        termA = eps[:, None] * (D + D.T)                       # f_pp (D_pq + D_qp)
-        termB = np.zeros((nmo, nmo))
-        termB[:, ofull] = (self.contract('rs,rpsq->pq', D, ERI[:, :, :, ofull])
-                           + self.contract('rs,rqsp->pq', D, ERI[:, ofull, :, :]))
-        termC = 4.0 * self.contract('prst,qrst->pq', ERI, Gam)
-        return -0.5 * (termA + termB + termC)
-
     def _so_mp2_relaxed_densities(self):
         """Spin-orbital MP2 relaxed 1-PDM ``D_r`` (``nmo x nmo``), cumulant ``Gamma``, and
         energy-weighted density ``W``, with the orbital response over the full occupied space
@@ -90,29 +67,8 @@ class MPderiv(CorrelatedDerivs):
                 "(the semicanonical response does not reproduce the restricted ROHF "
                 "response). RHF and UHF are supported.")
         D, Gam, _, _, _, _ = self._so_zvector()
-        W = self._so_mp2_lagrangian(D, Gam)
+        W = self._so_lagrangian(D, Gam)
         return D, Gam, W
-
-    def _mp2_lagrangian(self, D, Gam) -> np.ndarray:
-        """Spin-adapted generalized-Fock Lagrangian ``I'_pq`` (``nmo x nmo``) from a
-        full-MO 1-PDM ``D`` and cumulant 2-PDM ``Gamma`` -- the closed-shell analogue of
-        :meth:`_so_mp2_lagrangian`, with the spin-adapted ``L`` (= H.L) in the two-electron
-        1-PDM term and ``<pr|st>`` (= H.ERI) with ``Gamma`` in the 2-PDM term. The 1-PDM
-        term's column index runs over the full occupied space ``ofull`` (= core + active),
-        so the frozen-core rows/columns are built (for ``nfzc=0`` this is the whole occupied
-        space). Used both for the orbital-gradient Lagrangian (from the unrelaxed ``D``) and
-        for the energy-weighted density ``W = I'(D_relaxed)``."""
-        nmo = self.mp.nmo
-        ofull = slice(0, self.mp.nfzc + self.mp.no)
-        ERI = np.asarray(self.mp.H.ERI)
-        L = np.asarray(self.mp.H.L)
-        eps = np.diag(np.asarray(self.mp.H.F))
-        termA = eps[:, None] * (D + D.T)
-        termB = np.zeros((nmo, nmo))
-        termB[:, ofull] = (self.contract('rs,rpsq->pq', D, L[:, :, :, ofull])
-                           + self.contract('rs,rqsp->pq', D, L[:, ofull, :, :]))
-        termC = 4.0 * self.contract('prst,qrst->pq', ERI, Gam)
-        return -0.5 * (termA + termB + termC)
 
     def _mp2_relaxed_densities(self):
         """Spatial MP2 relaxed 1-PDM ``D_r`` (``nmo x nmo``), cumulant ``Gamma``, and
@@ -136,7 +92,7 @@ class MPderiv(CorrelatedDerivs):
         contribution reproduces the ``z_kc`` energy-weighted-density term. For ``nfzc=0`` the
         core blocks are empty and this reduces to the all-electron relaxed density."""
         D, Gam, _, _, hf, _ = self._zvector()
-        W = self._mp2_lagrangian(D, Gam)
+        W = self._spatial_lagrangian(D, Gam)
         return D, Gam, W, hf
 
     def mp2_relaxed_opdm(self) -> np.ndarray:
@@ -318,7 +274,7 @@ class MPderiv(CorrelatedDerivs):
             Du = np.zeros((nmo, nmo))
             Du[o, o] = np.asarray(Doo)
             Du[v, v] = np.asarray(Dvv)
-            Ip = self._so_mp2_lagrangian(Du, Gam)
+            Ip = self._so_lagrangian(Du, Gam)
             Drel = Du.copy()
             Pco = None
             if nfzc:
@@ -341,7 +297,7 @@ class MPderiv(CorrelatedDerivs):
 
     def _so_perturbed_lagrangian(self, pert, D=None, dD=None) -> np.ndarray:
         """First-order response ``d_x I'`` of the GSB orbital Lagrangian (``nmo x nmo``),
-        spin-orbital. Differentiates :meth:`_so_mp2_lagrangian` term by term with the perturbed
+        spin-orbital. Differentiates :meth:`_so_lagrangian` term by term with the perturbed
         integrals (:meth:`CPHF.perturbed_fock`/`perturbed_eri`) and the density response.
 
         With ``D``/``dD`` omitted this uses the **unrelaxed** 1-PDM and its response
@@ -445,7 +401,7 @@ class MPderiv(CorrelatedDerivs):
             Du = np.zeros((nmo, nmo))
             Du[o, o] = np.asarray(Doo)
             Du[v, v] = np.asarray(Dvv)
-            Ip = self._mp2_lagrangian(Du, Gam)
+            Ip = self._spatial_lagrangian(Du, Gam)
             Drel = Du.copy()
             Pco = None
             if nfzc:
@@ -669,7 +625,7 @@ class MPderiv(CorrelatedDerivs):
         # route == '2n+1-field'
         lagr = self._so_perturbed_lagrangian if so else self._perturbed_lagrangian
         Gam = np.asarray(self.mp._so_mp2_tpdm() if so else self.mp._mp2_tpdm())
-        W = (self._so_mp2_lagrangian if so else self._mp2_lagrangian)(Drel, Gam)
+        W = self._lagrangian(Drel, Gam)
         field = [Perturbation('field', a) for a in range(3)]
         dDrel = [popdm(field[a]) for a in range(3)]
         dGamF = [np.asarray(self._perturbed_densities(field[a])[1]) for a in range(3)]
@@ -760,7 +716,7 @@ class MPderiv(CorrelatedDerivs):
         nc = 3 * natom
         Drel = (self._so_zvector() if so else self._zvector())[0]
         Gam = np.asarray(self.mp._so_mp2_tpdm() if so else self.mp._mp2_tpdm())
-        W = (self._so_mp2_lagrangian if so else self._mp2_lagrangian)(Drel, Gam)
+        W = self._lagrangian(Drel, Gam)
         popdm = self._so_perturbed_relaxed_opdm if so else self._perturbed_relaxed_opdm
         lagr = self._so_perturbed_lagrangian if so else self._perturbed_lagrangian
         pert = [Perturbation('nuclear', (A, ct)) for A in range(natom) for ct in range(3)]

--- a/pycc/tests/test_084_cc_polarizability.py
+++ b/pycc/tests/test_084_cc_polarizability.py
@@ -93,7 +93,7 @@ def _findiff_alpha(geom, basis, F=5e-4, freeze_core='false'):
         D, G = (np.asarray(x) for x in pycc.ccdensity(cx, lm).gradient_densities())
         o, v = cx.o, cx.v; co = slice(0, cx.nfzc); of = slice(0, o.stop)
         c = cx.contract; eps = np.diag(np.asarray(cx.H.F)); L = np.asarray(cx.H.L)
-        Ip = np.asarray(cx.mp._mp2_lagrangian(D, G))
+        Ip = np.asarray(pycc.CCderiv(cx)._lagrangian(D, G))
         Dr = D.copy(); X = Ip[of, v] - Ip[v, of].T
         if cx.nfzc:
             Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])


### PR DESCRIPTION
# refactor(deriv): hoist the generalized-Fock Lagrangian to CorrelatedDerivs (Phase 2a)

## Summary

First hoist of Phase 2 (moving the shared, method-agnostic machinery into the `CorrelatedDerivs`
base). The generalized-Fock (Gauss/Stanton/Bartlett) orbital Lagrangian `I'(D, Gam)` is a pure
function of a full-MO 1-PDM `D`, a cumulant 2-PDM `Gam`, and the SCF reference integrals/Fock, so it
belongs in the base. It was already *de facto* shared -- `CCderiv._lagrangian` delegated to MP2's
copy via `cc.mp.deriv._mp2_lagrangian` -- so this makes that sharing explicit and drops the
cross-driver reach.

Branched from `main` after Phase 1c (#194, merged).

## Changes

- **`CorrelatedDerivs`**: new `_lagrangian(D, Gam)` (dispatches on the orbital basis) plus
  `_so_lagrangian` (antisymmetrized `<pq||rs>`) and `_spatial_lagrangian` (spin-adapted `L`). Each
  docstring carries the explicit expression

      I'_pq = -1/2 [ f_pp (D_pq + D_qp)
                     + delta_{q in ofull} sum_rs D_rs (w_rpsq + w_rqsp)
                     + 4 sum_rst <pr||st> Gamma_qrst ]

  (`w` = `<pq||rs>` / `L`). State is read through `self.wfn`.
- **`MPderiv`**: drop `_mp2_lagrangian` / `_so_mp2_lagrangian`; the callers (`_zvector` /
  `_so_zvector`, the relaxed-density builders, the APT/Hessian energy-weighted density) use the
  inherited `_spatial_lagrangian` / `_so_lagrangian` / dispatching `_lagrangian`.
- **`CCderiv`**: drop the `_lagrangian` dispatcher -- it inherits the base's. **This removes the
  `cc.mp.deriv._{so_}mp2_lagrangian` cross-call**: CC no longer reaches into the MP2 driver for the
  primitive, and the `mp2` misnomer is gone.
- Doc/recipe fixups: the `ccdensity` and CC perturbed-Lagrangian `:meth:` references, and the
  non-executed `_findiff_alpha` regeneration recipe in test_084 (now `pycc.CCderiv(cx)._lagrangian`).

## Behavior

Zero behavior change -- the Lagrangian body is byte-identical, only its home and the callers'
resolution changed. Validated:

- MP2: test_061, test_067, test_068, test_069 -- **40 passed**.
- CC: test_076, test_078, test_083, test_084 -- **29 passed** (2 slow deselected).

The SO==spatial keystones and the frozen-FD suites (from 1c) are the regression net; both leaves
now compute `I'` from the single base implementation.

## Files

pycc/correlatedderivs.py, pycc/mpderiv.py, pycc/ccderiv.py, pycc/ccdensity.py,
pycc/tests/test_084_cc_polarizability.py

## Next in Phase 2

2b (relaxed density / Z-vector, the higher-risk hoist -- SO inline orbital Hessian, frozen-core
`P_co`, the (T) dependent-pair hook), then 2c (relaxed-density gradient + `relaxed_dipole`). Each
hoisted method will carry its explicit math per the same convention used here.
