### PR TITLE
refactor(deriv): return an OrbitalResponse record from the Z-vector solve (Phase 3b)

### DIFF
--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -60,7 +60,7 @@ class CCderiv(CorrelatedDerivs):
     def _unrelaxed_densities(self):
         """CC unrelaxed reduced densities: the Lambda-response 1-PDM ``D`` and the (symmetrized)
         cumulant 2-PDM ``Gam`` (:meth:`ccdensity.gradient_densities`), full-MO arrays.  Supplies the
-        base Z-vector (:meth:`CorrelatedDerivs._zvector` / :meth:`_so_zvector`)."""
+        base Z-vector (:meth:`CorrelatedDerivs._orbital_response` / :meth:`_so_orbital_response`)."""
         D, Gam = self._density().gradient_densities()
         return np.asarray(D), np.asarray(Gam)
 

--- a/pycc/correlatedderivs.py
+++ b/pycc/correlatedderivs.py
@@ -9,7 +9,19 @@ base/leaf split and the phased plan; more machinery moves here in later phases.
 
 from __future__ import annotations
 
+from collections import namedtuple
+
 import numpy as np
+
+
+#: Result of the unperturbed orbital-response (Z-vector) solve.  ``Drel``/``Gam`` are the relaxed
+#: 1-PDM and cumulant 2-PDM; the remaining fields are the byproducts the perturbed (2n+1) machinery
+#: reuses: the unrelaxed 1-PDM ``D``, the ov Z-vector amplitudes ``z``, the MO orbital-Hessian
+#: solver handle ``mo_hessian`` (the reference ``HFwfn`` on the spatial path, the inline matrix ``G``
+#: on the spin-orbital path), the frozen-core core<->active divide ``Pco``, and the
+#: canonical-perturbed-MO oo/vv dependent-pair rotations ``Poo``/``Pvv`` (``None`` unless the gauge
+#: is canonical).
+OrbitalResponse = namedtuple('OrbitalResponse', 'Drel Gam D z mo_hessian Pco Poo Pvv')
 
 
 class CorrelatedDerivs:
@@ -172,7 +184,7 @@ class CorrelatedDerivs:
     # Given the leaf's unrelaxed reduced densities, the relaxed 1-PDM adds the orbital-relaxation
     # blocks driven by the Lagrangian's ov-antisymmetric part:
     #
-    #     Drel = D_u  +  P_co (core<->active-occ)  +  P_oo/P_vv (extra oo/vv, e.g. (T))  -  z (ov),
+    #     Drel = D  +  P_co (core<->active-occ)  +  P_oo/P_vv (extra oo/vv, e.g. (T))  -  z (ov),
     #
     # with the Z-vector  A z = X,  X_ai = I'_ia - I'_ai (over the full occupied space).  The
     # non-redundant core<->active-occupied rotation is a direct divide P_co = (I'_ci - I'_ic) /
@@ -182,24 +194,26 @@ class CorrelatedDerivs:
     # Method-agnostic given the two leaf hooks below.
 
     def _unrelaxed_densities(self):
-        """Leaf hook: the unrelaxed reduced densities ``(D_u, Gam)`` as full-MO arrays -- the 1-PDM
+        """Leaf hook: the unrelaxed reduced densities ``(D, Gam)`` as full-MO arrays -- the 1-PDM
         (``nmo x nmo``, occupied/virtual diagonal blocks) and cumulant 2-PDM (``nmo^4``).  Supplied
         by the method (MP2 amplitude seeds / CC :meth:`ccdensity.gradient_densities`)."""
         raise NotImplementedError
 
-    def _zvector(self):
-        """Spatial (closed-shell) unperturbed Z-vector data (cached, frozen-core aware):
-        ``(Drel, Gam, D_u, z, hf, P_co)``.  The relaxed 1-PDM
+    def _orbital_response(self):
+        """Spatial (closed-shell) unperturbed orbital-response (Z-vector) solve (cached, frozen-core
+        aware), returning an :class:`OrbitalResponse` record.  The relaxed 1-PDM
 
-            Drel = D_u + P_co + P_oo + P_vv - z,   X_ai = I'_ia - I'_ai,   A z = X,
+            Drel = D + P_co + P_oo + P_vv - z,   X_ai = I'_ia - I'_ai,   A z = X,
 
-        with ``I' = -1/2[...]`` (:meth:`_spatial_lagrangian`), the frozen-core divide
-        ``P_co = (I'_ci - I'_ic)/(eps_c - eps_i)`` coupled into ``X``, the canonical-perturbed-MO
-        oo/vv rotations ``P_oo``/``P_vv`` (the branch below, active only for
-        :attr:`perturbed_mo_gauge` ``== 'canonical'``, i.e. CCSD(T)), and the ov Z-vector solved with
-        the all-electron reference ``HFwfn`` CPHF (whose occupied space is the full ``ndocc``).
-        ``z`` is indexed ``(I, a)`` over the full occupied space."""
-        if getattr(self, '_zvec', None) is None:
+        with the generalized-Fock Lagrangian ``I'`` from :meth:`_spatial_lagrangian` (spin-adapted
+        ``L``), the frozen-core divide ``P_co = (I'_ci - I'_ic)/(eps_c - eps_i)`` coupled into ``X``,
+        the canonical-perturbed-MO oo/vv rotations ``P_oo``/``P_vv`` (populated only for
+        :attr:`perturbed_mo_gauge` ``== 'canonical'``), and the ov Z-vector ``A z = X`` solved with
+        the orbital Hessian ``A`` from the all-electron reference ``HFwfn`` CPHF (``mo_hessian`` =
+        that ``HFwfn``; occupied space = the full ``ndocc``).  ``z`` is indexed ``(I, a)`` over the
+        full occupied space.  The record's byproducts (``z``, ``mo_hessian``, ``Pco``, ``Poo``,
+        ``Pvv``, ``D``) are reused by the perturbed (2n+1) machinery."""
+        if getattr(self, '_orbresp', None) is None:
             nmo, nfzc, no = self.wfn.nmo, self.wfn.nfzc, self.wfn.no
             o, v = self.wfn.o, self.wfn.v
             co = slice(0, nfzc)
@@ -207,11 +221,11 @@ class CorrelatedDerivs:
             eps = np.diag(np.asarray(self.wfn.H.F))
             L = np.asarray(self.wfn.H.L)
             c = self.contract
-            Du, Gam = self._unrelaxed_densities()
-            Du = np.asarray(Du)
-            Ip = self._spatial_lagrangian(Du, Gam)
-            Drel = Du.copy()
-            Pco = None
+            D, Gam = self._unrelaxed_densities()
+            D = np.asarray(D)
+            Ip = self._spatial_lagrangian(D, Gam)
+            Drel = D.copy()
+            Pco = Poo = Pvv = None
             if nfzc:
                 Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
                 Drel[co, o] += Pco
@@ -237,20 +251,27 @@ class CorrelatedDerivs:
             zia = hf.cphf.solve(X)                              # (I,a) over full occ
             Drel[v, ofull] += -zia.T
             Drel[ofull, v] += -zia
-            self._zvec = (Drel, Gam, Du, zia, hf, Pco)
-        return self._zvec
+            self._orbresp = OrbitalResponse(Drel, Gam, D, zia, hf, Pco, Poo, Pvv)
+        return self._orbresp
 
-    def _so_zvector(self):
-        """Spin-orbital unperturbed Z-vector data (cached, frozen-core aware):
-        ``(Drel, Gam, D_u, z, G, P_co)`` -- the spin-orbital analogue of :meth:`_zvector`
-        (antisymmetrized ``<pq||rs>``; :meth:`_so_lagrangian`).  The orbital Hessian is built inline
+    def _so_orbital_response(self):
+        """Spin-orbital unperturbed orbital-response (Z-vector) solve (cached, frozen-core aware),
+        returning an :class:`OrbitalResponse` record.  The relaxed 1-PDM
 
-            G_ia,jb = <aj||ib> + <ab||ij> + delta_ij delta_ab (eps_a - eps_i),
+            Drel = D + P_co + P_oo + P_vv - z,   X_ai = I'_ia - I'_ai,   A z = X,
 
-        over the full occupied space (there is no all-electron spin-orbital ``HFwfn`` CPHF to borrow
-        -- it orders the spins differently from the densities).  **UHF only** -- raises for ROHF (the
-        semicanonical response does not reproduce the restricted ROHF response)."""
-        if getattr(self, '_so_zvec', None) is None:
+        with the generalized-Fock Lagrangian ``I'`` from :meth:`_so_lagrangian` (antisymmetrized
+        ``<pq||rs>``), the frozen-core divide ``P_co = (I'_ci - I'_ic)/(eps_c - eps_i)`` coupled into
+        ``X``, the canonical-perturbed-MO oo/vv rotations ``P_oo``/``P_vv`` (populated only for
+        :attr:`perturbed_mo_gauge` ``== 'canonical'``), and the ov Z-vector ``A z = X`` solved with
+        the orbital Hessian ``A = G`` built inline (``G_ia,jb = <aj||ib> + <ab||ij> + delta_ij
+        delta_ab (eps_a - eps_i)``, ``mo_hessian`` = that ``G``) -- there is no all-electron
+        spin-orbital ``HFwfn`` CPHF to borrow (it orders the spins differently from the densities).
+        ``z`` is indexed ``(I, a)`` over the full occupied space.  The record's byproducts (``z``,
+        ``mo_hessian``, ``Pco``, ``Poo``, ``Pvv``, ``D``) are reused by the perturbed (2n+1)
+        machinery.  **UHF only** -- raises for ROHF (the semicanonical response does not reproduce
+        the restricted ROHF response)."""
+        if getattr(self, '_so_orbresp', None) is None:
             if self.wfn.cphf.is_rohf:
                 raise NotImplementedError(
                     "The spin-orbital correlated relaxed gradient/dipole is not implemented for "
@@ -263,11 +284,11 @@ class CorrelatedDerivs:
             ERI = np.asarray(self.wfn.H.ERI)
             eps = np.diag(np.asarray(self.wfn.H.F))
             c = self.contract
-            Du, Gam = self._unrelaxed_densities()
-            Du = np.asarray(Du)
-            Ip = self._so_lagrangian(Du, Gam)
-            Drel = Du.copy()
-            Pco = None
+            D, Gam = self._unrelaxed_densities()
+            D = np.asarray(D)
+            Ip = self._so_lagrangian(D, Gam)
+            Drel = D.copy()
+            Pco = Poo = Pvv = None
             if nfzc:
                 Pco = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
                 Drel[co, o] += Pco
@@ -295,19 +316,21 @@ class CorrelatedDerivs:
             zia = np.linalg.solve(G, X.reshape(-1)).reshape(nof, nv)
             Drel[v, ofull] += -zia.T
             Drel[ofull, v] += -zia
-            self._so_zvec = (Drel, Gam, Du, zia, G, Pco)
-        return self._so_zvec
+            self._so_orbresp = OrbitalResponse(Drel, Gam, D, zia, G, Pco, Poo, Pvv)
+        return self._so_orbresp
 
     def _relaxed_density(self):
         """Relaxed 1-PDM ``Drel`` and cumulant 2-PDM ``Gam`` (``Tr(Drel mu)`` gives the correlation
-        dipole; ``Drel``/``Gam`` feed the gradient), dispatched on the orbital basis."""
-        z = self._so_zvector() if self.wfn.orbital_basis == 'spinorbital' else self._zvector()
-        return z[0], z[1]
+        dipole; ``Drel``/``Gam`` feed the gradient), dispatched on the orbital basis.  The full
+        orbital-response byproducts are available from :meth:`_orbital_response` /
+        :meth:`_so_orbital_response`."""
+        rec = self._so_orbital_response() if self.wfn.orbital_basis == 'spinorbital' else self._orbital_response()
+        return rec.Drel, rec.Gam
 
     def _so_relaxed_density(self):
-        """Spin-orbital relaxed 1-PDM and 2-PDM -- ``(Drel, Gam)`` from :meth:`_so_zvector`."""
-        z = self._so_zvector()
-        return z[0], z[1]
+        """Spin-orbital relaxed 1-PDM and 2-PDM -- ``(Drel, Gam)`` from :meth:`_so_orbital_response`."""
+        rec = self._so_orbital_response()
+        return rec.Drel, rec.Gam
 
     # ---- first-derivative properties: relaxed dipole and nuclear gradient ----
     # Both are contractions of the relaxed density against the property integrals, method-agnostic
@@ -389,7 +412,7 @@ class CorrelatedDerivs:
 
         This is the frozen-core core<->active-occupied divide generalized to an arbitrary square
         block; it also supplies the active oo/vv rotations of the canonical perturbed-MO gauge
-        (:attr:`perturbed_mo_gauge`, used by :meth:`_zvector` / :meth:`_so_zvector`)."""
+        (:attr:`perturbed_mo_gauge`, used by :meth:`_orbital_response` / :meth:`_so_orbital_response`)."""
         num = np.asarray(Iblock) - np.asarray(Iblock).T
         den = eps_block[:, None] - eps_block[None, :]
         P = np.zeros_like(num)

--- a/pycc/mpderiv.py
+++ b/pycc/mpderiv.py
@@ -141,7 +141,7 @@ class MPderiv(CorrelatedDerivs):
         dDg, dGam = self._perturbed_densities(pert)
         dGam = np.asarray(dGam)
         if D is None:
-            _, _, D, _, _, _ = self._so_zvector()      # unrelaxed 1-PDM
+            D = self._so_orbital_response().D         # unrelaxed 1-PDM
             dD = np.asarray(dDg)
         return self._so_perturbed_lagrangian_matrix(df, deri, D, dD, Gam, dGam)
 
@@ -166,7 +166,7 @@ class MPderiv(CorrelatedDerivs):
         ncore = o.stop - self.mp.no
         c = self.contract
         cphf = self._full_occ_cphf()
-        _, _, _, zia, G, Pco = self._so_zvector()
+        _r = self._so_orbital_response(); zia, G, Pco = _r.z, _r.mo_hessian, _r.Pco
         ERI = np.asarray(self.mp.H.ERI)
         eps = np.diag(np.asarray(self.mp.H.F))
         df = np.asarray(cphf.perturbed_fock(pert, ncore))
@@ -194,10 +194,10 @@ class MPderiv(CorrelatedDerivs):
         return dD
 
     def _unrelaxed_densities(self):
-        """MP2 unrelaxed reduced densities as full-MO arrays: the 1-PDM ``D_u`` (the ``Doo``/``Dvv``
+        """MP2 unrelaxed reduced densities as full-MO arrays: the 1-PDM ``D`` (the ``Doo``/``Dvv``
         correlation blocks on the occupied/virtual diagonal) and the cumulant 2-PDM ``Gamma``, from
         the amplitude seeds (:meth:`MPwfn._{so_}mp2_corr_opdm` / ``_{so_}mp2_tpdm``).  Supplies the
-        base Z-vector (:meth:`CorrelatedDerivs._zvector` / :meth:`_so_zvector`)."""
+        base Z-vector (:meth:`CorrelatedDerivs._orbital_response` / :meth:`_so_orbital_response`)."""
         nmo, o, v = self.mp.nmo, self.mp.o, self.mp.v
         if self.mp.orbital_basis == 'spinorbital':
             Doo, Dvv = self.mp._so_mp2_corr_opdm()
@@ -205,10 +205,10 @@ class MPderiv(CorrelatedDerivs):
         else:
             Doo, Dvv = self.mp._mp2_corr_opdm()
             Gam = self.mp._mp2_tpdm()
-        Du = np.zeros((nmo, nmo))
-        Du[o, o] = np.asarray(Doo)
-        Du[v, v] = np.asarray(Dvv)
-        return Du, np.asarray(Gam)
+        D = np.zeros((nmo, nmo))
+        D[o, o] = np.asarray(Doo)
+        D[v, v] = np.asarray(Dvv)
+        return D, np.asarray(Gam)
 
     def _perturbed_lagrangian(self, pert, D=None, dD=None) -> np.ndarray:
         """Spatial first-order response ``d_x I'`` of the GSB orbital Lagrangian (``nmo x nmo``),
@@ -231,7 +231,7 @@ class MPderiv(CorrelatedDerivs):
         dDg, dGam = self._perturbed_densities(pert)
         dGam = np.asarray(dGam)
         if D is None:
-            _, _, D, _, _, _ = self._zvector()          # unrelaxed 1-PDM
+            D = self._orbital_response().D             # unrelaxed 1-PDM
             dD = np.asarray(dDg)
         return self._perturbed_lagrangian_matrix(df, deri, dL, D, dD, Gam, dGam)
 
@@ -250,7 +250,7 @@ class MPderiv(CorrelatedDerivs):
         ncore = o.stop - self.mp.no
         c = self.contract
         cphf = self._full_occ_cphf()
-        _, _, _, zia, hf, Pco = self._zvector()
+        _r = self._orbital_response(); zia, hf, Pco = _r.z, _r.mo_hessian, _r.Pco
         L = np.asarray(self.mp.H.L)
         eps = np.diag(np.asarray(self.mp.H.F))
         df = np.asarray(cphf.perturbed_fock(pert, ncore))
@@ -316,10 +316,10 @@ class MPderiv(CorrelatedDerivs):
         cphf = self._full_occ_cphf()
         c = self.contract
         if self.mp.orbital_basis == 'spinorbital':
-            Drel = self._so_zvector()[0]
+            Drel = self._so_orbital_response().Drel
             perturbed_opdm = self._so_perturbed_relaxed_opdm
         else:
-            Drel = self._zvector()[0]
+            Drel = self._orbital_response().Drel
             perturbed_opdm = self._perturbed_relaxed_opdm
         mu = [np.asarray(self.mp.H.mu[a]) for a in range(3)]
         field = [Perturbation('field', b) for b in range(3)]
@@ -385,7 +385,7 @@ class MPderiv(CorrelatedDerivs):
         cphf = self._full_occ_cphf()
         d = self.mp.derivatives
         natom = d.natom
-        Drel = (self._so_zvector() if so else self._zvector())[0]
+        Drel = (self._so_orbital_response() if so else self._orbital_response()).Drel
         popdm = self._so_perturbed_relaxed_opdm if so else self._perturbed_relaxed_opdm
         mu = [np.asarray(self.mp.H.mu[a]) for a in range(3)]
         P = np.zeros((natom, 3, 3))
@@ -496,7 +496,7 @@ class MPderiv(CorrelatedDerivs):
         d = self.mp.derivatives
         natom = d.natom
         nc = 3 * natom
-        Drel = (self._so_zvector() if so else self._zvector())[0]
+        Drel = (self._so_orbital_response() if so else self._orbital_response()).Drel
         Gam = np.asarray(self.mp._so_mp2_tpdm() if so else self.mp._mp2_tpdm())
         W = self._lagrangian(Drel, Gam)
         popdm = self._so_perturbed_relaxed_opdm if so else self._perturbed_relaxed_opdm

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -168,7 +168,7 @@ def test_sa_mp2_gradient_631g():
 def test_ump2_gradient_nh2_631g():
     """Open-shell UHF-MP2 analytic nuclear gradient vs Psi4, NH2 (2-B1, C2v, pinned occupation) / 6-31G.
 
-    The open-shell oracle for the spin-orbital Z-vector gradient (``_so_zvector``).  psi4 is the
+    The open-shell oracle for the spin-orbital Z-vector gradient (``_so_orbital_response``).  psi4 is the
     right check here: an open-shell UHF spin-orbital orbital Hessian carries a near-zero mode, so
     the single linear solve the Z-vector route runs through is ill-conditioned and platform-
     dependent -- but the final gradient is orthogonal to that mode and reproduces psi4 to machine


### PR DESCRIPTION
# refactor(deriv): return an OrbitalResponse record from the Z-vector solve (Phase 3b)

## Summary

Rename the unperturbed Z-vector methods to reflect what they compute, and expose their byproducts
through a named record instead of a positional tuple. Pure refactor / renaming -- no numerics
change -- that sets up 3c (the perturbed relaxed density needs `P_oo`/`P_vv`).

Branched from `main` (after Phase 3a, #199).

## Changes

- **`_zvector` / `_so_zvector` -> `_orbital_response` / `_so_orbital_response`.** The `_zvector`
  name was a misnomer: the method computes the relaxed density and caches the Z-vector data as
  byproducts; the z-vector is one field, not the return value.
- **Return an `OrbitalResponse` namedtuple** `(Drel, Gam, D, z, mo_hessian, Pco, Poo, Pvv)` instead
  of a 6-tuple, and additionally expose **`Poo`/`Pvv`** -- the canonical-perturbed-MO oo/vv
  dependent-pair rotations, previously computed and folded into `Drel` but discarded -- so the
  perturbed (2n+1) machinery can reuse them in 3c/3d.
- **Field names follow the governing doc**: `D` is the unrelaxed 1-PDM (`Drel` the relaxed one), and
  `mo_hessian` is the orbital Hessian (named to disambiguate from the molecular/nuclear Hessian).
- **`_relaxed_density` / `_so_relaxed_density`** keep their role -- return `(Drel, Gam)`, now read as
  record fields. The full record is cached on the instance, so the `(Drel, Gam)` view and the
  perturbed byproduct consumers share one solve (nothing recomputed).
- **`MPderiv` consumers** repoint to named-field access (`rec.z`, `rec.mo_hessian`, `rec.Pco`,
  `rec.D`, `rec.Drel`) -- more readable than positional unpacking.
- The two computing-method docstrings are made **parallel** (same recipe + `Drel = D + P_co + P_oo +
  P_vv - z` math block, differing only in the Lagrangian kernel and the Hessian source). `CIwfn`'s
  own `_zvector` (a separate class) is untouched.

## Behavior

Zero behavior change (rename + named-tuple packaging; the numerics are identical). Validated:

- MP2: test_061, test_067, test_068, test_069 -- **40 passed**.
- CC: test_076 (gradient), test_084 (polarizability, incl. CCSD(T)/frozen-core/SO keystones) --
  **18 passed** (2 slow deselected).

## Files

pycc/correlatedderivs.py, pycc/mpderiv.py, pycc/ccderiv.py,
pycc/tests/test_061_mp2_relaxed_density.py (docstring reference only)

## Next

3c: the perturbed relaxed density -> base + the `_perturbed_unrelaxed_densities` leaf hook (which
will consume the `Poo`/`Pvv` now exposed here). Then 3d (2n+1 orchestration + gauge unification +
CC on the base Z-vector).
