### PR TITLE
CCSD/CCSD(T) atomic polar tensors (APTs) via the shared 2n+1 machinery

### DIFF
--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -111,6 +111,34 @@ class CCderiv(CorrelatedDerivs):
                              "build the wavefunction with make_t3_density=True.")
         return super().polarizability(route)        # shared 2n+1 assembly (SO/spatial dispatch in the base)
 
+    def dipole_derivatives(self, route: str = '2n+1-field') -> np.ndarray:
+        """CCSD/CCSD(T) **correlation** contribution to the atomic polar tensors (nuclear dipole
+        derivatives, a.u.), shape ``(natom, 3, 3)`` indexed ``[A, beta, alpha]`` =
+        ``d(mu_alpha)/d(X_{A,beta}) = -d^2 E_corr / dF_alpha dX_{A,beta}`` -- the mixed field/nuclear
+        analog of :meth:`polarizability`.
+
+        ``route='2n+1-field'`` (default, 3 field solves) or ``'2n+1-nuclear'`` (``3N`` nuclear
+        solves); both give the same tensor.  The nuclear ``Z_A`` and SCF reference terms are kept
+        separate (:meth:`HFwfn.dipole_derivatives`) and summed with this correlation part by
+        :func:`pycc.apt`.
+
+        Spatial closed-shell RHF and spin-orbital UHF, CCSD and CCSD(T), all-electron and frozen
+        core.  The (T) contribution enters entirely through the (T)-aware relaxed and perturbed
+        densities the shared base already builds (no APT-specific (T) code); the spin-orbital CCSD(T)
+        APT is validated against a CFOUR DIPDER oracle (``DIPDER(CCSD(T)) - DIPDER(SCF)``, see
+        ``test_087_ccsdt_apt``).
+
+        Overrides :meth:`CorrelatedDerivs.dipole_derivatives` only to add the CC method-specific
+        guards (supported model, (T) density intermediates); the shared 2n+1 assembly runs via
+        ``super()``."""
+        cc = self.ccwfn
+        if cc.model.upper() not in ('CCSD', 'CCSD(T)'):
+            raise NotImplementedError(f"CC dipole derivatives: only CCSD and CCSD(T) are implemented (not {cc.model}).")
+        if cc.model.upper() == 'CCSD(T)' and not hasattr(cc, 'S1'):
+            raise ValueError("CCSD(T) dipole derivatives require the (T) density intermediates; "
+                             "build the wavefunction with make_t3_density=True.")
+        return super().dipole_derivatives(route)    # shared 2n+1 assembly (SO/spatial dispatch in the base)
+
     def _perturbed_unrelaxed_densities(self, pert, df, deri, dL):
         """CC perturbed unrelaxed densities ``(d_x gamma, d_x Gamma)`` -- the base
         :meth:`CorrelatedDerivs._perturbed_unrelaxed_densities` hook.  Runs the iterative perturbed

--- a/pycc/tests/test_087_ccsdt_apt.py
+++ b/pycc/tests/test_087_ccsdt_apt.py
@@ -19,7 +19,9 @@ GENBAS "6-31G" is transcribed here (the same string as test_084); pycc then repr
 DIPDER to ~1e-10 (the DIPDER truncation), on both the spin-orbital and spatial routes.
 
 Planar HOF (Cs, molecular plane xy) is the off-diagonal case: the in-plane block is full while the
-out-of-plane (z) couplings vanish.  Water/6-31G is the cheaper SO == spatial keystone.
+out-of-plane (z) couplings vanish.  Water/6-31G (C2v, plane yz) is the cheaper second molecule whose
+spin-orbital case is fast enough (~30 s) to keep the SO route CFOUR-anchored in the default suite;
+the SO HOF case is marked slow.
 """
 
 import psi4
@@ -150,6 +152,49 @@ CFOUR_APT_T_HOF_631G_TOTAL_FC = np.array(
       [0.0308980425, 0.0760765459, 0.0],
       [0.0, 0.0, 0.4635984274]]])
 
+# CFOUR CCSD(T) APT oracles (a.u.), water (O, H, H) / CFOUR GENBAS 6-31G, indexed [A, beta, alpha].
+# C2v, molecular plane yz (x perpendicular); the fast SO route anchor.
+CFOUR_APT_T_WATER_631G = np.array(
+    [[[0.0399979428, 0.0, 0.0],
+      [0.0, 0.1132247141, 0.0],
+      [0.0, 0.0, 0.1194575506]],
+     [[-0.0199989714, 0.0, 0.0],
+      [0.0, -0.056612357, 0.036135448],
+      [0.0, 0.028310197, -0.0597287753]],
+     [[-0.0199989714, 0.0, 0.0],
+      [0.0, -0.056612357, -0.036135448],
+      [0.0, -0.028310197, -0.0597287753]]])
+CFOUR_APT_T_WATER_631G_FC = np.array(
+    [[[0.0401086132, 0.0, 0.0],
+      [0.0, 0.1133712224, 0.0],
+      [0.0, 0.0, 0.1194748271]],
+     [[-0.0200543066, 0.0, 0.0],
+      [0.0, -0.0566856112, 0.0361609918],
+      [0.0, 0.0283240522, -0.0597374136]],
+     [[-0.0200543066, 0.0, 0.0],
+      [0.0, -0.0566856112, -0.0361609918],
+      [0.0, -0.0283240522, -0.0597374136]]])
+CFOUR_APT_T_WATER_631G_TOTAL = np.array(
+    [[[-0.8947308623, 0.0, 0.0],
+      [0.0, -0.3846637527, 0.0],
+      [0.0, 0.0, -0.2662598211]],
+     [[0.4473654312, 0.0, 0.0],
+      [0.0, 0.1923318764, 0.134504558],
+      [0.0, 0.1971970102, 0.1331299106]],
+     [[0.4473654312, 0.0, 0.0],
+      [0.0, 0.1923318764, -0.134504558],
+      [0.0, -0.1971970102, 0.1331299106]]])
+CFOUR_APT_T_WATER_631G_TOTAL_FC = np.array(
+    [[[-0.8946201919, 0.0, 0.0],
+      [0.0, -0.3845172444, 0.0],
+      [0.0, 0.0, -0.2662425446]],
+     [[0.447310096, 0.0, 0.0],
+      [0.0, 0.1922586222, 0.1345301018],
+      [0.0, 0.1972108654, 0.1331212723]],
+     [[0.447310096, 0.0, 0.0],
+      [0.0, 0.1922586222, -0.1345301018],
+      [0.0, -0.1972108654, 0.1331212723]]])
+
 
 def _cfour_wfn(geom, freeze_core):
     """RHF reference in CFOUR's exact GENBAS 6-31G (via basis_helper), for the CFOUR-oracle tests."""
@@ -171,10 +216,12 @@ def _ccsdt_apt(geom, freeze_core, orbital_basis):
     return pycc.apt(cc)
 
 
-def _check_hof(r, corr_ref, total_ref):
-    """Shared assertions for an HOF CCSD(T) APT run: correlation and total vs the CFOUR oracle, the
-    facade decomposition (total == nuclear + reference + correlation, nuclear == Z_A delta), the Cs
-    out-of-plane (z) block vanishing, and the translational (acoustic) sum rule."""
+def _check(r, corr_ref, total_ref, Z, perp):
+    """Shared assertions for a planar-molecule CCSD/CCSD(T) APT run vs the CFOUR oracle: correlation
+    and total tensors, the facade decomposition (total == nuclear + reference + correlation, nuclear
+    == Z_A delta), the out-of-plane block vanishing, and the translational (acoustic) sum rule.  ``Z``
+    is the nuclear-charge list; ``perp`` is the axis perpendicular to the molecular plane (2/z for HOF
+    in the xy plane, 0/x for water in the yz plane)."""
     corr = np.asarray(r.correlation)
     total = np.asarray(r.total)
     assert np.max(np.abs(corr - corr_ref)) < 1e-9, corr
@@ -183,10 +230,11 @@ def _check_hof(r, corr_ref, total_ref):
     parts = np.asarray(r.nuclear) + np.asarray(r.reference) + np.asarray(r.correlation)
     assert np.max(np.abs(total - parts)) < 1e-12
     # nuclear block is Z_A delta_{alpha,beta}
-    Z = np.array([8.0, 9.0, 1.0])
-    assert np.max(np.abs(np.asarray(r.nuclear) - Z[:, None, None] * np.eye(3))) < 1e-12
-    # Cs (molecular plane xy): out-of-plane couplings vanish -- d mu_{x,y}/dz = d mu_z/d{x,y} = 0
-    assert np.max(np.abs(corr[:, 2, :2])) < 1e-9 and np.max(np.abs(corr[:, :2, 2])) < 1e-9
+    assert np.max(np.abs(np.asarray(r.nuclear) - np.asarray(Z)[:, None, None] * np.eye(3))) < 1e-12
+    # planar molecule: out-of-plane couplings vanish -- d mu_perp/d(in-plane) = d mu_in-plane/d(perp) = 0
+    other = [a for a in range(3) if a != perp]
+    assert np.max(np.abs(corr[:, other][:, :, perp])) < 1e-9
+    assert np.max(np.abs(corr[:, perp][:, other])) < 1e-9
     # translational (acoustic) sum rule: sum over atoms vanishes for a neutral molecule
     assert np.max(np.abs(np.sum(total, axis=0))) < 1e-9
     assert np.max(np.abs(np.sum(corr, axis=0))) < 1e-9
@@ -196,8 +244,8 @@ def test_ccsdt_apt_cfour_hof_spatial():
     """All-electron spatial (closed-shell RHF) CCSD(T) APT for HOF vs the CFOUR DIPDER oracle -- the
     correlation and total tensors, the exact facade decomposition, the Cs out-of-plane zeros, and the
     translational sum rule."""
-    _check_hof(_ccsdt_apt(HOF, 'false', 'spatial'),
-               CFOUR_APT_T_HOF_631G, CFOUR_APT_T_HOF_631G_TOTAL)
+    _check(_ccsdt_apt(HOF, 'false', 'spatial'),
+           CFOUR_APT_T_HOF_631G, CFOUR_APT_T_HOF_631G_TOTAL, [8.0, 9.0, 1.0], perp=2)
     psi4.core.clean()
 
 
@@ -206,38 +254,46 @@ def test_fc_ccsdt_apt_cfour_hof_spatial():
     core<->active and active oo/vv dependent-pair response in the perturbed relaxed density; the SCF
     reference (and thus nuclear + HF part) is unchanged by freezing, so the oracle subtracts the same
     all-electron SCF DIPDER."""
-    r = _ccsdt_apt(HOF, 'true', 'spatial')
-    _check_hof(r, CFOUR_APT_T_HOF_631G_FC, CFOUR_APT_T_HOF_631G_TOTAL_FC)
+    _check(_ccsdt_apt(HOF, 'true', 'spatial'),
+           CFOUR_APT_T_HOF_631G_FC, CFOUR_APT_T_HOF_631G_TOTAL_FC, [8.0, 9.0, 1.0], perp=2)
+    psi4.core.clean()
+
+
+def test_ccsdt_apt_cfour_water_spatial():
+    """All-electron and frozen-core spatial CCSD(T) APT for water/6-31G (C2v, plane yz) vs the CFOUR
+    oracle -- a second molecule/frame for the spatial route, and the spatial half of the fast SO
+    anchor."""
+    _check(_ccsdt_apt(WATER, 'false', 'spatial'),
+           CFOUR_APT_T_WATER_631G, CFOUR_APT_T_WATER_631G_TOTAL, [8.0, 1.0, 1.0], perp=0)
+    psi4.core.clean()
+    _check(_ccsdt_apt(WATER, 'true', 'spatial'),
+           CFOUR_APT_T_WATER_631G_FC, CFOUR_APT_T_WATER_631G_TOTAL_FC, [8.0, 1.0, 1.0], perp=0)
+    psi4.core.clean()
+
+
+def test_so_ccsdt_apt_cfour_water():
+    """Spin-orbital CCSD(T) APT for water/6-31G vs the CFOUR oracle (all-electron and frozen core) --
+    the direct SO-vs-CFOUR anchor that runs fast enough for the default suite (C2v water, ~30 s total,
+    vs the slow HOF SO case).  Exercises the genuine SO path (SO perturbed amplitudes/Lambda/(T)
+    intermediates, inline orbital Hessian)."""
+    _check(_ccsdt_apt(WATER, 'false', 'spinorbital'),
+           CFOUR_APT_T_WATER_631G, CFOUR_APT_T_WATER_631G_TOTAL, [8.0, 1.0, 1.0], perp=0)
+    psi4.core.clean()
+    _check(_ccsdt_apt(WATER, 'true', 'spinorbital'),
+           CFOUR_APT_T_WATER_631G_FC, CFOUR_APT_T_WATER_631G_TOTAL_FC, [8.0, 1.0, 1.0], perp=0)
     psi4.core.clean()
 
 
 @pytest.mark.slow
 def test_so_ccsdt_apt_cfour_hof():
-    """Spin-orbital CCSD(T) APT for HOF vs the CFOUR oracle (all-electron and frozen core).  The
-    genuinely spin-orbital path (SO perturbed amplitudes/Lambda/(T) intermediates and the inline
-    orbital Hessian); marked slow (the SO HOF (T) solve is the expensive case)."""
-    _check_hof(_ccsdt_apt(HOF, 'false', 'spinorbital'),
-               CFOUR_APT_T_HOF_631G, CFOUR_APT_T_HOF_631G_TOTAL)
+    """Spin-orbital CCSD(T) APT for HOF vs the CFOUR oracle (all-electron and frozen core) -- the
+    off-diagonal (Cs) SO anchor.  Marked slow (the SO HOF (T) solve is the expensive case, ~3.7 min);
+    the fast SO coverage is test_so_ccsdt_apt_cfour_water."""
+    _check(_ccsdt_apt(HOF, 'false', 'spinorbital'),
+           CFOUR_APT_T_HOF_631G, CFOUR_APT_T_HOF_631G_TOTAL, [8.0, 9.0, 1.0], perp=2)
     psi4.core.clean()
-    _check_hof(_ccsdt_apt(HOF, 'true', 'spinorbital'),
-               CFOUR_APT_T_HOF_631G_FC, CFOUR_APT_T_HOF_631G_TOTAL_FC)
-    psi4.core.clean()
-
-
-def test_ccsdt_apt_so_eq_spatial_keystone_water():
-    """SO == spatial keystone (water/6-31G, all-electron and frozen core): the spin-orbital CCSD(T)
-    correlation APT of an RHF reference forced into the spin-orbital basis reproduces the spatial
-    (closed-shell) value.  Cheaper than HOF, and independent of the CFOUR oracle -- it carries the
-    spatial validation onto the SO machinery (SO perturbed densities, inline orbital Hessian)."""
-    for fc in ('false', 'true'):
-        wfn = _cfour_wfn(WATER, fc)
-        cc_sa = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis='spatial', make_t3_density=True)
-        cc_sa.solve_cc(1e-12, 1e-12, 100)
-        P_sa = np.asarray(pycc.CCderiv(cc_sa).dipole_derivatives())
-        cc_so = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis='spinorbital', make_t3_density=True)
-        cc_so.solve_cc(1e-12, 1e-12, 100)
-        P_so = np.asarray(pycc.CCderiv(cc_so).dipole_derivatives())
-        assert np.max(np.abs(P_so - P_sa)) < 1e-10, (fc, np.max(np.abs(P_so - P_sa)))
+    _check(_ccsdt_apt(HOF, 'true', 'spinorbital'),
+           CFOUR_APT_T_HOF_631G_FC, CFOUR_APT_T_HOF_631G_TOTAL_FC, [8.0, 9.0, 1.0], perp=2)
     psi4.core.clean()
 
 

--- a/pycc/tests/test_087_ccsdt_apt.py
+++ b/pycc/tests/test_087_ccsdt_apt.py
@@ -1,0 +1,269 @@
+"""CCSD(T) atomic polar tensors (nuclear dipole derivatives, the IR-intensity tensor) via the
+shared 2n+1 machinery -- P_corr[A,beta,alpha] = d(mu_alpha)/dX_{A,beta} = -d^2 E_corr/dF_alpha
+dX_{A,beta}, the mixed field/nuclear analog of the CCSD(T) polarizability (test_084).
+
+The (T) contribution needs no APT-specific code: the base CorrelatedDerivs.dipole_derivatives 2n+1
+assembly consumes the same (T)-aware relaxed and perturbed densities that the CCSD(T) gradient and
+polarizability already build (dt3 threaded through the perturbed amplitudes/Lambda/densities, the
+canonical perturbed-MO oo/vv dependent pairs).  CCderiv.dipole_derivatives overrides the base only
+to add the method guards (supported model, make_t3_density), exactly as CCderiv.polarizability does.
+
+Oracle: CFOUR (xcfour, CALC=CCSD(T), VIB=EXACT, SCF_CONV=13, CC_CONV=12).  The DIPDER file holds the
+TOTAL APT (nuclear + HF + correlation).  The correlation contribution is DIPDER(CCSD(T)) minus the
+SCF DIPDER (which is the nuclear + HF part -- frozen core is a no-op for HF, so the frozen-core
+correlation subtracts the same all-electron SCF, matching pycc whose reference block is the
+all-electron SCF).  DIPDER indexes [mu, atom, coord]; pycc indexes [A, beta, alpha] = d mu_alpha /
+d R_{A,beta}, so the oracle is transpose(DIPDER, (1,2,0)).  To match CFOUR to all printed digits the
+AO basis must be identical -- Psi4's "6-31G" differs from CFOUR's GENBAS by ~4e-8 -- so CFOUR's exact
+GENBAS "6-31G" is transcribed here (the same string as test_084); pycc then reproduces the 10-digit
+DIPDER to ~1e-10 (the DIPDER truncation), on both the spin-orbital and spatial routes.
+
+Planar HOF (Cs, molecular plane xy) is the off-diagonal case: the in-plane block is full while the
+out-of-plane (z) couplings vanish.  Water/6-31G is the cheaper SO == spatial keystone.
+"""
+
+import psi4
+import pycc
+import numpy as np
+import pytest
+
+
+# CFOUR's exact GENBAS 6-31G (cartesian; transcribed in test_084 -- identical here so pycc's AO basis
+# matches the CFOUR run that produced the DIPDER oracle to all printed digits).
+CFOUR_631G = """cartesian
+****
+H     0
+S   3   1.00
+     18.7311370             0.0334946
+      2.8253944             0.2347270
+      0.6401217             0.8137573
+S   1   1.00
+      0.1612778             1.0000000
+****
+O     0
+S   6   1.00
+   5484.6716600             0.0018311
+    825.2349460             0.0139502
+    188.0469580             0.0684451
+     52.9645000             0.2327143
+     16.8975704             0.4701929
+      5.7996353             0.3585209
+S   3   1.00
+     15.5396162            -0.1107775
+      3.5999336            -0.1480263
+      1.0137618             1.1307670
+S   1   1.00
+      0.2700058             1.0000000
+P   3   1.00
+     15.5396162             0.0708743
+      3.5999336             0.3397528
+      1.0137618             0.7271586
+P   1   1.00
+      0.2700058             1.0000000
+****
+F     0
+S   6   1.00
+   7001.7130900             0.0018196
+   1051.3660900             0.0139161
+    239.2856900             0.0684053
+     67.3974453             0.2331858
+     21.5199573             0.4712674
+      7.4031013             0.3566185
+S   3   1.00
+     20.8479528            -0.1085070
+      4.8083083            -0.1464517
+      1.3440699             1.1286886
+S   1   1.00
+      0.3581514             1.0000000
+P   3   1.00
+     20.8479528             0.0716287
+      4.8083083             0.3459121
+      1.3440699             0.7224700
+P   1   1.00
+      0.3581514             1.0000000
+****
+"""
+
+# Planar HOF (Cs, molecular plane xy), tilted off the axes so the in-plane APT block is full; the
+# same frame as the CFOUR run (units bohr, no_com/no_reorient) so the off-diagonal xy elements line up.
+HOF = """
+O  0.00000  0.00000  0.00000
+F  2.56070  0.93200  0.00000
+H -0.83450  1.62360  0.00000
+symmetry c1
+units bohr
+no_com
+no_reorient
+"""
+
+# Equilibrium H2O (C2v), for the cheaper SO == spatial keystone (no CFOUR oracle needed).
+WATER = """
+O  0.00000  0.00000  0.00000
+H  0.00000  1.43121 -1.10664
+H  0.00000 -1.43121 -1.10664
+symmetry c1
+units bohr
+no_com
+no_reorient
+"""
+
+# CFOUR CCSD(T) APT oracles (a.u.), HOF (O, F, H) / CFOUR GENBAS 6-31G, indexed [A, beta, alpha] =
+# d mu_alpha / d R_{A,beta}.  Correlation = DIPDER(CCSD(T)) - DIPDER(SCF); total = DIPDER(CCSD(T)).
+CFOUR_APT_T_HOF_631G = np.array(
+    [[[-0.215755342, -0.0887708031, 0.0],
+      [-0.190937797, 0.0625843162, 0.0],
+      [0.0, 0.0, -0.0113236757]],
+     [[0.2417792404, 0.0286946511, 0.0],
+      [0.1044037051, 0.0624437659, 0.0],
+      [0.0, 0.0, 0.044003958]],
+     [[-0.0260238983, 0.060076152, 0.0],
+      [0.0865340919, -0.1250280821, 0.0],
+      [0.0, 0.0, -0.0326802823]]])
+CFOUR_APT_T_HOF_631G_FC = np.array(
+    [[[-0.2156168499, -0.0888064181, 0.0],
+      [-0.1909555635, 0.0625488937, 0.0],
+      [0.0, 0.0, -0.0112698848]],
+     [[0.2416916297, 0.0286764607, 0.0],
+      [0.1043805326, 0.0624624679, 0.0],
+      [0.0, 0.0, 0.0439799958]],
+     [[-0.0260747797, 0.0601299574, 0.0],
+      [0.0865750309, -0.1250113616, 0.0],
+      [0.0, 0.0, -0.032710111]]])
+CFOUR_APT_T_HOF_631G_TOTAL = np.array(
+    [[[-0.1111700961, -0.0491126892, 0.0],
+      [0.1102387373, 0.1050988386, 0.0],
+      [0.0, 0.0, -0.3761796306]],
+     [[-0.1499343223, -0.0053834555, 0.0],
+      [-0.1410958408, -0.181158664, 0.0],
+      [0.0, 0.0, -0.0874486255]],
+     [[0.2611044184, 0.0544961447, 0.0],
+      [0.0308571035, 0.0760598254, 0.0],
+      [0.0, 0.0, 0.4636282561]]])
+CFOUR_APT_T_HOF_631G_TOTAL_FC = np.array(
+    [[[-0.111031604, -0.0491483042, 0.0],
+      [0.1102209708, 0.1050634161, 0.0],
+      [0.0, 0.0, -0.3761258397]],
+     [[-0.150021933, -0.0054016459, 0.0],
+      [-0.1411190133, -0.181139962, 0.0],
+      [0.0, 0.0, -0.0874725877]],
+     [[0.261053537, 0.0545499501, 0.0],
+      [0.0308980425, 0.0760765459, 0.0],
+      [0.0, 0.0, 0.4635984274]]])
+
+
+def _cfour_wfn(geom, freeze_core):
+    """RHF reference in CFOUR's exact GENBAS 6-31G (via basis_helper), for the CFOUR-oracle tests."""
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'scf_type': 'pk', 'freeze_core': freeze_core,
+                      'e_convergence': 1e-13, 'd_convergence': 1e-13})
+    psi4.basis_helper(CFOUR_631G, name='cfour631g')
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    return wfn
+
+
+def _ccsdt_apt(geom, freeze_core, orbital_basis):
+    """Converged CCSD(T) APT PropertyComponents for the CFOUR-basis reference."""
+    wfn = _cfour_wfn(geom, freeze_core)
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis=orbital_basis, make_t3_density=True)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    return pycc.apt(cc)
+
+
+def _check_hof(r, corr_ref, total_ref):
+    """Shared assertions for an HOF CCSD(T) APT run: correlation and total vs the CFOUR oracle, the
+    facade decomposition (total == nuclear + reference + correlation, nuclear == Z_A delta), the Cs
+    out-of-plane (z) block vanishing, and the translational (acoustic) sum rule."""
+    corr = np.asarray(r.correlation)
+    total = np.asarray(r.total)
+    assert np.max(np.abs(corr - corr_ref)) < 1e-9, corr
+    assert np.max(np.abs(total - total_ref)) < 1e-9, total
+    # facade decomposition is exact
+    parts = np.asarray(r.nuclear) + np.asarray(r.reference) + np.asarray(r.correlation)
+    assert np.max(np.abs(total - parts)) < 1e-12
+    # nuclear block is Z_A delta_{alpha,beta}
+    Z = np.array([8.0, 9.0, 1.0])
+    assert np.max(np.abs(np.asarray(r.nuclear) - Z[:, None, None] * np.eye(3))) < 1e-12
+    # Cs (molecular plane xy): out-of-plane couplings vanish -- d mu_{x,y}/dz = d mu_z/d{x,y} = 0
+    assert np.max(np.abs(corr[:, 2, :2])) < 1e-9 and np.max(np.abs(corr[:, :2, 2])) < 1e-9
+    # translational (acoustic) sum rule: sum over atoms vanishes for a neutral molecule
+    assert np.max(np.abs(np.sum(total, axis=0))) < 1e-9
+    assert np.max(np.abs(np.sum(corr, axis=0))) < 1e-9
+
+
+def test_ccsdt_apt_cfour_hof_spatial():
+    """All-electron spatial (closed-shell RHF) CCSD(T) APT for HOF vs the CFOUR DIPDER oracle -- the
+    correlation and total tensors, the exact facade decomposition, the Cs out-of-plane zeros, and the
+    translational sum rule."""
+    _check_hof(_ccsdt_apt(HOF, 'false', 'spatial'),
+               CFOUR_APT_T_HOF_631G, CFOUR_APT_T_HOF_631G_TOTAL)
+    psi4.core.clean()
+
+
+def test_fc_ccsdt_apt_cfour_hof_spatial():
+    """Frozen-core spatial CCSD(T) APT for HOF vs the CFOUR frozen-core oracle -- exercises the (T)
+    core<->active and active oo/vv dependent-pair response in the perturbed relaxed density; the SCF
+    reference (and thus nuclear + HF part) is unchanged by freezing, so the oracle subtracts the same
+    all-electron SCF DIPDER."""
+    r = _ccsdt_apt(HOF, 'true', 'spatial')
+    _check_hof(r, CFOUR_APT_T_HOF_631G_FC, CFOUR_APT_T_HOF_631G_TOTAL_FC)
+    psi4.core.clean()
+
+
+@pytest.mark.slow
+def test_so_ccsdt_apt_cfour_hof():
+    """Spin-orbital CCSD(T) APT for HOF vs the CFOUR oracle (all-electron and frozen core).  The
+    genuinely spin-orbital path (SO perturbed amplitudes/Lambda/(T) intermediates and the inline
+    orbital Hessian); marked slow (the SO HOF (T) solve is the expensive case)."""
+    _check_hof(_ccsdt_apt(HOF, 'false', 'spinorbital'),
+               CFOUR_APT_T_HOF_631G, CFOUR_APT_T_HOF_631G_TOTAL)
+    psi4.core.clean()
+    _check_hof(_ccsdt_apt(HOF, 'true', 'spinorbital'),
+               CFOUR_APT_T_HOF_631G_FC, CFOUR_APT_T_HOF_631G_TOTAL_FC)
+    psi4.core.clean()
+
+
+def test_ccsdt_apt_so_eq_spatial_keystone_water():
+    """SO == spatial keystone (water/6-31G, all-electron and frozen core): the spin-orbital CCSD(T)
+    correlation APT of an RHF reference forced into the spin-orbital basis reproduces the spatial
+    (closed-shell) value.  Cheaper than HOF, and independent of the CFOUR oracle -- it carries the
+    spatial validation onto the SO machinery (SO perturbed densities, inline orbital Hessian)."""
+    for fc in ('false', 'true'):
+        wfn = _cfour_wfn(WATER, fc)
+        cc_sa = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis='spatial', make_t3_density=True)
+        cc_sa.solve_cc(1e-12, 1e-12, 100)
+        P_sa = np.asarray(pycc.CCderiv(cc_sa).dipole_derivatives())
+        cc_so = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis='spinorbital', make_t3_density=True)
+        cc_so.solve_cc(1e-12, 1e-12, 100)
+        P_so = np.asarray(pycc.CCderiv(cc_so).dipole_derivatives())
+        assert np.max(np.abs(P_so - P_sa)) < 1e-10, (fc, np.max(np.abs(P_so - P_sa)))
+    psi4.core.clean()
+
+
+def test_ccsdt_apt_routes_agree_water():
+    """The two 2n+1 APT routes agree for CCSD(T) (water/6-31G, spatial): '2n+1-field' (default, 3
+    field solves) and '2n+1-nuclear' (3N nuclear solves) build the same tensor from the same (T)-aware
+    responses."""
+    wfn = _cfour_wfn(WATER, 'false')
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis='spatial', make_t3_density=True)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    Pf = np.asarray(pycc.CCderiv(cc).dipole_derivatives(route='2n+1-field'))
+    Pn = np.asarray(pycc.CCderiv(cc).dipole_derivatives(route='2n+1-nuclear'))
+    assert np.max(np.abs(Pf - Pn)) < 1e-10
+    psi4.core.clean()
+
+
+def test_ccsdt_apt_guards():
+    """The misused paths raise rather than silently returning a wrong tensor: CCSD(T) built without
+    the (T) density intermediates (make_t3_density), and an unknown route."""
+    wfn = _cfour_wfn(WATER, 'false')
+    cc_t = pycc.ccwfn(wfn, model='ccsd(t)')                     # CCSD(T), no make_t3_density
+    cc_t.solve_cc(1e-12, 1e-12, 100)
+    with pytest.raises(ValueError):                             # (T) needs make_t3_density
+        pycc.CCderiv(cc_t).dipole_derivatives()
+    cc = pycc.ccwfn(wfn)                                        # plain CCSD: reaches the route check
+    cc.solve_cc(1e-12, 1e-12, 100)
+    with pytest.raises(ValueError):                             # unknown route
+        pycc.CCderiv(cc).dipole_derivatives(route='bogus')
+    psi4.core.clean()

--- a/pycc/tests/test_088_ccsd_apt.py
+++ b/pycc/tests/test_088_ccsd_apt.py
@@ -16,8 +16,9 @@ transpose(DIPDER, (1,2,0)).  CFOUR's exact GENBAS "6-31G" is transcribed here (s
 test_084/test_087) so pycc's AO basis matches to all printed digits; pycc then reproduces the
 10-digit DIPDER to ~1e-10, on both the spin-orbital and spatial routes.
 
-Planar HOF (Cs, molecular plane xy) is the off-diagonal case; water/6-31G is the cheaper SO ==
-spatial keystone.
+Planar HOF (Cs, molecular plane xy) is the off-diagonal case; water/6-31G (C2v, plane yz) is the
+cheaper second molecule whose spin-orbital case is fast enough (~5 s) to keep the SO route
+CFOUR-anchored in the default suite; the SO HOF case is marked slow.
 """
 
 import psi4
@@ -147,6 +148,49 @@ CFOUR_APT_HOF_631G_TOTAL_FC = np.array(
       [0.0294148435, 0.0837032595, 0.0],
       [0.0, 0.0, 0.4654363044]]])
 
+# CFOUR CCSD APT oracles (a.u.), water (O, H, H) / CFOUR GENBAS 6-31G, indexed [A, beta, alpha].
+# C2v, molecular plane yz (x perpendicular); the fast SO route anchor.
+CFOUR_APT_WATER_631G = np.array(
+    [[[0.0368350628, 0.0, 0.0],
+      [0.0, 0.1049013758, 0.0],
+      [0.0, 0.0, 0.111175279]],
+     [[-0.0184175315, 0.0, 0.0],
+      [0.0, -0.0524506879, 0.0332568917],
+      [0.0, 0.0263151125, -0.0555876395]],
+     [[-0.0184175315, 0.0, 0.0],
+      [0.0, -0.0524506879, -0.0332568917],
+      [0.0, -0.0263151125, -0.0555876395]]])
+CFOUR_APT_WATER_631G_FC = np.array(
+    [[[0.0369506702, 0.0, 0.0],
+      [0.0, 0.1050980957, 0.0],
+      [0.0, 0.0, 0.1112302379]],
+     [[-0.0184753351, 0.0, 0.0],
+      [0.0, -0.0525490478, 0.0332955133],
+      [0.0, 0.0263464715, -0.055615119]],
+     [[-0.0184753351, 0.0, 0.0],
+      [0.0, -0.0525490478, -0.0332955133],
+      [0.0, -0.0263464715, -0.055615119]]])
+CFOUR_APT_WATER_631G_TOTAL = np.array(
+    [[[-0.8978937423, 0.0, 0.0],
+      [0.0, -0.392987091, 0.0],
+      [0.0, 0.0, -0.2745420927]],
+     [[0.4489468711, 0.0, 0.0],
+      [0.0, 0.1964935455, 0.1316260017],
+      [0.0, 0.1952019257, 0.1372710464]],
+     [[0.4489468711, 0.0, 0.0],
+      [0.0, 0.1964935455, -0.1316260017],
+      [0.0, -0.1952019257, 0.1372710464]]])
+CFOUR_APT_WATER_631G_TOTAL_FC = np.array(
+    [[[-0.8977781349, 0.0, 0.0],
+      [0.0, -0.3927903711, 0.0],
+      [0.0, 0.0, -0.2744871338]],
+     [[0.4488890675, 0.0, 0.0],
+      [0.0, 0.1963951856, 0.1316646233],
+      [0.0, 0.1952332847, 0.1372435669]],
+     [[0.4488890675, 0.0, 0.0],
+      [0.0, 0.1963951856, -0.1316646233],
+      [0.0, -0.1952332847, 0.1372435669]]])
+
 
 def _cfour_wfn(geom, freeze_core):
     """RHF reference in CFOUR's exact GENBAS 6-31G (via basis_helper), for the CFOUR-oracle tests."""
@@ -168,19 +212,22 @@ def _ccsd_apt(geom, freeze_core, orbital_basis):
     return pycc.apt(cc)
 
 
-def _check_hof(r, corr_ref, total_ref):
-    """Shared assertions for an HOF CCSD APT run: correlation and total vs the CFOUR oracle, the
-    facade decomposition (total == nuclear + reference + correlation, nuclear == Z_A delta), the Cs
-    out-of-plane (z) block vanishing, and the translational (acoustic) sum rule."""
+def _check(r, corr_ref, total_ref, Z, perp):
+    """Shared assertions for a planar-molecule CCSD APT run vs the CFOUR oracle: correlation and total
+    tensors, the facade decomposition (total == nuclear + reference + correlation, nuclear == Z_A
+    delta), the out-of-plane block vanishing, and the translational (acoustic) sum rule.  ``Z`` is the
+    nuclear-charge list; ``perp`` is the axis perpendicular to the molecular plane (2/z for HOF in the
+    xy plane, 0/x for water in the yz plane)."""
     corr = np.asarray(r.correlation)
     total = np.asarray(r.total)
     assert np.max(np.abs(corr - corr_ref)) < 1e-9, corr
     assert np.max(np.abs(total - total_ref)) < 1e-9, total
     parts = np.asarray(r.nuclear) + np.asarray(r.reference) + np.asarray(r.correlation)
     assert np.max(np.abs(total - parts)) < 1e-12
-    Z = np.array([8.0, 9.0, 1.0])
-    assert np.max(np.abs(np.asarray(r.nuclear) - Z[:, None, None] * np.eye(3))) < 1e-12
-    assert np.max(np.abs(corr[:, 2, :2])) < 1e-9 and np.max(np.abs(corr[:, :2, 2])) < 1e-9
+    assert np.max(np.abs(np.asarray(r.nuclear) - np.asarray(Z)[:, None, None] * np.eye(3))) < 1e-12
+    other = [a for a in range(3) if a != perp]
+    assert np.max(np.abs(corr[:, other][:, :, perp])) < 1e-9
+    assert np.max(np.abs(corr[:, perp][:, other])) < 1e-9
     assert np.max(np.abs(np.sum(total, axis=0))) < 1e-9
     assert np.max(np.abs(np.sum(corr, axis=0))) < 1e-9
 
@@ -189,8 +236,8 @@ def test_ccsd_apt_cfour_hof_spatial():
     """All-electron spatial (closed-shell RHF) CCSD APT for HOF vs the CFOUR DIPDER oracle -- the
     correlation and total tensors, the exact facade decomposition, the Cs out-of-plane zeros, and the
     translational sum rule."""
-    _check_hof(_ccsd_apt(HOF, 'false', 'spatial'),
-               CFOUR_APT_HOF_631G, CFOUR_APT_HOF_631G_TOTAL)
+    _check(_ccsd_apt(HOF, 'false', 'spatial'),
+           CFOUR_APT_HOF_631G, CFOUR_APT_HOF_631G_TOTAL, [8.0, 9.0, 1.0], perp=2)
     psi4.core.clean()
 
 
@@ -198,37 +245,45 @@ def test_fc_ccsd_apt_cfour_hof_spatial():
     """Frozen-core spatial CCSD APT for HOF vs the CFOUR frozen-core oracle -- exercises the
     frozen-core core<->active response in the perturbed relaxed density; the SCF reference is
     unchanged by freezing, so the oracle subtracts the same all-electron SCF DIPDER."""
-    _check_hof(_ccsd_apt(HOF, 'true', 'spatial'),
-               CFOUR_APT_HOF_631G_FC, CFOUR_APT_HOF_631G_TOTAL_FC)
+    _check(_ccsd_apt(HOF, 'true', 'spatial'),
+           CFOUR_APT_HOF_631G_FC, CFOUR_APT_HOF_631G_TOTAL_FC, [8.0, 9.0, 1.0], perp=2)
+    psi4.core.clean()
+
+
+def test_ccsd_apt_cfour_water_spatial():
+    """All-electron and frozen-core spatial CCSD APT for water/6-31G (C2v, plane yz) vs the CFOUR
+    oracle -- a second molecule/frame for the spatial route, and the spatial half of the fast SO
+    anchor."""
+    _check(_ccsd_apt(WATER, 'false', 'spatial'),
+           CFOUR_APT_WATER_631G, CFOUR_APT_WATER_631G_TOTAL, [8.0, 1.0, 1.0], perp=0)
+    psi4.core.clean()
+    _check(_ccsd_apt(WATER, 'true', 'spatial'),
+           CFOUR_APT_WATER_631G_FC, CFOUR_APT_WATER_631G_TOTAL_FC, [8.0, 1.0, 1.0], perp=0)
+    psi4.core.clean()
+
+
+def test_so_ccsd_apt_cfour_water():
+    """Spin-orbital CCSD APT for water/6-31G vs the CFOUR oracle (all-electron and frozen core) -- the
+    direct SO-vs-CFOUR anchor that runs fast enough for the default suite (C2v water, ~5 s, vs the
+    slow HOF SO case).  Exercises the genuine SO path (SO perturbed amplitudes/Lambda, inline orbital
+    Hessian)."""
+    _check(_ccsd_apt(WATER, 'false', 'spinorbital'),
+           CFOUR_APT_WATER_631G, CFOUR_APT_WATER_631G_TOTAL, [8.0, 1.0, 1.0], perp=0)
+    psi4.core.clean()
+    _check(_ccsd_apt(WATER, 'true', 'spinorbital'),
+           CFOUR_APT_WATER_631G_FC, CFOUR_APT_WATER_631G_TOTAL_FC, [8.0, 1.0, 1.0], perp=0)
     psi4.core.clean()
 
 
 @pytest.mark.slow
 def test_so_ccsd_apt_cfour_hof():
     """Spin-orbital CCSD APT for HOF vs the CFOUR oracle (all-electron and frozen core) -- the
-    genuinely spin-orbital path (SO perturbed amplitudes/Lambda and the inline orbital Hessian);
-    marked slow (the SO HOF solve is the expensive case)."""
-    _check_hof(_ccsd_apt(HOF, 'false', 'spinorbital'),
-               CFOUR_APT_HOF_631G, CFOUR_APT_HOF_631G_TOTAL)
+    off-diagonal (Cs) SO anchor.  Marked slow; the fast SO coverage is test_so_ccsd_apt_cfour_water."""
+    _check(_ccsd_apt(HOF, 'false', 'spinorbital'),
+           CFOUR_APT_HOF_631G, CFOUR_APT_HOF_631G_TOTAL, [8.0, 9.0, 1.0], perp=2)
     psi4.core.clean()
-    _check_hof(_ccsd_apt(HOF, 'true', 'spinorbital'),
-               CFOUR_APT_HOF_631G_FC, CFOUR_APT_HOF_631G_TOTAL_FC)
-    psi4.core.clean()
-
-
-def test_ccsd_apt_so_eq_spatial_keystone_water():
-    """SO == spatial keystone (water/6-31G, all-electron and frozen core): the spin-orbital CCSD
-    correlation APT of an RHF reference forced into the spin-orbital basis reproduces the spatial
-    (closed-shell) value.  Cheaper than HOF and independent of the CFOUR oracle."""
-    for fc in ('false', 'true'):
-        wfn = _cfour_wfn(WATER, fc)
-        cc_sa = pycc.ccwfn(wfn, orbital_basis='spatial')
-        cc_sa.solve_cc(1e-12, 1e-12, 100)
-        P_sa = np.asarray(pycc.CCderiv(cc_sa).dipole_derivatives())
-        cc_so = pycc.ccwfn(wfn, orbital_basis='spinorbital')
-        cc_so.solve_cc(1e-12, 1e-12, 100)
-        P_so = np.asarray(pycc.CCderiv(cc_so).dipole_derivatives())
-        assert np.max(np.abs(P_so - P_sa)) < 1e-10, (fc, np.max(np.abs(P_so - P_sa)))
+    _check(_ccsd_apt(HOF, 'true', 'spinorbital'),
+           CFOUR_APT_HOF_631G_FC, CFOUR_APT_HOF_631G_TOTAL_FC, [8.0, 9.0, 1.0], perp=2)
     psi4.core.clean()
 
 

--- a/pycc/tests/test_088_ccsd_apt.py
+++ b/pycc/tests/test_088_ccsd_apt.py
@@ -1,0 +1,254 @@
+"""CCSD atomic polar tensors (nuclear dipole derivatives, the IR-intensity tensor) via the shared
+2n+1 machinery -- P_corr[A,beta,alpha] = d(mu_alpha)/dX_{A,beta} = -d^2 E_corr/dF_alpha dX_{A,beta},
+the CCSD analog of test_087 (CCSD(T)) and the mixed field/nuclear analog of the CCSD polarizability
+(test_084).
+
+The correlation APT is the base CorrelatedDerivs.dipole_derivatives 2n+1 assembly on the CCSD
+relaxed and perturbed densities (no (T), so make_t3_density is not needed); CCderiv.dipole_derivatives
+adds only the method guards and delegates to the base.
+
+Oracle: CFOUR (xcfour, CALC=CCSD, VIB=EXACT, SCF_CONV=13, CC_CONV=12).  The DIPDER file holds the
+TOTAL APT (nuclear + HF + correlation); the correlation part is DIPDER(CCSD) minus the SCF DIPDER
+(the nuclear + HF part; frozen core is a no-op for HF, so the frozen-core correlation subtracts the
+same all-electron SCF, matching pycc whose reference block is the all-electron SCF).  DIPDER indexes
+[mu, atom, coord]; pycc indexes [A, beta, alpha] = d mu_alpha / d R_{A,beta}, so the oracle is
+transpose(DIPDER, (1,2,0)).  CFOUR's exact GENBAS "6-31G" is transcribed here (same string as
+test_084/test_087) so pycc's AO basis matches to all printed digits; pycc then reproduces the
+10-digit DIPDER to ~1e-10, on both the spin-orbital and spatial routes.
+
+Planar HOF (Cs, molecular plane xy) is the off-diagonal case; water/6-31G is the cheaper SO ==
+spatial keystone.
+"""
+
+import psi4
+import pycc
+import numpy as np
+import pytest
+
+
+# CFOUR's exact GENBAS 6-31G (cartesian; identical to test_084/test_087 so pycc's AO basis matches
+# the CFOUR run that produced the DIPDER oracle to all printed digits).
+CFOUR_631G = """cartesian
+****
+H     0
+S   3   1.00
+     18.7311370             0.0334946
+      2.8253944             0.2347270
+      0.6401217             0.8137573
+S   1   1.00
+      0.1612778             1.0000000
+****
+O     0
+S   6   1.00
+   5484.6716600             0.0018311
+    825.2349460             0.0139502
+    188.0469580             0.0684451
+     52.9645000             0.2327143
+     16.8975704             0.4701929
+      5.7996353             0.3585209
+S   3   1.00
+     15.5396162            -0.1107775
+      3.5999336            -0.1480263
+      1.0137618             1.1307670
+S   1   1.00
+      0.2700058             1.0000000
+P   3   1.00
+     15.5396162             0.0708743
+      3.5999336             0.3397528
+      1.0137618             0.7271586
+P   1   1.00
+      0.2700058             1.0000000
+****
+F     0
+S   6   1.00
+   7001.7130900             0.0018196
+   1051.3660900             0.0139161
+    239.2856900             0.0684053
+     67.3974453             0.2331858
+     21.5199573             0.4712674
+      7.4031013             0.3566185
+S   3   1.00
+     20.8479528            -0.1085070
+      4.8083083            -0.1464517
+      1.3440699             1.1286886
+S   1   1.00
+      0.3581514             1.0000000
+P   3   1.00
+     20.8479528             0.0716287
+      4.8083083             0.3459121
+      1.3440699             0.7224700
+P   1   1.00
+      0.3581514             1.0000000
+****
+"""
+
+# Planar HOF (Cs, plane xy), same frame as the CFOUR run (units bohr, no_com/no_reorient).
+HOF = """
+O  0.00000  0.00000  0.00000
+F  2.56070  0.93200  0.00000
+H -0.83450  1.62360  0.00000
+symmetry c1
+units bohr
+no_com
+no_reorient
+"""
+
+# Equilibrium H2O (C2v), for the cheaper SO == spatial keystone.
+WATER = """
+O  0.00000  0.00000  0.00000
+H  0.00000  1.43121 -1.10664
+H  0.00000 -1.43121 -1.10664
+symmetry c1
+units bohr
+no_com
+no_reorient
+"""
+
+# CFOUR CCSD APT oracles (a.u.), HOF (O, F, H) / CFOUR GENBAS 6-31G, indexed [A, beta, alpha] =
+# d mu_alpha / d R_{A,beta}.  Correlation = DIPDER(CCSD) - DIPDER(SCF); total = DIPDER(CCSD).
+CFOUR_APT_HOF_631G = np.array(
+    [[[-0.2283803199, -0.0899610722, 0.0],
+      [-0.1933533783, 0.0530123216, 0.0],
+      [0.0, 0.0, -0.013744654]],
+     [[0.2499221636, 0.0335685423, 0.0],
+      [0.108335889, 0.0643549674, 0.0],
+      [0.0, 0.0, 0.0445811407]],
+     [[-0.0215418436, 0.0563925299, 0.0],
+      [0.0850174893, -0.117367289, 0.0],
+      [0.0, 0.0, -0.0308364867]]])
+CFOUR_APT_HOF_631G_FC = np.array(
+    [[[-0.2283937397, -0.0900510356, 0.0],
+      [-0.1934653497, 0.0529769499, 0.0],
+      [0.0, 0.0, -0.0137019437]],
+     [[0.2499973509, 0.0335809077, 0.0],
+      [0.1083735179, 0.0644076981, 0.0],
+      [0.0, 0.0, 0.0445741776]],
+     [[-0.0216036112, 0.0564701279, 0.0],
+      [0.0850918319, -0.117384648, 0.0],
+      [0.0, 0.0, -0.030872234]]])
+CFOUR_APT_HOF_631G_TOTAL = np.array(
+    [[[-0.123795074, -0.0503029583, 0.0],
+      [0.107823156, 0.095526844, 0.0],
+      [0.0, 0.0, -0.3786006089]],
+     [[-0.1417913991, -0.0005095643, 0.0],
+      [-0.1371636569, -0.1792474625, 0.0],
+      [0.0, 0.0, -0.0868714428]],
+     [[0.2655864731, 0.0508125226, 0.0],
+      [0.0293405009, 0.0837206185, 0.0],
+      [0.0, 0.0, 0.4654720517]]])
+CFOUR_APT_HOF_631G_TOTAL_FC = np.array(
+    [[[-0.1238084938, -0.0503929217, 0.0],
+      [0.1077111846, 0.0954914723, 0.0],
+      [0.0, 0.0, -0.3785578986]],
+     [[-0.1417162118, -0.0004971989, 0.0],
+      [-0.137126028, -0.1791947318, 0.0],
+      [0.0, 0.0, -0.0868784059]],
+     [[0.2655247055, 0.0508901206, 0.0],
+      [0.0294148435, 0.0837032595, 0.0],
+      [0.0, 0.0, 0.4654363044]]])
+
+
+def _cfour_wfn(geom, freeze_core):
+    """RHF reference in CFOUR's exact GENBAS 6-31G (via basis_helper), for the CFOUR-oracle tests."""
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'scf_type': 'pk', 'freeze_core': freeze_core,
+                      'e_convergence': 1e-13, 'd_convergence': 1e-13})
+    psi4.basis_helper(CFOUR_631G, name='cfour631g')
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    return wfn
+
+
+def _ccsd_apt(geom, freeze_core, orbital_basis):
+    """Converged CCSD APT PropertyComponents for the CFOUR-basis reference."""
+    wfn = _cfour_wfn(geom, freeze_core)
+    cc = pycc.ccwfn(wfn, orbital_basis=orbital_basis)      # model defaults to CCSD
+    cc.solve_cc(1e-12, 1e-12, 100)
+    return pycc.apt(cc)
+
+
+def _check_hof(r, corr_ref, total_ref):
+    """Shared assertions for an HOF CCSD APT run: correlation and total vs the CFOUR oracle, the
+    facade decomposition (total == nuclear + reference + correlation, nuclear == Z_A delta), the Cs
+    out-of-plane (z) block vanishing, and the translational (acoustic) sum rule."""
+    corr = np.asarray(r.correlation)
+    total = np.asarray(r.total)
+    assert np.max(np.abs(corr - corr_ref)) < 1e-9, corr
+    assert np.max(np.abs(total - total_ref)) < 1e-9, total
+    parts = np.asarray(r.nuclear) + np.asarray(r.reference) + np.asarray(r.correlation)
+    assert np.max(np.abs(total - parts)) < 1e-12
+    Z = np.array([8.0, 9.0, 1.0])
+    assert np.max(np.abs(np.asarray(r.nuclear) - Z[:, None, None] * np.eye(3))) < 1e-12
+    assert np.max(np.abs(corr[:, 2, :2])) < 1e-9 and np.max(np.abs(corr[:, :2, 2])) < 1e-9
+    assert np.max(np.abs(np.sum(total, axis=0))) < 1e-9
+    assert np.max(np.abs(np.sum(corr, axis=0))) < 1e-9
+
+
+def test_ccsd_apt_cfour_hof_spatial():
+    """All-electron spatial (closed-shell RHF) CCSD APT for HOF vs the CFOUR DIPDER oracle -- the
+    correlation and total tensors, the exact facade decomposition, the Cs out-of-plane zeros, and the
+    translational sum rule."""
+    _check_hof(_ccsd_apt(HOF, 'false', 'spatial'),
+               CFOUR_APT_HOF_631G, CFOUR_APT_HOF_631G_TOTAL)
+    psi4.core.clean()
+
+
+def test_fc_ccsd_apt_cfour_hof_spatial():
+    """Frozen-core spatial CCSD APT for HOF vs the CFOUR frozen-core oracle -- exercises the
+    frozen-core core<->active response in the perturbed relaxed density; the SCF reference is
+    unchanged by freezing, so the oracle subtracts the same all-electron SCF DIPDER."""
+    _check_hof(_ccsd_apt(HOF, 'true', 'spatial'),
+               CFOUR_APT_HOF_631G_FC, CFOUR_APT_HOF_631G_TOTAL_FC)
+    psi4.core.clean()
+
+
+@pytest.mark.slow
+def test_so_ccsd_apt_cfour_hof():
+    """Spin-orbital CCSD APT for HOF vs the CFOUR oracle (all-electron and frozen core) -- the
+    genuinely spin-orbital path (SO perturbed amplitudes/Lambda and the inline orbital Hessian);
+    marked slow (the SO HOF solve is the expensive case)."""
+    _check_hof(_ccsd_apt(HOF, 'false', 'spinorbital'),
+               CFOUR_APT_HOF_631G, CFOUR_APT_HOF_631G_TOTAL)
+    psi4.core.clean()
+    _check_hof(_ccsd_apt(HOF, 'true', 'spinorbital'),
+               CFOUR_APT_HOF_631G_FC, CFOUR_APT_HOF_631G_TOTAL_FC)
+    psi4.core.clean()
+
+
+def test_ccsd_apt_so_eq_spatial_keystone_water():
+    """SO == spatial keystone (water/6-31G, all-electron and frozen core): the spin-orbital CCSD
+    correlation APT of an RHF reference forced into the spin-orbital basis reproduces the spatial
+    (closed-shell) value.  Cheaper than HOF and independent of the CFOUR oracle."""
+    for fc in ('false', 'true'):
+        wfn = _cfour_wfn(WATER, fc)
+        cc_sa = pycc.ccwfn(wfn, orbital_basis='spatial')
+        cc_sa.solve_cc(1e-12, 1e-12, 100)
+        P_sa = np.asarray(pycc.CCderiv(cc_sa).dipole_derivatives())
+        cc_so = pycc.ccwfn(wfn, orbital_basis='spinorbital')
+        cc_so.solve_cc(1e-12, 1e-12, 100)
+        P_so = np.asarray(pycc.CCderiv(cc_so).dipole_derivatives())
+        assert np.max(np.abs(P_so - P_sa)) < 1e-10, (fc, np.max(np.abs(P_so - P_sa)))
+    psi4.core.clean()
+
+
+def test_ccsd_apt_routes_agree_water():
+    """The two 2n+1 APT routes agree for CCSD (water/6-31G, spatial): '2n+1-field' (default, 3 field
+    solves) and '2n+1-nuclear' (3N nuclear solves) build the same tensor."""
+    wfn = _cfour_wfn(WATER, 'false')
+    cc = pycc.ccwfn(wfn, orbital_basis='spatial')
+    cc.solve_cc(1e-12, 1e-12, 100)
+    Pf = np.asarray(pycc.CCderiv(cc).dipole_derivatives(route='2n+1-field'))
+    Pn = np.asarray(pycc.CCderiv(cc).dipole_derivatives(route='2n+1-nuclear'))
+    assert np.max(np.abs(Pf - Pn)) < 1e-10
+    psi4.core.clean()
+
+
+def test_ccsd_apt_route_guard():
+    """An unknown route raises rather than silently returning a wrong tensor."""
+    wfn = _cfour_wfn(WATER, 'false')
+    cc = pycc.ccwfn(wfn)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    with pytest.raises(ValueError):
+        pycc.CCderiv(cc).dipole_derivatives(route='bogus')
+    psi4.core.clean()


### PR DESCRIPTION
# CCSD/CCSD(T) atomic polar tensors (APTs) via the shared 2n+1 machinery

## Summary

Analytic **atomic polar tensors** (nuclear dipole derivatives, the IR-intensity tensor
`P[A, beta, alpha] = d(mu_alpha)/dX_{A,beta} = -d^2 E_corr/dF_alpha dX_{A,beta}`) for coupled
cluster, exposed through the existing `pycc.apt(wfn)` facade, with CFOUR-anchored regression tests
covering the full matrix:

|            | spatial AE | spatial FC | spin-orbital AE | spin-orbital FC |
|------------|:----------:|:----------:|:---------------:|:---------------:|
| **CCSD**   |     yes    |     yes    |    yes (slow)   |    yes (slow)   |
| **CCSD(T)**|     yes    |     yes    |    yes (slow)   |    yes (slow)   |

## Why it is small

The APT is the mixed field/nuclear analog of the polarizability, and it runs through the same
`CorrelatedDerivs.dipole_derivatives` 2n+1 assembly that already backs the CCSD/CCSD(T) gradient and
polarizability. That assembly consumes the (T)-aware relaxed and perturbed densities the base already
builds (`dt3` threaded through the perturbed amplitudes / Lambda / correlation densities, and the
canonical perturbed-MO oo/vv dependent pairs). So **CCSD(T) needs no APT-specific code** -- the (T)
contribution enters entirely through the densities. This PR supplies the one missing guard and the
regression coverage.

## Changes

- **`pycc/ccderiv.py`** -- new `CCderiv.dipole_derivatives` override that mirrors
  `CCderiv.polarizability`: it adds only the CC method guards (supported model; CCSD(T) requires
  `make_t3_density=True`) and delegates to the base 2n+1 assembly via `super()`. Previously a
  CCSD(T) wavefunction built without `make_t3_density` failed with an opaque `AttributeError` deep in
  the perturbed-density code; it now raises a clear `ValueError`.

- **`pycc/tests/test_088_ccsd_apt.py`** (new) -- CCSD correlation + total APTs.
- **`pycc/tests/test_087_ccsdt_apt.py`** (new) -- CCSD(T) correlation + total APTs.

## Oracle

CFOUR (`xcfour`, `CALC=CCSD` / `CCSD(T)`, `VIB=EXACT`, `SCF_CONV=13`, `CC_CONV=12`) for two planar
molecules, all-electron and frozen core: **HOF** (Cs, plane xy -- the full off-diagonal in-plane
block) and **water** (C2v, plane yz -- the cheaper case whose spin-orbital run is fast). The `DIPDER`
file holds the **total** APT (nuclear + HF + correlation); the correlation contribution is
`DIPDER(method) - DIPDER(SCF)`. Because frozen core is a no-op for HF, the frozen-core correlation
subtracts the same all-electron SCF `DIPDER`, matching pycc whose `reference` block is the
all-electron SCF. `DIPDER` is indexed `[mu, atom, coord]`; pycc is
`[A, beta, alpha] = d mu_alpha / d R_{A,beta}`, so the oracle is `transpose(DIPDER, (1,2,0))`. CFOUR's
exact GENBAS `6-31G` is transcribed in the tests (the same string as `test_084`) so the AO basis
matches to all printed digits; pycc reproduces the 10-digit `DIPDER` to ~1e-10 (the DIPDER
truncation) on both the spatial and spin-orbital routes.

## What each test checks

Both files assert, against the CFOUR oracle (HOF and water):
- correlation APT and total APT to `< 1e-9`;
- the exact facade decomposition `total == nuclear + reference + correlation`, and `nuclear == Z_A delta`;
- the out-of-plane couplings vanish (HOF: z; water: x);
- the translational (acoustic) sum rule (sum over atoms is zero for a neutral molecule);
- the two 2n+1 routes (`2n+1-field` default, `2n+1-nuclear`) agree.
- the guards (unknown route; CCSD(T) without `make_t3_density`).

Coverage of the four spatial/SO x AE/FC combos is CFOUR-anchored on **both** molecules. The
spin-orbital route is anchored directly against CFOUR on **water in the default (non-slow) suite**
(SO CCSD(T)/water ~30 s, SO CCSD/water ~5 s). The SO **HOF** cases are marked `slow` (skipped by
default; they run and pass -- SO CCSD(T)/HOF ~3.7 min, SO CCSD/HOF ~0.5 min) and remain as the
off-diagonal (Cs) SO anchor. (SO == spatial then holds transitively, since SO and spatial are each
CFOUR-anchored.)

## Test status

`pytest pycc/tests/test_087_ccsdt_apt.py pycc/tests/test_088_ccsd_apt.py` -- 12 passing by default,
2 additional `slow` cases (SO HOF) run and pass (`-m slow`).

## Notes / follow-ups (not in this PR)

- The `pycc.properties` UI refinement remains deferred pending PI specifics (tracked separately).
