### PR TITLE
refactor(deriv): hoist perturbed relaxed density to base (Phase 3c)

### DIFF
--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -111,55 +111,18 @@ class CCderiv(CorrelatedDerivs):
                              "build the wavefunction with make_t3_density=True.")
         if cc.orbital_basis == 'spinorbital':
             return self._so_polarizability()
-        from .cchbar import cchbar
-        from .cclambda import cclambda
-        from .ccdensity import ccdensity
         from .cphf import Perturbation
-        o, v = cc.o, cc.v
-        co = slice(0, cc.nfzc)                            # frozen-core occupied
-        ofull = slice(0, o.stop)                         # full occupied (core + active)
         c = self.contract
-        ncore = o.stop - cc.no
-        eps = np.diag(np.asarray(cc.H.F))
-        L = np.asarray(cc.H.L)
-
-        # Lambda inherits the wavefunction's convergence (set by solve_cc); the test/user tightens
-        # ccwfn convergence to reach the second-derivative oracle rather than hardwiring it here.
-        hbar = cchbar(cc)
-        lam = cclambda(cc, hbar)
-        lam.solve_lambda(e_conv=cc.e_conv, r_conv=cc.r_conv, maxiter=cc.maxiter)
-        dens = ccdensity(cc, lam)
-        D0, Gam0 = (np.asarray(x) for x in dens.gradient_densities())
-        Ip0 = np.asarray(self._lagrangian(D0, Gam0))
-        hf = self._reference_hf()
-        Drel = D0.copy()
-        Pco = None
-        if cc.nfzc:                                      # core<->active-occupied divide (as in _relaxed_density)
-            Pco = (Ip0[co, o] - Ip0[o, co].T) / (eps[co][:, None] - eps[o][None, :])
-            Drel[co, o] += Pco
-            Drel[o, co] += Pco.T
-        X0 = Ip0[ofull, v] - Ip0[v, ofull].T
-        if cc.nfzc:                                      # couple P_co into the Z-vector RHS
-            zjc = -Pco.T
-            X0 = X0 - (c('jc,ajic->ia', zjc, L[v, o, ofull, co]) + c('jc,acij->ia', zjc, L[v, co, ofull, o]))
-        Poo0 = Pvv0 = None
-        if cc.model.upper() == 'CCSD(T)':                # (T) oo/vv dependent-pairs (as in _relaxed_density)
-            Poo0 = self._dependent_pairs(Ip0[o, o], eps[o])
-            Pvv0 = self._dependent_pairs(Ip0[v, v], eps[v])
-            Drel[o, o] += Poo0
-            Drel[v, v] += Pvv0
-            X0 = X0 + (c('kl,akil->ia', Poo0, L[v, o, ofull, o]) + c('bc,ibac->ia', Pvv0, L[ofull, v, v, v]))
-        z = np.asarray(hf.cphf.solve(X0))
-        Drel[v, ofull] += -z.T
-        Drel[ofull, v] += -z
-
-        cphf = cc.mp.deriv._full_occ_cphf()
+        ncore = cc.o.stop - cc.no
+        canonical = self.perturbed_mo_gauge == 'canonical'
+        Drel = self._relaxed_density()[0]               # base Z-vector (unperturbed relaxed 1-PDM)
+        cphf = self._full_occ_cphf()
         mu = [np.asarray(cc.H.mu[a]) for a in range(3)]
         alpha = np.zeros((3, 3))
         for b in range(3):
             pert = Perturbation('field', b)
-            dDrel = self._perturbed_relaxed_density(pert, hbar, lam, D0, Gam0, z, Pco, Poo0, Pvv0)
-            Ub = np.asarray(cphf._full_U(pert, ncore, canonical=is_t))
+            dDrel = self._perturbed_relaxed_density(pert)
+            Ub = np.asarray(cphf._full_U(pert, ncore, canonical=canonical))
             for a in range(3):
                 rot = Ub.T @ mu[a] + mu[a] @ Ub
                 alpha[a, b] = c('pq,pq->', dDrel, mu[a]) + c('pq,pq->', Drel, rot)
@@ -167,192 +130,51 @@ class CCderiv(CorrelatedDerivs):
 
     def _so_polarizability(self) -> np.ndarray:
         """Spin-orbital (UHF) CCSD correlation polarizability -- the SO analog of
-        :meth:`polarizability` (all-electron or frozen core).  Raises for ROHF."""
-        from .cchbar import cchbar
-        from .cclambda import cclambda
-        from .ccdensity import ccdensity
+        :meth:`polarizability` (all-electron or frozen core).  Raises for ROHF (via the base
+        :meth:`CorrelatedDerivs._so_orbital_response`)."""
         from .cphf import Perturbation
         cc = self.ccwfn
-        if cc.mp.cphf.is_rohf:
-            raise NotImplementedError("CC polarizability: ROHF is not supported (RHF/UHF only).")
-        o, v, nv = cc.o, cc.v, cc.nv
-        co = slice(0, o.start)                            # frozen core (2*nfzc spin-orbitals)
-        ofull = slice(0, o.stop)
-        nof = o.stop
         c = self.contract
-        ncore = o.stop - cc.no
-        eps = np.diag(np.asarray(cc.H.F))
-        ERI = np.asarray(cc.H.ERI)
-
-        hbar = cchbar(cc)
-        lam = cclambda(cc, hbar)
-        lam.solve_lambda(e_conv=cc.e_conv, r_conv=cc.r_conv, maxiter=cc.maxiter)
-        D0, Gam0 = (np.asarray(x) for x in ccdensity(cc, lam).gradient_densities())
-        Ip0 = np.asarray(self._lagrangian(D0, Gam0))
-        Drel = D0.copy()
-        Pco = None
-        if cc.nfzc:
-            Pco = (Ip0[co, o] - Ip0[o, co].T) / (eps[co][:, None] - eps[o][None, :])
-            Drel[co, o] += Pco
-            Drel[o, co] += Pco.T
-        X0 = Ip0[ofull, v] - Ip0[v, ofull].T
-        if cc.nfzc:
-            zjc = -Pco.T
-            X0 = X0 - (c('jc,ajic->ia', zjc, ERI[v, o, ofull, co]) + c('jc,acij->ia', zjc, ERI[v, co, ofull, o]))
-        Poo0 = Pvv0 = None
-        if cc.model.upper() == 'CCSD(T)':                 # (T) oo/vv dependent-pairs (as in _so_relaxed_density)
-            Poo0 = self._dependent_pairs(Ip0[o, o], eps[o])
-            Pvv0 = self._dependent_pairs(Ip0[v, v], eps[v])
-            Drel[o, o] += Poo0
-            Drel[v, v] += Pvv0
-            X0 = X0 + (c('kl,akil->ia', Poo0, ERI[v, o, ofull, o]) + c('bc,ibac->ia', Pvv0, ERI[ofull, v, v, v]))
-        G = (c('ajib->iajb', ERI[v, ofull, ofull, v]) + c('abij->iajb', ERI[v, v, ofull, ofull])).reshape(nof*nv, nof*nv)
-        G[np.diag_indices(nof*nv)] += (eps[v][None, :] - eps[ofull][:, None]).reshape(-1)
-        z = np.linalg.solve(G, X0.reshape(-1)).reshape(nof, nv)
-        Drel[v, ofull] += -z.T
-        Drel[ofull, v] += -z
-
-        cphf = cc.mp.deriv._full_occ_cphf()
+        ncore = cc.o.stop - cc.no
+        canonical = self.perturbed_mo_gauge == 'canonical'
+        Drel = self._so_relaxed_density()[0]            # base Z-vector (inline G Hessian; raises for ROHF)
+        cphf = self._full_occ_cphf()
         mu = [np.asarray(cc.H.mu[a]) for a in range(3)]
         alpha = np.zeros((3, 3))
         for b in range(3):
             pert = Perturbation('field', b)
-            dDrel = self._so_perturbed_relaxed_density(pert, hbar, lam, D0, Gam0, z, G, Pco, Poo0, Pvv0)
-            Ub = np.asarray(cphf._full_U(pert, ncore, canonical=(cc.model.upper() == 'CCSD(T)')))
+            dDrel = self._so_perturbed_relaxed_density(pert)
+            Ub = np.asarray(cphf._full_U(pert, ncore, canonical=canonical))
             for a in range(3):
                 rot = Ub.T @ mu[a] + mu[a] @ Ub
                 alpha[a, b] = c('pq,pq->', dDrel, mu[a]) + c('pq,pq->', Drel, rot)
         return alpha
 
-    def _perturbed_relaxed_density(self, pert, hbar, lam, D0, Gam0, z, Pco=None,
-                                   Poo0=None, Pvv0=None) -> np.ndarray:
-        """Field response ``dD_rel`` of the CC relaxed 1-PDM (spatial; all-electron or frozen core).
-        Mirrors :meth:`MPwfn._perturbed_relaxed_opdm` with the CC densities, but (i) keeps the CC
-        *unrelaxed* ov/vo blocks (``D_ai != D_ia`` for CC; MP2 has none) and (ii) builds the perturbed
-        Lagrangian with the FULL-df Fock term (see :meth:`CorrelatedDerivs._perturbed_lagrangian_matrix`).  For frozen core
-        the perturbed core<->active Sylvester divide ``dP_co`` is added and coupled into the perturbed
-        Z-vector RHS, exactly as in the MP2 template / the unperturbed :meth:`_relaxed_density`.
-
-        CCSD(T): uses the **canonical** perturbed orbitals (``df``/``deri`` with ``canonical=True``, so
-        ``df`` is diagonal in oo/vv -- the non-invariant (T) kernels require it), threads the perturbed
-        (T) intermediates ``dt3`` into the density and the Lambda source, and adds the perturbed
-        active-oo/vv dependent-pairs ``dPoo``/``dPvv`` (the field-derivative of the unperturbed
-        ``Poo0``/``Pvv0``, including the ``d(eps_i-eps_j) = df_ii - df_jj`` denominator term) to
-        ``dD_rel`` + the perturbed Z-vector RHS."""
+    def _perturbed_unrelaxed_densities(self, pert, df, deri, dL):
+        """CC perturbed unrelaxed densities ``(d_x gamma, d_x Gamma)`` -- the base
+        :meth:`CorrelatedDerivs._perturbed_unrelaxed_densities` hook.  Runs the iterative perturbed
+        amplitude solve ``dt = dt(df, deri, dL)`` and the perturbed Lambda solve ``dLambda``
+        (reusing the converged ``hbar``/``lam`` from :meth:`_density`), threading the perturbed (T)
+        intermediates ``dt3`` into both and into the density for CCSD(T), then builds the perturbed
+        correlation densities (:meth:`_perturbed_correlation_densities`).  ``df``/``deri`` are already
+        canonical per :attr:`perturbed_mo_gauge` (passed in by the base perturbed Z-vector solve)."""
         cc = self.ccwfn
-        o, v = cc.o, cc.v
-        co = slice(0, cc.nfzc)
-        ofull = slice(0, o.stop)
-        c = self.contract
-        ncore = o.stop - cc.no
-        L = np.asarray(cc.H.L)
-        eps = np.diag(np.asarray(cc.H.F))
+        lam = self._density().cclambda
+        hbar = lam.hbar
         is_t = cc.model.upper() == 'CCSD(T)'
-        canon = is_t                                    # (T) needs canonical perturbed orbitals
-        cphf = cc.mp.deriv._full_occ_cphf()
-        df = np.asarray(cphf.perturbed_fock(pert, ncore, canonical=canon))
-        deri = np.asarray(cphf.perturbed_eri(pert, ncore, canonical=canon))
-        dL = 2.0 * deri - deri.swapaxes(2, 3)
-        hf = self._reference_hf()
-
-        dt1, dt2 = self._perturbed_amplitudes(df, deri, dL, hbar)
-        dt3 = self._perturbed_t3_intermediates(df, deri, dL, dt1, dt2) if is_t else None
-        dl1, dl2 = self._perturbed_lambda(df, deri, dL, dt1, dt2, hbar, lam,
-                                          dS1=(dt3['S1'] if is_t else None),
-                                          dS2=(dt3['S2'] if is_t else None))
-        dDg, dGam = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam, dt3=dt3)
-        dIp = self._perturbed_lagrangian_matrix(df, deri, dL, D0, dDg, Gam0, dGam)
-        dX = dIp[ofull, v] - dIp[v, ofull].T
-        dPco = None
-        if cc.nfzc:                                     # perturbed core<->active divide (Sylvester derivative)
-            gap = eps[co][:, None] - eps[o][None, :]
-            dPco = (dIp[co, o] - dIp[o, co].T - df[co, co] @ Pco + Pco @ df[o, o]) / gap
-            zjc, dzjc = -Pco.T, -dPco.T
-            dX = dX - (c('jc,ajic->ia', dzjc, L[v, o, ofull, co]) + c('jc,acij->ia', dzjc, L[v, co, ofull, o])
-                       + c('jc,ajic->ia', zjc, dL[v, o, ofull, co]) + c('jc,acij->ia', zjc, dL[v, co, ofull, o]))
-        dPoo = dPvv = None
-        if is_t:                                        # perturbed (T) oo/vv dependent-pairs
-            dfd = np.diag(df)                           # canonical df diagonal = the perturbed gaps
-            dPoo = self._perturbed_dependent_pairs(dIp[o, o], Poo0, eps[o], dfd[o])
-            dPvv = self._perturbed_dependent_pairs(dIp[v, v], Pvv0, eps[v], dfd[v])
-            dX = dX + (c('kl,akil->ia', dPoo, L[v, o, ofull, o]) + c('kl,akil->ia', Poo0, dL[v, o, ofull, o])
-                       + c('bc,ibac->ia', dPvv, L[ofull, v, v, v]) + c('bc,ibac->ia', Pvv0, dL[ofull, v, v, v]))
-        # perturbed orbital-Hessian response (A^x z); reference-only, as in MP2
-        Axz = (c('ajib,jb->ia', dL[v, ofull, ofull, v], z) + c('abij,jb->ia', dL[v, v, ofull, ofull], z)
-               + c('ab,ib->ia', df[v, v], z) - c('ij,ja->ia', df[ofull, ofull], z))
-        zx = np.asarray(hf.cphf.solve(dX - Axz))
-        dDrel = dDg.copy()                              # keep unrelaxed dD_ov/dD_vo (CC-only)
-        if cc.nfzc:
-            dDrel[co, o] += dPco
-            dDrel[o, co] += dPco.T
-        if is_t:
-            dDrel[o, o] += dPoo
-            dDrel[v, v] += dPvv
-        dDrel[v, ofull] += -zx.T
-        dDrel[ofull, v] += -zx
-        return dDrel
-
-    def _so_perturbed_relaxed_density(self, pert, hbar, lam, D0, Gam0, z, G, Pco,
-                                      Poo0=None, Pvv0=None):
-        """Spin-orbital field response ``dD_rel``; the SO analog of
-        :meth:`_perturbed_relaxed_density` (inline Hessian ``G``, antisymmetrized ERI).
-
-        CCSD(T): uses the **canonical** perturbed orbitals (``df``/``deri`` with ``canonical=True``,
-        so ``df`` is diagonal in oo/vv -- the non-invariant (T) kernels require it), threads the
-        perturbed (T) intermediates ``dt3`` into the density and the Lambda source, and adds the
-        perturbed active-oo/vv dependent-pairs ``dPoo``/``dPvv`` (the field derivative of the
-        unperturbed ``Poo0``/``Pvv0``, including the ``d(eps_i-eps_j) = df_ii - df_jj`` denominator
-        term) to ``dD_rel`` and the perturbed Z-vector RHS -- mirroring the spatial template."""
-        cc = self.ccwfn
-        o, v, nv = cc.o, cc.v, cc.nv
-        co = slice(0, o.start)
-        ofull = slice(0, o.stop)
-        nof = o.stop
-        c = self.contract
-        ncore = o.stop - cc.no
-        ERI = np.asarray(cc.H.ERI)
-        eps = np.diag(np.asarray(cc.H.F))
-        is_t = cc.model.upper() == 'CCSD(T)'
-        canon = is_t                                    # (T) needs canonical perturbed orbitals
-        cphf = cc.mp.deriv._full_occ_cphf()
-        df = np.asarray(cphf.perturbed_fock(pert, ncore, canonical=canon))
-        deri = np.asarray(cphf.perturbed_eri(pert, ncore, canonical=canon))
-
-        dt1, dt2 = self._so_perturbed_amplitudes(df, deri, hbar)
-        dt3 = self._so_perturbed_t3_intermediates(df, deri, dt1, dt2) if is_t else None
-        dl1, dl2 = self._so_perturbed_lambda(df, deri, dt1, dt2, hbar, lam,
-                                             dS1=(dt3['S1'] if is_t else None),
-                                             dS2=(dt3['S2'] if is_t else None))
-        dDg, dGam = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam, dt3=dt3)
-        dIp = self._so_perturbed_lagrangian_matrix(df, deri, D0, dDg, Gam0, dGam)
-        dX = dIp[ofull, v] - dIp[v, ofull].T
-        dPco = None
-        if cc.nfzc:
-            gap = eps[co][:, None] - eps[o][None, :]
-            dPco = (dIp[co, o] - dIp[o, co].T - df[co, co] @ Pco + Pco @ df[o, o]) / gap
-            zjc, dzjc = -Pco.T, -dPco.T
-            dX = dX - (c('jc,ajic->ia', dzjc, ERI[v, o, ofull, co]) + c('jc,acij->ia', dzjc, ERI[v, co, ofull, o])
-                       + c('jc,ajic->ia', zjc, deri[v, o, ofull, co]) + c('jc,acij->ia', zjc, deri[v, co, ofull, o]))
-        dPoo = dPvv = None
-        if is_t:                                        # perturbed (T) oo/vv dependent-pairs
-            dfd = np.diag(df)                           # canonical df diagonal = the perturbed gaps
-            dPoo = self._perturbed_dependent_pairs(dIp[o, o], Poo0, eps[o], dfd[o])
-            dPvv = self._perturbed_dependent_pairs(dIp[v, v], Pvv0, eps[v], dfd[v])
-            dX = dX + (c('kl,akil->ia', dPoo, ERI[v, o, ofull, o]) + c('kl,akil->ia', Poo0, deri[v, o, ofull, o])
-                       + c('bc,ibac->ia', dPvv, ERI[ofull, v, v, v]) + c('bc,ibac->ia', Pvv0, deri[ofull, v, v, v]))
-        Axz = (c('ajib,jb->ia', deri[v, ofull, ofull, v], z) + c('abij,jb->ia', deri[v, v, ofull, ofull], z)
-               + c('ab,ib->ia', df[v, v], z) - c('ij,ja->ia', df[ofull, ofull], z))
-        zx = np.linalg.solve(G, (dX - Axz).reshape(-1)).reshape(nof, nv)
-        dDrel = dDg.copy()
-        if cc.nfzc:
-            dDrel[co, o] += dPco
-            dDrel[o, co] += dPco.T
-        if is_t:
-            dDrel[o, o] += dPoo
-            dDrel[v, v] += dPvv
-        dDrel[v, ofull] += -zx.T
-        dDrel[ofull, v] += -zx
-        return dDrel
+        if cc.orbital_basis == 'spinorbital':
+            dt1, dt2 = self._so_perturbed_amplitudes(df, deri, hbar)
+            dt3 = self._so_perturbed_t3_intermediates(df, deri, dt1, dt2) if is_t else None
+            dl1, dl2 = self._so_perturbed_lambda(df, deri, dt1, dt2, hbar, lam,
+                                                 dS1=(dt3['S1'] if is_t else None),
+                                                 dS2=(dt3['S2'] if is_t else None))
+        else:
+            dt1, dt2 = self._perturbed_amplitudes(df, deri, dL, hbar)
+            dt3 = self._perturbed_t3_intermediates(df, deri, dL, dt1, dt2) if is_t else None
+            dl1, dl2 = self._perturbed_lambda(df, deri, dL, dt1, dt2, hbar, lam,
+                                              dS1=(dt3['S1'] if is_t else None),
+                                              dS2=(dt3['S2'] if is_t else None))
+        return self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam, dt3=dt3)
 
     def _ccsd_jacobian(self, X1, X2, hbar):
         """The CCSD Jacobian applied to an amplitude pair, ``(HBAR . X)_singles``,

--- a/pycc/correlatedderivs.py
+++ b/pycc/correlatedderivs.py
@@ -64,6 +64,20 @@ class CorrelatedDerivs:
         choice."""
         return 'canonical' if getattr(self.wfn, 'model', '').upper() == 'CCSD(T)' else 'non-canonical'
 
+    def _full_occ_cphf(self):
+        """A CPHF over the **full** occupied space (frozen core + active) in the wavefunction's own
+        MO ordering (cached).  The perturbed-response (2n+1) routes need the orbital response over the
+        full occupied space (core<->active and core-virtual), which the active-only ``wfn.cphf``
+        can't supply; building it here -- rather than borrowing an all-electron ``HFwfn`` -- keeps
+        the spin-orbital ordering consistent with the densities.  For ``nfzc=0`` it coincides with
+        ``wfn.cphf``.  CPHF depends only on the shared reference/orbitals/integrals, so building it on
+        ``self.wfn`` is equivalent for MP2 (``self.wfn`` is the MPwfn) and CC (the CCwfn shares those
+        with its ``cc.mp``)."""
+        if getattr(self, '_focphf', None) is None:
+            from .cphf import CPHF
+            self._focphf = CPHF(self.wfn, full_occ=True)
+        return self._focphf
+
     # ---- generalized-Fock orbital Lagrangian I'(D, Gam) ----
     # The Gauss/Stanton/Bartlett orbital-gradient Lagrangian: a method-agnostic function of a
     # full-MO 1-PDM ``D`` and cumulant 2-PDM ``Gam`` (both supplied by the leaf) plus the SCF
@@ -331,6 +345,137 @@ class CorrelatedDerivs:
         """Spin-orbital relaxed 1-PDM and 2-PDM -- ``(Drel, Gam)`` from :meth:`_so_orbital_response`."""
         rec = self._so_orbital_response()
         return rec.Drel, rec.Gam
+
+    # ---- first-order response of the relaxed density (perturbed Z-vector) ----
+    # d_x Drel differentiates the relaxed-density build once more.  Given the leaf's perturbed
+    # unrelaxed densities (dDg, dGam), the assembly is method-agnostic: the perturbed Lagrangian dI'
+    # (with the perturbed integrals df/deri/dL), the perturbed frozen-core divide d_x P_co (a
+    # Sylvester relation), the perturbed canonical-MO oo/vv rotations d_x P_oo/d_x P_vv (gauge-gated),
+    # and the perturbed ov Z-vector z^x = A^{-1}(dX - A^x z) reusing the unperturbed orbital Hessian A
+    # and z from the OrbitalResponse record.
+
+    def _perturbed_unrelaxed_densities(self, pert, df, deri, dL):
+        """Leaf hook: the first-order response ``(d_x gamma, d_x Gamma)`` of the unrelaxed reduced
+        densities to ``pert`` (full-MO arrays).  MP2 supplies the closed-form response
+        (:meth:`MPderiv._perturbed_densities`); CC supplies the iterative perturbed-amplitude /
+        perturbed-Lambda response.  ``df``/``deri``/``dL`` are the CPHF-folded perturbed integrals
+        (canonical per :attr:`perturbed_mo_gauge`) the CC iterative solve consumes; the MP2 closed
+        form recomputes its own and ignores them."""
+        raise NotImplementedError
+
+    def _perturbed_relaxed_density(self, pert):
+        """Spatial first-order response ``d_x Drel`` of the relaxed 1-PDM (``nmo x nmo``)
+
+            d_x Drel = d_x D + d_x P_co + d_x P_oo + d_x P_vv - z^x,   A z^x = dX - A^x z,
+
+        with the perturbed unrelaxed density ``d_x D`` (:meth:`_perturbed_unrelaxed_densities`), the
+        perturbed Lagrangian ``dI'`` (:meth:`_perturbed_lagrangian_matrix`) giving the perturbed
+        Z-vector RHS ``dX_ai = dI'_ia - dI'_ai``, the perturbed frozen-core Sylvester divide
+        ``d_x P_co = [d_x(I'_ci - I'_ic) - df_cd P_di + P_cj df_ji] / (eps_c - eps_i)`` coupled into
+        ``dX``, the perturbed canonical-MO oo/vv rotations ``d_x P_oo``/``d_x P_vv``
+        (:meth:`_perturbed_dependent_pairs`, populated only for :attr:`perturbed_mo_gauge` ``==
+        'canonical'``) coupled into ``dX``, and the perturbed ov Z-vector ``z^x`` reusing the
+        unperturbed orbital Hessian ``A`` and ``z`` from :meth:`_orbital_response` (``A^x z`` the
+        perturbed-Hessian response).  The perturbed integrals ``df``/``deri`` are canonical per
+        :attr:`perturbed_mo_gauge`."""
+        wfn = self.wfn
+        o, v = wfn.o, wfn.v
+        co = slice(0, wfn.nfzc)
+        ofull = slice(0, o.stop)
+        ncore = o.stop - wfn.no
+        c = self.contract
+        L = np.asarray(wfn.H.L)
+        eps = np.diag(np.asarray(wfn.H.F))
+        canonical = self.perturbed_mo_gauge == 'canonical'
+        rec = self._orbital_response()
+        z, hf, Pco, Poo0, Pvv0, D0, Gam0 = rec.z, rec.mo_hessian, rec.Pco, rec.Poo, rec.Pvv, rec.D, rec.Gam
+        cphf = self._full_occ_cphf()
+        df = np.asarray(cphf.perturbed_fock(pert, ncore, canonical=canonical))
+        deri = np.asarray(cphf.perturbed_eri(pert, ncore, canonical=canonical))
+        dL = 2.0 * deri - deri.swapaxes(2, 3)
+        dDg, dGam = self._perturbed_unrelaxed_densities(pert, df, deri, dL)
+        dDg = np.asarray(dDg)
+        dIp = self._perturbed_lagrangian_matrix(df, deri, dL, D0, dDg, Gam0, np.asarray(dGam))
+        dX = dIp[ofull, v] - dIp[v, ofull].T
+        dPco = None
+        if wfn.nfzc:
+            gap = eps[co][:, None] - eps[o][None, :]
+            dPco = (dIp[co, o] - dIp[o, co].T - df[co, co] @ Pco + Pco @ df[o, o]) / gap
+            zjc, dzjc = -Pco.T, -dPco.T
+            dX = dX - (c('jc,ajic->ia', dzjc, L[v, o, ofull, co]) + c('jc,acij->ia', dzjc, L[v, co, ofull, o])
+                       + c('jc,ajic->ia', zjc, dL[v, o, ofull, co]) + c('jc,acij->ia', zjc, dL[v, co, ofull, o]))
+        dPoo = dPvv = None
+        if canonical:
+            dfd = np.diag(df)                              # canonical df diagonal = the perturbed gaps
+            dPoo = self._perturbed_dependent_pairs(dIp[o, o], Poo0, eps[o], dfd[o])
+            dPvv = self._perturbed_dependent_pairs(dIp[v, v], Pvv0, eps[v], dfd[v])
+            dX = dX + (c('kl,akil->ia', dPoo, L[v, o, ofull, o]) + c('kl,akil->ia', Poo0, dL[v, o, ofull, o])
+                       + c('bc,ibac->ia', dPvv, L[ofull, v, v, v]) + c('bc,ibac->ia', Pvv0, dL[ofull, v, v, v]))
+        Axz = (c('ajib,jb->ia', dL[v, ofull, ofull, v], z) + c('abij,jb->ia', dL[v, v, ofull, ofull], z)
+               + c('ab,ib->ia', df[v, v], z) - c('ij,ja->ia', df[ofull, ofull], z))
+        zx = np.asarray(hf.cphf.solve(dX - Axz))
+        dDrel = dDg.copy()
+        if wfn.nfzc:
+            dDrel[co, o] += dPco
+            dDrel[o, co] += dPco.T
+        if canonical:
+            dDrel[o, o] += dPoo
+            dDrel[v, v] += dPvv
+        dDrel[v, ofull] += -zx.T
+        dDrel[ofull, v] += -zx
+        return dDrel
+
+    def _so_perturbed_relaxed_density(self, pert):
+        """Spin-orbital first-order response ``d_x Drel`` -- the spin-orbital analogue of
+        :meth:`_perturbed_relaxed_density` (antisymmetrized ``<pq||rs>`` derivatives ``deri`` in the
+        couplings; the inline orbital Hessian ``G`` from :meth:`_so_orbital_response` solved with
+        ``numpy.linalg.solve``)."""
+        wfn = self.wfn
+        o, v, nv = wfn.o, wfn.v, wfn.nv
+        co = wfn.co
+        ofull = slice(0, o.stop)
+        nof = o.stop
+        ncore = o.stop - wfn.no
+        c = self.contract
+        ERI = np.asarray(wfn.H.ERI)
+        eps = np.diag(np.asarray(wfn.H.F))
+        canonical = self.perturbed_mo_gauge == 'canonical'
+        rec = self._so_orbital_response()
+        z, G, Pco, Poo0, Pvv0, D0, Gam0 = rec.z, rec.mo_hessian, rec.Pco, rec.Poo, rec.Pvv, rec.D, rec.Gam
+        cphf = self._full_occ_cphf()
+        df = np.asarray(cphf.perturbed_fock(pert, ncore, canonical=canonical))
+        deri = np.asarray(cphf.perturbed_eri(pert, ncore, canonical=canonical))
+        dDg, dGam = self._perturbed_unrelaxed_densities(pert, df, deri, None)
+        dDg = np.asarray(dDg)
+        dIp = self._so_perturbed_lagrangian_matrix(df, deri, D0, dDg, Gam0, np.asarray(dGam))
+        dX = dIp[ofull, v] - dIp[v, ofull].T
+        dPco = None
+        if wfn.nfzc:
+            gap = eps[co][:, None] - eps[o][None, :]
+            dPco = (dIp[co, o] - dIp[o, co].T - df[co, co] @ Pco + Pco @ df[o, o]) / gap
+            zjc, dzjc = -Pco.T, -dPco.T
+            dX = dX - (c('jc,ajic->ia', dzjc, ERI[v, o, ofull, co]) + c('jc,acij->ia', dzjc, ERI[v, co, ofull, o])
+                       + c('jc,ajic->ia', zjc, deri[v, o, ofull, co]) + c('jc,acij->ia', zjc, deri[v, co, ofull, o]))
+        dPoo = dPvv = None
+        if canonical:
+            dfd = np.diag(df)
+            dPoo = self._perturbed_dependent_pairs(dIp[o, o], Poo0, eps[o], dfd[o])
+            dPvv = self._perturbed_dependent_pairs(dIp[v, v], Pvv0, eps[v], dfd[v])
+            dX = dX + (c('kl,akil->ia', dPoo, ERI[v, o, ofull, o]) + c('kl,akil->ia', Poo0, deri[v, o, ofull, o])
+                       + c('bc,ibac->ia', dPvv, ERI[ofull, v, v, v]) + c('bc,ibac->ia', Pvv0, deri[ofull, v, v, v]))
+        Axz = (c('ajib,jb->ia', deri[v, ofull, ofull, v], z) + c('abij,jb->ia', deri[v, v, ofull, ofull], z)
+               + c('ab,ib->ia', df[v, v], z) - c('ij,ja->ia', df[ofull, ofull], z))
+        zx = np.linalg.solve(G, (dX - Axz).reshape(-1)).reshape(nof, nv)
+        dDrel = dDg.copy()
+        if wfn.nfzc:
+            dDrel[co, o] += dPco
+            dDrel[o, co] += dPco.T
+        if canonical:
+            dDrel[o, o] += dPoo
+            dDrel[v, v] += dPvv
+        dDrel[v, ofull] += -zx.T
+        dDrel[ofull, v] += -zx
+        return dDrel
 
     # ---- first-derivative properties: relaxed dipole and nuclear gradient ----
     # Both are contractions of the relaxed density against the property integrals, method-agnostic

--- a/pycc/mpderiv.py
+++ b/pycc/mpderiv.py
@@ -43,18 +43,6 @@ class MPderiv(CorrelatedDerivs):
 
     # ---- full-occupied CPHF (shared by the 2n+1 perturbed-response routes) ----
 
-    def _full_occ_cphf(self):
-        """A CPHF over the **full** occupied space (frozen core + active) in the wavefunction's
-        own MO ordering (cached). The 2n+1 perturbed-response routes need the orbital response over
-        the full occupied space (core<->active and core-virtual), which ``self.mp.cphf`` (active
-        only) can't supply; building it here -- rather than borrowing an all-electron ``HFwfn``
-        -- keeps the spin-orbital ordering consistent with the densities (the all-electron SO
-        ``HFwfn`` orders the spins differently). For ``nfzc=0`` it coincides with ``self.mp.cphf``."""
-        if getattr(self, '_focphf', None) is None:
-            from .cphf import CPHF
-            self._focphf = CPHF(self.mp, full_occ=True)
-        return self._focphf
-
     # ---- perturbed amplitudes / densities (for the second derivatives) ----
 
     def _perturbed_t2(self, pert) -> np.ndarray:
@@ -108,12 +96,20 @@ class MPderiv(CorrelatedDerivs):
         dGam[v, v, o, o] = u.transpose(2, 3, 0, 1)
         return dgam, dGam
 
-    # ---- 2n+1 route: perturbed relaxed density ----
+    def _perturbed_unrelaxed_densities(self, pert, df, deri, dL):
+        """MP2 perturbed unrelaxed densities -- the closed-form response
+        (:meth:`_perturbed_densities`).  The perturbed integrals ``df``/``deri``/``dL`` are unused
+        (recomputed internally from the non-canonical perturbed integrals); the argument matches the
+        base :meth:`CorrelatedDerivs._perturbed_unrelaxed_densities` hook that the CC iterative path
+        needs."""
+        return self._perturbed_densities(pert)
+
+    # ---- 2n+1 route: perturbed relaxed density (assembly hoisted to CorrelatedDerivs) ----
     # The relaxed-density gradient is already the 2n+1 first derivative; its second derivative
     # (polarizability/APT/Hessian) needs the *response* of the relaxed density, whose new piece
-    # is the perturbed Z-vector z^x (same orbital Hessian as the gradient, perturbed RHS). The
-    # spin-orbital path builds G inline; the spatial analogue carries the spin-adapted L and
-    # solves through the all-electron HFwfn CPHF. See mp2_2n1_perturbed.tex / DERIVATIVES_PLAN.
+    # is the perturbed Z-vector z^x (same orbital Hessian as the gradient, perturbed RHS).  The
+    # assembly lives in CorrelatedDerivs._{so_}perturbed_relaxed_density, driven by the
+    # _perturbed_unrelaxed_densities hook above.  See mp2_2n1_perturbed.tex / DERIVATIVES_PLAN.
 
     def _so_perturbed_lagrangian(self, pert, D=None, dD=None) -> np.ndarray:
         """First-order response ``d_x I'`` of the GSB orbital Lagrangian (``nmo x nmo``),
@@ -122,7 +118,7 @@ class MPderiv(CorrelatedDerivs):
 
         With ``D``/``dD`` omitted this uses the **unrelaxed** 1-PDM and its response
         (:meth:`_perturbed_densities`) -- the Z-vector RHS derivative. Passing ``D`` = the
-        relaxed 1-PDM and ``dD`` = its response (:meth:`_so_perturbed_relaxed_opdm`) gives
+        relaxed 1-PDM and ``dD`` = its response (:meth:`_so_perturbed_relaxed_density`) gives
         instead ``d_x W`` (the perturbed energy-weighted density; :meth:`_so_gradient` uses
         ``W = I'(D_rel)`` with the nuclear ``S^X``). The 2-PDM response ``dGam`` is the same
         either way (:meth:`_perturbed_densities`). The ``termA`` derivative is the full Fock
@@ -144,54 +140,6 @@ class MPderiv(CorrelatedDerivs):
             D = self._so_orbital_response().D         # unrelaxed 1-PDM
             dD = np.asarray(dDg)
         return self._so_perturbed_lagrangian_matrix(df, deri, D, dD, Gam, dGam)
-
-    def _so_perturbed_relaxed_opdm(self, pert) -> np.ndarray:
-        """First-order response ``d_x D_rel`` of the relaxed MP2 1-PDM (``nmo x nmo``),
-        spin-orbital, frozen-core aware: the unrelaxed oo/vv responses
-        (:meth:`_perturbed_densities`), the perturbed core-active divide ``d_x P_co``, and the
-        **perturbed Z-vector** ``z^x`` in the ov/vo blocks over the full occupied space. ``z^x``
-        solves the same orbital Hessian ``G`` as the gradient's Z-vector with the perturbed RHS
-        ``X^x - A^x z`` (``A^x z`` uses the full non-canonical ``d_x f`` vv/oo blocks).
-
-        ``d_x P_co`` is the derivative of the divide ``(eps_c - eps_i) P_ci = I'_ci - I'_ic``,
-        a Sylvester relation ``(eps_c - eps_i) d_x P_ci = d_x(I'_ci - I'_ic) - sum_d d_x f_cd
-        P_di + sum_j P_cj d_x f_ji``: the diagonal ``d=c``/``j=i`` terms are the
-        ``-P_ci(d_x eps_c - d_x eps_i)`` orbital-energy shift, and the off-diagonal ``j != i``
-        active-active ``d_x f`` couples the block because a field leaves the active occupied
-        space non-canonical. ``P_co`` also feeds the ov RHS coupling (perturbed here too)."""
-        nmo, nfzc, nv = self.mp.nmo, self.mp.nfzc, self.mp.nv
-        o, v, co = self.mp.o, self.mp.v, self.mp.co
-        ofull = slice(0, o.stop)
-        nof = o.stop
-        ncore = o.stop - self.mp.no
-        c = self.contract
-        cphf = self._full_occ_cphf()
-        _r = self._so_orbital_response(); zia, G, Pco = _r.z, _r.mo_hessian, _r.Pco
-        ERI = np.asarray(self.mp.H.ERI)
-        eps = np.diag(np.asarray(self.mp.H.F))
-        df = np.asarray(cphf.perturbed_fock(pert, ncore))
-        deri = np.asarray(cphf.perturbed_eri(pert, ncore))
-        dIp = self._so_perturbed_lagrangian(pert)
-        dDg, _ = self._perturbed_densities(pert)
-        dDg = np.asarray(dDg)
-        dD = np.zeros((nmo, nmo))
-        dD[o, o] = dDg[o, o]
-        dD[v, v] = dDg[v, v]
-        dX = dIp[ofull, v] - dIp[v, ofull].T
-        if nfzc:
-            gap = eps[co][:, None] - eps[o][None, :]
-            dPco = (dIp[co, o] - dIp[o, co].T - df[co, co] @ Pco + Pco @ df[o, o]) / gap
-            dD[co, o] = dPco
-            dD[o, co] = dPco.T
-            zjc, dzjc = -Pco.T, -dPco.T
-            dX = dX - (c('jc,ajic->ia', dzjc, ERI[v, o, ofull, co]) + c('jc,acij->ia', dzjc, ERI[v, co, ofull, o])
-                       + c('jc,ajic->ia', zjc, deri[v, o, ofull, co]) + c('jc,acij->ia', zjc, deri[v, co, ofull, o]))
-        Axz = (c('ajib,jb->ia', deri[v, ofull, ofull, v], zia) + c('abij,jb->ia', deri[v, v, ofull, ofull], zia)
-               + c('ab,ib->ia', df[v, v], zia) - c('ij,ja->ia', df[ofull, ofull], zia))
-        zx = np.linalg.solve(G, (dX - Axz).reshape(-1)).reshape(nof, nv)
-        dD[v, ofull] = -zx.T
-        dD[ofull, v] = -zx
-        return dD
 
     def _unrelaxed_densities(self):
         """MP2 unrelaxed reduced densities as full-MO arrays: the 1-PDM ``D`` (the ``Doo``/``Dvv``
@@ -235,49 +183,6 @@ class MPderiv(CorrelatedDerivs):
             dD = np.asarray(dDg)
         return self._perturbed_lagrangian_matrix(df, deri, dL, D, dD, Gam, dGam)
 
-    def _perturbed_relaxed_opdm(self, pert) -> np.ndarray:
-        """Spatial first-order response ``d_x D_rel`` of the relaxed MP2 1-PDM (``nmo x nmo``),
-        frozen-core aware: the unrelaxed oo/vv responses, the perturbed core-active divide
-        ``d_x P_co`` (the Sylvester derivative -- see :meth:`_so_perturbed_relaxed_opdm`), and
-        the perturbed Z-vector ``z^x`` in the ov/vo blocks over the full occupied space. ``z^x``
-        reuses the all-electron HFwfn CPHF (same orbital Hessian as the gradient's Z-vector)
-        with the perturbed RHS ``X^x - A^x z``; ``A^x z`` uses ``dL`` and the full non-canonical
-        ``d_x f`` vv/oo blocks, and (for ``nfzc>0``) the perturbed ``P_co`` RHS coupling."""
-        nmo, nfzc, no = self.mp.nmo, self.mp.nfzc, self.mp.no
-        o, v = self.mp.o, self.mp.v
-        co = slice(0, nfzc)
-        ofull = slice(0, nfzc + no)
-        ncore = o.stop - self.mp.no
-        c = self.contract
-        cphf = self._full_occ_cphf()
-        _r = self._orbital_response(); zia, hf, Pco = _r.z, _r.mo_hessian, _r.Pco
-        L = np.asarray(self.mp.H.L)
-        eps = np.diag(np.asarray(self.mp.H.F))
-        df = np.asarray(cphf.perturbed_fock(pert, ncore))
-        deri = np.asarray(cphf.perturbed_eri(pert, ncore))
-        dL = 2.0 * deri - deri.swapaxes(2, 3)
-        dIp = self._perturbed_lagrangian(pert)
-        dDg, _ = self._perturbed_densities(pert)
-        dDg = np.asarray(dDg)
-        dD = np.zeros((nmo, nmo))
-        dD[o, o] = dDg[o, o]
-        dD[v, v] = dDg[v, v]
-        dX = dIp[ofull, v] - dIp[v, ofull].T
-        if nfzc:
-            gap = eps[co][:, None] - eps[o][None, :]
-            dPco = (dIp[co, o] - dIp[o, co].T - df[co, co] @ Pco + Pco @ df[o, o]) / gap
-            dD[co, o] = dPco
-            dD[o, co] = dPco.T
-            zjc, dzjc = -Pco.T, -dPco.T
-            dX = dX - (c('jc,ajic->ia', dzjc, L[v, o, ofull, co]) + c('jc,acij->ia', dzjc, L[v, co, ofull, o])
-                       + c('jc,ajic->ia', zjc, dL[v, o, ofull, co]) + c('jc,acij->ia', zjc, dL[v, co, ofull, o]))
-        Axz = (c('ajib,jb->ia', dL[v, ofull, ofull, v], zia) + c('abij,jb->ia', dL[v, v, ofull, ofull], zia)
-               + c('ab,ib->ia', df[v, v], zia) - c('ij,ja->ia', df[ofull, ofull], zia))
-        zx = hf.cphf.solve(dX - Axz)
-        dD[v, ofull] = -zx.T
-        dD[ofull, v] = -zx
-        return dD
-
     # ---- second derivatives: polarizability, APT (dipole derivatives), Hessian ----
 
     def polarizability(self, route: str = '2n+1') -> np.ndarray:
@@ -285,7 +190,7 @@ class MPderiv(CorrelatedDerivs):
         (a.u.), shape ``(3, 3)``: ``alpha_corr_ab = -d^2 E_corr / dF_a dF_b``, via the 2n+1
         route (:meth:`_polarizability_2n1`): differentiate the relaxed-density gradient in a
         field, using only the first-order perturbed *relaxed* density
-        (:meth:`_so_perturbed_relaxed_opdm` / :meth:`_perturbed_relaxed_opdm`, which carry the
+        (:meth:`_so_perturbed_relaxed_density` / :meth:`_perturbed_relaxed_density`, which carry the
         perturbed Z-vector). Frozen-core aware (both spin-orbital and spin-adapted paths).
 
         ``route`` accepts only ``'2n+1'`` (the sole route; the argument is retained for a uniform
@@ -305,7 +210,7 @@ class MPderiv(CorrelatedDerivs):
             alpha_ab = sum_pq d_a D_rel_pq (mu_b)_pq
                      + sum_pq D_rel_pq [ (U^a).T mu_b + mu_b U^a ]_pq
 
-        The first term is the perturbed relaxed density (:meth:`_so_perturbed_relaxed_opdm`,
+        The first term is the perturbed relaxed density (:meth:`_so_perturbed_relaxed_density`,
         carrying the perturbed Z-vector and, for frozen core, the perturbed core-active divide);
         the second is the MO dipole rotating under the field (``d_a f^(b) = rotate(U^a, -mu_b)``,
         with ``U^a`` over the full occupied space -- ``ncore`` canonical core-active block). No
@@ -317,10 +222,10 @@ class MPderiv(CorrelatedDerivs):
         c = self.contract
         if self.mp.orbital_basis == 'spinorbital':
             Drel = self._so_orbital_response().Drel
-            perturbed_opdm = self._so_perturbed_relaxed_opdm
+            perturbed_opdm = self._so_perturbed_relaxed_density
         else:
             Drel = self._orbital_response().Drel
-            perturbed_opdm = self._perturbed_relaxed_opdm
+            perturbed_opdm = self._perturbed_relaxed_density
         mu = [np.asarray(self.mp.H.mu[a]) for a in range(3)]
         field = [Perturbation('field', b) for b in range(3)]
         alpha = np.zeros((3, 3))
@@ -370,7 +275,7 @@ class MPderiv(CorrelatedDerivs):
             P[X,a] = -[ sum d_a D_rel f^X + sum D_rel d_a f^X + sum d_a Gamma <>^X
                         + sum Gamma d_a <>^X + sum d_a W S^X + sum W d_a S^X ],
 
-        with the 3 field responses ``d_a D_rel`` (:meth:`_so_perturbed_relaxed_opdm`),
+        with the 3 field responses ``d_a D_rel`` (:meth:`_so_perturbed_relaxed_density`),
         ``d_a Gamma`` (:meth:`_perturbed_densities`), and the perturbed energy-weighted density
         ``d_a W`` (:meth:`_so_perturbed_lagrangian` at the relaxed density). The field-derivatives
         of the nuclear skeletons carry the orbital rotation ``rotate(U^a, .)`` plus, for
@@ -386,7 +291,7 @@ class MPderiv(CorrelatedDerivs):
         d = self.mp.derivatives
         natom = d.natom
         Drel = (self._so_orbital_response() if so else self._orbital_response()).Drel
-        popdm = self._so_perturbed_relaxed_opdm if so else self._perturbed_relaxed_opdm
+        popdm = self._so_perturbed_relaxed_density if so else self._perturbed_relaxed_density
         mu = [np.asarray(self.mp.H.mu[a]) for a in range(3)]
         P = np.zeros((natom, 3, 3))
 
@@ -474,7 +379,7 @@ class MPderiv(CorrelatedDerivs):
 
         the nuclear-nuclear analog of the ``'2n+1-field'`` APT (:meth:`_dipole_derivatives_2n1`).
         Only ``3N`` first-order solves -- the perturbed relaxed density ``d_Y D_rel``
-        (:meth:`_so_perturbed_relaxed_opdm`), the perturbed energy-weighted density ``d_Y W``
+        (:meth:`_so_perturbed_relaxed_density`), the perturbed energy-weighted density ``d_Y W``
         (:meth:`_so_perturbed_lagrangian` at ``D_rel``), ``d_Y Gamma``
         (:meth:`_perturbed_densities`), and ``U^Y`` (:meth:`CPHF._full_U`) -- vs the explicit
         route's ``O(N^2)`` ``U^{XY}`` solves.
@@ -499,7 +404,7 @@ class MPderiv(CorrelatedDerivs):
         Drel = (self._so_orbital_response() if so else self._orbital_response()).Drel
         Gam = np.asarray(self.mp._so_mp2_tpdm() if so else self.mp._mp2_tpdm())
         W = self._lagrangian(Drel, Gam)
-        popdm = self._so_perturbed_relaxed_opdm if so else self._perturbed_relaxed_opdm
+        popdm = self._so_perturbed_relaxed_density if so else self._perturbed_relaxed_density
         lagr = self._so_perturbed_lagrangian if so else self._perturbed_lagrangian
         pert = [Perturbation('nuclear', (A, ct)) for A in range(natom) for ct in range(3)]
 

--- a/pycc/tests/test_068_mp2_apt.py
+++ b/pycc/tests/test_068_mp2_apt.py
@@ -185,7 +185,7 @@ def test_fc_mp2_apt_translational_sum_rule_631g():
 def test_mp2_apt_2n1_routes_agree_631g():
     """The two 2n+1 APT routes agree, all four spin/frozen-core combinations (H2O/6-31G).
     '2n+1-nuclear' differentiates the relaxed dipole w.r.t. the nuclei (3N responses, reuses
-    _perturbed_relaxed_opdm); '2n+1-field' (the default) differentiates the relaxed nuclear
+    _perturbed_relaxed_density); '2n+1-field' (the default) differentiates the relaxed nuclear
     gradient w.r.t. the field (3 field responses -- d_F D_rel, d_F Gamma, and the perturbed
     energy-weighted density d_F W -- contracted with the nuclear skeletons + their field
     rotations)."""


### PR DESCRIPTION
# refactor(deriv): hoist the perturbed relaxed density to the base class (Phase 3c)

## Summary

Move the perturbed relaxed density (the d_x Drel assembly that the 2n+1 property codes
drive) into `CorrelatedDerivs`, so MP2 and CC share one implementation and differ only in
how they produce the *unperturbed* perturbed densities. Same pattern as 2b (unperturbed
relaxed density): a method-agnostic assembly in the base, one leaf hook for the densities.

Branched from `main` (after Phase 3b, #200).

## Changes

- **`_perturbed_relaxed_density` / `_so_perturbed_relaxed_density` -> base.** The full
  assembly now lives in `CorrelatedDerivs`: the perturbed Lagrangian `dI'`
  (`_perturbed_lagrangian_matrix`, from 3a), the perturbed frozen-core Sylvester solve
  `dP_co`, the gauge-gated perturbed dependent-pair rotations `dP_oo`/`dP_vv`, and the
  perturbed Z-vector `zx = A^{-1}(dX - A^x z)`. It reads the unperturbed byproducts
  (`z`, `mo_hessian`, `Pco`, `Poo`, `Pvv`, `D`, `Gam`) from the cached `OrbitalResponse`
  record (3b) rather than recomputing them, and gates the oo/vv terms on
  `perturbed_mo_gauge` (canonical for CCSD(T)).
- **New leaf hook `_perturbed_unrelaxed_densities(pert, df, deri, dL)`** (abstract in the
  base). MP2 returns the closed-form `_perturbed_densities`; CC runs the iterative
  `dt`/`dLambda` (+`dt3` for CCSD(T)) solve, reusing `_density().cclambda` and its `hbar`.
- **`_full_occ_cphf` hoisted** to the base as `CPHF(self.wfn, full_occ=True)` (cached). No
  `_cphf_source` hook: `CPHF` depends only on the `Wavefunction` base state, so the same
  call serves MP2 and CC. MPderiv's copy and CC's four `cc.mp.deriv._full_occ_cphf()`
  detours are gone.
- **MPderiv slims down**: `_perturbed_relaxed_opdm` / `_so_perturbed_relaxed_opdm` deleted;
  the 2n+1 callers (`_polarizability_2n1`, `_dipole_derivatives_2n1`, `_hessian_2n1`)
  repoint to the base method.
- **CCderiv slims down**: the fat-signature `_perturbed_relaxed_density` /
  `_so_perturbed_relaxed_density` deleted; **`polarizability` / `_so_polarizability`
  rewired** onto the shared Z-vector -- inline rebuilds removed, `Drel` from
  `_relaxed_density`, `canonical` from `perturbed_mo_gauge` (was a local `is_t` flag).

Net: +204 / -332 across the three modules -- the base grows by one shared method, the two
leaves shed their duplicated copies.

## Behavior

Zero behavior change (shared assembly is byte-identical given the density inputs; only
density production differs, which the leaf hook preserves). Validated:

- MP2: test_061, test_067, test_068, test_069 -- **40 passed**.
- CC: test_076, test_078, test_083 (CCSD(T) gradient), test_084 (polarizability, incl.
  CCSD(T) / frozen-core / SO keystones), test_086 -- **31 passed** (2 slow deselected).
- SO==spatial keystone holds for MP2 and CCSD polarizability through the shared path.

## Files

pycc/correlatedderivs.py, pycc/mpderiv.py, pycc/ccderiv.py,
pycc/tests/test_068_mp2_apt.py (docstring reference only)

## Next

3d: hoist the 2n+1 orchestration (polarizability/APT/Hessian) -- MP2 all three, CC
polarizability -- onto the base, closing the refactor. Deferred to their own PRs: CC
APT/Hessian; `Derivatives.eri()`/`eri2()` Mulliken->Dirac notation; the post-refactor
naming/notation sweep against docs/cc_gradients_orbital_response.tex; the `CIderiv` stub.
