### PR TITLE
refactor(deriv): hoist the relaxed density / Z-vector to CorrelatedDerivs (Phase 2b)

### DIFF
--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -54,106 +54,12 @@ class CCderiv(CorrelatedDerivs):
             self._dens = ccdensity(self.ccwfn, lam)
         return self._dens
 
-    def _relaxed_density(self):
-        """The relaxed correlation 1-PDM ``Drel`` and the symmetrized 2-PDM ``Gam`` (spatial
-        closed-shell RHF).  ``Drel`` is the Lambda-response 1-PDM ``D`` plus the orbital-relaxation
-        blocks: the frozen-core core<->active-occupied divide ``P_co``, the CCSD(T) oo/vv
-        dependent-pair ``kappa_oo``/``kappa_vv`` (model-gated), and the ov Z-vector ``-z`` (one CPHF
-        solve, RHS = the ov-antisymmetric generalized Fock ``I'_ia - I'_ai``).  This is the
-        **perturbation-independent** relaxed density shared by :meth:`gradient` (contracted with the
-        skeleton derivative integrals) and :meth:`relaxed_dipole` (contracted with the dipole
-        integrals); the (T) response rides along in ``Drel`` for both."""
-        cc = self.ccwfn
-        o, v = cc.o, cc.v
-        nfzc = cc.nfzc
-        co = slice(0, nfzc)                              # frozen-core occupied
-        ofull = slice(0, o.stop)                         # full occupied (core + active)
-        c = self.contract
-        eps = np.diag(np.asarray(cc.H.F))
-        L = np.asarray(cc.H.L)
+    def _unrelaxed_densities(self):
+        """CC unrelaxed reduced densities: the Lambda-response 1-PDM ``D`` and the (symmetrized)
+        cumulant 2-PDM ``Gam`` (:meth:`ccdensity.gradient_densities`), full-MO arrays.  Supplies the
+        base Z-vector (:meth:`CorrelatedDerivs._zvector` / :meth:`_so_zvector`)."""
         D, Gam = self._density().gradient_densities()
-        Ip = self._lagrangian(D, Gam)
-        Drel = D.copy()
-        if nfzc:                                         # core<->active-occupied: direct divide
-            Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
-            Drel[co, o] += Pco
-            Drel[o, co] += Pco.T
-        X = Ip[ofull, v] - Ip[v, ofull].T               # ov-antisymmetric generalized Fock (full occ)
-        if nfzc:                                         # couple P_co into the Z-vector RHS
-            zjc = -Pco.T
-            X = X - (c('jc,ajic->ia', zjc, L[v, o, ofull, co])
-                     + c('jc,acij->ia', zjc, L[v, co, ofull, o]))
-        if cc.model.upper() == 'CCSD(T)':
-            # (T) breaks the occ-occ / virt-virt rotation invariance, so the canonical perturbed
-            # orbitals acquire dependent-pair rotations kappa_oo/kappa_vv beyond the ov Z-vector:
-            # (I'_ij-I'_ji)/(eps_i-eps_j) over the active oo pairs and the vv analog
-            # (:meth:`_dependent_pairs`), added to the relaxed density and coupled into the ov
-            # Z-vector RHS through the antisymmetrized ERI.  For CCSD both blocks vanish (oo/vv
-            # invariance).  Frozen core: the core<->active-occupied (T) response is already carried
-            # by P_co above (its I' is the (T)-inclusive Lagrangian); these blocks add the
-            # active<->active oo and the vv pairs, and the ov-occupied index of the coupling runs
-            # over the full occupied space (ofull), reducing to the active space when nfzc=0.
-            Poo = self._dependent_pairs(Ip[o, o], eps[o])
-            Pvv = self._dependent_pairs(Ip[v, v], eps[v])
-            Drel[o, o] += Poo
-            Drel[v, v] += Pvv
-            X = X + (c('kl,akil->ia', Poo, L[v, o, ofull, o])
-                     + c('bc,ibac->ia', Pvv, L[ofull, v, v, v]))
-        z = self._reference_hf().cphf.solve(X)          # Z-vector: A z = X (full-occ SCF Hessian)
-        Drel[v, ofull] += -z.T
-        Drel[ofull, v] += -z
-        return Drel, Gam
-
-    def _so_relaxed_density(self):
-        """Spin-orbital (UHF) analog of :meth:`_relaxed_density`: the relaxed correlation 1-PDM
-        ``Drel`` and 2-PDM ``Gam``, with the antisymmetrized-ERI Lagrangian and the inline orbital
-        Hessian (``G_ia,jb = <aj||ib> + <ab||ij> + delta (eps_a - eps_i)``) rather than a borrowed
-        all-electron CPHF.  **UHF only** -- raises for ROHF (the semicanonical response does not
-        reproduce the restricted ROHF response)."""
-        cc = self.ccwfn
-        if cc.mp.cphf.is_rohf:
-            raise NotImplementedError(
-                "The spin-orbital CCSD/CCSD(T) gradient and relaxed dipole are not implemented for "
-                "ROHF references (the semicanonical response does not reproduce the restricted ROHF "
-                "response); RHF and UHF are supported.")
-        o, v = cc.o, cc.v
-        nfzc, nv = cc.nfzc, cc.nv
-        co = slice(0, o.start)                            # frozen-core occupied (2*nfzc spin-orbitals)
-        ofull = slice(0, o.stop)                          # full occupied (core + active)
-        nof = o.stop
-        c = self.contract
-        eps = np.diag(np.asarray(cc.H.F))
-        ERI = np.asarray(cc.H.ERI)                        # spin-orbital <pq||rs>
-        D, Gam = self._density().gradient_densities()
-        Ip = self._lagrangian(D, Gam)
-        Drel = D.copy()
-        if nfzc:                                          # core<->active-occupied: direct divide
-            Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
-            Drel[co, o] += Pco
-            Drel[o, co] += Pco.T
-        X = Ip[ofull, v] - Ip[v, ofull].T                # ov-antisymmetric generalized Fock
-        if nfzc:                                          # couple P_co into the Z-vector RHS
-            zjc = -Pco.T
-            X = X - (c('jc,ajic->ia', zjc, ERI[v, o, ofull, co])
-                     + c('jc,acij->ia', zjc, ERI[v, co, ofull, o]))
-        if cc.model.upper() == 'CCSD(T)':
-            # (T) breaks the occ-occ / virt-virt rotation invariance: the canonical perturbed
-            # orbitals acquire dependent-pair rotations kappa_oo/kappa_vv beyond the ov Z-vector --
-            # the spin-orbital analog of the (T) branch in :meth:`_relaxed_density` (spatial L ->
-            # <pq||rs>).  For CCSD both blocks vanish.
-            Poo = self._dependent_pairs(Ip[o, o], eps[o])
-            Pvv = self._dependent_pairs(Ip[v, v], eps[v])
-            Drel[o, o] += Poo
-            Drel[v, v] += Pvv
-            X = X + (c('kl,akil->ia', Poo, ERI[v, o, ofull, o])
-                     + c('bc,ibac->ia', Pvv, ERI[ofull, v, v, v]))
-        G = (c('ajib->iajb', ERI[v, ofull, ofull, v])    # orbital Hessian, built inline
-             + c('abij->iajb', ERI[v, v, ofull, ofull])).reshape(nof * nv, nof * nv)
-        G[np.diag_indices(nof * nv)] += (eps[v][None, :] - eps[ofull][:, None]).reshape(-1)
-        z = np.linalg.solve(G, X.reshape(-1)).reshape(nof, nv)   # Z-vector A z = X
-        Drel[v, ofull] += -z.T
-        Drel[ofull, v] += -z
-        return Drel, Gam
+        return np.asarray(D), np.asarray(Gam)
 
     def relaxed_dipole(self) -> np.ndarray:
         """CCSD / CCSD(T) **correlation** contribution to the relaxed electronic dipole (a.u.),
@@ -223,7 +129,7 @@ class CCderiv(CorrelatedDerivs):
     def _so_gradient(self) -> np.ndarray:
         """Spin-orbital (UHF) CCSD / CCSD(T) **correlation** gradient via the Z-vector route -- the
         spin-orbital analog of :meth:`gradient`, mirroring :meth:`MPwfn._so_gradient` /
-        :meth:`MPwfn._so_zvector`::
+        :meth:`CorrelatedDerivs._so_zvector`::
 
             dE_corr/dX = sum_pq D~_pq f^X_pq + sum_pqrs Gamma_pqrs <pq||rs>^X + sum_pq W_pq S^X_pq
 
@@ -241,7 +147,7 @@ class CCderiv(CorrelatedDerivs):
 
         **UHF only** -- ROHF is not supported (the semicanonical response does not reproduce the
         restricted ROHF response).  Frozen-core aware (the core<->active-occupied ``P_co`` divide,
-        coupled into the Z-vector RHS, exactly as the spatial path and :meth:`MPwfn._so_zvector`).
+        coupled into the Z-vector RHS, exactly as the spatial path and :meth:`CorrelatedDerivs._so_zvector`).
         Validated against ``psi4.gradient('ccsd')`` (UHF), the spatial closed-shell gradient (SO ==
         spatial, CCSD and CCSD(T)), and a finite difference of pycc's own SO CCSD(T) energy
         (open-shell UHF)."""

--- a/pycc/correlatedderivs.py
+++ b/pycc/correlatedderivs.py
@@ -34,6 +34,24 @@ class CorrelatedDerivs:
             self._ref_hf = HFwfn(self.wfn.ref, orbital_basis=self.wfn.orbital_basis)
         return self._ref_hf
 
+    @property
+    def perturbed_mo_gauge(self):
+        """The active occ-occ / virt-virt perturbed-orbital gauge, ``'canonical'`` or
+        ``'non-canonical'`` (docs/cc_gradients_orbital_response.tex, sec. Canonical Perturbed
+        Orbitals).  ``'non-canonical'`` uses the orthonormality conditions ``U^x_ij = -1/2 S^(x)_ij``
+        (occ) and ``U^x_ab = -1/2 S^(x)_ab`` (vir), leaving the oo/vv dependent-pair rotations to
+        vanish -- valid when the correlation energy is invariant to oo/vv rotations (MP2, CCSD).
+        ``'canonical'`` keeps the perturbed occ/vir blocks canonical (``d f_ij/dx = 0``, ``i != j``),
+        carrying the oo/vv dependent-pair rotations ``P_oo``/``P_vv`` explicitly; it is the choice
+        for the CCSD(T) gradient, where building the (T) contributions to ``Doo``/``Dvv`` from their
+        diagonal oo/vv blocks alone saves an O(N^7) step.  (The two routes give the same result; for
+        oo/vv-invariant methods the pairs vanish and the canonical recipe reduces to the
+        non-canonical one.)  Defaults to ``'canonical'`` for CCSD(T), ``'non-canonical'`` otherwise;
+        a future non-canonical-(T) route (building the full (T) density) would override this.  The
+        frozen-core core<->active-occupied divide ``P_co`` is always canonical, independent of this
+        choice."""
+        return 'canonical' if getattr(self.wfn, 'model', '').upper() == 'CCSD(T)' else 'non-canonical'
+
     # ---- generalized-Fock orbital Lagrangian I'(D, Gam) ----
     # The Gauss/Stanton/Bartlett orbital-gradient Lagrangian: a method-agnostic function of a
     # full-MO 1-PDM ``D`` and cumulant 2-PDM ``Gam`` (both supplied by the leaf) plus the SCF
@@ -102,6 +120,147 @@ class CorrelatedDerivs:
         termC = 4.0 * self.contract('prst,qrst->pq', ERI, Gam)
         return -0.5 * (termA + termB + termC)
 
+    # ---- unperturbed relaxed density and orbital-response (Z-vector) ----
+    # Given the leaf's unrelaxed reduced densities, the relaxed 1-PDM adds the orbital-relaxation
+    # blocks driven by the Lagrangian's ov-antisymmetric part:
+    #
+    #     Drel = D_u  +  P_co (core<->active-occ)  +  P_oo/P_vv (extra oo/vv, e.g. (T))  -  z (ov),
+    #
+    # with the Z-vector  A z = X,  X_ai = I'_ia - I'_ai (over the full occupied space).  The
+    # non-redundant core<->active-occupied rotation is a direct divide P_co = (I'_ci - I'_ic) /
+    # (eps_c - eps_i) (the SCF energy is invariant to occ-occ rotations), coupled into X.  The orbital
+    # Hessian A is the all-electron SCF Hessian: borrowed from the reference HFwfn CPHF (spatial) or
+    # built inline (spin-orbital, G_ia,jb = <aj||ib> + <ab||ij> + delta_ij delta_ab (eps_a - eps_i)).
+    # Method-agnostic given the two leaf hooks below.
+
+    def _unrelaxed_densities(self):
+        """Leaf hook: the unrelaxed reduced densities ``(D_u, Gam)`` as full-MO arrays -- the 1-PDM
+        (``nmo x nmo``, occupied/virtual diagonal blocks) and cumulant 2-PDM (``nmo^4``).  Supplied
+        by the method (MP2 amplitude seeds / CC :meth:`ccdensity.gradient_densities`)."""
+        raise NotImplementedError
+
+    def _zvector(self):
+        """Spatial (closed-shell) unperturbed Z-vector data (cached, frozen-core aware):
+        ``(Drel, Gam, D_u, z, hf, P_co)``.  The relaxed 1-PDM
+
+            Drel = D_u + P_co + P_oo + P_vv - z,   X_ai = I'_ia - I'_ai,   A z = X,
+
+        with ``I' = -1/2[...]`` (:meth:`_spatial_lagrangian`), the frozen-core divide
+        ``P_co = (I'_ci - I'_ic)/(eps_c - eps_i)`` coupled into ``X``, the canonical-perturbed-MO
+        oo/vv rotations ``P_oo``/``P_vv`` (the branch below, active only for
+        :attr:`perturbed_mo_gauge` ``== 'canonical'``, i.e. CCSD(T)), and the ov Z-vector solved with
+        the all-electron reference ``HFwfn`` CPHF (whose occupied space is the full ``ndocc``).
+        ``z`` is indexed ``(I, a)`` over the full occupied space."""
+        if getattr(self, '_zvec', None) is None:
+            nmo, nfzc, no = self.wfn.nmo, self.wfn.nfzc, self.wfn.no
+            o, v = self.wfn.o, self.wfn.v
+            co = slice(0, nfzc)
+            ofull = slice(0, nfzc + no)
+            eps = np.diag(np.asarray(self.wfn.H.F))
+            L = np.asarray(self.wfn.H.L)
+            c = self.contract
+            Du, Gam = self._unrelaxed_densities()
+            Du = np.asarray(Du)
+            Ip = self._spatial_lagrangian(Du, Gam)
+            Drel = Du.copy()
+            Pco = None
+            if nfzc:
+                Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
+                Drel[co, o] += Pco
+                Drel[o, co] += Pco.T
+            X = Ip[ofull, v] - Ip[v, ofull].T
+            if nfzc:
+                zjc = -Pco.T                                   # z_jc, active-occupied x core
+                X = X - (c('jc,ajic->ia', zjc, L[v, o, ofull, co])
+                         + c('jc,acij->ia', zjc, L[v, co, ofull, o]))
+            # Canonical perturbed MOs: carry the off-diagonal oo/vv orbital response as the
+            # dependent-pair rotations kappa_oo/kappa_vv (added to Drel, coupled into X).  This is
+            # the CCSD(T) choice -- the (T) contributions to Doo/Dvv are then built from their
+            # diagonal oo/vv blocks alone, saving an O(N^7) step.  For oo/vv-invariant methods the
+            # pairs vanish, so the non-canonical default (MP2, CCSD) simply skips them.
+            if self.perturbed_mo_gauge == 'canonical':
+                Poo = self._dependent_pairs(Ip[o, o], eps[o])
+                Pvv = self._dependent_pairs(Ip[v, v], eps[v])
+                Drel[o, o] += Poo
+                Drel[v, v] += Pvv
+                X = X + (c('kl,akil->ia', Poo, L[v, o, ofull, o])
+                         + c('bc,ibac->ia', Pvv, L[ofull, v, v, v]))
+            hf = self._reference_hf()
+            zia = hf.cphf.solve(X)                              # (I,a) over full occ
+            Drel[v, ofull] += -zia.T
+            Drel[ofull, v] += -zia
+            self._zvec = (Drel, Gam, Du, zia, hf, Pco)
+        return self._zvec
+
+    def _so_zvector(self):
+        """Spin-orbital unperturbed Z-vector data (cached, frozen-core aware):
+        ``(Drel, Gam, D_u, z, G, P_co)`` -- the spin-orbital analogue of :meth:`_zvector`
+        (antisymmetrized ``<pq||rs>``; :meth:`_so_lagrangian`).  The orbital Hessian is built inline
+
+            G_ia,jb = <aj||ib> + <ab||ij> + delta_ij delta_ab (eps_a - eps_i),
+
+        over the full occupied space (there is no all-electron spin-orbital ``HFwfn`` CPHF to borrow
+        -- it orders the spins differently from the densities).  **UHF only** -- raises for ROHF (the
+        semicanonical response does not reproduce the restricted ROHF response)."""
+        if getattr(self, '_so_zvec', None) is None:
+            if self.wfn.cphf.is_rohf:
+                raise NotImplementedError(
+                    "The spin-orbital correlated relaxed gradient/dipole is not implemented for "
+                    "ROHF references (the semicanonical response does not reproduce the restricted "
+                    "ROHF response); RHF and UHF are supported.")
+            nmo, nfzc, nv = self.wfn.nmo, self.wfn.nfzc, self.wfn.nv
+            o, v, co = self.wfn.o, self.wfn.v, self.wfn.co
+            ofull = slice(0, o.stop)
+            nof = o.stop
+            ERI = np.asarray(self.wfn.H.ERI)
+            eps = np.diag(np.asarray(self.wfn.H.F))
+            c = self.contract
+            Du, Gam = self._unrelaxed_densities()
+            Du = np.asarray(Du)
+            Ip = self._so_lagrangian(Du, Gam)
+            Drel = Du.copy()
+            Pco = None
+            if nfzc:
+                Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
+                Drel[co, o] += Pco
+                Drel[o, co] += Pco.T
+            X = Ip[ofull, v] - Ip[v, ofull].T
+            if nfzc:
+                zjc = -Pco.T                                   # z_jc, active-occupied x core
+                X = X - (c('jc,ajic->ia', zjc, ERI[v, o, ofull, co])
+                         + c('jc,acij->ia', zjc, ERI[v, co, ofull, o]))
+            # Canonical perturbed MOs: carry the off-diagonal oo/vv orbital response as the
+            # dependent-pair rotations kappa_oo/kappa_vv (added to Drel, coupled into X).  This is
+            # the CCSD(T) choice -- the (T) contributions to Doo/Dvv are then built from their
+            # diagonal oo/vv blocks alone, saving an O(N^7) step.  For oo/vv-invariant methods the
+            # pairs vanish, so the non-canonical default (MP2, CCSD) simply skips them.
+            if self.perturbed_mo_gauge == 'canonical':
+                Poo = self._dependent_pairs(Ip[o, o], eps[o])
+                Pvv = self._dependent_pairs(Ip[v, v], eps[v])
+                Drel[o, o] += Poo
+                Drel[v, v] += Pvv
+                X = X + (c('kl,akil->ia', Poo, ERI[v, o, ofull, o])
+                         + c('bc,ibac->ia', Pvv, ERI[ofull, v, v, v]))
+            G = (c('ajib->iajb', ERI[v, ofull, ofull, v])
+                 + c('abij->iajb', ERI[v, v, ofull, ofull])).reshape(nof * nv, nof * nv)
+            G[np.diag_indices(nof * nv)] += (eps[v][None, :] - eps[ofull][:, None]).reshape(-1)
+            zia = np.linalg.solve(G, X.reshape(-1)).reshape(nof, nv)
+            Drel[v, ofull] += -zia.T
+            Drel[ofull, v] += -zia
+            self._so_zvec = (Drel, Gam, Du, zia, G, Pco)
+        return self._so_zvec
+
+    def _relaxed_density(self):
+        """Relaxed 1-PDM ``Drel`` and cumulant 2-PDM ``Gam`` (``Tr(Drel mu)`` gives the correlation
+        dipole; ``Drel``/``Gam`` feed the gradient), dispatched on the orbital basis."""
+        z = self._so_zvector() if self.wfn.orbital_basis == 'spinorbital' else self._zvector()
+        return z[0], z[1]
+
+    def _so_relaxed_density(self):
+        """Spin-orbital relaxed 1-PDM and 2-PDM -- ``(Drel, Gam)`` from :meth:`_so_zvector`."""
+        z = self._so_zvector()
+        return z[0], z[1]
+
     @staticmethod
     def _dependent_pairs(Iblock, eps_block, thresh=1e-8):
         """Canonical dependent-pair rotation ``P_mn = (I'_mn - I'_nm)/(eps_m - eps_n)`` for a square
@@ -110,8 +269,8 @@ class CorrelatedDerivs:
         near-degenerate pairs.  ``P`` is symmetric (numerator and denominator both antisymmetric).
 
         This is the frozen-core core<->active-occupied divide generalized to an arbitrary square
-        block; methods that break occ-occ/virt-virt rotation invariance (CCSD(T), CI) need it over
-        the full oo and vv blocks."""
+        block; it also supplies the active oo/vv rotations of the canonical perturbed-MO gauge
+        (:attr:`perturbed_mo_gauge`, used by :meth:`_zvector` / :meth:`_so_zvector`)."""
         num = np.asarray(Iblock) - np.asarray(Iblock).T
         den = eps_block[:, None] - eps_block[None, :]
         P = np.zeros_like(num)

--- a/pycc/mpderiv.py
+++ b/pycc/mpderiv.py
@@ -254,47 +254,6 @@ class MPderiv(CorrelatedDerivs):
     # spin-orbital path builds G inline; the spatial analogue carries the spin-adapted L and
     # solves through the all-electron HFwfn CPHF. See mp2_2n1_perturbed.tex / DERIVATIVES_PLAN.
 
-    def _so_zvector(self):
-        """Unperturbed spin-orbital Z-vector data (cached, frozen-core aware): the relaxed
-        1-PDM ``D_rel``, cumulant ``Gam``, unrelaxed ``D_u``, the Z-vector amplitudes ``z``
-        (indexed ``(I,a)`` over the full occupied space), the orbital Hessian ``G``
-        (``nof*nv`` square), and the core-active block ``P_co`` (``None`` for ``nfzc=0``) --
-        shared by the relaxed density (:meth:`_so_mp2_relaxed_densities` delegates here) and
-        its perturbed response."""
-        if getattr(self, '_so_zvec', None) is None:
-            nmo, nfzc, nv = self.mp.nmo, self.mp.nfzc, self.mp.nv
-            o, v, co = self.mp.o, self.mp.v, self.mp.co
-            ofull = slice(0, o.stop)
-            nof = o.stop
-            ERI = np.asarray(self.mp.H.ERI)
-            eps = np.diag(np.asarray(self.mp.H.F))
-            c = self.contract
-            Doo, Dvv = self.mp._so_mp2_corr_opdm()
-            Gam = np.asarray(self.mp._so_mp2_tpdm())
-            Du = np.zeros((nmo, nmo))
-            Du[o, o] = np.asarray(Doo)
-            Du[v, v] = np.asarray(Dvv)
-            Ip = self._so_lagrangian(Du, Gam)
-            Drel = Du.copy()
-            Pco = None
-            if nfzc:
-                Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
-                Drel[co, o] = Pco
-                Drel[o, co] = Pco.T
-            X = Ip[ofull, v] - Ip[v, ofull].T
-            if nfzc:
-                zjc = -Pco.T                                   # z_jc, active-occupied x core
-                X = X - (c('jc,ajic->ia', zjc, ERI[v, o, ofull, co])
-                         + c('jc,acij->ia', zjc, ERI[v, co, ofull, o]))
-            G = (c('ajib->iajb', ERI[v, ofull, ofull, v])
-                 + c('abij->iajb', ERI[v, v, ofull, ofull])).reshape(nof * nv, nof * nv)
-            G[np.diag_indices(nof * nv)] += (eps[v][None, :] - eps[ofull][:, None]).reshape(-1)
-            zia = np.linalg.solve(G, X.reshape(-1)).reshape(nof, nv)
-            Drel[v, ofull] = -zia.T
-            Drel[ofull, v] = -zia
-            self._so_zvec = (Drel, Gam, Du, zia, G, Pco)
-        return self._so_zvec
-
     def _so_perturbed_lagrangian(self, pert, D=None, dD=None) -> np.ndarray:
         """First-order response ``d_x I'`` of the GSB orbital Lagrangian (``nmo x nmo``),
         spin-orbital. Differentiates :meth:`_so_lagrangian` term by term with the perturbed
@@ -381,44 +340,22 @@ class MPderiv(CorrelatedDerivs):
         dD[ofull, v] = -zx
         return dD
 
-    def _zvector(self):
-        """Spatial (closed-shell) unperturbed Z-vector data (cached, frozen-core aware):
-        relaxed 1-PDM ``D_rel``, cumulant ``Gam``, unrelaxed ``D_u``, the Z-vector amplitudes
-        ``z`` (indexed ``(I,a)`` over the full occupied space), the all-electron ``HFwfn``
-        whose CPHF carries the orbital Hessian, and the core-active block ``P_co`` (``None``
-        for ``nfzc=0``). :meth:`_mp2_relaxed_densities` delegates here."""
-        if getattr(self, '_zvec', None) is None:
-            from .hfwfn import HFwfn
-            nmo, nfzc, no = self.mp.nmo, self.mp.nfzc, self.mp.no
-            o, v = self.mp.o, self.mp.v
-            co = slice(0, nfzc)
-            ofull = slice(0, nfzc + no)
-            eps = np.diag(np.asarray(self.mp.H.F))
-            L = np.asarray(self.mp.H.L)
-            c = self.contract
+    def _unrelaxed_densities(self):
+        """MP2 unrelaxed reduced densities as full-MO arrays: the 1-PDM ``D_u`` (the ``Doo``/``Dvv``
+        correlation blocks on the occupied/virtual diagonal) and the cumulant 2-PDM ``Gamma``, from
+        the amplitude seeds (:meth:`MPwfn._{so_}mp2_corr_opdm` / ``_{so_}mp2_tpdm``).  Supplies the
+        base Z-vector (:meth:`CorrelatedDerivs._zvector` / :meth:`_so_zvector`)."""
+        nmo, o, v = self.mp.nmo, self.mp.o, self.mp.v
+        if self.mp.orbital_basis == 'spinorbital':
+            Doo, Dvv = self.mp._so_mp2_corr_opdm()
+            Gam = self.mp._so_mp2_tpdm()
+        else:
             Doo, Dvv = self.mp._mp2_corr_opdm()
-            Gam = np.asarray(self.mp._mp2_tpdm())
-            Du = np.zeros((nmo, nmo))
-            Du[o, o] = np.asarray(Doo)
-            Du[v, v] = np.asarray(Dvv)
-            Ip = self._spatial_lagrangian(Du, Gam)
-            Drel = Du.copy()
-            Pco = None
-            if nfzc:
-                Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
-                Drel[co, o] = Pco
-                Drel[o, co] = Pco.T
-            hf = HFwfn(self.mp.ref)
-            X = Ip[ofull, v] - Ip[v, ofull].T
-            if nfzc:
-                zjc = -Pco.T                                   # z_jc, active-occupied x core
-                X = X - (c('jc,ajic->ia', zjc, L[v, o, ofull, co])
-                         + c('jc,acij->ia', zjc, L[v, co, ofull, o]))
-            zia = hf.cphf.solve(X)                              # (I,a) over full occ
-            Drel[v, ofull] = -zia.T
-            Drel[ofull, v] = -zia
-            self._zvec = (Drel, Gam, Du, zia, hf, Pco)
-        return self._zvec
+            Gam = self.mp._mp2_tpdm()
+        Du = np.zeros((nmo, nmo))
+        Du[o, o] = np.asarray(Doo)
+        Du[v, v] = np.asarray(Dvv)
+        return Du, np.asarray(Gam)
 
     def _perturbed_lagrangian(self, pert, D=None, dD=None) -> np.ndarray:
         """Spatial first-order response ``d_x I'`` of the GSB orbital Lagrangian (``nmo x nmo``),


### PR DESCRIPTION
# refactor(deriv): hoist the relaxed density / Z-vector to CorrelatedDerivs (Phase 2b)

## Summary

Second Phase-2 hoist: the unperturbed relaxed-density (orbital-response) build moves into the base.
Given the leaf's unrelaxed reduced densities, the relaxed 1-PDM is method-agnostic:

    Drel = D_u + P_co + P_oo + P_vv - z,   X_ai = I'_ia - I'_ai,   A z = X

with the frozen-core core<->active-occ divide `P_co = (I'_ci - I'_ic)/(eps_c - eps_i)`, the ov
Z-vector (borrowed reference `HFwfn` CPHF on the spatial path, inline orbital Hessian `G` on the
spin-orbital path), and -- for CCSD(T) only -- the oo/vv dependent-pair rotations `P_oo`/`P_vv`.

Branched from `main` after Phase 2a (#195, in review); stacked on 2a.

## Changes

- **`CorrelatedDerivs`**: `_zvector` / `_so_zvector` (cached) and the `_relaxed_density` /
  `_so_relaxed_density` accessors, each docstring carrying its explicit expression. The single
  genuine leaf difference is one hook:
    - `_unrelaxed_densities() -> (D_u, Gam)` -- MP2 builds it from the amplitude seeds; CC returns
      `ccdensity.gradient_densities()`.
  The ROHF guard moves to `_so_zvector`.
- **oo/vv dependent pairs gated on a perturbed-orbital gauge, not the method** (per review): the
  `P_oo`/`P_vv` rotations are written inline in the Z-vector, gated on a new
  `CorrelatedDerivs.perturbed_mo_gauge` property (`'canonical'` / `'non-canonical'`; default
  `'canonical'` for CCSD(T), `'non-canonical'` for MP2/CCSD). The document (§Canonical Perturbed
  Orbitals / §Computational Summary) frames this as the perturbed-orbital gauge choice: `'canonical'`
  carries `P_oo`/`P_vv` explicitly so the (T) parts of `Doo`/`Dvv` need only their diagonal oo/vv
  blocks (saving an O(N^7) step); `'non-canonical'` uses the `-1/2 S` conditions and the pairs vanish
  (valid whenever the energy is oo/vv-rotation invariant, i.e. MP2/CCSD). A future non-canonical-(T)
  route overrides the property. This also corrects the old CC docstrings, which wrongly attributed
  the term to (T) "breaking oo/vv rotation invariance" -- with the full `[F, T3] -> T3` terms the (T)
  energy *is* oo/vv-rotation invariant; the term is a cost choice.
- **`MPderiv`**: drop `_zvector` / `_so_zvector`; add `_unrelaxed_densities`. The
  `_mp2_relaxed_densities` wrappers call the inherited Z-vector.
- **`CCderiv`**: drop `_relaxed_density` / `_so_relaxed_density` (inherit the base accessors); add
  `_unrelaxed_densities`. Fixed the stale `MPwfn._so_zvector` doc references.

## Behavior

Zero behavior change -- the Z-vector body is the same computation, now shared. The CC polarizability
drivers rebuild the Z-vector inline (Phase-3 code) and are untouched here. Validated:

- MP2: test_061, test_067, test_068, test_069 -- **40 passed**.
- CC (incl. CCSD(T) gradient, the inline `P_oo`/`P_vv` path): test_076, test_077, test_078,
  test_083, test_084, test_086 -- **37 passed** (2 slow deselected).

The SO==spatial keystones and the frozen-FD suites are the regression net; both leaves now compute
the relaxed density from the single base implementation.

## Files

pycc/correlatedderivs.py, pycc/mpderiv.py, pycc/ccderiv.py

## Next

2c: relaxed-density gradient + `relaxed_dipole` (both are `Tr(Drel . X)` assemblies now that both
leaves share `_relaxed_density`). Then Phase 3 consolidates the perturbed relaxed density / 2n+1
orchestration (including the CC polarizability's inline Z-vector rebuild).
