### PR TITLE
feat(properties): migrate MP2/CC call sites to driver objects; partial hard break

### DIFF
--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -932,8 +932,7 @@ class ccdensity(object):
         return Doovv
 
     def build_so_twopdm(self, t1, t2, l1, l2):
-        r"""Spin-orbital CCSD two-particle density -- the nine unique blocks of Table 6.3 of the
-        coupled-cluster notes (Crawford), returned as a dict keyed by block label.
+        r"""Spin-orbital CCSD two-particle density, returned as a dict keyed by block label.
 
         Because the spin-orbital 2-PDM is fully antisymmetric (``Gamma_pqrs = -Gamma_qprs =
         -Gamma_pqsr``), these nine blocks are *representatives*: every one of the sixteen o/v
@@ -999,7 +998,6 @@ class ccdensity(object):
                      + 0.5 * contract('kmef,ijef,ma->ijka', l2, tau, t1)
                      + Pij(contract('mkef,imae,jf->ijka', l2, t2, t1))
                      - 0.5 * Pij(contract('kmef,imef,ja->ijka', l2, t2, t1)))
-        # NB: the t^{ae}_{in} term carries a leading minus sign (erratum vs the printed table).
         G['ciab'] = (contract('mc,miab->ciab', l1, tau)
                      - 0.5 * contract('mnce,mnab,ie->ciab', l2, tau, t1)
                      - Pab(contract('mnce,inae,mb->ciab', l2, t2, t1))

--- a/pycc/properties.py
+++ b/pycc/properties.py
@@ -3,11 +3,13 @@ as its additive physical decomposition
 
     total = nuclear + reference + correlation
 
-Each property takes a **derivative driver** (``CCderiv``/``MPderiv``/``CIderiv`` -- the object that
-owns the solve and the correlation-derivative methods) or, for a reference-only value, a bare
-``HFwfn`` (its correlation block is zero).  During the transition to the driver-object API a bare
-correlated wavefunction is also accepted and wrapped in its registered driver (the construction the
-facade used to do implicitly); this path is temporary and will be removed once callers pass drivers.
+Each property takes a **derivative driver** (``CCderiv``/``MPderiv`` -- the object that owns the
+solve and the correlation-derivative methods) or, for a reference-only value, a bare ``HFwfn`` (its
+correlation block is zero).  A bare *registered* correlated wavefunction (``CCwfn``/``MPwfn``) is
+rejected: construct the driver yourself, e.g. ``pycc.gradient(pycc.CCderiv(cc))`` -- so the solve
+cost sits in an explicit constructor.  CISD is the one exception (transitional): its ``CIwfn`` is
+still accepted directly, because ``CIderiv`` is not yet a working driver; that path goes away when
+it is.  ``aat`` keeps its own wavefunction-based interface for now (pending the AAT/VG-APT hoist).
 The pieces are genuinely computed apart -- the correlation contribution is built from correlation
 quantities only, never as (total - reference).
 """
@@ -124,18 +126,20 @@ def _correlated(obj):
     """Resolve ``obj`` to ``(reference_hf, target)``: the SCF-reference ``HFwfn`` carrying the
     reference derivative, and the driver carrying the correlation-derivative methods.
 
-    ``obj`` may be a derivative driver (``CCderiv``/``MPderiv``/``CIderiv``) -- used directly -- or,
-    during the transition to the driver-object property API, a correlated wavefunction, which is
-    wrapped in its registered driver (``deriv_cls(wfn)``, the same construction the facade did
-    implicitly before).  A wavefunction with no registered driver is used as its own target
-    (transitional, while a method's derivative code still lives on its wfn class -- CISD)."""
+    ``obj`` must be a derivative driver (``CCderiv``/``MPderiv``): the property is computed on it and
+    the solve cost lives in its explicit constructor.  A bare **registered** correlated wavefunction
+    (``CCwfn``/``MPwfn``) is rejected -- construct the driver yourself.  A correlated wavefunction
+    with no registered driver (CISD, whose ``CIderiv`` is still a stub) is used as its own target
+    (transitional; removed once CISD has a real driver)."""
     from .correlatedderivs import CorrelatedDerivs
     if isinstance(obj, CorrelatedDerivs):
         return obj._reference_hf(), obj
     deriv_cls = _DERIV_REGISTRY.get(type(obj))
     if deriv_cls is not None:
-        target = deriv_cls(obj)
-        return target._reference_hf(), target
+        raise TypeError(
+            f"pycc property facade: pass a {deriv_cls.__name__}, not a bare "
+            f"{type(obj).__name__} -- e.g. pycc.gradient(pycc.{deriv_cls.__name__}(wfn)).  "
+            f"The driver's constructor owns the solve; see pycc.{deriv_cls.__name__}.")
     return obj._reference_hf(), obj
 
 

--- a/pycc/tests/test_034_ccsd_t_density.py
+++ b/pycc/tests/test_034_ccsd_t_density.py
@@ -164,7 +164,7 @@ def test_ccsdt_relaxed_dipole(rhf_wfn):
     mu = np.asarray(pycc.CCderiv(cc).relaxed_dipole())
     assert abs(mu[2] - RELAXED_DIPOLE_Z_REF) < 1e-10, mu[2]
     # facade: total = nuclear + reference + correlation, and correlation == relaxed_dipole
-    r = pycc.dipole(cc)
+    r = pycc.dipole(pycc.CCderiv(cc))
     assert np.max(np.abs(np.asarray(r.total) - (np.asarray(r.nuclear)
                   + np.asarray(r.reference) + np.asarray(r.correlation)))) < 1e-12
     assert np.max(np.abs(np.asarray(r.correlation) - mu)) < 1e-12

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -136,7 +136,7 @@ def _pycc_gradient(geom, basis, orbital_basis='spinorbital', freeze_core='false'
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
-    return np.asarray(pycc.gradient(mp).total)
+    return np.asarray(pycc.gradient(pycc.MPderiv(mp)).total)
 
 
 def _psi4_mp2_gradient(geom, basis, reference='rhf', occ=None):
@@ -252,7 +252,7 @@ def test_fc_mp2_gradient_vs_energy_fd_631g():
     mp = pycc.MPwfn(wfn, orbital_basis='spatial')
     mp.compute_energy()
     assert mp.nfzc > 0                                   # frozen core is actually active
-    gA = np.asarray(pycc.gradient(mp).total)             # total = SCF + correlation
+    gA = np.asarray(pycc.gradient(pycc.MPderiv(mp)).total)             # total = SCF + correlation
 
     h = 2.0e-3
     gF = np.zeros((3, 3))
@@ -322,7 +322,7 @@ def test_mp2_total_dipole_631g():
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis='spinorbital')
     mp.compute_energy()
-    total = np.asarray(pycc.dipole(mp).total)
+    total = np.asarray(pycc.dipole(pycc.MPderiv(mp)).total)
     assert abs(total[2] - FF_TOTAL_MU_Z_631) < 1e-8
 
 

--- a/pycc/tests/test_068_mp2_apt.py
+++ b/pycc/tests/test_068_mp2_apt.py
@@ -148,7 +148,7 @@ def test_mp2_apt_translational_sum_rule_631g():
     total APT vanishes (the correlation APT sums to zero on its own -- Tr(gamma_corr) = 0)."""
     mp0 = _mpwfn(BASE, '6-31G', 'spatial')
     P_corr = mp0.dipole_derivatives()
-    P_tot = np.asarray(pycc.apt(mp0).total)
+    P_tot = np.asarray(pycc.apt(pycc.MPderiv(mp0)).total)
     assert np.max(np.abs(np.sum(P_corr, axis=0))) < 1e-10
     assert np.max(np.abs(np.sum(P_tot, axis=0))) < 1e-10
 
@@ -179,7 +179,7 @@ def test_fc_mp2_apt_translational_sum_rule_631g():
     vanishes for neutral water."""
     mp0 = _mpwfn(BASE, '6-31G', 'spatial', freeze_core='true')
     assert np.max(np.abs(np.sum(mp0.dipole_derivatives(), axis=0))) < 1e-10
-    assert np.max(np.abs(np.sum(np.asarray(pycc.apt(mp0).total), axis=0))) < 1e-10
+    assert np.max(np.abs(np.sum(np.asarray(pycc.apt(pycc.MPderiv(mp0)).total), axis=0))) < 1e-10
 
 
 # ---- the two 2n+1 routes agree with each other ----

--- a/pycc/tests/test_073_mp2_vg_apt.py
+++ b/pycc/tests/test_073_mp2_vg_apt.py
@@ -61,14 +61,14 @@ def _mpwfn(orbital_basis='spatial', freeze_core='false', geom=H2O2, basis='STO-3
 def test_mp2_vg_apt_all_electron():
     """All-electron spatial MP2 VG APT (total, via the pycc.apt velocity-gauge facade) reproduces
     the regression reference for (P)-H2O2/STO-3G."""
-    P = np.asarray(pycc.apt(_mpwfn()[0], gauge='velocity').total).reshape(-1, 3)
+    P = np.asarray(pycc.apt(pycc.MPderiv(_mpwfn()[0]), gauge='velocity').total).reshape(-1, 3)
     for (row, col), ref in VG_REF['false'].items():
         assert abs(P[row, col] - ref) < 1e-6, (row, col, P[row, col], ref)
 
 
 def test_mp2_vg_apt_frozen_core():
     """Frozen-core spatial MP2 VG APT (total) reproduces the regression reference."""
-    P = np.asarray(pycc.apt(_mpwfn(freeze_core='true')[0], gauge='velocity').total).reshape(-1, 3)
+    P = np.asarray(pycc.apt(pycc.MPderiv(_mpwfn(freeze_core='true')[0]), gauge='velocity').total).reshape(-1, 3)
     for (row, col), ref in VG_REF['true'].items():
         assert abs(P[row, col] - ref) < 1e-6, (row, col, P[row, col], ref)
 
@@ -77,7 +77,7 @@ def test_mp2_vg_apt_reduces_to_hf():
     """The MP2 VG APT total reduces to the (Amos-pinned) HF VG APT total as the correlation
     vanishes: the difference is the small MP2 correlation contribution."""
     mp, wfn = _mpwfn()
-    VG = np.asarray(pycc.apt(mp, gauge='velocity').total)
+    VG = np.asarray(pycc.apt(pycc.MPderiv(mp), gauge='velocity').total)
     HF = np.asarray(pycc.HFwfn(wfn).velocity_dipole_derivatives())
     diff = np.max(np.abs(VG - HF))
     assert diff < 0.05, diff            # small correlation contribution

--- a/pycc/tests/test_074_property_facade.py
+++ b/pycc/tests/test_074_property_facade.py
@@ -2,8 +2,9 @@
 Property facade -- pycc.aat() and pycc.PropertyComponents.
 
 The facade returns the additive physical decomposition ``total = nuclear + reference +
-correlation`` for any supported wavefunction type, with the pieces genuinely computed apart
-(the correlation excludes the SCF reference density; the reference is the independent SCF AAT).
+correlation``, taking a derivative driver (``MPderiv``/``CCderiv``) for the correlated methods or a
+bare ``HFwfn`` for the reference, with the pieces genuinely computed apart (the correlation excludes
+the SCF reference density; the reference is the independent SCF value).
 """
 
 import psi4
@@ -110,15 +111,16 @@ def test_aat_frozen_core_total():
 # ---- the other properties under the same umbrella ----
 
 def _facade_and_pieces(hf, mp):
-    """Each facade function paired with (HF public method, MP2 correlation method) that
-    reconstruct the physical total, for the composition check."""
+    """Each facade function (called on the MP2 driver) paired with (HF public method, MP2
+    correlation method) that reconstruct the physical total, for the composition check."""
+    d = pycc.MPderiv(mp)
     return [
-        ("dipole",         pycc.dipole(mp),               hf.dipole(),                     mp.relaxed_dipole()),
-        ("gradient",       pycc.gradient(mp),             hf.gradient(),                   mp.gradient()),
-        ("polarizability", pycc.polarizability(mp),       hf.polarizability(),             mp.polarizability()),
-        ("hessian",        pycc.hessian(mp),              hf.hessian(),                    mp.hessian()),
-        ("apt-length",     pycc.apt(mp, 'length'),        hf.dipole_derivatives(),         mp.dipole_derivatives()),
-        ("apt-velocity",   pycc.apt(mp, 'velocity'),      hf.velocity_dipole_derivatives(), mp.velocity_dipole_derivatives()),
+        ("dipole",         pycc.dipole(d),                hf.dipole(),                     mp.relaxed_dipole()),
+        ("gradient",       pycc.gradient(d),              hf.gradient(),                   mp.gradient()),
+        ("polarizability", pycc.polarizability(d),        hf.polarizability(),             mp.polarizability()),
+        ("hessian",        pycc.hessian(d),               hf.hessian(),                    mp.hessian()),
+        ("apt-length",     pycc.apt(d, 'length'),         hf.dipole_derivatives(),         mp.dipole_derivatives()),
+        ("apt-velocity",   pycc.apt(d, 'velocity'),       hf.velocity_dipole_derivatives(), mp.velocity_dipole_derivatives()),
     ]
 
 
@@ -131,9 +133,9 @@ def test_facade_decomposition_and_total():
         assert np.max(np.abs(comp.total - (np.asarray(hf_pub) + np.asarray(mp_corr)))) < 1e-10, name
 
 
-def test_facade_accepts_driver_object():
-    """The facade takes a derivative driver (the driver-object API) as well as a bare wavefunction
-    (the transitional path); both give identical PropertyComponents for every property."""
+def test_facade_requires_driver_object():
+    """The facade takes a derivative driver; a bare (registered) correlated wavefunction is rejected
+    with a TypeError telling the caller to construct the driver first."""
     _, mp = _wfns()
     driver = pycc.MPderiv(mp)
     cases = [
@@ -145,9 +147,13 @@ def test_facade_accepts_driver_object():
         ("apt-velocity",   lambda x: pycc.apt(x, 'velocity')),
     ]
     for name, fn in cases:
-        via_wfn, via_driver = fn(mp), fn(driver)
-        assert np.max(np.abs(via_driver.total - via_wfn.total)) < 1e-12, name
-        assert np.max(np.abs(via_driver.correlation - via_wfn.correlation)) < 1e-12, name
+        r = fn(driver)                                   # driver object works
+        assert np.max(np.abs(r.total - (r.nuclear + r.reference + r.correlation))) < 1e-12, name
+        try:
+            fn(mp)                                       # bare registered wfn is rejected
+            assert False, f"expected TypeError for a bare wavefunction: {name}"
+        except TypeError:
+            pass
 
 
 def test_facade_hf_wavefunction():
@@ -169,7 +175,7 @@ def test_facade_hf_wavefunction():
 def test_facade_polarizability_no_nuclear():
     """The polarizability has no nuclear contribution (pure electronic response)."""
     _, mp = _wfns()
-    assert np.all(pycc.polarizability(mp).nuclear == 0.0)
+    assert np.all(pycc.polarizability(pycc.MPderiv(mp)).nuclear == 0.0)
 
 
 def test_apt_bad_gauge():
@@ -186,12 +192,13 @@ def test_facade_route_option():
     """route (MP2 correlation algorithm) is exposed and passed through; the two APT 2n+1 routes
     agree, and route is ignored for HF."""
     hf, mp = _wfns()
-    assert np.max(np.abs(pycc.polarizability(mp, route='2n+1').total
-                         - pycc.polarizability(mp).total)) < 1e-12
-    assert np.max(np.abs(pycc.hessian(mp, route='2n+1').total
-                         - pycc.hessian(mp).total)) < 1e-12
-    assert np.max(np.abs(pycc.apt(mp, 'length', route='2n+1-nuclear').total
-                         - pycc.apt(mp, 'length', route='2n+1-field').total)) < 1e-10
+    d = pycc.MPderiv(mp)
+    assert np.max(np.abs(pycc.polarizability(d, route='2n+1').total
+                         - pycc.polarizability(d).total)) < 1e-12
+    assert np.max(np.abs(pycc.hessian(d, route='2n+1').total
+                         - pycc.hessian(d).total)) < 1e-12
+    assert np.max(np.abs(pycc.apt(d, 'length', route='2n+1-nuclear').total
+                         - pycc.apt(d, 'length', route='2n+1-field').total)) < 1e-10
     assert np.all(pycc.hessian(hf, route='2n+1').correlation == 0.0)
 
 
@@ -199,8 +206,10 @@ def test_facade_orbital_gauge_option():
     """orbital_gauge (expert-only) is exposed on aat / apt(velocity); the tensor is invariant to
     it (the knob reaches the correlation method, which is gauge invariant), ignored for HF."""
     hf, mp = _wfns()
+    # aat keeps its wavefunction-based interface for now (pending the AAT/VG-APT hoist)
     assert np.max(np.abs(pycc.aat(mp, orbital_gauge='non-canonical').total
                          - pycc.aat(mp, orbital_gauge='canonical').total)) < 1e-9
-    assert np.max(np.abs(pycc.apt(mp, 'velocity', orbital_gauge='non-canonical').total
-                         - pycc.apt(mp, 'velocity', orbital_gauge='canonical').total)) < 1e-9
+    d = pycc.MPderiv(mp)
+    assert np.max(np.abs(pycc.apt(d, 'velocity', orbital_gauge='non-canonical').total
+                         - pycc.apt(d, 'velocity', orbital_gauge='canonical').total)) < 1e-9
     assert np.all(pycc.apt(hf, 'velocity', orbital_gauge='canonical').correlation == 0.0)

--- a/pycc/tests/test_076_ccsd_gradient.py
+++ b/pycc/tests/test_076_ccsd_gradient.py
@@ -95,7 +95,7 @@ def test_ccsd_gradient_vs_findiff():
     cc = _ccwfn(REF, "STO-3G")
     g = np.asarray(pycc.CCderiv(cc).gradient())
     assert np.max(np.abs(g - GRAD_REF_STO3G)) < 1e-11, g
-    r = pycc.gradient(cc)
+    r = pycc.gradient(pycc.CCderiv(cc))
     assert np.max(np.abs(r.total - (r.nuclear + r.reference + r.correlation))) < 1e-12
     assert np.max(np.abs(np.asarray(r.correlation) - GRAD_REF_STO3G)) < 1e-11
 

--- a/pycc/tests/test_078_so_ccsd_gradient.py
+++ b/pycc/tests/test_078_so_ccsd_gradient.py
@@ -68,7 +68,7 @@ def test_so_ccsd_gradient_vs_psi4_uhf():
     This is the open-shell validation: an external check against a converged, non-degenerate UHF
     reference (NH2)."""
     cc, _ = _so_ccwfn(NH2, reference="uhf")
-    r = pycc.gradient(cc)
+    r = pycc.gradient(pycc.CCderiv(cc))
     assert np.max(np.abs(r.total - (r.nuclear + r.reference + r.correlation))) < 1e-12
 
     psi4.core.clean_options()
@@ -88,7 +88,7 @@ def test_so_ccsd_gradient_vs_psi4_uhf_oh_c2v():
     near-singular (this is the case that is *not* reproducible when forced into C1)."""
     cc, wfn = _so_ccwfn(OH_C2V, reference="uhf", basis="6-31G")
     assert wfn.molecule().point_group().symbol() == "c2v"        # actually running in C2v
-    r = pycc.gradient(cc)
+    r = pycc.gradient(pycc.CCderiv(cc))
 
     psi4.core.clean_options()
     psi4.set_options({'basis': '6-31G', 'scf_type': 'pk', 'reference': 'uhf',

--- a/pycc/tests/test_083_ccsdt_gradient.py
+++ b/pycc/tests/test_083_ccsdt_gradient.py
@@ -115,13 +115,13 @@ def test_ccsdt_gradient_facade_components():
     contribution to the correlation gradient on top of plain CCSD."""
     basis = "6-31G"
     cc_t = _ccwfn_grad(REF, basis)
-    r = pycc.gradient(cc_t)
+    r = pycc.gradient(pycc.CCderiv(cc_t))
     assert np.max(np.abs(r.total - (r.nuclear + r.reference + r.correlation))) < 1e-12
 
     cc = pycc.ccwfn(_scf_wfn(REF, basis))                # plain CCSD
     with open(os.devnull, 'w') as dn, contextlib.redirect_stdout(dn):
         cc.solve_cc(1e-12, 1e-12, 200)
-    r_ccsd = pycc.gradient(cc)
+    r_ccsd = pycc.gradient(pycc.CCderiv(cc))
     # the (T) contribution (density + dependent-pair orbital response) is nonzero
     assert np.max(np.abs(np.asarray(r.correlation) - np.asarray(r_ccsd.correlation))) > 1e-4
 

--- a/pycc/tests/test_084_cc_polarizability.py
+++ b/pycc/tests/test_084_cc_polarizability.py
@@ -120,7 +120,7 @@ def test_ccsd_polarizability_water_631g(rhf_wfn):
     assert np.max(np.abs(alpha - alpha.T)) < 1e-9              # symmetric
 
     # facade: total = nuclear (0) + reference (HF) + correlation, and correlation == analytic alpha
-    r = pycc.polarizability(cc)
+    r = pycc.polarizability(pycc.CCderiv(cc))
     assert np.max(np.abs(np.asarray(r.nuclear))) < 1e-14
     assert np.max(np.abs(np.asarray(r.correlation) - alpha)) < 1e-12
     assert np.max(np.abs(np.asarray(r.total) - (np.asarray(r.nuclear)
@@ -156,7 +156,7 @@ def test_ccsd_polarizability_hof_offdiagonal(rhf_wfn):
     assert abs(alpha[0, 1]) > 0.5                              # genuine in-plane off-diagonal
     assert abs(alpha[0, 2]) < 1e-9 and abs(alpha[1, 2]) < 1e-9  # out-of-plane block vanishes (Cs)
 
-    r = pycc.polarizability(cc)
+    r = pycc.polarizability(pycc.CCderiv(cc))
     total = np.asarray(r.total)
     assert np.all(np.linalg.eigvalsh(0.5 * (total + total.T)) > 0.0), np.linalg.eigvalsh(total)
     psi4.core.clean()

--- a/pycc/tests/test_087_ccsdt_apt.py
+++ b/pycc/tests/test_087_ccsdt_apt.py
@@ -214,7 +214,7 @@ def _ccsdt_apt(geom, freeze_core, orbital_basis):
     wfn = _cfour_wfn(geom, freeze_core)
     cc = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis=orbital_basis, make_t3_density=True)
     cc.solve_cc(1e-12, 1e-12, 100)
-    return pycc.apt(cc)
+    return pycc.apt(pycc.CCderiv(cc))
 
 
 def _check(r, corr_ref, total_ref, Z, perp):

--- a/pycc/tests/test_088_ccsd_apt.py
+++ b/pycc/tests/test_088_ccsd_apt.py
@@ -209,7 +209,7 @@ def _ccsd_apt(geom, freeze_core, orbital_basis):
     wfn = _cfour_wfn(geom, freeze_core)
     cc = pycc.ccwfn(wfn, orbital_basis=orbital_basis)      # model defaults to CCSD
     cc.solve_cc(1e-12, 1e-12, 100)
-    return pycc.apt(cc)
+    return pycc.apt(pycc.CCderiv(cc))
 
 
 def _check(r, corr_ref, total_ref, Z, perp):

--- a/pycc/tests/test_089_ccsdt_hessian.py
+++ b/pycc/tests/test_089_ccsdt_hessian.py
@@ -201,7 +201,7 @@ def _ccsdt_hess(geom, freeze_core, orbital_basis):
     wfn = _cfour_wfn(geom, freeze_core)
     cc = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis=orbital_basis, make_t3_density=True)
     cc.solve_cc(1e-12, 1e-12, 100)
-    return pycc.hessian(cc)
+    return pycc.hessian(pycc.CCderiv(cc))
 
 
 def _check(r, corr_ref):

--- a/pycc/tests/test_090_ccsd_hessian.py
+++ b/pycc/tests/test_090_ccsd_hessian.py
@@ -196,7 +196,7 @@ def _ccsd_hess(geom, freeze_core, orbital_basis):
     wfn = _cfour_wfn(geom, freeze_core)
     cc = pycc.ccwfn(wfn, orbital_basis=orbital_basis)      # model defaults to CCSD
     cc.solve_cc(1e-12, 1e-12, 100)
-    return pycc.hessian(cc)
+    return pycc.hessian(pycc.CCderiv(cc))
 
 
 def _check(r, corr_ref):


### PR DESCRIPTION
# feat(properties): migrate MP2/CC call sites to driver objects; partial hard break

Follow-up to the derivative-object property API (#210).  Completes the driver-object transition for
the **registered** correlated methods (MP2, CCSD/CCSD(T)): the facade now **requires a driver
object** for those, and all internal call sites pass one.

## Facade: partial hard break

`properties._correlated` now **rejects a bare registered correlated wavefunction** (`MPwfn`/`CCwfn`)
with a clear `TypeError` -- e.g. `pycc.gradient(pycc.CCderiv(cc))`, not `pycc.gradient(cc)` -- so
the solve cost sits in an explicit constructor (the Option-A end state, scoped to the registered
methods).  Two transitional exceptions remain, by design:

- **CISD**: `CIderiv` is still a Phase-4 stub (unregistered), so a `CIwfn` is still accepted directly
  via the wfn-fallback.  Removed once CISD has a real driver.
- **`aat`**: keeps its own wavefunction-based interface (its own dispatch, not `_correlated`),
  pending the AAT/VG-APT hoist.

`HFwfn` (reference-only) is unaffected.

## Call-site migration

Every MP2/CC facade call site now passes a driver object: `pycc.<prop>(pycc.MPderiv(mp))` /
`pycc.<prop>(pycc.CCderiv(cc))` -- across test_034/061/068/073/074/076/078/083/084/087/088/089/090.
Multi-property tests build one driver and reuse it (test_074's `_facade_and_pieces`, the route /
orbital-gauge tests).  CISD tests (079/080/081/082) and all `aat` calls are unchanged (still wfn).

## Tests

- The dual-accept test is rewritten as `test_facade_requires_driver_object`: a driver object works;
  a bare registered wfn raises `TypeError` for every property.
- `test_apt_bad_gauge` unchanged (an unknown gauge is rejected before dispatch, so it never reaches
  the wfn check).

## Validation

Full correlated-property suite (HF/MP2/CCSD/CCSD(T)/CISD gradient, dipole, polarizability, APT,
Hessian, AAT; spatial + spin-orbital; all-electron + frozen core).  CISD fallback and the bare-wfn
rejection both exercised.

## Still to come (unchanged plan)

The wfn path is fully removed (dropping the CISD fallback) once `CIderiv` becomes a real registered
driver; `aat` is unified onto the driver interface when the AAT/VG-APT hoist lands.
