### PR TITLE
CCSD/CCSD(T) molecular (nuclear) Hessians via the shared 2n+1 machinery

### DIFF
--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -139,6 +139,32 @@ class CCderiv(CorrelatedDerivs):
                              "build the wavefunction with make_t3_density=True.")
         return super().dipole_derivatives(route)    # shared 2n+1 assembly (SO/spatial dispatch in the base)
 
+    def hessian(self, route: str = '2n+1') -> np.ndarray:
+        """CCSD/CCSD(T) **correlation** contribution to the molecular (nuclear) Hessian (a.u.), shape
+        ``(3*natom, 3*natom)`` indexed ``(A*3+a, B*3+b)`` = ``d^2 E_corr / dX_{Aa} dX_{Bb}`` -- the
+        nuclear-nuclear analog of :meth:`polarizability` / :meth:`dipole_derivatives`.
+
+        ``route`` accepts only ``'2n+1'`` (``3N`` nuclear perturbed solves).  The nuclear-repulsion
+        second derivative and the SCF reference Hessian are kept separate
+        (:meth:`HFwfn.hessian` / :meth:`Derivatives.nuclear_repulsion2`) and summed with this
+        correlation part by :func:`pycc.hessian`.
+
+        Spatial closed-shell RHF and spin-orbital UHF, CCSD and CCSD(T), all-electron and frozen
+        core.  As for the APT, the (T) contribution enters entirely through the (T)-aware relaxed and
+        perturbed densities the shared base already builds (no Hessian-specific (T) code); validated
+        against a CFOUR FCMFINAL oracle (``FCMFINAL(CCSD(T)) - FCMFINAL(SCF)``, see
+        ``test_089_ccsdt_hessian``).
+
+        Overrides :meth:`CorrelatedDerivs.hessian` only to add the CC method-specific guards
+        (supported model, (T) density intermediates); the shared 2n+1 assembly runs via ``super()``."""
+        cc = self.ccwfn
+        if cc.model.upper() not in ('CCSD', 'CCSD(T)'):
+            raise NotImplementedError(f"CC hessian: only CCSD and CCSD(T) are implemented (not {cc.model}).")
+        if cc.model.upper() == 'CCSD(T)' and not hasattr(cc, 'S1'):
+            raise ValueError("CCSD(T) hessian requires the (T) density intermediates; "
+                             "build the wavefunction with make_t3_density=True.")
+        return super().hessian(route)               # shared 2n+1 assembly (SO/spatial dispatch in the base)
+
     def _perturbed_unrelaxed_densities(self, pert, df, deri, dL):
         """CC perturbed unrelaxed densities ``(d_x gamma, d_x Gamma)`` -- the base
         :meth:`CorrelatedDerivs._perturbed_unrelaxed_densities` hook.  Runs the iterative perturbed

--- a/pycc/tests/test_089_ccsdt_hessian.py
+++ b/pycc/tests/test_089_ccsdt_hessian.py
@@ -1,0 +1,270 @@
+"""CCSD(T) molecular (nuclear) Hessian (correlation contribution) via the 2n+1 route --
+H_corr[Aa,Bb] = d^2 E_corr / dX_{Aa} dX_{Bb}, the nuclear-nuclear analog of the CCSD(T)
+polarizability (test_084) and APT (test_087).
+
+As for the APT, the (T) contribution needs no Hessian-specific code: the base
+CorrelatedDerivs.hessian 2n+1 assembly (3N nuclear perturbed solves plus the full nuclear-nuclear
+second skeletons) consumes the same (T)-aware relaxed and perturbed densities the CCSD(T) gradient,
+polarizability, and APT already build (dt3 threaded through the perturbed amplitudes/Lambda/
+densities, canonical perturbed-MO oo/vv dependent pairs).  CCderiv.hessian adds only the method
+guards (supported model; CCSD(T) requires make_t3_density) and delegates to the base.
+
+Oracle: CFOUR (xcfour, CALC=CCSD(T), VIB=EXACT, SCF_CONV=13, CC_CONV=12).  FCMFINAL holds the TOTAL
+force-constant matrix; the correlation contribution is FCMFINAL(CCSD(T)) - FCMFINAL(SCF) (frozen core
+is a no-op for HF, so the frozen-core correlation subtracts the same all-electron SCF FCMFINAL,
+matching pycc whose reference block is the all-electron SCF).  FCMFINAL is row-major (A*3+a, B*3+b),
+the same index order as pycc.  CFOUR's exact GENBAS 6-31G is transcribed here (same string as
+test_084/087) so the AO basis matches to all printed digits; pycc reproduces the 10-digit FCMFINAL to
+~1e-10.
+
+The Hessian's 3N nuclear solves make it much costlier than the APT/polarizability, so the tiers are
+tighter: water/6-31G (C2v) carries the default suite -- spatial (AE + FC) and the spin-orbital
+all-electron case (the direct SO-(T) CFOUR anchor, ~55 s).  The spin-orbital frozen-core water case
+and the HOF (Cs) spatial cross-check are marked slow.  The spin-orbital HOF CCSD(T) Hessian (~8.5 min
+per build) is not included; SO-(T) is anchored on water and HOF-(T) spatially.
+"""
+
+import psi4
+import pycc
+import numpy as np
+import pytest
+
+
+CFOUR_631G = """cartesian
+****
+H     0
+S   3   1.00
+     18.7311370             0.0334946
+      2.8253944             0.2347270
+      0.6401217             0.8137573
+S   1   1.00
+      0.1612778             1.0000000
+****
+O     0
+S   6   1.00
+   5484.6716600             0.0018311
+    825.2349460             0.0139502
+    188.0469580             0.0684451
+     52.9645000             0.2327143
+     16.8975704             0.4701929
+      5.7996353             0.3585209
+S   3   1.00
+     15.5396162            -0.1107775
+      3.5999336            -0.1480263
+      1.0137618             1.1307670
+S   1   1.00
+      0.2700058             1.0000000
+P   3   1.00
+     15.5396162             0.0708743
+      3.5999336             0.3397528
+      1.0137618             0.7271586
+P   1   1.00
+      0.2700058             1.0000000
+****
+F     0
+S   6   1.00
+   7001.7130900             0.0018196
+   1051.3660900             0.0139161
+    239.2856900             0.0684053
+     67.3974453             0.2331858
+     21.5199573             0.4712674
+      7.4031013             0.3566185
+S   3   1.00
+     20.8479528            -0.1085070
+      4.8083083            -0.1464517
+      1.3440699             1.1286886
+S   1   1.00
+      0.3581514             1.0000000
+P   3   1.00
+     20.8479528             0.0716287
+      4.8083083             0.3459121
+      1.3440699             0.7224700
+P   1   1.00
+      0.3581514             1.0000000
+****
+"""
+
+WATER = """
+O  0.00000  0.00000  0.00000
+H  0.00000  1.43121 -1.10664
+H  0.00000 -1.43121 -1.10664
+symmetry c1
+units bohr
+no_com
+no_reorient
+"""
+
+HOF = """
+O  0.00000  0.00000  0.00000
+F  2.56070  0.93200  0.00000
+H -0.83450  1.62360  0.00000
+symmetry c1
+units bohr
+no_com
+no_reorient
+"""
+
+# CFOUR CCSD(T) correlation Hessians (a.u.), FCMFINAL(CCSD(T)) - FCMFINAL(SCF), row-major (A*3+a, B*3+b).
+CFOUR_HESS_T_WATER = np.array(
+    [[-0.0318157571,  0.          ,  0.          ,  0.0159078786,  0.          ,  0.          ,
+       0.0159078786, -0.          ,  0.          ],
+     [ 0.          , -0.0108003877,  0.          ,  0.          ,  0.0054001939,  0.0081247505,
+      -0.          ,  0.0054001939, -0.0081247505],
+     [ 0.          ,  0.          , -0.039088771 ,  0.          ,  0.0047811046,  0.0195443856,
+       0.          , -0.0047811046,  0.0195443856],
+     [ 0.0159078786,  0.          ,  0.          , -0.0146150076, -0.          ,  0.          ,
+      -0.0012928709,  0.          ,  0.          ],
+     [ 0.          ,  0.0054001939,  0.0047811046, -0.          , -0.0060683374, -0.0064529276,
+       0.          ,  0.0006681436,  0.001671823 ],
+     [ 0.          ,  0.0081247507,  0.0195443856,  0.          , -0.0064529277, -0.0132921518,
+       0.          , -0.0016718231, -0.0062522337],
+     [ 0.0159078786, -0.          ,  0.          , -0.0012928709,  0.          ,  0.          ,
+      -0.0146150076,  0.          ,  0.          ],
+     [-0.          ,  0.0054001939, -0.0047811046,  0.          ,  0.0006681436, -0.001671823 ,
+       0.          , -0.0060683374,  0.0064529276],
+     [ 0.          , -0.0081247507,  0.0195443856,  0.          ,  0.0016718231, -0.0062522337,
+       0.          ,  0.0064529277, -0.0132921518]])
+CFOUR_HESS_T_WATER_FC = np.array(
+    [[-0.0318820814,  0.          ,  0.          ,  0.0159410408,  0.          ,  0.          ,
+       0.0159410408, -0.          ,  0.          ],
+     [ 0.          , -0.0106817843,  0.          ,  0.          ,  0.0053408921,  0.0081962453,
+      -0.          ,  0.0053408921, -0.0081962453],
+     [ 0.          ,  0.          , -0.038974217 ,  0.          ,  0.0048511178,  0.0194871086,
+       0.          , -0.0048511178,  0.0194871086],
+     [ 0.0159410408,  0.          ,  0.          , -0.0146415199, -0.          ,  0.          ,
+      -0.0012995208,  0.          ,  0.          ],
+     [ 0.          ,  0.0053408921,  0.0048511178, -0.          , -0.0060145929, -0.0065236817,
+       0.          ,  0.0006737007,  0.0016725637],
+     [ 0.          ,  0.0081962453,  0.0194871086,  0.          , -0.0065236817, -0.013245804 ,
+       0.          , -0.0016725637, -0.0062413046],
+     [ 0.0159410408, -0.          ,  0.          , -0.0012995208,  0.          ,  0.          ,
+      -0.0146415199,  0.          ,  0.          ],
+     [-0.          ,  0.0053408921, -0.0048511178,  0.          ,  0.0006737007, -0.0016725637,
+       0.          , -0.0060145929,  0.0065236817],
+     [ 0.          , -0.0081962453,  0.0194871086,  0.          ,  0.0016725637, -0.0062413046,
+       0.          ,  0.0065236817, -0.013245804 ]])
+CFOUR_HESS_T_HOF = np.array(
+    [[-0.0267392581, -0.0009548925,  0.          ,  0.0107396156, -0.0029320561,  0.          ,
+       0.0159996425,  0.0038869486, -0.          ],
+     [-0.0009548924, -0.0360010422,  0.          , -0.0085422723,  0.0234676607,  0.          ,
+       0.0094971648,  0.0125333815,  0.          ],
+     [ 0.          , -0.          , -0.038063371 ,  0.          ,  0.          ,  0.0217778677,
+      -0.          ,  0.          ,  0.0162855032],
+     [ 0.0107396156, -0.0085422722,  0.          , -0.0150803169,  0.0060529887, -0.          ,
+       0.0043407013,  0.0024892836,  0.          ],
+     [-0.0029320561,  0.0234676606,  0.          ,  0.0060529887, -0.021831902 ,  0.          ,
+      -0.0031209325, -0.0016357587,  0.          ],
+     [ 0.          ,  0.          ,  0.0217778676, -0.          ,  0.          , -0.0215857036,
+       0.          , -0.          , -0.0001921641],
+     [ 0.0159996425,  0.0094971648, -0.          ,  0.0043407013, -0.0031209325,  0.          ,
+      -0.0203403439, -0.0063762322,  0.          ],
+     [ 0.0038869485,  0.0125333816,  0.          ,  0.0024892837, -0.0016357588, -0.          ,
+      -0.0063762322, -0.0108976228, -0.          ],
+     [-0.          ,  0.          ,  0.0162855033,  0.          ,  0.          , -0.0001921642,
+       0.          ,  0.          , -0.0160933392]])
+CFOUR_HESS_T_HOF_FC = np.array(
+    [[-0.0267132577, -0.0009874858,  0.          ,  0.010721736 , -0.0029446097,  0.          ,
+       0.0159915217,  0.0039320954, -0.          ],
+     [-0.0009874858, -0.0359045783,  0.          , -0.0085618486,  0.0234649825,  0.          ,
+       0.0095493343,  0.0124395958,  0.          ],
+     [ 0.          , -0.          , -0.0380915628,  0.          ,  0.          ,  0.0217862544,
+      -0.          ,  0.          ,  0.0163053083],
+     [ 0.0107217359, -0.0085618486,  0.          , -0.0150694409,  0.0060666971, -0.          ,
+       0.004347705 ,  0.0024951514,  0.          ],
+     [-0.0029446097,  0.0234649826,  0.          ,  0.0060666971, -0.0218330826,  0.          ,
+      -0.0031220874, -0.0016319001,  0.          ],
+     [ 0.          ,  0.          ,  0.0217862544, -0.          ,  0.          , -0.0215928145,
+       0.          , -0.          , -0.00019344  ],
+     [ 0.0159915218,  0.0095493343, -0.          ,  0.0043477049, -0.0031220874,  0.          ,
+      -0.0203392267, -0.0064272468,  0.          ],
+     [ 0.0039320954,  0.0124395957,  0.          ,  0.0024951514, -0.0016319   , -0.          ,
+      -0.0064272468, -0.0108076957, -0.          ],
+     [-0.          ,  0.          ,  0.0163053083,  0.          ,  0.          , -0.00019344  ,
+       0.          ,  0.          , -0.0161118684]])
+
+
+def _cfour_wfn(geom, freeze_core):
+    """RHF reference in CFOUR's exact GENBAS 6-31G (via basis_helper), for the CFOUR-oracle tests."""
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'scf_type': 'pk', 'freeze_core': freeze_core,
+                      'e_convergence': 1e-13, 'd_convergence': 1e-13})
+    psi4.basis_helper(CFOUR_631G, name='cfour631g')
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    return wfn
+
+
+def _ccsdt_hess(geom, freeze_core, orbital_basis):
+    """Converged CCSD(T) Hessian PropertyComponents for the CFOUR-basis reference."""
+    wfn = _cfour_wfn(geom, freeze_core)
+    cc = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis=orbital_basis, make_t3_density=True)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    return pycc.hessian(cc)
+
+
+def _check(r, corr_ref):
+    """Shared assertions for a CCSD(T) Hessian run vs the CFOUR oracle: the full 9x9 correlation
+    matrix, the facade decomposition (total == nuclear + reference + correlation), and the FD-free
+    physics checks -- symmetry and the translational (acoustic) sum rule (E_corr is invariant under
+    uniform translation, so summing over the second atom vanishes)."""
+    corr = np.asarray(r.correlation)
+    total = np.asarray(r.total)
+    assert corr.shape == (9, 9)
+    assert np.max(np.abs(corr - corr_ref)) < 1e-9, np.max(np.abs(corr - corr_ref))
+    parts = np.asarray(r.nuclear) + np.asarray(r.reference) + np.asarray(r.correlation)
+    assert np.max(np.abs(total - parts)) < 1e-12
+    assert np.max(np.abs(corr - corr.T)) < 1e-8
+    assert np.max(np.abs(corr.reshape(3, 3, 3, 3).sum(axis=2))) < 1e-8
+
+
+def test_ccsdt_hessian_cfour_water_spatial():
+    """All-electron and frozen-core spatial CCSD(T) Hessian for water/6-31G vs the CFOUR FCMFINAL
+    oracle -- the full correlation matrix, the facade decomposition, symmetry, and the translational
+    sum rule.  Exercises the (T) core<->active and active oo/vv dependent-pair response in the
+    perturbed relaxed density (frozen-core case)."""
+    _check(_ccsdt_hess(WATER, 'false', 'spatial'), CFOUR_HESS_T_WATER)
+    psi4.core.clean()
+    _check(_ccsdt_hess(WATER, 'true', 'spatial'), CFOUR_HESS_T_WATER_FC)
+    psi4.core.clean()
+
+
+def test_so_ccsdt_hessian_cfour_water():
+    """All-electron spin-orbital CCSD(T) Hessian for water/6-31G vs the CFOUR oracle -- the direct
+    SO-(T) CFOUR anchor kept in the default suite (~55 s).  The genuine SO path (SO perturbed
+    amplitudes/Lambda/(T) intermediates, inline orbital Hessian, nuclear-nuclear second skeletons)."""
+    _check(_ccsdt_hess(WATER, 'false', 'spinorbital'), CFOUR_HESS_T_WATER)
+    psi4.core.clean()
+
+
+@pytest.mark.slow
+def test_fc_so_ccsdt_hessian_cfour_water():
+    """Frozen-core spin-orbital CCSD(T) Hessian for water/6-31G vs the CFOUR oracle -- the SO (T)
+    frozen-core case (core<->active response through the SO perturbed densities).  Marked slow."""
+    _check(_ccsdt_hess(WATER, 'true', 'spinorbital'), CFOUR_HESS_T_WATER_FC)
+    psi4.core.clean()
+
+
+@pytest.mark.slow
+def test_ccsdt_hessian_cfour_hof_spatial():
+    """Second-geometry cross-check: spatial CCSD(T) Hessian for HOF/6-31G (Cs) vs the CFOUR oracle
+    (all-electron and frozen core).  Marked slow."""
+    _check(_ccsdt_hess(HOF, 'false', 'spatial'), CFOUR_HESS_T_HOF)
+    psi4.core.clean()
+    _check(_ccsdt_hess(HOF, 'true', 'spatial'), CFOUR_HESS_T_HOF_FC)
+    psi4.core.clean()
+
+
+def test_ccsdt_hessian_guards():
+    """The misused paths raise rather than silently returning a wrong matrix: CCSD(T) built without
+    the (T) density intermediates (make_t3_density), and an unknown route."""
+    wfn = _cfour_wfn(WATER, 'false')
+    cc_t = pycc.ccwfn(wfn, model='ccsd(t)')                     # CCSD(T), no make_t3_density
+    cc_t.solve_cc(1e-12, 1e-12, 100)
+    with pytest.raises(ValueError):                             # (T) needs make_t3_density
+        pycc.CCderiv(cc_t).hessian()
+    cc = pycc.ccwfn(wfn)                                        # plain CCSD: reaches the route check
+    cc.solve_cc(1e-12, 1e-12, 100)
+    with pytest.raises(ValueError):                             # unknown route
+        pycc.CCderiv(cc).hessian(route='bogus')
+    psi4.core.clean()

--- a/pycc/tests/test_090_ccsd_hessian.py
+++ b/pycc/tests/test_090_ccsd_hessian.py
@@ -1,0 +1,264 @@
+"""CCSD molecular (nuclear) Hessian (correlation contribution) via the 2n+1 route --
+H_corr[Aa,Bb] = d^2 E_corr / dX_{Aa} dX_{Bb}, the nuclear-nuclear analog of the CCSD polarizability
+(test_084) and APT (test_088).
+
+The correlation Hessian is the base CorrelatedDerivs.hessian 2n+1 assembly (3N nuclear perturbed
+solves of the relaxed / energy-weighted density plus the full nuclear-nuclear second skeletons) on
+the CCSD relaxed and perturbed densities; CCderiv.hessian adds only the method guards and delegates
+to the base. The reference (SCF) Hessian carries the nuclear-repulsion second derivative and is kept
+separate; pycc.hessian sums nuclear + reference + this correlation part.
+
+Oracle: CFOUR (xcfour, CALC=CCSD, VIB=EXACT, SCF_CONV=13, CC_CONV=12).  The FCMFINAL file holds the
+TOTAL force-constant matrix (nuclear + HF + correlation); the correlation contribution is
+FCMFINAL(CCSD) - FCMFINAL(SCF) (frozen core is a no-op for HF, so the frozen-core correlation
+subtracts the same all-electron SCF FCMFINAL, matching pycc whose reference block is the all-electron
+SCF).  FCMFINAL is row-major (A*3+a, B*3+b), the same index order as pycc.  CFOUR's exact GENBAS
+6-31G is transcribed here (same string as test_084/087) so the AO basis matches to all printed
+digits; pycc reproduces the 10-digit FCMFINAL to ~1e-10 (the FCMFINAL truncation).
+
+Water/6-31G (C2v) is the primary anchor and, being cheap, carries the default (non-slow) suite for
+both the spatial and spin-orbital routes; HOF/6-31G (Cs) is a slower second-geometry cross-check.
+"""
+
+import psi4
+import pycc
+import numpy as np
+import pytest
+
+
+CFOUR_631G = """cartesian
+****
+H     0
+S   3   1.00
+     18.7311370             0.0334946
+      2.8253944             0.2347270
+      0.6401217             0.8137573
+S   1   1.00
+      0.1612778             1.0000000
+****
+O     0
+S   6   1.00
+   5484.6716600             0.0018311
+    825.2349460             0.0139502
+    188.0469580             0.0684451
+     52.9645000             0.2327143
+     16.8975704             0.4701929
+      5.7996353             0.3585209
+S   3   1.00
+     15.5396162            -0.1107775
+      3.5999336            -0.1480263
+      1.0137618             1.1307670
+S   1   1.00
+      0.2700058             1.0000000
+P   3   1.00
+     15.5396162             0.0708743
+      3.5999336             0.3397528
+      1.0137618             0.7271586
+P   1   1.00
+      0.2700058             1.0000000
+****
+F     0
+S   6   1.00
+   7001.7130900             0.0018196
+   1051.3660900             0.0139161
+    239.2856900             0.0684053
+     67.3974453             0.2331858
+     21.5199573             0.4712674
+      7.4031013             0.3566185
+S   3   1.00
+     20.8479528            -0.1085070
+      4.8083083            -0.1464517
+      1.3440699             1.1286886
+S   1   1.00
+      0.3581514             1.0000000
+P   3   1.00
+     20.8479528             0.0716287
+      4.8083083             0.3459121
+      1.3440699             0.7224700
+P   1   1.00
+      0.3581514             1.0000000
+****
+"""
+
+WATER = """
+O  0.00000  0.00000  0.00000
+H  0.00000  1.43121 -1.10664
+H  0.00000 -1.43121 -1.10664
+symmetry c1
+units bohr
+no_com
+no_reorient
+"""
+
+HOF = """
+O  0.00000  0.00000  0.00000
+F  2.56070  0.93200  0.00000
+H -0.83450  1.62360  0.00000
+symmetry c1
+units bohr
+no_com
+no_reorient
+"""
+
+# CFOUR CCSD correlation Hessians (a.u.), FCMFINAL(CCSD) - FCMFINAL(SCF), row-major (A*3+a, B*3+b).
+CFOUR_HESS_WATER = np.array(
+    [[-0.0308188741,  0.          ,  0.          ,  0.0154094371,  0.          ,  0.          ,
+       0.0154094371, -0.          ,  0.          ],
+     [ 0.          , -0.0092226159,  0.          ,  0.          ,  0.0046113079,  0.008349328 ,
+      -0.          ,  0.0046113079, -0.008349328 ],
+     [ 0.          ,  0.          , -0.0363638331,  0.          ,  0.0054010052,  0.0181819166,
+       0.          , -0.0054010052,  0.0181819166],
+     [ 0.0154094371,  0.          ,  0.          , -0.0141424341, -0.          ,  0.          ,
+      -0.001267003 ,  0.          ,  0.          ],
+     [ 0.          ,  0.0046113079,  0.0054010052, -0.          , -0.0050377578, -0.0068751667,
+       0.          ,  0.0004264498,  0.0014741614],
+     [ 0.          ,  0.008349328 ,  0.0181819166,  0.          , -0.0068751667, -0.0123007408,
+       0.          , -0.0014741614, -0.0058811758],
+     [ 0.0154094371, -0.          ,  0.          , -0.001267003 ,  0.          ,  0.          ,
+      -0.0141424341,  0.          ,  0.          ],
+     [-0.          ,  0.0046113079, -0.0054010052,  0.          ,  0.0004264498, -0.0014741614,
+       0.          , -0.0050377578,  0.0068751667],
+     [ 0.          , -0.008349328 ,  0.0181819166,  0.          ,  0.0014741614, -0.0058811758,
+       0.          ,  0.0068751667, -0.0123007408]])
+CFOUR_HESS_WATER_FC = np.array(
+    [[-0.0308883645,  0.          ,  0.          ,  0.0154441824,  0.          ,  0.          ,
+       0.0154441824, -0.          ,  0.          ],
+     [ 0.          , -0.0091156512,  0.          ,  0.          ,  0.0045578256,  0.0084175471,
+      -0.          ,  0.0045578256, -0.0084175471],
+     [ 0.          ,  0.          , -0.0362627154,  0.          ,  0.0054677955,  0.0181313578,
+       0.          , -0.0054677955,  0.0181313578],
+     [ 0.0154441824,  0.          ,  0.          , -0.0141704769, -0.          ,  0.          ,
+      -0.0012737054,  0.          ,  0.          ],
+     [ 0.          ,  0.0045578256,  0.0054677956, -0.          , -0.0049891396, -0.0069426715,
+       0.          ,  0.000431314 ,  0.0014748758],
+     [ 0.          ,  0.0084175472,  0.0181313578,  0.          , -0.0069426715, -0.0122597573,
+       0.          , -0.0014748759, -0.0058716004],
+     [ 0.0154441824, -0.          ,  0.          , -0.0012737054,  0.          ,  0.          ,
+      -0.0141704769,  0.          ,  0.          ],
+     [-0.          ,  0.0045578256, -0.0054677956,  0.          ,  0.000431314 , -0.0014748758,
+       0.          , -0.0049891396,  0.0069426715],
+     [ 0.          , -0.0084175472,  0.0181313578,  0.          ,  0.0014748759, -0.0058716004,
+       0.          ,  0.0069426715, -0.0122597573]])
+CFOUR_HESS_HOF = np.array(
+    [[-0.0187302056,  0.0019866565,  0.          ,  0.0042677948, -0.0050917598,  0.          ,
+       0.0144624108,  0.0031051032, -0.          ],
+     [ 0.0019866566, -0.0297889719,  0.          , -0.0111083661,  0.0194693731,  0.          ,
+       0.0091217096,  0.0103195988,  0.          ],
+     [ 0.          , -0.          , -0.0347973108,  0.          ,  0.          ,  0.0193876249,
+      -0.          ,  0.          ,  0.0154096858],
+     [ 0.0042677948, -0.011108366 ,  0.          , -0.0081442929,  0.0076985441, -0.          ,
+       0.0038764981,  0.0034098219,  0.          ],
+     [-0.0050917598,  0.0194693731,  0.          ,  0.0076985441, -0.0184029217,  0.          ,
+      -0.0026067843, -0.0010664515,  0.          ],
+     [ 0.          ,  0.          ,  0.0193876249, -0.          ,  0.          , -0.0192495431,
+       0.          , -0.          , -0.0001380818],
+     [ 0.0144624108,  0.0091217096, -0.          ,  0.0038764981, -0.0026067843,  0.          ,
+      -0.0183389089, -0.0065149251,  0.          ],
+     [ 0.0031051031,  0.0103195988,  0.          ,  0.003409822 , -0.0010664515, -0.          ,
+      -0.0065149251, -0.0092531473, -0.          ],
+     [-0.          ,  0.          ,  0.0154096858,  0.          ,  0.          , -0.0001380818,
+       0.          ,  0.          , -0.0152716041]])
+CFOUR_HESS_HOF_FC = np.array(
+    [[-0.018737059 ,  0.0019535633,  0.          ,  0.0042803695, -0.00509794  ,  0.          ,
+       0.0144566895,  0.0031443766, -0.          ],
+     [ 0.0019535632, -0.0297108973,  0.          , -0.0111255029,  0.0194780839,  0.          ,
+       0.0091719397,  0.0102328134,  0.          ],
+     [ 0.          , -0.          , -0.0348365012,  0.          ,  0.          ,  0.0194058422,
+      -0.          ,  0.          ,  0.015430659 ],
+     [ 0.0042803695, -0.0111255029,  0.          , -0.0081665372,  0.0077065306, -0.          ,
+       0.0038861677,  0.0034189723,  0.          ],
+     [-0.0050979399,  0.0194780839,  0.          ,  0.0077065306, -0.0184162175,  0.          ,
+      -0.0026085906, -0.0010618666,  0.          ],
+     [ 0.          ,  0.          ,  0.0194058422, -0.          ,  0.          , -0.0192665042,
+       0.          , -0.          , -0.0001393381],
+     [ 0.0144566895,  0.0091719396, -0.          ,  0.0038861677, -0.0026085905,  0.          ,
+      -0.0183428572, -0.006563349 ,  0.          ],
+     [ 0.0031443766,  0.0102328134,  0.          ,  0.0034189723, -0.0010618666, -0.          ,
+      -0.006563349 , -0.0091709468, -0.          ],
+     [-0.          ,  0.          ,  0.015430659 ,  0.          ,  0.          , -0.0001393381,
+       0.          ,  0.          , -0.015291321 ]])
+
+
+def _cfour_wfn(geom, freeze_core):
+    """RHF reference in CFOUR's exact GENBAS 6-31G (via basis_helper), for the CFOUR-oracle tests."""
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(geom)
+    psi4.set_options({'scf_type': 'pk', 'freeze_core': freeze_core,
+                      'e_convergence': 1e-13, 'd_convergence': 1e-13})
+    psi4.basis_helper(CFOUR_631G, name='cfour631g')
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    return wfn
+
+
+def _ccsd_hess(geom, freeze_core, orbital_basis):
+    """Converged CCSD Hessian PropertyComponents for the CFOUR-basis reference."""
+    wfn = _cfour_wfn(geom, freeze_core)
+    cc = pycc.ccwfn(wfn, orbital_basis=orbital_basis)      # model defaults to CCSD
+    cc.solve_cc(1e-12, 1e-12, 100)
+    return pycc.hessian(cc)
+
+
+def _check(r, corr_ref):
+    """Shared assertions for a CCSD Hessian run vs the CFOUR oracle: the full 9x9 correlation matrix,
+    the facade decomposition (total == nuclear + reference + correlation), and the FD-free physics
+    checks -- symmetry and the translational (acoustic) sum rule (E_corr is invariant under uniform
+    translation, so summing over the second atom vanishes)."""
+    corr = np.asarray(r.correlation)
+    total = np.asarray(r.total)
+    assert corr.shape == (9, 9)
+    assert np.max(np.abs(corr - corr_ref)) < 1e-9, np.max(np.abs(corr - corr_ref))
+    parts = np.asarray(r.nuclear) + np.asarray(r.reference) + np.asarray(r.correlation)
+    assert np.max(np.abs(total - parts)) < 1e-12
+    assert np.max(np.abs(corr - corr.T)) < 1e-8
+    assert np.max(np.abs(corr.reshape(3, 3, 3, 3).sum(axis=2))) < 1e-8
+
+
+def test_ccsd_hessian_cfour_water_spatial():
+    """All-electron and frozen-core spatial (closed-shell RHF) CCSD Hessian for water/6-31G vs the
+    CFOUR FCMFINAL oracle -- the full correlation matrix, the facade decomposition, symmetry, and the
+    translational sum rule."""
+    _check(_ccsd_hess(WATER, 'false', 'spatial'), CFOUR_HESS_WATER)
+    psi4.core.clean()
+    _check(_ccsd_hess(WATER, 'true', 'spatial'), CFOUR_HESS_WATER_FC)
+    psi4.core.clean()
+
+
+def test_so_ccsd_hessian_cfour_water():
+    """Spin-orbital CCSD Hessian for water/6-31G vs the CFOUR oracle (all-electron and frozen core) --
+    the direct SO-vs-CFOUR anchor, fast enough for the default suite (SO perturbed amplitudes/Lambda,
+    inline orbital Hessian, and the nuclear-nuclear second skeletons)."""
+    _check(_ccsd_hess(WATER, 'false', 'spinorbital'), CFOUR_HESS_WATER)
+    psi4.core.clean()
+    _check(_ccsd_hess(WATER, 'true', 'spinorbital'), CFOUR_HESS_WATER_FC)
+    psi4.core.clean()
+
+
+@pytest.mark.slow
+def test_ccsd_hessian_cfour_hof_spatial():
+    """Second-geometry cross-check: spatial CCSD Hessian for HOF/6-31G (Cs) vs the CFOUR oracle
+    (all-electron and frozen core).  Marked slow."""
+    _check(_ccsd_hess(HOF, 'false', 'spatial'), CFOUR_HESS_HOF)
+    psi4.core.clean()
+    _check(_ccsd_hess(HOF, 'true', 'spatial'), CFOUR_HESS_HOF_FC)
+    psi4.core.clean()
+
+
+@pytest.mark.slow
+def test_so_ccsd_hessian_cfour_hof():
+    """Spin-orbital CCSD Hessian for HOF/6-31G vs the CFOUR oracle (all-electron and frozen core) --
+    the off-diagonal (Cs) SO cross-check.  Marked slow."""
+    _check(_ccsd_hess(HOF, 'false', 'spinorbital'), CFOUR_HESS_HOF)
+    psi4.core.clean()
+    _check(_ccsd_hess(HOF, 'true', 'spinorbital'), CFOUR_HESS_HOF_FC)
+    psi4.core.clean()
+
+
+def test_ccsd_hessian_route_guard():
+    """An unknown Hessian route raises rather than silently returning a wrong matrix (only '2n+1')."""
+    wfn = _cfour_wfn(WATER, 'false')
+    cc = pycc.ccwfn(wfn)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    with pytest.raises(ValueError):
+        pycc.CCderiv(cc).hessian(route='bogus')
+    psi4.core.clean()


### PR DESCRIPTION
# CCSD/CCSD(T) molecular (nuclear) Hessians via the shared 2n+1 machinery

## Summary

Analytic **molecular Hessians** (`H_corr[Aa,Bb] = d^2 E_corr / dX_{Aa} dX_{Bb}`) for coupled cluster,
exposed through the existing `pycc.hessian(wfn)` facade, with CFOUR-anchored regression tests.
Coverage (all CFOUR-anchored on water; HOF as a slow second-geometry cross-check):

|            | spatial AE | spatial FC | spin-orbital AE | spin-orbital FC |
|------------|:----------:|:----------:|:---------------:|:---------------:|
| **CCSD**   |     yes    |     yes    |       yes       |       yes       |
| **CCSD(T)**|     yes    |     yes    |       yes       |    yes (slow)   |

## Why it is small

The Hessian is the nuclear-nuclear analog of the polarizability/APT and runs through the same
`CorrelatedDerivs.hessian` 2n+1 assembly (`3N` nuclear perturbed solves plus the full nuclear-nuclear
second skeletons). That assembly consumes the (T)-aware relaxed and perturbed densities the base
already builds (`dt3` threaded through the perturbed amplitudes / Lambda / correlation densities, and
the canonical perturbed-MO oo/vv dependent pairs). So **CCSD(T) needs no Hessian-specific code** --
the (T) contribution enters entirely through the densities. This PR supplies the one missing guard
and the regression coverage.

## Changes

- **`pycc/ccderiv.py`** -- new `CCderiv.hessian` override that mirrors `CCderiv.dipole_derivatives`:
  it adds only the CC method guards (supported model; CCSD(T) requires `make_t3_density=True`) and
  delegates to the base 2n+1 assembly via `super()`. Previously a CCSD(T) wavefunction built without
  `make_t3_density` failed with an opaque `AttributeError` in the perturbed-density code; it now
  raises a clear `ValueError`.
- **`pycc/tests/test_090_ccsd_hessian.py`** (new) -- CCSD correlation Hessian.
- **`pycc/tests/test_089_ccsdt_hessian.py`** (new) -- CCSD(T) correlation Hessian.

## Oracle

CFOUR (`xcfour`, `CALC=CCSD` / `CCSD(T)`, `VIB=EXACT`, `SCF_CONV=13`, `CC_CONV=12`). The `FCMFINAL`
file holds the **total** force-constant matrix (nuclear + HF + correlation); the correlation
contribution is `FCMFINAL(method) - FCMFINAL(SCF)`. Because frozen core is a no-op for HF, the
frozen-core correlation subtracts the same all-electron SCF `FCMFINAL`, matching pycc whose
`reference` block is the all-electron SCF. `FCMFINAL` is row-major `(A*3+a, B*3+b)`, the same index
order as pycc (no transform). CFOUR's exact GENBAS `6-31G` is transcribed in the tests (same string
as `test_084`) so the AO basis matches to all printed digits; pycc reproduces the 10-digit `FCMFINAL`
to ~1e-10 (the FCMFINAL truncation).

## What each test checks

Each test asserts, against the CFOUR oracle:
- the full 9x9 correlation Hessian to `< 1e-9`;
- the exact facade decomposition `total == nuclear + reference + correlation`;
- symmetry (`H == H.T`) and the translational (acoustic) sum rule (`sum over the second atom
  vanishes`, since `E_corr` is invariant under uniform translation);
- the guards (unknown route; CCSD(T) without `make_t3_density`).

## Test tiers

The Hessian's `3N` nuclear solves make it 3-8x costlier than the APT, so the tiers are tighter than
the APT's. **Default (non-slow), ~2 min:** water spatial CCSD & CCSD(T) (AE + FC), water SO CCSD
(AE + FC), and water SO CCSD(T) all-electron -- the direct SO-(T) CFOUR anchor (~55 s). **Slow:**
water SO CCSD(T) frozen core, and the HOF (Cs) spatial cross-checks (+ SO HOF for CCSD). The
spin-orbital HOF CCSD(T) Hessian (~8.5 min/build) is **omitted** -- SO-(T) is CFOUR-anchored on
water and HOF-(T) spatially, so it would add ~17 min for marginal coverage.

## Test status

`pytest test_089_ccsdt_hessian.py test_090_ccsd_hessian.py` -- 6 passing by default, 4 additional
`slow` cases run and pass (`-m slow`); all match CFOUR to ~2e-10.

## Notes / follow-ups (not in this PR)

- The `pycc.properties` UI refinement remains deferred pending PI specifics (tracked separately).
