### PR TITLE
refactor(properties): expunge the obsolete route='explicit'; drop the vestigial route from polarizability/hessian

### DIFF
--- a/pycc/correlatedderivs.py
+++ b/pycc/correlatedderivs.py
@@ -664,7 +664,7 @@ class CorrelatedDerivs:
     # separate and are summed by the facade.  A leaf overrides one of these only to add
     # method-specific behavior (e.g. CCderiv.polarizability's model / (T)-intermediate guards).
 
-    def polarizability(self, route: str = '2n+1') -> np.ndarray:
+    def polarizability(self) -> np.ndarray:
         r"""Correlation contribution to the static (omega=0) dipole polarizability (a.u.), shape
         ``(3, 3)``: ``alpha_corr_ab = -d^2 E_corr / dF_a dF_b``, via the 2n+1 route (frozen-core
         aware; spin-orbital and spin-adapted paths).  Differentiating the relaxed dipole
@@ -683,11 +683,8 @@ class CorrelatedDerivs:
         canonical core-active block, gauge per :attr:`perturbed_mo_gauge`).  No second-order CPHF
         ``U^{ab}`` -- only first-order responses.
 
-        ``route`` accepts only ``'2n+1'`` (the sole route; the argument is retained for a uniform
-        property signature).  The reference part is kept separate (:meth:`HFwfn.polarizability`) and
-        summed with this correlation part by :func:`pycc.polarizability`."""
-        if route != '2n+1':
-            raise ValueError(f"unknown polarizability route {route!r} (only '2n+1')")
+        The reference part is kept separate (:meth:`HFwfn.polarizability`) and summed with this
+        correlation part by :func:`pycc.polarizability`."""
         from .cphf import Perturbation
         wfn = self.wfn
         c = self.contract
@@ -829,7 +826,7 @@ class CorrelatedDerivs:
                                           + c('pq,pq->', dW[alpha], SX) + c('pq,pq->', W, rot1(Um, SX)))
         return P
 
-    def hessian(self, route: str = '2n+1') -> np.ndarray:
+    def hessian(self) -> np.ndarray:
         r"""Correlation contribution to the molecular (nuclear) Hessian (a.u.), shape
         ``(3*natom, 3*natom)`` indexed ``(A*3+a, B*3+b)`` = ``d^2 E_corr / dX_{Aa} dX_{Bb}`` -- the
         nuclear-nuclear analog of :meth:`polarizability` / :meth:`dipole_derivatives`, via the 2n+1
@@ -862,10 +859,8 @@ class CorrelatedDerivs:
         skeleton's occupied-sum response as the per-``X`` intermediate ``J^X`` contracted with
         ``U^Y`` (so no ``O(N^2)`` four-index rotation).
 
-        ``route`` accepts only ``'2n+1'`` (retained for a uniform property signature).  The reference
-        and nuclear parts are separate and summed with this correlation part by :func:`pycc.hessian`."""
-        if route != '2n+1':
-            raise ValueError(f"unknown hessian route {route!r} (only '2n+1')")
+        The reference and nuclear parts are separate and summed with this correlation part by
+        :func:`pycc.hessian`."""
         from .cphf import Perturbation
         wfn = self.wfn
         c = self.contract

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -186,13 +186,13 @@ class MPwfn(Wavefunction):
         """MP2 correlation nuclear gradient -- delegates to :meth:`MPderiv.gradient`."""
         return self.deriv.gradient()
 
-    def polarizability(self, route: str = '2n+1') -> np.ndarray:
+    def polarizability(self) -> np.ndarray:
         """MP2 correlation polarizability -- delegates to :meth:`MPderiv.polarizability`."""
-        return self.deriv.polarizability(route)
+        return self.deriv.polarizability()
 
-    def hessian(self, route: str = '2n+1') -> np.ndarray:
+    def hessian(self) -> np.ndarray:
         """MP2 correlation Hessian -- delegates to :meth:`MPderiv.hessian`."""
-        return self.deriv.hessian(route)
+        return self.deriv.hessian()
 
     def dipole_derivatives(self, route: str = '2n+1-field') -> np.ndarray:
         """MP2 correlation length-gauge APT -- delegates to :meth:`MPderiv.dipole_derivatives`."""

--- a/pycc/properties.py
+++ b/pycc/properties.py
@@ -183,24 +183,18 @@ def gradient(wfn) -> PropertyComponents:
     return PropertyComponents(nuclear, reference, correlation)
 
 
-def polarizability(wfn, route='2n+1') -> PropertyComponents:
+def polarizability(wfn) -> PropertyComponents:
     """Static electric-dipole polarizability as a :class:`PropertyComponents`, shape ``(3, 3)``
-    each.  A pure electronic response property: the nuclear block is zero.
-
-    ``route`` selects the MP2 correlation algorithm, ``'2n+1'`` (default -- the O(N)-cheaper 2n+1
-    route) or ``'explicit'``; both give the same tensor and it is ignored for an ``HFwfn``."""
-    reference, correlation = _dispatch(wfn, 'polarizability', 'polarizability', {'route': route})
+    each.  A pure electronic response property: the nuclear block is zero."""
+    reference, correlation = _dispatch(wfn, 'polarizability', 'polarizability')
     return PropertyComponents(np.zeros((3, 3)), reference, correlation)
 
 
-def hessian(wfn, route='2n+1') -> PropertyComponents:
+def hessian(wfn) -> PropertyComponents:
     """Molecular (nuclear) Hessian as a :class:`PropertyComponents` (``nuclear + reference +
     correlation``, shape ``(3*natom, 3*natom)`` each).  The nuclear block is the nuclear-
-    repulsion second derivative ``d^2 V_NN/dX dY``.
-
-    ``route`` selects the MP2 correlation algorithm, ``'2n+1'`` (default -- the O(N)-cheaper 2n+1
-    route) or ``'explicit'``; both give the same matrix and it is ignored for an ``HFwfn``."""
-    reference, correlation = _dispatch(wfn, '_hessian_electronic', 'hessian', {'route': route})
+    repulsion second derivative ``d^2 V_NN/dX dY``."""
+    reference, correlation = _dispatch(wfn, '_hessian_electronic', 'hessian')
     nuclear = np.asarray(_wfn_of(wfn).derivatives.nuclear_repulsion2())
     return PropertyComponents(nuclear, reference, correlation)
 
@@ -213,9 +207,8 @@ def apt(wfn, gauge='length', route='2n+1-field', orbital_gauge='non-canonical') 
     ``gauge='length'`` (default) is the length-gauge APT (:meth:`dipole_derivatives`);
     ``gauge='velocity'`` is the velocity-gauge APT (:meth:`velocity_dipole_derivatives`).
 
-    ``route`` (length gauge only) selects the MP2 correlation algorithm -- ``'2n+1-field'``
-    (default -- the O(N)-cheaper route, 3 field solves), ``'2n+1-nuclear'``, or ``'explicit'``;
-    all give the same tensor.
+    ``route`` (length gauge only) selects the algorithm -- ``'2n+1-field'`` (default -- the
+    O(N)-cheaper route, 3 field solves) or ``'2n+1-nuclear'``; both give the same tensor.
 
     ``orbital_gauge`` (velocity gauge only; **expert only**) selects the redundant momentum
     orbital-rotation gauge, ``'non-canonical'`` (default, numerically stable) or ``'canonical'``.

--- a/pycc/tests/test_069_mp2_hessian.py
+++ b/pycc/tests/test_069_mp2_hessian.py
@@ -125,12 +125,3 @@ def test_fc_so_mp2_corr_hessian_vs_spatial_631g():
     H_so = _mpwfn(BASE, 'spinorbital', freeze_core='true').hessian()
     H_sa = _mpwfn(BASE, 'spatial', freeze_core='true').hessian()
     assert np.max(np.abs(H_so - H_sa)) < 1e-11
-
-
-# ---- route argument guard ----
-
-def test_mp2_hessian_bad_route_raises():
-    """An unknown Hessian route raises (only '2n+1' is accepted)."""
-    import pytest
-    with pytest.raises(ValueError):
-        _mpwfn(BASE, 'spatial').hessian(route='bogus')

--- a/pycc/tests/test_074_property_facade.py
+++ b/pycc/tests/test_074_property_facade.py
@@ -189,17 +189,12 @@ def test_apt_bad_gauge():
 
 
 def test_facade_route_option():
-    """route (MP2 correlation algorithm) is exposed and passed through; the two APT 2n+1 routes
-    agree, and route is ignored for HF."""
-    hf, mp = _wfns()
+    """The APT route (the only property that still takes one) is exposed and passed through: its
+    two 2n+1 sub-routes (field vs nuclear) give the same tensor."""
+    _, mp = _wfns()
     d = pycc.MPderiv(mp)
-    assert np.max(np.abs(pycc.polarizability(d, route='2n+1').total
-                         - pycc.polarizability(d).total)) < 1e-12
-    assert np.max(np.abs(pycc.hessian(d, route='2n+1').total
-                         - pycc.hessian(d).total)) < 1e-12
     assert np.max(np.abs(pycc.apt(d, 'length', route='2n+1-nuclear').total
                          - pycc.apt(d, 'length', route='2n+1-field').total)) < 1e-10
-    assert np.all(pycc.hessian(hf, route='2n+1').correlation == 0.0)
 
 
 def test_facade_orbital_gauge_option():

--- a/pycc/tests/test_078_so_ccsd_gradient.py
+++ b/pycc/tests/test_078_so_ccsd_gradient.py
@@ -4,9 +4,8 @@ Spin-orbital (UHF) CCSD analytic nuclear gradient -- pycc.gradient(ccwfn) / CCde
 The spin-orbital gradient mirrors the spatial one (Z-vector route) with the antisymmetrized
 generalized-Fock Lagrangian, an inline orbital Hessian, and the spin-orbital derivative integrals.
 Validated by: the SO == spatial keystone (a closed-shell RHF driven through the spin-orbital path
-must reproduce the spatial closed-shell gradient), psi4's analytic UHF-CCSD gradient, the
-independent explicit-derivative route (Z-vector == explicit), and -- for frozen core, which psi4's
-CC gradients do not support -- the spatial frozen-core gradient.
+must reproduce the spatial closed-shell gradient), psi4's analytic UHF-CCSD gradient, and -- for
+frozen core, which psi4's CC gradients do not support -- the spatial frozen-core gradient.
 """
 
 import numpy as np

--- a/pycc/tests/test_084_cc_polarizability.py
+++ b/pycc/tests/test_084_cc_polarizability.py
@@ -366,17 +366,14 @@ def test_ccsdt_polarizability_cfour(route, mol, fc):
 
 def test_ccsd_polarizability_guards(rhf_wfn):
     """Constructing a CCderiv sets the (T) density itself -- so a CCSD(T) property no longer needs
-    the user to pass make_t3_density (the former footgun) -- while a misused route still raises.
-    Both the spatial and spin-orbital CCSD(T) paths build without the flag."""
-    import pytest
+    the user to pass make_t3_density (the former footgun).  Both the spatial and spin-orbital
+    CCSD(T) paths build without the flag."""
     wfn = rhf_wfn(WATER, "6-31G", freeze_core="false")
     cc = pycc.ccwfn(wfn, model='ccsd(t)')                              # spatial CCSD(T), no make_t3_density
     cc.solve_cc(1e-12, 1e-12, 100)
     d = pycc.CCderiv(cc)                                              # sets make_t3_density, builds the (T) density
     assert cc.make_t3_density is True
     d.polarizability()                                               # works without the user setting the flag
-    with pytest.raises(ValueError):                                  # unknown route still raises
-        d.polarizability(route='explicit')
     cc_so = pycc.ccwfn(wfn, model='ccsd(t)', orbital_basis='spinorbital')   # no make_t3_density
     cc_so.solve_cc(1e-12, 1e-12, 100)
     pycc.CCderiv(cc_so).polarizability()                             # SO path likewise works without the flag

--- a/pycc/tests/test_089_ccsdt_hessian.py
+++ b/pycc/tests/test_089_ccsdt_hessian.py
@@ -258,14 +258,10 @@ def test_ccsdt_hessian_cfour_hof_spatial():
 
 def test_ccsdt_hessian_guards():
     """Constructing a CCderiv sets the (T) density itself, so a CCSD(T) Hessian no longer needs the
-    user to pass make_t3_density (the former footgun); an unknown route still raises."""
+    user to pass make_t3_density (the former footgun)."""
     wfn = _cfour_wfn(WATER, 'false')
     cc_t = pycc.ccwfn(wfn, model='ccsd(t)')                     # CCSD(T), no make_t3_density
     cc_t.solve_cc(1e-12, 1e-12, 100)
     pycc.CCderiv(cc_t)                                          # sets the flag + builds the (T) density
     assert cc_t.make_t3_density is True and hasattr(cc_t, 'S1')
-    cc = pycc.ccwfn(wfn)                                        # plain CCSD: reaches the route check
-    cc.solve_cc(1e-12, 1e-12, 100)
-    with pytest.raises(ValueError):                             # unknown route still raises
-        pycc.CCderiv(cc).hessian(route='bogus')
     psi4.core.clean()

--- a/pycc/tests/test_090_ccsd_hessian.py
+++ b/pycc/tests/test_090_ccsd_hessian.py
@@ -252,13 +252,3 @@ def test_so_ccsd_hessian_cfour_hof():
     psi4.core.clean()
     _check(_ccsd_hess(HOF, 'true', 'spinorbital'), CFOUR_HESS_HOF_FC)
     psi4.core.clean()
-
-
-def test_ccsd_hessian_route_guard():
-    """An unknown Hessian route raises rather than silently returning a wrong matrix (only '2n+1')."""
-    wfn = _cfour_wfn(WATER, 'false')
-    cc = pycc.ccwfn(wfn)
-    cc.solve_cc(1e-12, 1e-12, 100)
-    with pytest.raises(ValueError):
-        pycc.CCderiv(cc).hessian(route='bogus')
-    psi4.core.clean()


### PR DESCRIPTION
# refactor(properties): expunge the obsolete route='explicit'; drop the vestigial route from polarizability/hessian

The `'explicit'` second-derivative route was scaffolding from the early derivative infrastructure
(an independent double-perturbation cross-check for the 2n+1 route).  We are past that -- only the
2n+1 route remains, and there is no explicit-computation machinery left in the deriv codes -- so this
removes the last vestiges of it.

## Changes

- **`polarizability` / `hessian` (base `CorrelatedDerivs` + `pycc.properties` facade + the `MPwfn`
  delegators): the `route` argument is removed.**  Its only legal value was `'2n+1'`, so it was a
  no-op that existed solely to reject typos -- pure clutter now.  `CorrelatedDerivs.polarizability`
  and `hessian` take `self` only; the facade functions drop the `route` parameter and passthrough.
- **`dipole_derivatives` / `apt` keep `route`** -- there it is genuine (`'2n+1-field'` vs
  `'2n+1-nuclear'`, the two ways to form the mixed field/nuclear APT) -- but `'explicit'` is removed
  from its documentation.
- Facade docstrings no longer mention `'explicit'`.

## Tests

- Deleted the now-moot hessian route-guard tests (`test_069`'s `test_mp2_hessian_bad_route_raises`,
  `test_090`'s `test_ccsd_hessian_route_guard`) -- there is no route to reject.
- Trimmed the route sub-assertion from the CCSD(T) polarizability / Hessian construction guards
  (`test_084` / `test_089`); they keep the make_t3_density-behavior check.
- `test_074`'s route-option test is now APT-only (the only property that still takes a route).
- Fixed `test_078`'s stale docstring (it advertised a "Z-vector == explicit" cross-check that no
  longer exists).
- The APT route-guard tests (`test_068` / `test_087` / `test_088`, `dipole_derivatives(route='bogus')`)
  are unchanged -- that route is still live.

## Scope

CISD is **left untouched**: its `dipole_derivatives` / `hessian` still carry the inert
`route='explicit'` label, and dropping those is explicitly part of the in-flight CISD driver
migration (see the `cideriv.py` roadmap), not this PR.  This is compatible with the facade change --
the facade no longer passes `route` to `hessian`, and CISD's methods ignore `route` regardless.

## Validation

Full correlated-property suite (MP2/CCSD/CCSD(T)/CISD polarizability, APT, Hessian; the facade;
CISD via its fallback) plus the fast polarizability/Hessian set.  Docs build: 0 warnings.
