### PR TITLE
refactor(deriv): hoist the perturbed generalized-Fock Lagrangian to CorrelatedDerivs (Phase 3a)

### DIFF
--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -229,7 +229,7 @@ class CCderiv(CorrelatedDerivs):
         """Field response ``dD_rel`` of the CC relaxed 1-PDM (spatial; all-electron or frozen core).
         Mirrors :meth:`MPwfn._perturbed_relaxed_opdm` with the CC densities, but (i) keeps the CC
         *unrelaxed* ov/vo blocks (``D_ai != D_ia`` for CC; MP2 has none) and (ii) builds the perturbed
-        Lagrangian with the FULL-df Fock term (see :meth:`_cc_perturbed_lagrangian`).  For frozen core
+        Lagrangian with the FULL-df Fock term (see :meth:`CorrelatedDerivs._perturbed_lagrangian_matrix`).  For frozen core
         the perturbed core<->active Sylvester divide ``dP_co`` is added and coupled into the perturbed
         Z-vector RHS, exactly as in the MP2 template / the unperturbed :meth:`_relaxed_density`.
 
@@ -261,7 +261,7 @@ class CCderiv(CorrelatedDerivs):
                                           dS1=(dt3['S1'] if is_t else None),
                                           dS2=(dt3['S2'] if is_t else None))
         dDg, dGam = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam, dt3=dt3)
-        dIp = self._cc_perturbed_lagrangian(df, deri, dL, D0, dDg, Gam0, dGam)
+        dIp = self._perturbed_lagrangian_matrix(df, deri, dL, D0, dDg, Gam0, dGam)
         dX = dIp[ofull, v] - dIp[v, ofull].T
         dPco = None
         if cc.nfzc:                                     # perturbed core<->active divide (Sylvester derivative)
@@ -324,7 +324,7 @@ class CCderiv(CorrelatedDerivs):
                                              dS1=(dt3['S1'] if is_t else None),
                                              dS2=(dt3['S2'] if is_t else None))
         dDg, dGam = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam, dt3=dt3)
-        dIp = self._so_cc_perturbed_lagrangian(df, deri, D0, dDg, Gam0, dGam)
+        dIp = self._so_perturbed_lagrangian_matrix(df, deri, D0, dDg, Gam0, dGam)
         dX = dIp[ofull, v] - dIp[v, ofull].T
         dPco = None
         if cc.nfzc:
@@ -1040,43 +1040,3 @@ class CCderiv(CorrelatedDerivs):
         dG[v, o, v, v] = 0.5 * dDvvvo.transpose(2, 3, 0, 1)
         dG = 0.25 * (dG + dG.transpose(1, 0, 3, 2) + dG.transpose(2, 3, 0, 1) + dG.transpose(3, 2, 1, 0))
         return dD, dG
-
-    def _cc_perturbed_lagrangian(self, df, deri, dL, D, dD, Gam, dGam):
-        """Field response ``dI'`` of the generalized-Fock (GSB) Lagrangian, density-generic.  The
-        Fock term is the **full matrix product** ``df @ (D + D.T)`` -- NOT the diagonal ``diag(df)``
-        a stencil of :meth:`CorrelatedDerivs._spatial_lagrangian` (which uses ``eps[:,None]*(D+D.T)``,
-        valid only at the canonical F=0) would give.  The omitted ``df_offdiag @ (D+D.T)`` vanishes
-        for MP2 (unrelaxed ``D`` has no ov block) but is nonzero for CC (couples to ``Dov``/``Dvo``);
-        see DERIVATIVES_PLAN sec 8.2.  (Same formula as :meth:`MPderiv._perturbed_lagrangian`;
-        destined to merge with it under ``CorrelatedDerivs`` in Phase 3.)"""
-        cc = self.ccwfn
-        o = cc.o
-        ofull = slice(0, o.stop)
-        c = self.contract
-        ERI = np.asarray(cc.H.ERI)
-        L = np.asarray(cc.H.L)
-        eps = np.diag(np.asarray(cc.H.F))
-        nmo = cc.nmo
-        dA = df @ (D + D.T) + eps[:, None] * (dD + dD.T)
-        dB = np.zeros((nmo, nmo))
-        dB[:, ofull] = (c('rs,rpsq->pq', dD, L[:, :, :, ofull]) + c('rs,rpsq->pq', D, dL[:, :, :, ofull])
-                        + c('rs,rqsp->pq', dD, L[:, ofull, :, :]) + c('rs,rqsp->pq', D, dL[:, ofull, :, :]))
-        dC = 4.0 * (c('prst,qrst->pq', deri, Gam) + c('prst,qrst->pq', ERI, dGam))
-        return -0.5 * (dA + dB + dC)
-
-    def _so_cc_perturbed_lagrangian(self, df, deri, D, dD, Gam, dGam):
-        """Spin-orbital field response ``dI'`` of the GSB Lagrangian (full-df Fock term, as in
-        :meth:`MPwfn._so_perturbed_lagrangian`), density-generic with the CC densities."""
-        cc = self.ccwfn
-        o = cc.o
-        ofull = slice(0, o.stop)
-        c = self.contract
-        ERI = np.asarray(cc.H.ERI)
-        eps = np.diag(np.asarray(cc.H.F))
-        nmo = cc.nmo
-        dA = df @ (D + D.T) + eps[:, None] * (dD + dD.T)
-        dB = np.zeros((nmo, nmo))
-        dB[:, ofull] = (c('rs,rpsq->pq', dD, ERI[:, :, :, ofull]) + c('rs,rpsq->pq', D, deri[:, :, :, ofull])
-                        + c('rs,rqsp->pq', dD, ERI[:, ofull, :, :]) + c('rs,rqsp->pq', D, deri[:, ofull, :, :]))
-        dC = 4.0 * (c('prst,qrst->pq', deri, Gam) + c('prst,qrst->pq', ERI, dGam))
-        return -0.5 * (dA + dB + dC)

--- a/pycc/correlatedderivs.py
+++ b/pycc/correlatedderivs.py
@@ -120,6 +120,54 @@ class CorrelatedDerivs:
         termC = 4.0 * self.contract('prst,qrst->pq', ERI, Gam)
         return -0.5 * (termA + termB + termC)
 
+    # ---- first-order response dI' of the generalized-Fock Lagrangian ----
+    # The field/nuclear derivative of I'(D, Gam), method-agnostic given the perturbed integrals
+    # (df = d_x f, deri = d_x <pq|rs>, dL = 2 deri - deri.swap) and the density responses (dD, dGam).
+    # Its ov-antisymmetric part is the perturbed Z-vector RHS; evaluated at the relaxed density (with
+    # its response) it is the perturbed energy-weighted density d_x W.  The termA derivative is the
+    # FULL Fock matrix product df @ (D + D.T) -- not the diagonal d_x(eps) stencil of the unperturbed
+    # form (valid only at F=0); the off-diagonal df couples the ov/core-active blocks of a relaxed D
+    # (zero for an unrelaxed MP2 D, nonzero for CC's Dov/Dvo).
+
+    def _perturbed_lagrangian_matrix(self, df, deri, dL, D, dD, Gam, dGam) -> np.ndarray:
+        """Spin-adapted first-order response ``dI'`` (``nmo x nmo``) given the perturbed integrals
+        and density responses
+
+            dI'_pq = -1/2 [ df @ (D + D.T) + eps_p (dD_pq + dD_qp)
+                            + delta_{q in ofull} sum_rs ( dD_rs L_rpsq + D_rs dL_rpsq
+                                                          + dD_rs L_rqsp + D_rs dL_rqsp )
+                            + 4 sum_rst ( deri_prst Gamma_qrst + <pr|st> dGamma_qrst ) ]
+
+        with ``L`` (= ``H.L``) and its derivative ``dL`` in the 1-PDM term, and ``<pr|st>`` (= ``H.ERI``)
+        with ``Gamma``/``dGamma`` in the 2-PDM term.  The caller supplies the perturbed integrals and
+        the (unrelaxed or relaxed) densities + responses."""
+        nmo, ofull = self.wfn.nmo, slice(0, self.wfn.o.stop)
+        ERI = np.asarray(self.wfn.H.ERI)
+        L = np.asarray(self.wfn.H.L)
+        eps = np.diag(np.asarray(self.wfn.H.F))
+        c = self.contract
+        dA = df @ (D + D.T) + eps[:, None] * (dD + dD.T)
+        dB = np.zeros((nmo, nmo))
+        dB[:, ofull] = (c('rs,rpsq->pq', dD, L[:, :, :, ofull]) + c('rs,rpsq->pq', D, dL[:, :, :, ofull])
+                        + c('rs,rqsp->pq', dD, L[:, ofull, :, :]) + c('rs,rqsp->pq', D, dL[:, ofull, :, :]))
+        dC = 4.0 * (c('prst,qrst->pq', deri, Gam) + c('prst,qrst->pq', ERI, dGam))
+        return -0.5 * (dA + dB + dC)
+
+    def _so_perturbed_lagrangian_matrix(self, df, deri, D, dD, Gam, dGam) -> np.ndarray:
+        """Spin-orbital first-order response ``dI'`` -- the antisymmetrized-integral analogue of
+        :meth:`_perturbed_lagrangian_matrix` (the ``<pq||rs>`` derivative ``deri`` in the 1-PDM term
+        in place of ``L``/``dL``)."""
+        nmo, ofull = self.wfn.nmo, slice(0, self.wfn.o.stop)
+        ERI = np.asarray(self.wfn.H.ERI)
+        eps = np.diag(np.asarray(self.wfn.H.F))
+        c = self.contract
+        dA = df @ (D + D.T) + eps[:, None] * (dD + dD.T)
+        dB = np.zeros((nmo, nmo))
+        dB[:, ofull] = (c('rs,rpsq->pq', dD, ERI[:, :, :, ofull]) + c('rs,rpsq->pq', D, deri[:, :, :, ofull])
+                        + c('rs,rqsp->pq', dD, ERI[:, ofull, :, :]) + c('rs,rqsp->pq', D, deri[:, ofull, :, :]))
+        dC = 4.0 * (c('prst,qrst->pq', deri, Gam) + c('prst,qrst->pq', ERI, dGam))
+        return -0.5 * (dA + dB + dC)
+
     # ---- unperturbed relaxed density and orbital-response (Z-vector) ----
     # Given the leaf's unrelaxed reduced densities, the relaxed 1-PDM adds the orbital-relaxation
     # blocks driven by the Lagrangian's ov-antisymmetric part:

--- a/pycc/mpderiv.py
+++ b/pycc/mpderiv.py
@@ -128,13 +128,12 @@ class MPderiv(CorrelatedDerivs):
         either way (:meth:`_perturbed_densities`). The ``termA`` derivative is the full Fock
         matrix product ``d_x f @ (D + D.T)`` (the diagonal ``d_x eps`` alone suffices for the
         unrelaxed ``D`` -- no ov block -- but the relaxed ``D`` has ov/core-active blocks that
-        the off-diagonal ``d_x f`` couples)."""
-        nmo, o, v = self.mp.nmo, self.mp.o, self.mp.v
-        ofull = slice(0, o.stop)
+        the off-diagonal ``d_x f`` couples).
+
+        MP2 (closed-form) adapter: builds the perturbed integrals + densities and evaluates the
+        shared :meth:`CorrelatedDerivs._so_perturbed_lagrangian_matrix`."""
+        o = self.mp.o
         ncore = o.stop - self.mp.no
-        ERI = np.asarray(self.mp.H.ERI)
-        eps = np.diag(np.asarray(self.mp.H.F))
-        c = self.contract
         cphf = self._full_occ_cphf()
         Gam = np.asarray(self.mp._so_mp2_tpdm())
         df = np.asarray(cphf.perturbed_fock(pert, ncore))
@@ -144,14 +143,7 @@ class MPderiv(CorrelatedDerivs):
         if D is None:
             _, _, D, _, _, _ = self._so_zvector()      # unrelaxed 1-PDM
             dD = np.asarray(dDg)
-        dA = df @ (D + D.T) + eps[:, None] * (dD + dD.T)
-        dB = np.zeros((nmo, nmo))
-        dB[:, ofull] = (c('rs,rpsq->pq', dD, ERI[:, :, :, ofull])
-                        + c('rs,rpsq->pq', D, deri[:, :, :, ofull])
-                        + c('rs,rqsp->pq', dD, ERI[:, ofull, :, :])
-                        + c('rs,rqsp->pq', D, deri[:, ofull, :, :]))
-        dC = 4.0 * (c('prst,qrst->pq', deri, Gam) + c('prst,qrst->pq', ERI, dGam))
-        return -0.5 * (dA + dB + dC)
+        return self._so_perturbed_lagrangian_matrix(df, deri, D, dD, Gam, dGam)
 
     def _so_perturbed_relaxed_opdm(self, pert) -> np.ndarray:
         """First-order response ``d_x D_rel`` of the relaxed MP2 1-PDM (``nmo x nmo``),
@@ -224,14 +216,13 @@ class MPderiv(CorrelatedDerivs):
         (and its derivative ``dL = 2 d_x<pq|rs> - d_x<pq|sr>``) in the two-electron 1-PDM term,
         ``<pr|st>`` (H.ERI) with ``Gamma`` in the 2-PDM term. ``D``/``dD`` default to the
         unrelaxed 1-PDM and its response (Z-vector RHS); pass the relaxed 1-PDM and its response
-        for ``d_x W``. See :meth:`_so_perturbed_lagrangian`."""
-        nmo, o, v = self.mp.nmo, self.mp.o, self.mp.v
-        ofull = slice(0, o.stop)
+        for ``d_x W``. See :meth:`_so_perturbed_lagrangian`.
+
+        This is the MP2 (closed-form) adapter: it builds the perturbed integrals ``df``/``deri``/``dL``
+        (CPHF) and the perturbed densities ``dDg``/``dGam`` (:meth:`_perturbed_densities`), then
+        evaluates the shared :meth:`CorrelatedDerivs._perturbed_lagrangian_matrix`."""
+        o = self.mp.o
         ncore = o.stop - self.mp.no
-        ERI = np.asarray(self.mp.H.ERI)
-        L = np.asarray(self.mp.H.L)
-        eps = np.diag(np.asarray(self.mp.H.F))
-        c = self.contract
         cphf = self._full_occ_cphf()
         Gam = np.asarray(self.mp._mp2_tpdm())
         df = np.asarray(cphf.perturbed_fock(pert, ncore))
@@ -242,14 +233,7 @@ class MPderiv(CorrelatedDerivs):
         if D is None:
             _, _, D, _, _, _ = self._zvector()          # unrelaxed 1-PDM
             dD = np.asarray(dDg)
-        dA = df @ (D + D.T) + eps[:, None] * (dD + dD.T)
-        dB = np.zeros((nmo, nmo))
-        dB[:, ofull] = (c('rs,rpsq->pq', dD, L[:, :, :, ofull])
-                        + c('rs,rpsq->pq', D, dL[:, :, :, ofull])
-                        + c('rs,rqsp->pq', dD, L[:, ofull, :, :])
-                        + c('rs,rqsp->pq', D, dL[:, ofull, :, :]))
-        dC = 4.0 * (c('prst,qrst->pq', deri, Gam) + c('prst,qrst->pq', ERI, dGam))
-        return -0.5 * (dA + dB + dC)
+        return self._perturbed_lagrangian_matrix(df, deri, dL, D, dD, Gam, dGam)
 
     def _perturbed_relaxed_opdm(self, pert) -> np.ndarray:
         """Spatial first-order response ``d_x D_rel`` of the relaxed MP2 1-PDM (``nmo x nmo``),


### PR DESCRIPTION
# refactor(deriv): hoist the perturbed generalized-Fock Lagrangian to CorrelatedDerivs (Phase 3a)

## Summary

First of the Phase 3 hoists (the 2n+1 / perturbed machinery). The first-order response `dI'` of the
generalized-Fock (GSB) Lagrangian is method-agnostic given the perturbed integrals (`df`, `deri`,
`dL`) and the density responses (`dD`, `dGam`) -- the MP2 and CC copies were byte-for-byte identical
(both already use the full `df @ (D + D.T)` Fock term, not the diagonal-eps stencil). Move it to the
base.

Branched from `main` (after Phase 3-conv, #198).

## Changes

- **`CorrelatedDerivs`**: adds `_perturbed_lagrangian_matrix(df, deri, dL, D, dD, Gam, dGam)`
  (spatial) and `_so_perturbed_lagrangian_matrix(df, deri, D, dD, Gam, dGam)` (spin-orbital) -- the
  pure "given the perturbed integrals and densities" form, each docstring carrying its explicit
  `dI'` expression.
- **`CCderiv`**: drop `_cc_perturbed_lagrangian` / `_so_cc_perturbed_lagrangian`; the two call sites
  (in the perturbed relaxed density) repoint to the base.
- **`MPderiv`**: `_perturbed_lagrangian` / `_so_perturbed_lagrangian` keep their perturbation-in
  adapter role (build the perturbed integrals via CPHF + the closed-form perturbed densities) but
  delegate the math to the base matrix forms.

### Naming

The base form is `*_matrix` because MP2's pert-in adapters still occupy the plain
`_perturbed_lagrangian` / `_so_perturbed_lagrangian` names, with a different (perturbation-in)
signature. The suffix marks "given the perturbed integrals/densities" vs. "given a perturbation,"
and can drop in 3c/3d once those adapters' callers (`_perturbed_relaxed_opdm`, the 2n+1 dW) move
into the base.

## Behavior

Zero behavior change -- the `dI'` math is identical, now shared. Validated:

- MP2 2n+1: test_067 (polarizability), test_068 (APT), test_069 (Hessian) -- **23 passed**.
- CC: test_084 (polarizability, incl. CCSD(T), frozen core, SO==spatial keystones, UHF NH2) --
  **14 passed** (2 slow deselected).

## Files

pycc/correlatedderivs.py, pycc/mpderiv.py, pycc/ccderiv.py

## Next

3b (`_zvector` refactor: record + `P_oo`/`P_vv` exposure + `_orbital_response` accessor), then 3c
(perturbed relaxed density + `_perturbed_unrelaxed_densities` hook), 3d (2n+1 orchestration + gauge
unification + CC on the base Z-vector).
