### PR TITLE
refactor(deriv): return ERI skeleton derivatives in physicist notation

### DIFF
--- a/pycc/correlatedderivs.py
+++ b/pycc/correlatedderivs.py
@@ -616,9 +616,9 @@ class CorrelatedDerivs:
         d = self.wfn.derivatives
         grad = np.zeros((d.natom, 3))
         for atom in range(d.natom):
-            hx = d.core(atom); Sx = d.overlap(atom); ERIx = d.eri(atom)   # chemist (pq|rs)^X
+            hx = d.core(atom); Sx = d.overlap(atom); ERIx = d.eri(atom)   # physicist <pq|rs>^(X)
             for cart in range(3):
-                phys = ERIx[cart].transpose(0, 2, 1, 3)                   # -> physicist <pq|rs>^(X)
+                phys = ERIx[cart]
                 Lx = 2.0 * phys - phys.transpose(0, 1, 3, 2)
                 fx = hx[cart] + c('pmqm->pq', Lx[:, ofull, :, ofull])     # skeleton Fock deriv (full occ)
                 grad[atom, cart] = (c('pq,pq->', Drel, fx)
@@ -811,7 +811,7 @@ class CorrelatedDerivs:
                 eriF = [np.asarray(e) for e in d.so_eri(A)]          # <pq||rs>^(X) (Fock and Gamma)
                 gamX = eriF
             else:
-                phys = [np.asarray(ch).transpose(0, 2, 1, 3) for ch in d.eri(A)]  # <pq|rs>^(X) (Gamma)
+                phys = [np.asarray(ch) for ch in d.eri(A)]                        # <pq|rs>^(X) (Gamma)
                 eriF = [2.0 * p - p.transpose(0, 1, 3, 2) for p in phys]          # L^X (Fock)
                 gamX = phys
             for beta in range(3):
@@ -907,7 +907,7 @@ class CorrelatedDerivs:
                 eF = np.asarray(d.so_eri(A)[ct])
                 gm = eF
             else:
-                ph = np.asarray(d.eri(A)[ct]).transpose(0, 2, 1, 3)     # <pq|rs>^(X) (Gamma)
+                ph = np.asarray(d.eri(A)[ct])                           # <pq|rs>^(X) (Gamma)
                 eF = 2.0 * ph - ph.transpose(0, 1, 3, 2)                # L^X (Fock)
                 gm = ph
             fX.append(hx + c('pmqm->pq', eF[:, ofull, :, ofull]))

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -313,7 +313,7 @@ class CPHF(object):
             else:
                 hx = np.asarray(d.core(atom)[cart])
                 Sx = np.asarray(d.overlap(atom)[cart])
-                gx = np.asarray(d.eri(atom)[cart]).swapaxes(1, 2)  # chemist -> physicist <pq|rs>^(x)
+                gx = np.asarray(d.eri(atom)[cart])                 # physicist <pq|rs>^(x)
                 w = 2.0 * gx - gx.swapaxes(2, 3)              # spin-adapted L^(x)
             fx = hx + self.contract('pmqm->pq', w[:, o, :, o])   # skeleton Fock derivative
         else:
@@ -545,10 +545,11 @@ class CPHF(object):
                 core = [np.asarray(m) for m in d.core2(a1, a2)]
                 overlap = [np.asarray(m) for m in d.overlap2(a1, a2)]
                 eri = []
-                for ch in d.eri2(a1, a2):                            # chemist (pq|rs)^{XY}
-                    ch = np.asarray(ch)
-                    ch = 0.5 * (ch + ch.transpose(2, 3, 0, 1))       # enforce (pq|rs)=(rs|pq)
-                    eri.append(ch.swapaxes(1, 2))                    # -> physicist <pq|rs>^{XY}
+                for ph in d.eri2(a1, a2):                            # physicist <pq|rs>^{XY}
+                    ph = np.asarray(ph)
+                    # eri2 does not symmetrize a single (A, B) ordering; enforce the
+                    # electron-swap symmetry <pq|rs> = <qp|sr> (chemist (pq|rs) = (rs|pq)).
+                    eri.append(0.5 * (ph + ph.transpose(1, 0, 3, 2)))
             self._d2int[key] = {'core': core, 'overlap': overlap, 'eri': eri}
         return self._d2int[key]
 

--- a/pycc/derivatives.py
+++ b/pycc/derivatives.py
@@ -186,20 +186,27 @@ class Derivatives(object):
     def eri(self, atom: int, b1: str = 'all', b2: str = 'all',
             b3: str = 'all', b4: str = 'all') -> List[np.ndarray]:
         r"""Two-electron (ERI) skeleton derivatives for ``atom``: 3 (x, y, z) arrays, in
-        chemist notation ``(pq|rs)^(X)``::
+        physicist notation ``<pq|rs>^(X)`` (matching the stored integrals and
+        :meth:`so_eri`, so callers need no transpose)::
 
-            (pq|rs)^(X) = C_mu,p C_nu,q (d(mu,nu|lam,sig) / dX) C_lam,r C_sig,s
+            <pq|rs>^(X) = (pr|qs)^(X),
+            (pr|qs)^(X) = C_mu,p C_nu,r (d(mu,nu|lam,sig) / dX) C_lam,q C_sig,s
 
         .. math::
 
-            (pq|rs)^{(X)} = C^{\mu}_{p} C^{\nu}_{q}\,
-                \frac{\partial (\mu\nu|\lambda\sigma)}{\partial X}\,C^{\lambda}_{r} C^{\sigma}_{s}
+            \langle pq|rs\rangle^{(X)} = (pr|qs)^{(X)}
+                = C^{\mu}_{p} C^{\nu}_{r}\,
+                \frac{\partial (\mu\nu|\lambda\sigma)}{\partial X}\,C^{\lambda}_{q} C^{\sigma}_{s}
+
+        Psi4's ``mo_tei_deriv1`` returns the chemist integral ``(pq|rs)^(X)``; the
+        ``swapaxes(1, 2)`` converts it to physicist order (as in :meth:`so_eri`, minus the
+        spin-orbital antisymmetrization).
 
         Cached one atom at a time (:meth:`_eri_cached`) so an atom-outer sweep never holds
         more than one atom's block yet reuses the dominant ``nmo^4`` transform across the
         atom's Cartesians and its several callers."""
         return self._eri_cached(atom, ('eri', b1, b2, b3, b4), lambda: [
-            np.asarray(m) for m in self.mints.mo_tei_deriv1(
+            np.asarray(m).swapaxes(1, 2) for m in self.mints.mo_tei_deriv1(
                 atom, self._mo(b1), self._mo(b2), self._mo(b3), self._mo(b4))])
 
     def iter_eri(self, b1: str = 'all', b2: str = 'all', b3: str = 'all',
@@ -244,18 +251,26 @@ class Derivatives(object):
     def eri2(self, atom1: int, atom2: int, b1: str = 'all', b2: str = 'all',
              b3: str = 'all', b4: str = 'all') -> List[np.ndarray]:
         r"""Second two-electron (ERI) derivatives for the ``(atom1, atom2)`` pair: 9 arrays,
-        indexed ``cart1*3 + cart2``, in chemist notation::
+        indexed ``cart1*3 + cart2``, in physicist notation ``<pq|rs>^(XY)`` (matching the
+        stored integrals and :meth:`so_eri2`, so callers need no transpose)::
 
-            (pq|rs)^(XY) = C_mu,p C_nu,q (d2(mu,nu|lam,sig) / dX dY) C_lam,r C_sig,s
+            <pq|rs>^(XY) = (pr|qs)^(XY),
+            (pr|qs)^(XY) = C_mu,p C_nu,r (d2(mu,nu|lam,sig) / dX dY) C_lam,q C_sig,s
 
         .. math::
 
-            (pq|rs)^{(XY)} = C^{\mu}_{p} C^{\nu}_{q}\,
-                \frac{\partial^2 (\mu\nu|\lambda\sigma)}{\partial X\,\partial Y}\,C^{\lambda}_{r} C^{\sigma}_{s}
+            \langle pq|rs\rangle^{(XY)} = (pr|qs)^{(XY)}
+                = C^{\mu}_{p} C^{\nu}_{r}\,
+                \frac{\partial^2 (\mu\nu|\lambda\sigma)}{\partial X\,\partial Y}\,C^{\lambda}_{q} C^{\sigma}_{s}
+
+        The ``swapaxes(1, 2)`` converts Psi4's chemist ``mo_tei_deriv2`` to physicist order.
+        Unlike :meth:`so_eri2`, the bra<->ket symmetrization ``<pq|rs> = <qp|sr>`` (needed
+        because a single ``mo_tei_deriv2(A, B)`` is one ordering of ``d^2/dXA dXB``) is NOT
+        applied here; a caller that needs it (e.g. :mod:`~pycc.cphf`) enforces it itself.
 
         The Hessian skeleton needs only the occupied block, so callers pass ``'o'``
         (n_occ**4 per pair)."""
-        return [np.asarray(m) for m in self.mints.mo_tei_deriv2(
+        return [np.asarray(m).swapaxes(1, 2) for m in self.mints.mo_tei_deriv2(
             atom1, atom2, self._mo(b1), self._mo(b2), self._mo(b3), self._mo(b4))]
 
     # ---- spin-orbital one-electron (spin-blocked from the spatial MO derivatives) ----

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -87,11 +87,11 @@ class HFwfn(Wavefunction):
         for atom in range(d.natom):
             Sx = d.overlap(atom, 'o', 'o')
             hx = d.core(atom, 'o', 'o')
-            erix = d.eri(atom, 'o', 'o', 'o', 'o')
+            erix = d.eri(atom, 'o', 'o', 'o', 'o')   # physicist <ij|kl>^X (2J - K)
             for c in range(3):
                 grad[atom, c] = (2.0 * np.trace(hx[c])
-                                 + 2.0 * self.contract('iijj->', erix[c])
-                                 - self.contract('ijij->', erix[c])
+                                 + 2.0 * self.contract('ijij->', erix[c])
+                                 - self.contract('iijj->', erix[c])
                                  - 2.0 * self.contract('i,ii->', eps, Sx[c]))
         return grad
 
@@ -340,7 +340,7 @@ class HFwfn(Wavefunction):
             for Bat in range(natom):
                 S2 = d.overlap2(A, Bat, 'o', 'o')                 # 9 x (no,no)
                 h2 = d.core2(A, Bat, 'o', 'o')                    # 9 x (no,no)
-                g2 = d.eri2(A, Bat, 'o', 'o', 'o', 'o')           # 9 x (no,no,no,no) chemist
+                g2 = d.eri2(A, Bat, 'o', 'o', 'o', 'o')           # 9 x (no,no,no,no) physicist
                 for a in range(3):
                     for b in range(3):
                         c = a * 3 + b
@@ -350,8 +350,8 @@ class HFwfn(Wavefunction):
                         Fx, Fy = Foo[A][a], Foo[Bat][b]
                         # --- skeleton (second-derivative integrals), as in the gradient ---
                         skel = (2.0 * np.trace(h2[c])
-                                + 2.0 * self.contract('iijj->', g2[c])
-                                - self.contract('ijij->', g2[c])
+                                + 2.0 * self.contract('ijij->', g2[c])
+                                - self.contract('iijj->', g2[c])
                                 - 2.0 * self.contract('i,ii->', eps_o, S2[c]))
                         # --- first-order CPHF response + first-derivative cross terms ---
                         resp = (-4.0 * self.contract('ia,ia->', Ux, By)


### PR DESCRIPTION
# refactor(deriv): return ERI skeleton derivatives in physicist notation

`Derivatives.eri()` / `eri2()` were the only place in pycc that returned two-electron
integrals in chemist (Mulliken) order `(pq|rs)^(X)`. Everything else -- the stored
integrals (`H.ERI` / `H.L`) and the spin-orbital `so_eri()` / `so_eri2()` -- is physicist
(Dirac) `<pq|rs>`. That forced every spatial consumer to transpose on the way in and left
pycc mixing the two notations. This PR makes the spatial pair conform.

## Provider (`derivatives.py`)

- `eri()` -> physicist `<pq|rs>^(X)`, plain (`swapaxes(1,2)`, exactly what `so_eri` does
  before its spin-orbital antisymmetrization).
- `eri2()` -> physicist `<pq|rs>^(XY)`, plain and **unsymmetrized**. A single
  `mo_tei_deriv2(A, B)` is one ordering of `d^2/dXA dXB` and breaks the electron-swap
  symmetry `<pq|rs> = <qp|sr>`; rather than fold the symmetrization into the provider (the
  `so_eri2` choice), it is left to the one caller that needs it, keeping `eri2` a thin
  transform. Docstrings on both updated from "chemist" to physicist.

## Consumers (7 sites, 3 modules)

- `correlatedderivs.py` (gradient, 2n+1 property loop, 2n+1 nuclear route): drop the
  `transpose(0,2,1,3)` -- 3 sites.
- `cphf.py`: nuclear RHS drops `swapaxes(1,2)`; the second-derivative integral cache keeps
  its bra<->ket symmetrization but now expresses it in physicist coords
  (`0.5*(ph + ph.transpose(1,0,3,2))`) and drops the trailing `swapaxes`.
- `hfwfn.py` HF gradient + HF Hessian (chemist-direct contractions): swap the two
  contraction strings `iijj <-> ijij`. Because `phys = chem.swapaxes(1,2)` is a view, the
  physicist `2<ij|ij> - <ii|jj>` (2J - K) reads the same memory the old chemist
  `2(ii|jj) - (ij|ij)` did -- bit-identical, no oracle shift.

All spin-orbital paths (`so_eri` / `so_eri2` and their consumers) are untouched.

## Validation

HF / MP2 / CCSD / CCSD(T) / CISD gradient + Hessian + APT + polarizability + CPHF, spatial
and spin-orbital: **114 tests pass**. Full docs build: 0 warnings.
