### PR TITLE
feat(deriv): CIderiv scaffold/stub (Phase 4)

### DIFF
--- a/pycc/__init__.py
+++ b/pycc/__init__.py
@@ -19,14 +19,19 @@ from pycc.rt.rtcc import rtcc
 from .cceom import cceom
 from .ccderiv import CCderiv
 from .mpderiv import MPderiv
+from .cideriv import CIderiv
 from .properties import PropertyComponents, aat, apt, dipole, gradient, hessian, polarizability, register_deriv
 
 # Route the property facade's correlation-derivative calls for each wavefunction to its downstream
 # driver (the CorrelatedDerivs leaf carrying the correlation-property methods).
 register_deriv(CCwfn, CCderiv)
 register_deriv(MPwfn, MPderiv)
+# CIderiv is a Phase-4 stub (density hooks not yet implemented); until they are, CISD properties
+# stay on the transitional CIwfn code. Uncomment to route CISD through the driver once the hooks in
+# cideriv.py work -- see the cideriv module docstring for the migration roadmap.
+# register_deriv(CIwfn, CIderiv)
 
-__all__ = ['CCwfn', 'ccwfn', 'MPwfn', 'HFwfn', 'CIwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom', 'CCderiv', 'MPderiv', 'PropertyComponents', 'aat', 'apt', 'dipole', 'gradient', 'hessian', 'polarizability']
+__all__ = ['CCwfn', 'ccwfn', 'MPwfn', 'HFwfn', 'CIwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom', 'CCderiv', 'MPderiv', 'CIderiv', 'PropertyComponents', 'aat', 'apt', 'dipole', 'gradient', 'hessian', 'polarizability']
 
 # Handle versioneer
 from ._version import get_versions

--- a/pycc/cideriv.py
+++ b/pycc/cideriv.py
@@ -1,0 +1,127 @@
+"""
+cideriv.py: CISD analytic-derivative property driver (SCAFFOLD / STUB).
+
+This is the Phase-4 slot of the CorrelatedDerivs refactor: the place where CISD's analytic
+derivative properties will live behind a driver, exactly as MP2 lives on :class:`~pycc.mpderiv.MPderiv`
+and CC on :class:`~pycc.ccderiv.CCderiv`.  It is intentionally a STUB -- the two density hooks below
+raise :class:`NotImplementedError`.  Filling them in is a programmer task.
+
+WHY A STUB IS ENOUGH
+--------------------
+:class:`~pycc.correlatedderivs.CorrelatedDerivs` already owns the entire method-agnostic
+orbital-response + property-assembly machinery: the unperturbed Z-vector
+(:meth:`~pycc.correlatedderivs.CorrelatedDerivs._orbital_response`), the perturbed relaxed density
+(:meth:`~pycc.correlatedderivs.CorrelatedDerivs._perturbed_relaxed_density`), and the public
+properties ``gradient`` / ``relaxed_dipole`` / ``polarizability`` / ``dipole_derivatives`` /
+``hessian``.  All of that is driven by just two method-specific hooks, which each leaf supplies:
+
+  * :meth:`_unrelaxed_densities`            -- the unrelaxed reduced densities ``(D, Gam)``
+  * :meth:`_perturbed_unrelaxed_densities`  -- their first-order response to a perturbation
+
+Implement those two hooks for CISD and ``CIderiv`` immediately inherits gradients, the relaxed
+dipole, the polarizability, the atomic polar tensors (LG-APT), and the molecular Hessian -- no
+per-property CISD code required.  (Atomic axial tensors and the velocity-gauge APT are NOT provided
+by the base -- they are method-specific overlap formulations -- so those stay as bespoke methods,
+as they are for MP2 on ``MPderiv`` and currently for CISD on ``CIwfn``.)
+
+MIGRATION ROADMAP (for the programmer)
+--------------------------------------
+1. Implement :meth:`_unrelaxed_densities` and :meth:`_perturbed_unrelaxed_densities` below, drawing
+   on the CISD density machinery that already exists on :class:`~pycc.ciwfn.CIwfn`
+   (``_cisd_densities``, ``_solve_cpci``, ``_perturbed_cisd_corr_opdm``, ``_perturbed_cisd_tpdm``,
+   ``_solve_dz_dR``).  The crux is the DENSITY CONVENTION (see each hook's docstring): the base
+   wants the *correlation* 1-PDM (no HF ``2*delta_oo`` block) and the *cumulant* 2-PDM (no HF 2-RDM
+   block), matching :meth:`~pycc.correlatedderivs.CorrelatedDerivs._lagrangian`.  ``CIwfn._corr_QGX``
+   already strips exactly those HF blocks off ``CIwfn._zvector``'s full ``Q``/``G`` -- study it.
+2. Validate.  ``CIwfn``'s current ``dipole_derivatives`` / ``hessian`` / ``atomic_axial_tensors`` /
+   ``velocity_dipole_derivatives`` are already the perturbed-relaxed-density (2n+1-style) results
+   (their ``route='explicit'`` argument is a vestigial, inert label -- the body never branches on
+   it), so they are a ready-made numerical oracle for the new base-driven ``CIderiv`` output.  Also
+   check the SO==spatial keystone and a tight finite-difference oracle, per pycc convention.
+3. Register the driver: uncomment ``register_deriv(CIwfn, CIderiv)`` in ``pycc/__init__.py`` so the
+   :mod:`pycc.properties` facade routes CISD through ``CIderiv`` instead of the transitional
+   on-``CIwfn`` code.  Then retire the now-redundant per-property CISD derivative code on ``CIwfn``
+   (keeping only the genuinely CISD-specific AAT / VG-APT pieces), and drop the inert ``route``
+   arguments.
+
+ORBITAL GAUGE
+-------------
+CISD is invariant to occupied-occupied and virtual-virtual orbital rotations, so it takes the
+NON-CANONICAL perturbed-MO approach (the ``U^x_ij = -1/2 S^(x)_ij`` / ``U^x_ab = -1/2 S^(x)_ab``
+orthonormality gauge; the oo/vv dependent-pair rotations vanish) -- the same choice as MP2 and CCSD,
+and the opposite of CCSD(T).  This is already the default: the inherited
+:attr:`~pycc.correlatedderivs.CorrelatedDerivs.perturbed_mo_gauge` returns ``'non-canonical'`` for
+any wavefunction whose ``model`` is not ``CCSD(T)``, and ``CIwfn.model`` is ``'CISD'``, so no
+override is needed here.  The programmer should nonetheless CONFIRM this holds for their CISD variant
+(a non-invariant CI truncation would need the canonical route and an override).
+"""
+
+from __future__ import annotations
+
+from .correlatedderivs import CorrelatedDerivs
+
+
+class CIderiv(CorrelatedDerivs):
+    """CISD correlation derivative-property driver -- SCAFFOLD / STUB (Phase 4).
+
+    Constructed from a converged :class:`~pycc.ciwfn.CIwfn`.  Inherits the full orbital-response and
+    property-assembly machinery from :class:`~pycc.correlatedderivs.CorrelatedDerivs`; a programmer
+    supplies the two CISD density hooks (:meth:`_unrelaxed_densities`,
+    :meth:`_perturbed_unrelaxed_densities`) to bring it to life.  See the module docstring for the
+    migration roadmap and the density-convention notes.
+    """
+
+    def __init__(self, ciwfn) -> None:
+        super().__init__(ciwfn)
+        self.ciwfn = ciwfn                             # alias: this class uses .ciwfn, the base .wfn
+
+    def _unrelaxed_densities(self):
+        """Leaf hook: the unrelaxed reduced densities ``(D, Gam)`` as full-MO arrays -- the CISD
+        analogue of :meth:`~pycc.mpderiv.MPderiv._unrelaxed_densities` /
+        :meth:`~pycc.ccderiv.CCderiv._unrelaxed_densities`.
+
+        Must return:
+
+        * ``D``   -- the **correlation** 1-PDM (``nmo x nmo``): the Doo/Dov/Dvo/Dvv correlation
+          blocks only, WITHOUT the reference ``2*delta_ij`` occupied block (the base adds the
+          reference contribution separately via the SCF ``HFwfn``).
+        * ``Gam`` -- the **cumulant** 2-PDM (``nmo^4``), WITHOUT the closed-shell HF 2-RDM block
+          (``2 d_ik d_jl - d_il d_jk``), carrying the permutational symmetry expected by
+          :meth:`~pycc.correlatedderivs.CorrelatedDerivs._lagrangian` (whose 2-PDM term is
+          ``4 sum_rst <pr||st> Gam_qrst``).
+
+        IMPLEMENTATION POINTERS.  ``CIwfn._cisd_densities`` returns ``(D_pq, D_pq_corr, D_pqrs)`` and
+        ``CIwfn._zvector`` builds the full ``Q``/``G``; ``CIwfn._corr_QGX`` already strips the HF
+        blocks off those to give the correlation-only ``(Q_corr, G_corr, X_corr)``.  Reconciling
+        those CISD conventions to the base's ``(D, Gam)`` contract above is the main task -- compare
+        against how ``MPderiv._unrelaxed_densities`` assembles its full-MO ``(D, Gam)`` from the MP2
+        seeds.
+        """
+        raise NotImplementedError(
+            "CIderiv._unrelaxed_densities is a Phase-4 stub. Return the CISD correlation 1-PDM D "
+            "and cumulant 2-PDM Gam (full-MO, HF blocks removed) in the CorrelatedDerivs convention "
+            "-- see this method's docstring and CIwfn._cisd_densities / CIwfn._corr_QGX."
+        )
+
+    def _perturbed_unrelaxed_densities(self, pert, df, deri, dL):
+        """Leaf hook: the first-order response ``(d_x gamma, d_x Gamma)`` of the unrelaxed reduced
+        densities to ``pert`` (full-MO arrays), in the same convention as :meth:`_unrelaxed_densities`
+        -- the CISD analogue of the MP2 closed form / the CC iterative response.
+
+        ``pert`` is a :class:`~pycc.cphf.Perturbation`.  ``df``/``deri``/``dL`` are the CPHF-folded
+        perturbed integrals the base has already built (canonical per
+        :attr:`~pycc.correlatedderivs.CorrelatedDerivs.perturbed_mo_gauge`); a CISD implementation
+        will likely solve its own perturbed CI response from ``pert`` and may ignore them, exactly as
+        ``MPderiv._perturbed_unrelaxed_densities`` ignores them for the closed-form MP2 response.
+
+        IMPLEMENTATION POINTERS.  ``CIwfn._solve_cpci(pert)`` solves the perturbed CI coefficients
+        ``(dc1, dc2, dc0v)``; ``CIwfn._perturbed_cisd_corr_opdm(dc1, dc2)`` and
+        ``CIwfn._perturbed_cisd_tpdm(dc1, dc2, dc0v)`` build the perturbed 1-PDM / 2-PDM from them.
+        Return those in the base convention (HF blocks removed), matching what
+        :meth:`_unrelaxed_densities` returns for the unperturbed case.
+        """
+        raise NotImplementedError(
+            "CIderiv._perturbed_unrelaxed_densities is a Phase-4 stub. Return the first-order "
+            "response (d_x gamma, d_x Gamma) of the CISD correlation densities -- see this method's "
+            "docstring and CIwfn._solve_cpci / _perturbed_cisd_corr_opdm / _perturbed_cisd_tpdm."
+        )

--- a/pycc/correlatedderivs.py
+++ b/pycc/correlatedderivs.py
@@ -364,8 +364,8 @@ class CorrelatedDerivs:
     def _perturbed_unrelaxed_densities(self, pert, df, deri, dL):
         """Leaf hook: the first-order response ``(d_x gamma, d_x Gamma)`` of the unrelaxed reduced
         densities to ``pert`` (full-MO arrays).  MP2 supplies the closed-form response
-        (:meth:`MPderiv._perturbed_densities`); CC supplies the iterative perturbed-amplitude /
-        perturbed-Lambda response.  ``df``/``deri``/``dL`` are the CPHF-folded perturbed integrals
+        (:meth:`MPderiv._perturbed_unrelaxed_densities`); CC supplies the iterative
+        perturbed-amplitude / perturbed-Lambda response.  ``df``/``deri``/``dL`` are the CPHF-folded perturbed integrals
         (canonical per :attr:`perturbed_mo_gauge`) the CC iterative solve consumes; the MP2 closed
         form recomputes its own and ignores them."""
         raise NotImplementedError

--- a/pycc/mpderiv.py
+++ b/pycc/mpderiv.py
@@ -32,17 +32,6 @@ class MPderiv(CorrelatedDerivs):
         super().__init__(wfn)
         self.mp = wfn                       # alias: the MP2 wavefunction whose densities we differentiate
 
-    # ---- relaxed one-particle density accessor (the base owns the Z-vector build) ----
-
-    def mp2_relaxed_opdm(self) -> np.ndarray:
-        """Relaxed MP2 one-particle correlation density (``nmo x nmo``): the unrelaxed
-        ``Doo``/``Dvv`` plus the orbital-relaxation blocks from the base Z-vector solve
-        (:meth:`CorrelatedDerivs._relaxed_density`).  The MP2-named accessor the
-        :class:`~pycc.mpwfn.MPwfn` facade shim delegates to."""
-        return self._relaxed_density()[0]
-
-    # ---- full-occupied CPHF (shared by the 2n+1 perturbed-response routes) ----
-
     # ---- perturbed amplitudes / densities (for the second derivatives) ----
 
     def _perturbed_t2(self, pert) -> np.ndarray:
@@ -70,12 +59,18 @@ class MPderiv(CorrelatedDerivs):
                - c('ik,kjab->ijab', dfoo, t2) - c('jk,ikab->ijab', dfoo, t2))
         return num / np.asarray(self.mp.Dijab)
 
-    def _perturbed_densities(self, pert):
+    def _perturbed_unrelaxed_densities(self, pert, df=None, deri=None, dL=None):
         """First-order response of the unrelaxed correlation densities to ``pert``: returns
         ``(d_a gamma, d_a Gamma)`` (full-MO arrays), from the perturbed amplitudes
         :meth:`_perturbed_t2` by the product rule -- the same density expressions as the
         unrelaxed densities (:meth:`MPwfn._so_mp2_corr_opdm`/`MPwfn._so_mp2_tpdm` and the
-        spatial siblings), differentiated. Basis-aware."""
+        spatial siblings), differentiated. Basis-aware.
+
+        This is MP2's implementation of the base
+        :meth:`CorrelatedDerivs._perturbed_unrelaxed_densities` hook.  The MP2 response is closed
+        form, so it rebuilds its own perturbed integrals from ``pert`` and ignores the CPHF-folded
+        ``df``/``deri``/``dL`` the base passes in (those exist for the CC iterative path); they
+        default to ``None`` so the closed form can also be called directly with just ``pert``."""
         o, v, nmo = self.mp.o, self.mp.v, self.mp.nmo
         t2 = np.asarray(self.mp.t2)
         ta = self._perturbed_t2(pert)
@@ -95,14 +90,6 @@ class MPderiv(CorrelatedDerivs):
         dGam[o, o, v, v] = u
         dGam[v, v, o, o] = u.transpose(2, 3, 0, 1)
         return dgam, dGam
-
-    def _perturbed_unrelaxed_densities(self, pert, df, deri, dL):
-        """MP2 perturbed unrelaxed densities -- the closed-form response
-        (:meth:`_perturbed_densities`).  The perturbed integrals ``df``/``deri``/``dL`` are unused
-        (recomputed internally from the non-canonical perturbed integrals); the argument matches the
-        base :meth:`CorrelatedDerivs._perturbed_unrelaxed_densities` hook that the CC iterative path
-        needs."""
-        return self._perturbed_densities(pert)
 
     # ---- 2n+1 route: perturbed relaxed density (assembly hoisted to CorrelatedDerivs) ----
     # The relaxed-density gradient is already the 2n+1 first derivative; its second derivative

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -193,11 +193,6 @@ class MPwfn(Wavefunction):
         """MP2 correlation dipole -- delegates to :meth:`MPderiv.relaxed_dipole`."""
         return self.deriv.relaxed_dipole()
 
-    def mp2_relaxed_opdm(self) -> np.ndarray:
-        """Relaxed MP2 one-particle correlation density -- delegates to
-        :meth:`MPderiv.mp2_relaxed_opdm`."""
-        return self.deriv.mp2_relaxed_opdm()
-
     def gradient(self) -> np.ndarray:
         """MP2 correlation nuclear gradient -- delegates to :meth:`MPderiv.gradient`."""
         return self.deriv.gradient()
@@ -223,10 +218,10 @@ class MPwfn(Wavefunction):
         """MP2 correlation AAT -- delegates to :meth:`MPderiv.atomic_axial_tensors`."""
         return self.deriv.atomic_axial_tensors(gauge)
 
-    def _perturbed_densities(self, pert):
+    def _perturbed_unrelaxed_densities(self, pert):
         """First-order unrelaxed correlation-density response -- delegates to
-        :meth:`MPderiv._perturbed_densities`."""
-        return self.deriv._perturbed_densities(pert)
+        :meth:`MPderiv._perturbed_unrelaxed_densities`."""
+        return self.deriv._perturbed_unrelaxed_densities(pert)
 
     # ---- reference for the total (reference + correlation) properties ----
     # The property methods above are the correlation contribution only.  The full molecular

--- a/pycc/tests/test_068_mp2_apt.py
+++ b/pycc/tests/test_068_mp2_apt.py
@@ -102,7 +102,7 @@ APT_631G_FC = {  # frozen core
 
 
 def test_mp2_nuclear_t2_response_631g():
-    """Nuclear T2 density response d_X gamma / d_X Gamma (the analytic MPwfn._perturbed_densities)
+    """Nuclear T2 density response d_X gamma / d_X Gamma (the analytic MPwfn._perturbed_unrelaxed_densities)
     vs its frozen reference, via the gauge-invariant scalars d Tr(gamma^2), d ||Gamma||^2 (spatial,
     H2O/6-31G).  The reference was validated against a 5-point FD of the invariants to ~6e-12."""
     from pycc.cphf import Perturbation
@@ -111,7 +111,7 @@ def test_mp2_nuclear_t2_response_631g():
     Doo, Dvv = mp0._mp2_corr_opdm(); Gam = np.asarray(mp0._mp2_tpdm())
     g = np.zeros((nmo, nmo)); g[o, o] = np.asarray(Doo); g[v, v] = np.asarray(Dvv)
     for (atom, cart) in [(0, 2), (2, 1)]:
-        dgX, dGX = mp0._perturbed_densities(Perturbation('nuclear', (atom, cart)))
+        dgX, dGX = mp0._perturbed_unrelaxed_densities(Perturbation('nuclear', (atom, cart)))
         dTrg2 = 2.0 * np.sum(g * np.asarray(dgX))
         dGam2 = 2.0 * np.sum(Gam * np.asarray(dGX))
         ref_g, ref_G = NUCLEAR_T2[(atom, cart)]


### PR DESCRIPTION
# feat(deriv): CIderiv scaffold/stub (Phase 4)

## Summary

Add the CISD slot of the CorrelatedDerivs refactor: `CIderiv(CorrelatedDerivs)`, mirroring
`MPderiv`/`CCderiv`.  It is intentionally a **stub** -- the two method-specific density hooks raise
`NotImplementedError` with detailed guidance.  Filling them in is a programmer task; this PR gives them
a defined slot, the base machinery to build on, and a written migration roadmap.

Branched from `main` (after Phase 3d, #202).

## Why a stub is enough

`CorrelatedDerivs` already owns all the method-agnostic orbital-response and property-assembly
machinery (unperturbed + perturbed relaxed density, and the public `gradient` / `relaxed_dipole` /
`polarizability` / `dipole_derivatives` / `hessian`).  It is driven by just two leaf hooks --
`_unrelaxed_densities` and `_perturbed_unrelaxed_densities`.  Implement those for CISD and `CIderiv`
inherits gradients, the relaxed dipole, the polarizability, the LG-APT, and the molecular Hessian
with no per-property CISD code.  (AATs and the velocity-gauge APT are overlap formulations the base
does not provide, so those stay method-specific, as they are for MP2 on `MPderiv`.)

## Changes

- **`pycc/cideriv.py`** (new): `CIderiv` with the two density hooks as `NotImplementedError` stubs.
  The docstrings spell out
  - the required base convention (correlation 1-PDM `D` + cumulant 2-PDM `Gam`, HF blocks removed);
  - the existing CISD machinery to draw on (`CIwfn._cisd_densities`, `_corr_QGX`, `_solve_cpci`,
    `_perturbed_cisd_corr_opdm`/`_tpdm`, `_solve_dz_dR`);
  - the migration roadmap: implement the two hooks -> the base properties come free -> validate
    against `CIwfn`'s current results -> register the driver and retire the transitional on-`CIwfn`
    code (keeping the CISD-specific AAT/VG-APT);
  - that CISD is oo/vv invariant, so the inherited non-canonical `perturbed_mo_gauge` is correct
    (programmer to confirm), and that `CIwfn`'s `route='explicit'` argument is a vestigial, inert label
    (those methods already run the 2n+1-style perturbed-density algorithm, so they are a ready-made
    numerical oracle).
- **`pycc/__init__.py`**: export `CIderiv`; `register_deriv(CIwfn, CIderiv)` left **commented** with
  an explanation (CISD properties stay on the transitional `CIwfn` path until the hooks work).

## Behavior

No behavior change: `CIderiv` is unregistered, so the `pycc.properties` facade still routes CISD
through `CIwfn`.  Verified `CIderiv` is exported, inherits the base, is NOT registered, inherits
`perturbed_mo_gauge == 'non-canonical'`, and both hooks raise `NotImplementedError`; the existing
CISD LG-APT test (`test_079`) still passes.

## Files

pycc/cideriv.py (new), pycc/__init__.py

## Also in this PR: MP2 deriv tidy (commit 2)

Small cleanups prompted by reviewing mpderiv.py vs ccderiv.py; no behavior change.

- **Removed dead `mp2_relaxed_opdm`** (the `MPderiv` method and its `MPwfn` shim): it had no caller
  anywhere in the repo -- no test, no facade path, no CC analog -- a leftover from the MPderiv
  extraction.
- **Merged `MPderiv._perturbed_densities` into `_perturbed_unrelaxed_densities`** (the base-hook
  name, which is clearer). The former was a thin 1-arg closed form the latter merely wrapped; the
  body now lives in the hook with `df`/`deri`/`dL` defaulting to `None` (unused by the MP2 closed
  form, present for the CC iterative path / base-hook signature). The `MPwfn` shim, `test_068`, and a
  base docstring were repointed to the merged name.

Validated: MP2 `test_061/067/068/069` + facade `test_074` -- **52 passed**.

Files: pycc/mpderiv.py, pycc/mpwfn.py, pycc/correlatedderivs.py, pycc/tests/test_068_mp2_apt.py.

## Next

This closes the planned refactor phases (base + MP2/CC leaves + CIderiv slot).  Separate follow-ups,
each its own PR: the programmer's CISD hook implementation + validation + retiring the transitional
CIwfn code; the deferred magnetic orbital-Hessian unification in cphf.py; a possible hoist of the
AAT / VG-APT machinery into the base; the post-refactor naming/notation sweep against
docs/cc_gradients_orbital_response.tex.
