### PR TITLE
feat(properties): explicit derivative-object property API (transition: driver or wfn)

### DIFF
--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -21,50 +21,71 @@ if TYPE_CHECKING:
 
 
 class CCderiv(CorrelatedDerivs):
-    """Analytic derivative properties of a converged CCSD wavefunction.
+    """Analytic derivative properties of a CCSD / CCSD(T) wavefunction.
 
     Parameters
     ----------
     ccwfn : CCwfn
-        A converged coupled-cluster wavefunction (call :meth:`CCwfn.solve_cc` first).
+        A ``CCSD`` or ``CCSD(T)`` wavefunction.  The constructor solves it (and, for ``CCSD(T)``,
+        builds the (T) density) and then builds Lambda and the reduced densities.
 
     Notes
     -----
-    Both the spatial (closed-shell RHF) and spin-orbital (UHF) paths are supported; ROHF is not
-    (the semicanonical response does not reproduce the restricted ROHF response).  Lambda and the
-    reduced densities are solved/built on first use and cached.  The analytic gradient, static
-    polarizability, atomic polar tensors (length-gauge APTs), and molecular Hessian are implemented,
-    for CCSD and CCSD(T), all-electron and frozen core.
+    The correlation properties -- relaxed dipole, analytic gradient, static polarizability,
+    length-gauge atomic polar tensors, and molecular Hessian -- are inherited from
+    :class:`~pycc.correlatedderivs.CorrelatedDerivs` and computed via its asymmetric (2n+1) route (a
+    single (T)-capable formulation; see DERIVATIVES_PLAN_2026-06.md sec 8).  ``CCderiv`` supplies
+    only the CC-specific density hooks: there is no property-specific (T) code -- the (T)
+    contribution enters entirely through the (T)-aware relaxed and perturbed densities the base
+    builds.  Both the spatial (closed-shell RHF) and spin-orbital (UHF) paths are supported, all-
+    electron and frozen core; ROHF is not (the semicanonical response does not reproduce the
+    restricted ROHF response).
+
+    Validation: CCSD against tight finite fields of the relaxed dipole and SO == spatial keystones;
+    CCSD(T) against energy finite differences and CFOUR oracles (``POLAR`` / ``DIPDER`` /
+    ``FCMFINAL`` minus their SCF values; see test_084 / test_087 / test_089).
     """
 
-    def __init__(self, ccwfn: "CCwfn") -> None:
-        """Bind the converged CCwfn (aliased as ``ccwfn``; the base stores it as ``wfn``) and
-        initialize the lazy Lambda/reduced-density cache (see :meth:`_density`)."""
+    def __init__(self, ccwfn: "CCwfn", e_conv=None, r_conv=None, maxiter=None,
+                 max_diis=8, start_diis=1) -> None:
+        """Build the CCSD/CCSD(T) derivative machinery for ``ccwfn``: run ``solve_cc`` for the
+        T amplitudes, then build the similarity-transformed Hamiltonian ``self.hbar``, solve the
+        Lambda amplitudes ``self.cclambda``, and build the (Lambda-response) reduced densities
+        ``self.ccdensity``.
+
+        ``solve_cc`` is run unconditionally; it warm-starts from the wavefunction's current
+        amplitudes, so an already-converged wfn costs only about one iteration.  For a
+        ``CCSD(T)`` wavefunction this sets ``make_t3_density`` so the (T) density is built during
+        the (T) pass -- the derivative-property codes require it.  Convergence
+        (``e_conv``/``r_conv``/``maxiter``) and DIIS (``max_diis``/``start_diis``) default to the
+        wavefunction's current settings (its ``solve_cc`` defaults, or a prior solve); Lambda
+        inherits the same convergence.  Pass values to override.  ``CCSD`` and ``CCSD(T)`` only
+        (raises otherwise)."""
+        from .cchbar import cchbar
+        from .cclambda import cclambda
+        from .ccdensity import ccdensity
         super().__init__(ccwfn)
         self.ccwfn = ccwfn                              # alias: this class uses .ccwfn, the base .wfn
-        self._dens = None
-
-    def _density(self):
-        """Converged Lambda amplitudes and the (Lambda-response) reduced densities, cached.
-        Builds ``cchbar`` -> ``cclambda`` (solved) -> ``ccdensity`` on first use.  Lambda inherits
-        the wavefunction's convergence criteria (``ccwfn.e_conv``/``r_conv``/``maxiter``, set by
-        ``solve_cc``) rather than hardwiring its own."""
-        if self._dens is None:
-            from .cchbar import cchbar
-            from .cclambda import cclambda
-            from .ccdensity import ccdensity
-            cc = self.ccwfn
-            hbar = cchbar(cc)
-            lam = cclambda(cc, hbar)
-            lam.solve_lambda(e_conv=cc.e_conv, r_conv=cc.r_conv, maxiter=cc.maxiter)
-            self._dens = ccdensity(cc, lam)
-        return self._dens
+        model = ccwfn.model.upper()
+        if model not in ('CCSD', 'CCSD(T)'):
+            raise NotImplementedError(
+                f"CCderiv: only CCSD and CCSD(T) are implemented (not {ccwfn.model}).")
+        e_conv = ccwfn.e_conv if e_conv is None else e_conv
+        r_conv = ccwfn.r_conv if r_conv is None else r_conv
+        maxiter = ccwfn.maxiter if maxiter is None else maxiter
+        if model == 'CCSD(T)':
+            ccwfn.make_t3_density = True                # (T) density built by solve_cc's (T) pass
+        ccwfn.solve_cc(e_conv, r_conv, maxiter, max_diis, start_diis)
+        self.hbar = cchbar(ccwfn)
+        self.cclambda = cclambda(ccwfn, self.hbar)
+        self.cclambda.solve_lambda(e_conv=e_conv, r_conv=r_conv, maxiter=maxiter)
+        self.ccdensity = ccdensity(ccwfn, self.cclambda)
 
     def _unrelaxed_densities(self):
         """CC unrelaxed reduced densities: the Lambda-response 1-PDM ``D`` and the (symmetrized)
         cumulant 2-PDM ``Gam`` (:meth:`ccdensity.gradient_densities`), full-MO arrays.  Supplies the
         base Z-vector (:meth:`CorrelatedDerivs._orbital_response` / :meth:`_so_orbital_response`)."""
-        D, Gam = self._density().gradient_densities()
+        D, Gam = self.ccdensity.gradient_densities()
         return np.asarray(D), np.asarray(Gam)
 
     # ---- second derivatives: static dipole polarizability ----------------
@@ -87,115 +108,18 @@ class CCderiv(CorrelatedDerivs):
     _SO_HBAR_BLOCKS = ('Hov', 'Hvv', 'Hoo', 'Hoooo', 'Hvvvv', 'Hvovv', 'Hooov',
                        'Hovvo', 'Hvvvo', 'Hovoo')
 
-    def polarizability(self, route: str = '2n+1') -> np.ndarray:
-        r"""CCSD **correlation** contribution to the static (omega=0) dipole polarizability (a.u.),
-        shape ``(3, 3)``, the CC analog of :meth:`MPwfn.polarizability`::
-
-            alpha_corr[a,b] = -d^2 E_corr / dF_a dF_b
-
-        .. math::
-
-            \alpha^\mathrm{corr}_{ab} = -\frac{\partial^2 E_\mathrm{corr}}{\partial F_a\,\partial F_b}
-
-        Only the **asymmetric (2n+1) route** is available for CC -- differentiate the relaxed-density
-        gradient a second time (a single (T)-capable formulation; see DERIVATIVES_PLAN sec 8).  The
-        ``route`` argument (from the :func:`pycc.polarizability` facade) accepts only ``'2n+1'``.
-
-        The reference (SCF) polarizability is kept separate (:meth:`HFwfn.polarizability`); the
-        :func:`pycc.polarizability` facade sums nuclear (zero) + reference + this correlation part.
-
-        Spatial closed-shell RHF and spin-orbital UHF, CCSD and CCSD(T), all-electron and frozen
-        core.  CCSD is validated against a tight finite field of :meth:`relaxed_dipole` and the
-        SO == spatial keystone; CCSD(T) against the energy second-derivative finite field and the
-        SO == spatial keystone (SO CCSD(T) itself matched to CFOUR).
-
-        Overrides :meth:`CorrelatedDerivs.polarizability` only to add the CC method-specific guards
-        (supported model, (T) density intermediates); the shared 2n+1 assembly runs via ``super()``."""
-        cc = self.ccwfn
-        if cc.model.upper() not in ('CCSD', 'CCSD(T)'):
-            raise NotImplementedError(f"CC polarizability: only CCSD and CCSD(T) are implemented (not {cc.model}).")
-        if cc.model.upper() == 'CCSD(T)' and not hasattr(cc, 'S1'):
-            raise ValueError("CCSD(T) polarizability requires the (T) density intermediates; "
-                             "build the wavefunction with make_t3_density=True.")
-        return super().polarizability(route)        # shared 2n+1 assembly (SO/spatial dispatch in the base)
-
-    def dipole_derivatives(self, route: str = '2n+1-field') -> np.ndarray:
-        r"""CCSD/CCSD(T) **correlation** contribution to the atomic polar tensors (nuclear dipole
-        derivatives, a.u.), shape ``(natom, 3, 3)`` indexed ``[A, beta, alpha]``, the mixed
-        field/nuclear analog of :meth:`polarizability`::
-
-            d(mu_alpha)/d(X_{A,beta}) = -d^2 E_corr / dF_alpha dX_{A,beta}
-
-        .. math::
-
-            \frac{\partial \mu_\alpha}{\partial X_{A\beta}}
-                = -\frac{\partial^2 E_\mathrm{corr}}{\partial F_\alpha\,\partial X_{A\beta}}
-
-        ``route='2n+1-field'`` (default, 3 field solves) or ``'2n+1-nuclear'`` (``3N`` nuclear
-        solves); both give the same tensor.  The nuclear ``Z_A`` and SCF reference terms are kept
-        separate (:meth:`HFwfn.dipole_derivatives`) and summed with this correlation part by
-        :func:`pycc.apt`.
-
-        Spatial closed-shell RHF and spin-orbital UHF, CCSD and CCSD(T), all-electron and frozen
-        core.  The (T) contribution enters entirely through the (T)-aware relaxed and perturbed
-        densities the shared base already builds (no APT-specific (T) code); the spin-orbital CCSD(T)
-        APT is validated against a CFOUR DIPDER oracle (``DIPDER(CCSD(T)) - DIPDER(SCF)``, see
-        ``test_087_ccsdt_apt``).
-
-        Overrides :meth:`CorrelatedDerivs.dipole_derivatives` only to add the CC method-specific
-        guards (supported model, (T) density intermediates); the shared 2n+1 assembly runs via
-        ``super()``."""
-        cc = self.ccwfn
-        if cc.model.upper() not in ('CCSD', 'CCSD(T)'):
-            raise NotImplementedError(f"CC dipole derivatives: only CCSD and CCSD(T) are implemented (not {cc.model}).")
-        if cc.model.upper() == 'CCSD(T)' and not hasattr(cc, 'S1'):
-            raise ValueError("CCSD(T) dipole derivatives require the (T) density intermediates; "
-                             "build the wavefunction with make_t3_density=True.")
-        return super().dipole_derivatives(route)    # shared 2n+1 assembly (SO/spatial dispatch in the base)
-
-    def hessian(self, route: str = '2n+1') -> np.ndarray:
-        r"""CCSD/CCSD(T) **correlation** contribution to the molecular (nuclear) Hessian (a.u.), shape
-        ``(3*natom, 3*natom)`` indexed ``(A*3+a, B*3+b)``, the nuclear-nuclear analog of
-        :meth:`polarizability` / :meth:`dipole_derivatives`::
-
-            H[Aa,Bb] = d^2 E_corr / dX_{Aa} dX_{Bb}
-
-        .. math::
-
-            H_{Aa,Bb} = \frac{\partial^2 E_\mathrm{corr}}{\partial X_{Aa}\,\partial X_{Bb}}
-
-        ``route`` accepts only ``'2n+1'`` (``3N`` nuclear perturbed solves).  The nuclear-repulsion
-        second derivative and the SCF reference Hessian are kept separate
-        (:meth:`HFwfn.hessian` / :meth:`Derivatives.nuclear_repulsion2`) and summed with this
-        correlation part by :func:`pycc.hessian`.
-
-        Spatial closed-shell RHF and spin-orbital UHF, CCSD and CCSD(T), all-electron and frozen
-        core.  As for the APT, the (T) contribution enters entirely through the (T)-aware relaxed and
-        perturbed densities the shared base already builds (no Hessian-specific (T) code); validated
-        against a CFOUR FCMFINAL oracle (``FCMFINAL(CCSD(T)) - FCMFINAL(SCF)``, see
-        ``test_089_ccsdt_hessian``).
-
-        Overrides :meth:`CorrelatedDerivs.hessian` only to add the CC method-specific guards
-        (supported model, (T) density intermediates); the shared 2n+1 assembly runs via ``super()``."""
-        cc = self.ccwfn
-        if cc.model.upper() not in ('CCSD', 'CCSD(T)'):
-            raise NotImplementedError(f"CC hessian: only CCSD and CCSD(T) are implemented (not {cc.model}).")
-        if cc.model.upper() == 'CCSD(T)' and not hasattr(cc, 'S1'):
-            raise ValueError("CCSD(T) hessian requires the (T) density intermediates; "
-                             "build the wavefunction with make_t3_density=True.")
-        return super().hessian(route)               # shared 2n+1 assembly (SO/spatial dispatch in the base)
-
     def _perturbed_unrelaxed_densities(self, pert, df, deri, dL):
         """CC perturbed unrelaxed densities ``(d_x gamma, d_x Gamma)`` -- the base
         :meth:`CorrelatedDerivs._perturbed_unrelaxed_densities` hook.  Runs the iterative perturbed
         amplitude solve ``dt = dt(df, deri, dL)`` and the perturbed Lambda solve ``dLambda``
-        (reusing the converged ``hbar``/``lam`` from :meth:`_density`), threading the perturbed (T)
-        intermediates ``dt3`` into both and into the density for CCSD(T), then builds the perturbed
-        correlation densities (:meth:`_perturbed_correlation_densities`).  ``df``/``deri`` are already
-        canonical per :attr:`perturbed_mo_gauge` (passed in by the base perturbed Z-vector solve)."""
+        (reusing the converged ``self.hbar``/``self.cclambda`` built in ``__init__``), threading the
+        perturbed (T) intermediates ``dt3`` into both and into the density for CCSD(T), then builds
+        the perturbed correlation densities (:meth:`_perturbed_correlation_densities`).
+        ``df``/``deri`` are already canonical per :attr:`perturbed_mo_gauge` (passed in by the base
+        perturbed Z-vector solve)."""
         cc = self.ccwfn
-        lam = self._density().cclambda
-        hbar = lam.hbar
+        lam = self.cclambda
+        hbar = self.hbar
         is_t = cc.model.upper() == 'CCSD(T)'
         if cc.orbital_basis == 'spinorbital':
             dt1, dt2 = self._so_perturbed_amplitudes(df, deri, hbar)

--- a/pycc/mpderiv.py
+++ b/pycc/mpderiv.py
@@ -36,9 +36,14 @@ class MPderiv(CorrelatedDerivs):
     spin-orbital (``_so_``) paths are frozen-core aware.
     """
 
-    def __init__(self, wfn) -> None:
+    def __init__(self, wfn, e_conv=None, r_conv=None, maxiter=None,
+                 max_diis=8, start_diis=1) -> None:
         """Bind the converged MPwfn (aliased as ``mp``; the base stores it as ``wfn``); the
-        reduced-density seeds and derivatives are built on demand from ``self.mp.t2``."""
+        reduced-density seeds and their derivatives are built on demand from ``self.mp.t2``.
+
+        The convergence / DIIS keyword arguments are accepted for signature parity with
+        :class:`~pycc.ccderiv.CCderiv` but have no effect -- MP2 amplitudes are closed-form
+        (non-iterative)."""
         super().__init__(wfn)
         self.mp = wfn                       # alias: the MP2 wavefunction whose densities we differentiate
 

--- a/pycc/properties.py
+++ b/pycc/properties.py
@@ -1,11 +1,15 @@
-"""Molecular-property facade: uniform, wavefunction-type-agnostic access to the analytic
-derivative properties, each returned as its additive physical decomposition
+"""Molecular-property facade: uniform access to the analytic derivative properties, each returned
+as its additive physical decomposition
 
     total = nuclear + reference + correlation
 
-The same call works for any supported wavefunction (``HFwfn``, ``MPwfn``, ...): the correlation
-block is simply zero for an SCF wavefunction.  The pieces are genuinely computed apart -- the
-correlation contribution is built from correlation quantities only, never as (total - reference).
+Each property takes a **derivative driver** (``CCderiv``/``MPderiv``/``CIderiv`` -- the object that
+owns the solve and the correlation-derivative methods) or, for a reference-only value, a bare
+``HFwfn`` (its correlation block is zero).  During the transition to the driver-object API a bare
+correlated wavefunction is also accepted and wrapped in its registered driver (the construction the
+facade used to do implicitly); this path is temporary and will be removed once callers pass drivers.
+The pieces are genuinely computed apart -- the correlation contribution is built from correlation
+quantities only, never as (total - reference).
 """
 
 from dataclasses import dataclass
@@ -116,30 +120,44 @@ def register_deriv(wfn_cls, deriv_cls) -> None:
     _DERIV_REGISTRY[wfn_cls] = deriv_cls
 
 
-def _correlated(wfn):
-    """For a correlated wavefunction, return ``(reference_hf, target)``: the SCF-reference
-    ``HFwfn`` that carries the reference derivative, and the object that carries the correlation
-    derivative methods -- the registered derivative driver (``deriv_cls(wfn)``) if one exists,
-    else the wavefunction itself (transitional, while a method type's derivative code still lives
-    on its wfn class)."""
-    deriv_cls = _DERIV_REGISTRY.get(type(wfn))
+def _correlated(obj):
+    """Resolve ``obj`` to ``(reference_hf, target)``: the SCF-reference ``HFwfn`` carrying the
+    reference derivative, and the driver carrying the correlation-derivative methods.
+
+    ``obj`` may be a derivative driver (``CCderiv``/``MPderiv``/``CIderiv``) -- used directly -- or,
+    during the transition to the driver-object property API, a correlated wavefunction, which is
+    wrapped in its registered driver (``deriv_cls(wfn)``, the same construction the facade did
+    implicitly before).  A wavefunction with no registered driver is used as its own target
+    (transitional, while a method's derivative code still lives on its wfn class -- CISD)."""
+    from .correlatedderivs import CorrelatedDerivs
+    if isinstance(obj, CorrelatedDerivs):
+        return obj._reference_hf(), obj
+    deriv_cls = _DERIV_REGISTRY.get(type(obj))
     if deriv_cls is not None:
-        target = deriv_cls(wfn)
+        target = deriv_cls(obj)
         return target._reference_hf(), target
-    return wfn._reference_hf(), wfn
+    return obj._reference_hf(), obj
 
 
-def _dispatch(wfn, hf_method, corr_method, corr_kwargs=None):
-    """Reference (SCF electronic) and correlation blocks of a property, computed apart.  For a
-    correlated wavefunction the reference is the all-electron SCF value and the correlation comes
-    from its derivative driver (:func:`_correlated`), called with ``corr_kwargs`` (``route`` /
-    ``gauge`` knobs the SCF reference does not take).  For an ``HFwfn`` the reference is the SCF
-    value and the correlation is an all-zeros array of the same shape."""
+def _wfn_of(obj):
+    """The underlying wavefunction of ``obj``: ``obj.wfn`` if ``obj`` is a derivative driver, else
+    ``obj`` itself (a wavefunction).  Used for the nuclear terms (molecule / nuclear-repulsion
+    derivatives), which live on the wavefunction regardless of what the facade was handed."""
+    from .correlatedderivs import CorrelatedDerivs
+    return obj.wfn if isinstance(obj, CorrelatedDerivs) else obj
+
+
+def _dispatch(obj, hf_method, corr_method, corr_kwargs=None):
+    """Reference (SCF electronic) and correlation blocks of a property, computed apart.  ``obj`` is
+    a derivative driver or (transitionally) a correlated wavefunction: the reference is the
+    all-electron SCF value and the correlation comes from the driver (:func:`_correlated`), called
+    with ``corr_kwargs`` (``route`` / ``gauge`` knobs the SCF reference does not take).  For an
+    ``HFwfn`` the reference is the SCF value and the correlation is an all-zeros array."""
     from .hfwfn import HFwfn
-    if isinstance(wfn, HFwfn):
-        reference = np.asarray(getattr(wfn, hf_method)())
+    if isinstance(obj, HFwfn):
+        reference = np.asarray(getattr(obj, hf_method)())
         return reference, np.zeros_like(reference)
-    reference_hf, target = _correlated(wfn)
+    reference_hf, target = _correlated(obj)
     reference = np.asarray(getattr(reference_hf, hf_method)())
     correlation = np.asarray(getattr(target, corr_method)(**(corr_kwargs or {})))
     return reference, correlation
@@ -149,7 +167,7 @@ def dipole(wfn) -> PropertyComponents:
     """Electric-dipole moment as a :class:`PropertyComponents` (``nuclear + reference +
     correlation``, shape ``(3,)`` each) for any supported wavefunction type."""
     reference, correlation = _dispatch(wfn, '_dipole_electronic', 'relaxed_dipole')
-    return PropertyComponents(_nuclear_dipole(wfn.ref.molecule()), reference, correlation)
+    return PropertyComponents(_nuclear_dipole(_wfn_of(wfn).ref.molecule()), reference, correlation)
 
 
 def gradient(wfn) -> PropertyComponents:
@@ -157,7 +175,7 @@ def gradient(wfn) -> PropertyComponents:
     correlation``, shape ``(natom, 3)`` each).  The nuclear block is the nuclear-repulsion
     derivative ``dV_NN/dX``."""
     reference, correlation = _dispatch(wfn, '_gradient_electronic', 'gradient')
-    nuclear = np.asarray(wfn.derivatives.nuclear_repulsion())
+    nuclear = np.asarray(_wfn_of(wfn).derivatives.nuclear_repulsion())
     return PropertyComponents(nuclear, reference, correlation)
 
 
@@ -179,7 +197,7 @@ def hessian(wfn, route='2n+1') -> PropertyComponents:
     ``route`` selects the MP2 correlation algorithm, ``'2n+1'`` (default -- the O(N)-cheaper 2n+1
     route) or ``'explicit'``; both give the same matrix and it is ignored for an ``HFwfn``."""
     reference, correlation = _dispatch(wfn, '_hessian_electronic', 'hessian', {'route': route})
-    nuclear = np.asarray(wfn.derivatives.nuclear_repulsion2())
+    nuclear = np.asarray(_wfn_of(wfn).derivatives.nuclear_repulsion2())
     return PropertyComponents(nuclear, reference, correlation)
 
 
@@ -207,7 +225,7 @@ def apt(wfn, gauge='length', route='2n+1-field', orbital_gauge='non-canonical') 
                                            'velocity_dipole_derivatives', {'gauge': orbital_gauge})
     else:
         raise ValueError(f"apt: gauge must be 'length' or 'velocity', got {gauge!r}")
-    return PropertyComponents(_nuclear_apt(wfn.ref.molecule()), reference, correlation)
+    return PropertyComponents(_nuclear_apt(_wfn_of(wfn).ref.molecule()), reference, correlation)
 
 
 def aat(wfn, origin=None, orbital_gauge='non-canonical') -> PropertyComponents:

--- a/pycc/tests/test_074_property_facade.py
+++ b/pycc/tests/test_074_property_facade.py
@@ -131,6 +131,25 @@ def test_facade_decomposition_and_total():
         assert np.max(np.abs(comp.total - (np.asarray(hf_pub) + np.asarray(mp_corr)))) < 1e-10, name
 
 
+def test_facade_accepts_driver_object():
+    """The facade takes a derivative driver (the driver-object API) as well as a bare wavefunction
+    (the transitional path); both give identical PropertyComponents for every property."""
+    _, mp = _wfns()
+    driver = pycc.MPderiv(mp)
+    cases = [
+        ("dipole",         pycc.dipole),
+        ("gradient",       pycc.gradient),
+        ("polarizability", pycc.polarizability),
+        ("hessian",        pycc.hessian),
+        ("apt-length",     lambda x: pycc.apt(x, 'length')),
+        ("apt-velocity",   lambda x: pycc.apt(x, 'velocity')),
+    ]
+    for name, fn in cases:
+        via_wfn, via_driver = fn(mp), fn(driver)
+        assert np.max(np.abs(via_driver.total - via_wfn.total)) < 1e-12, name
+        assert np.max(np.abs(via_driver.correlation - via_wfn.correlation)) < 1e-12, name
+
+
 def test_facade_hf_wavefunction():
     """pycc.<property>(HFwfn): correlation is an all-zeros block and the total equals the SCF
     public method (same shape/type as the MP2 result)."""

--- a/pycc/tests/test_076_ccsd_gradient.py
+++ b/pycc/tests/test_076_ccsd_gradient.py
@@ -104,7 +104,7 @@ def test_ccsd_gradient_density_energy():
     """The gradient-convention densities (CCderiv adapter) reproduce the CCSD correlation energy:
     E_corr = contract(D, F) + contract(Gamma, ERI) (no prefactor on the two-particle term)."""
     cc = _ccwfn(REF, "STO-3G")
-    dens = pycc.CCderiv(cc)._density()
+    dens = pycc.CCderiv(cc).ccdensity
     ecc = dens.compute_energy()
     D, G = dens.gradient_densities()
     E = cc.contract('pq,pq->', D, np.asarray(cc.H.F)) + cc.contract('pqrs,pqrs->', G, np.asarray(cc.H.ERI))
@@ -118,7 +118,7 @@ def test_ccsd_gradient_ccpvdz():
     cc = _ccwfn(REF, "cc-pVDZ")
     g = np.asarray(pycc.CCderiv(cc).gradient())
     assert np.max(np.abs(g - GRAD_REF_PVDZ)) < 1e-11, g
-    dens = pycc.CCderiv(cc)._density()
+    dens = pycc.CCderiv(cc).ccdensity
     D, G = dens.gradient_densities()
     E = cc.contract('pq,pq->', D, np.asarray(cc.H.F)) + cc.contract('pqrs,pqrs->', G, np.asarray(cc.H.ERI))
     assert abs(E - dens.compute_energy()) < 1e-12

--- a/pycc/tests/test_084_cc_polarizability.py
+++ b/pycc/tests/test_084_cc_polarizability.py
@@ -365,18 +365,19 @@ def test_ccsdt_polarizability_cfour(route, mol, fc):
 
 
 def test_ccsd_polarizability_guards(rhf_wfn):
-    """The misused paths raise rather than silently returning a wrong tensor: CCSD(T) (spatial or
-    spin-orbital) built without the (T) density intermediates, and an unknown route."""
+    """Constructing a CCderiv sets the (T) density itself -- so a CCSD(T) property no longer needs
+    the user to pass make_t3_density (the former footgun) -- while a misused route still raises.
+    Both the spatial and spin-orbital CCSD(T) paths build without the flag."""
     import pytest
     wfn = rhf_wfn(WATER, "6-31G", freeze_core="false")
     cc = pycc.ccwfn(wfn, model='ccsd(t)')                              # spatial CCSD(T), no make_t3_density
     cc.solve_cc(1e-12, 1e-12, 100)
-    with pytest.raises(ValueError):                                   # (T) needs make_t3_density
-        pycc.CCderiv(cc).polarizability()
-    with pytest.raises(ValueError):                                   # unknown route
-        pycc.CCderiv(cc).polarizability(route='explicit')
+    d = pycc.CCderiv(cc)                                              # sets make_t3_density, builds the (T) density
+    assert cc.make_t3_density is True
+    d.polarizability()                                               # works without the user setting the flag
+    with pytest.raises(ValueError):                                  # unknown route still raises
+        d.polarizability(route='explicit')
     cc_so = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis='spinorbital')   # no make_t3_density
     cc_so.solve_cc(1e-12, 1e-12, 100)
-    with pytest.raises(ValueError):                                   # SO (T) needs make_t3_density
-        pycc.CCderiv(cc_so).polarizability()
+    pycc.CCderiv(cc_so).polarizability()                             # SO path likewise works without the flag
     psi4.core.clean()

--- a/pycc/tests/test_086_ccsdt_unrelaxed_dipole.py
+++ b/pycc/tests/test_086_ccsdt_unrelaxed_dipole.py
@@ -58,7 +58,7 @@ def _ccwfn(wfn, orbital_basis):
 def _unrelaxed_dipole(cc):
     """Unrelaxed correlation dipole Tr(D . mu) for all three axes, from the full unrelaxed 1-PDM
     (gradient_densities places the Doo/Dov/Dvo/Dvv blocks, including the (T) ov increment)."""
-    D = np.asarray(pycc.CCderiv(cc)._density().gradient_densities()[0])
+    D = np.asarray(pycc.CCderiv(cc).ccdensity.gradient_densities()[0])
     return np.array([np.einsum('pq,pq->', D, np.asarray(cc.H.mu[a])) for a in range(3)])
 
 

--- a/pycc/tests/test_087_ccsdt_apt.py
+++ b/pycc/tests/test_087_ccsdt_apt.py
@@ -5,8 +5,9 @@ dX_{A,beta}, the mixed field/nuclear analog of the CCSD(T) polarizability (test_
 The (T) contribution needs no APT-specific code: the base CorrelatedDerivs.dipole_derivatives 2n+1
 assembly consumes the same (T)-aware relaxed and perturbed densities that the CCSD(T) gradient and
 polarizability already build (dt3 threaded through the perturbed amplitudes/Lambda/densities, the
-canonical perturbed-MO oo/vv dependent pairs).  CCderiv.dipole_derivatives overrides the base only
-to add the method guards (supported model, make_t3_density), exactly as CCderiv.polarizability does.
+canonical perturbed-MO oo/vv dependent pairs).  CCderiv inherits dipole_derivatives from
+CorrelatedDerivs; the supported-model check and the (T)-density build happen when the CCderiv is
+constructed.
 
 Oracle: CFOUR (xcfour, CALC=CCSD(T), VIB=EXACT, SCF_CONV=13, CC_CONV=12).  The DIPDER file holds the
 TOTAL APT (nuclear + HF + correlation).  The correlation contribution is DIPDER(CCSD(T)) minus the
@@ -311,15 +312,15 @@ def test_ccsdt_apt_routes_agree_water():
 
 
 def test_ccsdt_apt_guards():
-    """The misused paths raise rather than silently returning a wrong tensor: CCSD(T) built without
-    the (T) density intermediates (make_t3_density), and an unknown route."""
+    """Constructing a CCderiv sets the (T) density itself, so a CCSD(T) APT no longer needs the user
+    to pass make_t3_density (the former footgun); an unknown route still raises."""
     wfn = _cfour_wfn(WATER, 'false')
     cc_t = pycc.ccwfn(wfn, model='ccsd(t)')                     # CCSD(T), no make_t3_density
     cc_t.solve_cc(1e-12, 1e-12, 100)
-    with pytest.raises(ValueError):                             # (T) needs make_t3_density
-        pycc.CCderiv(cc_t).dipole_derivatives()
+    pycc.CCderiv(cc_t)                                          # sets the flag + builds the (T) density
+    assert cc_t.make_t3_density is True and hasattr(cc_t, 'S1')
     cc = pycc.ccwfn(wfn)                                        # plain CCSD: reaches the route check
     cc.solve_cc(1e-12, 1e-12, 100)
-    with pytest.raises(ValueError):                             # unknown route
+    with pytest.raises(ValueError):                             # unknown route still raises
         pycc.CCderiv(cc).dipole_derivatives(route='bogus')
     psi4.core.clean()

--- a/pycc/tests/test_089_ccsdt_hessian.py
+++ b/pycc/tests/test_089_ccsdt_hessian.py
@@ -6,8 +6,9 @@ As for the APT, the (T) contribution needs no Hessian-specific code: the base
 CorrelatedDerivs.hessian 2n+1 assembly (3N nuclear perturbed solves plus the full nuclear-nuclear
 second skeletons) consumes the same (T)-aware relaxed and perturbed densities the CCSD(T) gradient,
 polarizability, and APT already build (dt3 threaded through the perturbed amplitudes/Lambda/
-densities, canonical perturbed-MO oo/vv dependent pairs).  CCderiv.hessian adds only the method
-guards (supported model; CCSD(T) requires make_t3_density) and delegates to the base.
+densities, canonical perturbed-MO oo/vv dependent pairs).  CCderiv inherits hessian from
+CorrelatedDerivs; the supported-model check and the (T)-density build happen when the CCderiv is
+constructed.
 
 Oracle: CFOUR (xcfour, CALC=CCSD(T), VIB=EXACT, SCF_CONV=13, CC_CONV=12).  FCMFINAL holds the TOTAL
 force-constant matrix; the correlation contribution is FCMFINAL(CCSD(T)) - FCMFINAL(SCF) (frozen core
@@ -256,15 +257,15 @@ def test_ccsdt_hessian_cfour_hof_spatial():
 
 
 def test_ccsdt_hessian_guards():
-    """The misused paths raise rather than silently returning a wrong matrix: CCSD(T) built without
-    the (T) density intermediates (make_t3_density), and an unknown route."""
+    """Constructing a CCderiv sets the (T) density itself, so a CCSD(T) Hessian no longer needs the
+    user to pass make_t3_density (the former footgun); an unknown route still raises."""
     wfn = _cfour_wfn(WATER, 'false')
     cc_t = pycc.ccwfn(wfn, model='ccsd(t)')                     # CCSD(T), no make_t3_density
     cc_t.solve_cc(1e-12, 1e-12, 100)
-    with pytest.raises(ValueError):                             # (T) needs make_t3_density
-        pycc.CCderiv(cc_t).hessian()
+    pycc.CCderiv(cc_t)                                          # sets the flag + builds the (T) density
+    assert cc_t.make_t3_density is True and hasattr(cc_t, 'S1')
     cc = pycc.ccwfn(wfn)                                        # plain CCSD: reaches the route check
     cc.solve_cc(1e-12, 1e-12, 100)
-    with pytest.raises(ValueError):                             # unknown route
+    with pytest.raises(ValueError):                             # unknown route still raises
         pycc.CCderiv(cc).hessian(route='bogus')
     psi4.core.clean()


### PR DESCRIPTION
# feat(properties): explicit derivative-object property API (transition: driver or wfn)

Reworks the correlated-derivative property interface around an **explicit, persistent derivative
object** (`CCderiv`/`MPderiv`), resolving three coupled problems in one move: the `make_t3_density`
footgun, the per-call driver recreation, and the opacity of where the solve cost lives.

## The two-object model

- **`cc = pycc.ccwfn(scf, model='ccsd(t)')` owns T.**  Energy path stays `cc.solve_cc()`; it never
  touches `make_t3_density`.
- **`ccd = pycc.CCderiv(cc, e_conv=..., ...)` owns Lambda + densities + response.**  Its
  constructor runs `solve_cc` (unconditionally -- it warm-starts in place, so an already-converged
  wfn costs ~one iteration), builds `hbar`/`cclambda`/`ccdensity` eagerly, and for a `CCSD(T)`
  wavefunction sets `make_t3_density=True` so the (T) density is built during the (T) pass.
  Convergence defaults to the wavefunction's current settings (a prior `solve_cc`, or its defaults);
  kwargs override.  Supported models validated at construction.
- **Property evaluators take the object:** `pycc.gradient(ccd)`, `pycc.polarizability(ccd)`,
  `pycc.apt(ccd, ...)`, `pycc.hessian(ccd)`, `pycc.dipole(ccd)`.

Because the constructor sets `make_t3_density` itself, a CCSD(T) derivative property no longer needs
the user to know that flag exists -- the former footgun (a raw `AttributeError` on the gradient
path, a `ValueError` on the others) is eliminated **by construction**.

## Transition policy: accept both (end-state = require the driver)

The end state is a hard break (facade requires a driver object), but this PR ships the transition:
the facade **accepts either a driver object or a bare correlated wavefunction**.  A wfn is wrapped in
its registered driver -- exactly the construction `_correlated` already did implicitly -- so the
~69 existing call sites keep working unchanged (and gain the `make_t3_density` fix for free).
Migrating call sites to persistent driver objects is a later, incremental step; the wfn path is
removed once that lands.

## Changes

- `ccderiv.py`: `CCderiv.__init__` eager-builds (above); `_density()` **removed** and inlined
  (stores `self.hbar`/`self.cclambda`/`self.ccdensity`); the `make_t3_density`/model guards deleted
  from `polarizability`/`dipole_derivatives`/`hessian` -- which, now pure pass-throughs, are
  **deleted** and inherited from `CorrelatedDerivs` (their CC-specific documentation, incl. the
  CFOUR `POLAR`/`DIPDER`/`FCMFINAL` and energy-FD validation provenance, folded into the class
  docstring).
- `mpderiv.py`: `MPderiv.__init__` accepts the same convergence/DIIS kwargs for signature parity
  (no-ops -- MP2 is non-iterative).
- `properties.py`: `_correlated`/`_dispatch` take a driver or a wfn; new `_wfn_of` helper supplies
  the nuclear terms from the underlying wavefunction regardless; module docstring updated.
- Tests: the three CCSD(T) footgun-guard tests (test_084/087/089) rewritten to assert the new
  behavior (construction sets the flag + builds the (T) density; unknown route still raises); new
  `test_facade_accepts_driver_object` (test_074) checks a driver and a wfn give identical
  `PropertyComponents`; `._density()` references updated to `.ccdensity`.

## Scope

`aat` (and thus the AAT path) is deliberately left on its wfn-based interface for now -- it is
tangled with the deferred AAT/VG-APT hoist and in-flight CISD work; it will be unified when that
lands.  `apt` (both length and velocity gauges) is converted.  CISD continues to route through its
transitional wfn-fallback (unregistered driver), unchanged.

## Validation

Full correlated-property suite (HF/MP2/CCSD/CCSD(T)/CISD gradient, dipole, polarizability, APT,
Hessian, AAT; spatial + spin-orbital; all-electron + frozen core) plus HF facade controls.  Docs
build: no new warnings.
