### PR TITLE
Add CISD polarizability (2n+1 + explicit routes); fix hessian/dipole_…

### DIFF
--- a/pycc/cideriv.py
+++ b/pycc/cideriv.py
@@ -1,127 +1,664 @@
 """
-cideriv.py: CISD analytic-derivative property driver (SCAFFOLD / STUB).
+cideriv.py: CISD analytic-derivative property driver.
 
-This is the Phase-4 slot of the CorrelatedDerivs refactor: the place where CISD's analytic
-derivative properties will live behind a driver, exactly as MP2 lives on :class:`~pycc.mpderiv.MPderiv`
-and CC on :class:`~pycc.ccderiv.CCderiv`.  It is intentionally a STUB -- the two density hooks below
-raise :class:`NotImplementedError`.  Filling them in is a programmer task.
+`CIderiv` is the CISD leaf of the :class:`~pycc.correlatedderivs.CorrelatedDerivs` hierarchy.
 
-WHY A STUB IS ENOUGH
---------------------
-:class:`~pycc.correlatedderivs.CorrelatedDerivs` already owns the entire method-agnostic
-orbital-response + property-assembly machinery: the unperturbed Z-vector
-(:meth:`~pycc.correlatedderivs.CorrelatedDerivs._orbital_response`), the perturbed relaxed density
-(:meth:`~pycc.correlatedderivs.CorrelatedDerivs._perturbed_relaxed_density`), and the public
-properties ``gradient`` / ``relaxed_dipole`` / ``polarizability`` / ``dipole_derivatives`` /
-``hessian``.  All of that is driven by just two method-specific hooks, which each leaf supplies:
+* `relaxed_dipole` and `gradient` are inherited from the base, driven by the two density hooks
+  below (:meth:`_unrelaxed_densities` / :meth:`_perturbed_unrelaxed_densities`, built from
+  `CIwfn._corr_QGX()`'s true-normalized correlation 1-/2-PDM).
+* `polarizability`, `dipole_derivatives`, and `hessian` are custom, using `CIwfn`'s own
+  equilibrium Z-vector (`_zvector`/`_corr_QGX`/`_solve_dz_dR`) rather than the base's generic
+  machinery.
+* `atomic_axial_tensors` and `velocity_dipole_derivatives` are custom wave-function-overlap
+  constructions the base does not provide at all.
 
-  * :meth:`_unrelaxed_densities`            -- the unrelaxed reduced densities ``(D, Gam)``
-  * :meth:`_perturbed_unrelaxed_densities`  -- their first-order response to a perturbation
+CPCI/magnetic/vecpot machinery (`_cpci_ints`/`_solve_cpci`/`_cpci_raw`, the magnetic/vecpot
+integral builders) and the density builders (`_perturbed_cisd_corr_opdm`/`_perturbed_cisd_tpdm`/
+`_corr_QGX`/`_zvector`) stay on `CIwfn` and are called from here.
 
-Implement those two hooks for CISD and ``CIderiv`` immediately inherits gradients, the relaxed
-dipole, the polarizability, the atomic polar tensors (LG-APT), and the molecular Hessian -- no
-per-property CISD code required.  (Atomic axial tensors and the velocity-gauge APT are NOT provided
-by the base -- they are method-specific overlap formulations -- so those stay as bespoke methods,
-as they are for MP2 on ``MPderiv`` and currently for CISD on ``CIwfn``.)
-
-MIGRATION ROADMAP (for the programmer)
---------------------------------------
-1. Implement :meth:`_unrelaxed_densities` and :meth:`_perturbed_unrelaxed_densities` below, drawing
-   on the CISD density machinery that already exists on :class:`~pycc.ciwfn.CIwfn`
-   (``_cisd_densities``, ``_solve_cpci``, ``_perturbed_cisd_corr_opdm``, ``_perturbed_cisd_tpdm``,
-   ``_solve_dz_dR``).  The crux is the DENSITY CONVENTION (see each hook's docstring): the base
-   wants the *correlation* 1-PDM (no HF ``2*delta_oo`` block) and the *cumulant* 2-PDM (no HF 2-RDM
-   block), matching :meth:`~pycc.correlatedderivs.CorrelatedDerivs._lagrangian`.  ``CIwfn._corr_QGX``
-   already strips exactly those HF blocks off ``CIwfn._zvector``'s full ``Q``/``G`` -- study it.
-2. Validate.  ``CIwfn``'s current ``dipole_derivatives`` / ``hessian`` / ``atomic_axial_tensors`` /
-   ``velocity_dipole_derivatives`` are already the perturbed-relaxed-density (2n+1-style) results
-   (their ``route='explicit'`` argument is a vestigial, inert label -- the body never branches on
-   it), so they are a ready-made numerical oracle for the new base-driven ``CIderiv`` output.  Also
-   check the SO==spatial keystone and a tight finite-difference oracle, per pycc convention.
-3. Register the driver: uncomment ``register_deriv(CIwfn, CIderiv)`` in ``pycc/__init__.py`` so the
-   :mod:`pycc.properties` facade routes CISD through ``CIderiv`` instead of the transitional
-   on-``CIwfn`` code.  Then retire the now-redundant per-property CISD derivative code on ``CIwfn``
-   (keeping only the genuinely CISD-specific AAT / VG-APT pieces), and drop the inert ``route``
-   arguments.
-
-ORBITAL GAUGE
--------------
-CISD is invariant to occupied-occupied and virtual-virtual orbital rotations, so it takes the
-NON-CANONICAL perturbed-MO approach (the ``U^x_ij = -1/2 S^(x)_ij`` / ``U^x_ab = -1/2 S^(x)_ab``
-orthonormality gauge; the oo/vv dependent-pair rotations vanish) -- the same choice as MP2 and CCSD,
-and the opposite of CCSD(T).  This is already the default: the inherited
-:attr:`~pycc.correlatedderivs.CorrelatedDerivs.perturbed_mo_gauge` returns ``'non-canonical'`` for
-any wavefunction whose ``model`` is not ``CCSD(T)``, and ``CIwfn.model`` is ``'CISD'``, so no
-override is needed here.  The programmer should nonetheless CONFIRM this holds for their CISD variant
-(a non-invariant CI truncation would need the canonical route and an override).
 """
 
 from __future__ import annotations
+
+import numpy as np
 
 from .correlatedderivs import CorrelatedDerivs
 
 
 class CIderiv(CorrelatedDerivs):
-    """CISD correlation derivative-property driver -- SCAFFOLD / STUB (Phase 4).
-
-    Constructed from a converged :class:`~pycc.ciwfn.CIwfn`.  Inherits the full orbital-response and
-    property-assembly machinery from :class:`~pycc.correlatedderivs.CorrelatedDerivs`; a programmer
-    supplies the two CISD density hooks (:meth:`_unrelaxed_densities`,
-    :meth:`_perturbed_unrelaxed_densities`) to bring it to life.  See the module docstring for the
-    migration roadmap and the density-convention notes.
-    """
+    """CISD correlation derivative-property driver. Constructed from a converged CIwfn
+    (aliased `self.ci`). See the module docstring for which properties are inherited vs custom.
+    Spatial (closed-shell RHF), all-electron only."""
 
     def __init__(self, ciwfn) -> None:
         super().__init__(ciwfn)
-        self.ciwfn = ciwfn                             # alias: this class uses .ciwfn, the base .wfn
+        self.ci = ciwfn                                # alias: this class uses .ci, the base .wfn
 
     def _unrelaxed_densities(self):
-        """Leaf hook: the unrelaxed reduced densities ``(D, Gam)`` as full-MO arrays -- the CISD
-        analogue of :meth:`~pycc.mpderiv.MPderiv._unrelaxed_densities` /
-        :meth:`~pycc.ccderiv.CCderiv._unrelaxed_densities`.
+        """(D, Gam) from CIwfn._corr_QGX(). Feeds relaxed_dipole/gradient only."""
+        Q_corr, G_corr, _X_corr = self.ci._corr_QGX()
+        return Q_corr, G_corr
 
-        Must return:
+    def _perturbed_unrelaxed_densities(self, pert, df=None, deri=None, dL=None):
+        """First-order response (d_x D, d_x Gam) to pert. Feeds base-driven gradient/relaxed_dipole
+        second-derivative uses; dipole_derivatives/hessian/polarizability use their own _solve_dz_dR below instead."""
+        ci = self.ci
+        no = ci.no
+        dc1, dc2, dc0v = ci._solve_cpci(pert)
 
-        * ``D``   -- the **correlation** 1-PDM (``nmo x nmo``): the Doo/Dov/Dvo/Dvv correlation
-          blocks only, WITHOUT the reference ``2*delta_ij`` occupied block (the base adds the
-          reference contribution separately via the SCF ``HFwfn``).
-        * ``Gam`` -- the **cumulant** 2-PDM (``nmo^4``), WITHOUT the closed-shell HF 2-RDM block
-          (``2 d_ik d_jl - d_il d_jk``), carrying the permutational symmetry expected by
-          :meth:`~pycc.correlatedderivs.CorrelatedDerivs._lagrangian` (whose 2-PDM term is
-          ``4 sum_rst <pr||st> Gam_qrst``).
+        dD_corr = ci._perturbed_cisd_corr_opdm(dc1, dc2)
+        dG_raw = ci._perturbed_cisd_tpdm(dc1, dc2, dc0v)
 
-        IMPLEMENTATION POINTERS.  ``CIwfn._cisd_densities`` returns ``(D_pq, D_pq_corr, D_pqrs)`` and
-        ``CIwfn._zvector`` builds the full ``Q``/``G``; ``CIwfn._corr_QGX`` already strips the HF
-        blocks off those to give the correlation-only ``(Q_corr, G_corr, X_corr)``.  Reconciling
-        those CISD conventions to the base's ``(D, Gam)`` contract above is the main task -- compare
-        against how ``MPderiv._unrelaxed_densities`` assembles its full-MO ``(D, Gam)`` from the MP2
-        seeds.
+        dG_sym = 0.25 * (dG_raw + dG_raw.transpose(1, 0, 3, 2) + dG_raw.transpose(2, 3, 0, 1) + dG_raw.transpose(3, 2, 1, 0))
+        dGam = dG_sym.copy()
+        dG_cross = np.zeros_like(dGam)
+        for i in range(no):
+            dG_cross[i, :, i, :] += 2.0 * dD_corr
+            dG_cross[:, i, :, i] += 2.0 * dD_corr
+            dG_cross[i, :, :, i] -= dD_corr.T
+            dG_cross[:, i, i, :] -= dD_corr
+        dGam = dGam + 0.5 * dG_cross
+
+        return dD_corr, dGam
+
+    # length-gauge APT 
+
+    def polarizability(self, route: str = '2n+1') -> np.ndarray:
+        """CISD correlation static polarizability (a.u.), shape (3, 3):
+        alpha[a,b] = -d^2 E_corr / dF_a dF_b. Both routes are custom,
+        using CIwfn's own equilibrium Z-vector.
+
+        route='2n+1' (default): differentiate the relaxed dipole a second
+        time. See _polarizability_2n1().
+        route='explicit': differentiate the energy twice, reusing the
+        Hessian's T0-T5/Z-vector machinery for field-field pairs. See
+        _polarizability_explicit()."""
+        if route == '2n+1':
+            return self._polarizability_2n1()
+        if route == 'explicit':
+            return self._polarizability_explicit()
+        raise ValueError(f"unknown polarizability route {route!r} (use '2n+1' or 'explicit')")
+
+    def _polarizability_2n1(self) -> np.ndarray:
+        """2n+1 route: uses CIwfn's own equilibrium Z-vector and perturbed
+        Z-vector solve, matching dipole_derivatives()/hessian()."""
+        from .cphf import Perturbation
+        c = self.contract
+        ci = self.ci
+        o, v = ci.o, ci.v
+
+        zv = ci._zvector()
+        Drel = zv['Q_relaxed'].copy()
+        for i in range(ci.no):
+            Drel[i, i] -= 2.0
+        mu = [np.asarray(ci.H.mu[a]) for a in range(3)]
+
+        alpha = np.zeros((3, 3))
+        for b in range(3):
+            pert = Perturbation('field', b)
+            U_b = np.asarray(ci.cphf.full_U(pert))
+            dc1, dc2, dc0v = ci._solve_cpci(pert)
+            dc1, dc2 = dc1.real, dc2.real
+            dc0v = dc0v.real if hasattr(dc0v, 'real') else dc0v
+            dz, dD_corr = self._solve_dz_dR(pert, dc1, dc2, dc0v)
+            dDrel = dD_corr.copy()
+            dDrel[v, o] += dz
+            dDrel[o, v] += dz.T
+            for a in range(3):
+                rot = U_b.T @ mu[a] + mu[a] @ U_b
+                alpha[a, b] = (c('pq,pq->', dDrel, mu[a]) + c('pq,pq->', Drel, rot))
+        return alpha
+
+    def _polarizability_explicit(self) -> np.ndarray:
+        """Explicit route: reuses the Hessian's Z-vector machinery
+        (build_xi_ab/build_X_deriv/build_cpci_term/_hess_build_Y/_hess_X_tilde)
+        for field-field pairs - all second-derivative skeletons vanish
+        for a static field, so no U^{fg} solve is needed."""
+        from .cphf import Perturbation
+        ct = self.contract
+        ci = self.ci
+        o, v, no, nv = ci.o, ci.v, ci.no, ci.nv
+        F = np.asarray(ci.H.F)
+        eps = np.diag(F)
+        nmo = ci.nmo
+
+        zv = ci._zvector()
+        Q, G, _ = ci._corr_QGX()
+        X_t = self._hess_X_tilde()
+        Y = self._hess_build_Y()
+        ERI = np.asarray(ci.H.ERI)
+        z = zv['z_ai']
+        n0 = ci._normalized_amplitudes()[0]
+
+        ERI_M = ERI.transpose(0, 2, 1, 3)
+        W_M = 2 * ERI_M - ERI_M.transpose(0, 2, 1, 3)
+        A_M = 4 * ERI_M - ERI_M.transpose(0, 2, 1, 3) - ERI_M.transpose(0, 3, 2, 1)
+
+        mu = [np.asarray(ci.H.mu[a]) for a in range(3)]
+        zero_g = np.zeros((nmo, nmo, nmo, nmo))
+        zero_S = np.zeros((nmo, nmo))
+
+        # First-order field quantities: U^a, field-CPCI raw amplitudes,
+        # X_deriv[a] = -Q_corr.mu_a, Fa_M[a] = -mu_a (g-dependent piece is 0)
+        U_all, dT1_all, dT2_all, X_deriv, Fa_M = {}, {}, {}, {}, {}
+        for a in range(3):
+            pert = Perturbation('field', a)
+            U_all[a] = np.asarray(ci.cphf.full_U(pert))
+            dT1_all[a], dT2_all[a] = ci._cpci_raw(pert)
+            h_a_skel = -mu[a]
+            X_deriv[a] = self.build_X_deriv(h_a_skel, zero_g)
+            Fa_M[a] = h_a_skel.copy()
+            # Aa_M[a] is identically zero for a field (built from g^f = 0)
+
+        alpha = np.zeros((3, 3))
+        for a in range(3):
+            for b in range(3):
+                U_a, U_b = U_all[a], U_all[b]
+
+                # T0: skeleton density contraction - vanishes (h^{fg}=g^{fg}=0)
+                t0_val = 0.0
+
+                # T2: Z-vector replacement (no U^{fg} solved - same as hessian())
+                xi = self.build_xi_ab(U_a, U_b, zero_S, zero_S, zero_S)
+                t2_xiXt = -ct('ij,ji->', xi, X_t)
+                # F_ab_M = 0 (h^{fg} = g^{fg} = 0)
+                Bab = np.zeros((nmo, nmo))
+                Bab -= ct('ij,j->ij', xi, eps)
+                Bab -= ct('kl,ijkl->ij', xi[o, o], W_M[:, :, o, o])
+                Bab += ct('ki,kj->ij', U_a, Fa_M[b])
+                Bab += ct('ki,kj->ij', U_b, Fa_M[a])
+                Bab += ct('kj,ik->ij', U_a, Fa_M[b])
+                Bab += ct('kj,ik->ij', U_b, Fa_M[a])
+                Bab += ct('ki,kj,k->ij', U_a, U_b, eps)
+                Bab += ct('ki,kj,k->ij', U_b, U_a, eps)
+                UaUbT = U_a[:, o] @ U_b[:, o].T
+                Bab += ct('kl,ijkl->ij', UaUbT, A_M)
+                temp5_b = ct('lm,kjlm->kj', U_b[:, o], A_M[:, :, :, o])
+                temp5_a = ct('lm,kjlm->kj', U_a[:, o], A_M[:, :, :, o])
+                Bab += ct('ki,kj->ij', U_a, temp5_b)
+                Bab += ct('ki,kj->ij', U_b, temp5_a)
+                temp6_b = ct('lm,iklm->ik', U_b[:, o], A_M[:, :, :, o])
+                temp6_a = ct('lm,iklm->ik', U_a[:, o], A_M[:, :, :, o])
+                Bab += ct('kj,ik->ij', U_a, temp6_b)
+                Bab += ct('kj,ik->ij', U_b, temp6_a)
+                # Aa_M[a]/[b] terms dropped - identically zero for a field
+                t2_zvec = 2.0 * ct('ai,ai->', Bab[v, o], z)
+                t2_val = t2_xiXt + t2_zvec
+
+                # T3+T4: orbital-response Lagrangian + Y tensor (Y equilibrium, reused)
+                t3_val = 2.0 * (ct('ij,ij->', U_b, X_deriv[a])
+                                + ct('ij,ij->', U_a, X_deriv[b]))
+                t4_val = 2.0 * ct('ij,kl,ijkl->', U_a, U_b, Y)
+
+                # T5: CPCI amplitude response (field-perturbed raw amplitudes)
+                t5_val = n0**2 * self.build_cpci_term(
+                    dT1_all[a], dT2_all[a], dT1_all[b], dT2_all[b]).real
+
+                # alpha = -d^2 E_corr / dF dG (hessian() returns +d^2E/dXdY
+                # with no extra sign, so the field-field analog needs the
+                # explicit minus here)
+                alpha[a, b] = -(t0_val + t2_val + t3_val + t4_val + t5_val).real
+
+        alpha = 0.5 * (alpha + alpha.T)
+        return alpha
+
+    def dipole_derivatives(self, route: str = 'explicit') -> np.ndarray:
+        """CISD CORRELATION-ONLY LG-APT, shape (natom, 3, 3), [A, beta, alpha].
         """
-        raise NotImplementedError(
-            "CIderiv._unrelaxed_densities is a Phase-4 stub. Return the CISD correlation 1-PDM D "
-            "and cumulant 2-PDM Gam (full-MO, HF blocks removed) in the CorrelatedDerivs convention "
-            "-- see this method's docstring and CIwfn._cisd_densities / CIwfn._corr_QGX."
-        )
+        from .cphf import Perturbation
+        c = self.contract
+        o, v = self.ci.o, self.ci.v
+        zv = self.ci._zvector()
+        # Correlation-only relaxed density: Q_relaxed minus the HF 2*delta_oo.
+        # T3/T3z are already pure correlation (amplitude/Z-vector response).
+        Qt = zv['Q_relaxed'].copy()
+        for i in range(self.ci.no):
+            Qt[i, i] -= 2.0
+        natom = self.ci.derivatives.natom
+        h_E = [np.asarray(self.ci.H.mu[f]) for f in range(3)]
 
-    def _perturbed_unrelaxed_densities(self, pert, df, deri, dL):
-        """Leaf hook: the first-order response ``(d_x gamma, d_x Gamma)`` of the unrelaxed reduced
-        densities to ``pert`` (full-MO arrays), in the same convention as :meth:`_unrelaxed_densities`
-        -- the CISD analogue of the MP2 closed form / the CC iterative response.
+        APT = np.zeros((natom, 3, 3))
+        for A in range(natom):
+            dip = self.ci.derivatives.dipole(A)
+            for beta in range(3):
+                pert = Perturbation('nuclear', (A, beta))
+                U_R = np.asarray(self.ci.cphf.full_U(pert))
+                dc1, dc2, dc0v = self.ci._solve_cpci(pert)
+                dc1, dc2 = dc1.real, dc2.real
+                dc0v = dc0v.real if hasattr(dc0v, 'real') else dc0v
+                dz, dD_corr = self._solve_dz_dR(pert, dc1, dc2, dc0v)
 
-        ``pert`` is a :class:`~pycc.cphf.Perturbation`.  ``df``/``deri``/``dL`` are the CPHF-folded
-        perturbed integrals the base has already built (canonical per
-        :attr:`~pycc.correlatedderivs.CorrelatedDerivs.perturbed_mo_gauge`); a CISD implementation
-        will likely solve its own perturbed CI response from ``pert`` and may ignore them, exactly as
-        ``MPderiv._perturbed_unrelaxed_densities`` ignores them for the closed-form MP2 response.
+                for alpha in range(3):
+                    h_RE = np.asarray(dip[alpha * 3 + beta])
+                    T1 = c('ij,ij->', Qt, h_RE)
+                    T2 = (c('rp,pq,rq->', U_R, Qt, h_E[alpha]) + c('pq,ps,sq->', Qt, h_E[alpha], U_R))
+                    T3 = c('pq,pq->', dD_corr, h_E[alpha])
+                    T3z = 2.0 * c('ai,ai->', dz, h_E[alpha][v, o])
+                    APT[A, beta, alpha] = (T1 + T2 + T3 + T3z).real
+        return APT
 
-        IMPLEMENTATION POINTERS.  ``CIwfn._solve_cpci(pert)`` solves the perturbed CI coefficients
-        ``(dc1, dc2, dc0v)``; ``CIwfn._perturbed_cisd_corr_opdm(dc1, dc2)`` and
-        ``CIwfn._perturbed_cisd_tpdm(dc1, dc2, dc0v)`` build the perturbed 1-PDM / 2-PDM from them.
-        Return those in the base convention (HF blocks removed), matching what
-        :meth:`_unrelaxed_densities` returns for the unperturbed case.
-        """
-        raise NotImplementedError(
-            "CIderiv._perturbed_unrelaxed_densities is a Phase-4 stub. Return the first-order "
-            "response (d_x gamma, d_x Gamma) of the CISD correlation densities -- see this method's "
-            "docstring and CIwfn._solve_cpci / _perturbed_cisd_corr_opdm / _perturbed_cisd_tpdm."
-        )
+    def _solve_dz_dR(self, pert, dc1, dc2, dc0v):
+        c = self.contract
+        o, v, no, nv = self.ci.o, self.ci.v, self.ci.no, self.ci.nv
+        zv = self.ci._zvector()
+        z = zv['z_ai']
+
+        dF, dERI, _ = self.ci._cpci_ints(pert)
+        dD_corr = self.ci._perturbed_cisd_corr_opdm(dc1, dc2)
+        dD_pqrs = self.ci._perturbed_cisd_tpdm(dc1, dc2, dc0v)
+
+        o_ = self.ci.o
+        dh_mo = dF - c('piqi->pq', 2.0 * dERI[:, o_, :, o_] - dERI.swapaxes(2, 3)[:, o_, :, o_])
+        dG_sym = 0.25 * (dD_pqrs + dD_pqrs.transpose(1, 0, 3, 2) + dD_pqrs.transpose(2, 3, 0, 1) + dD_pqrs.transpose(3, 2, 1, 0))
+        dG = dG_sym.copy()
+        dG_cross = np.zeros_like(dG)
+        for i in range(no):
+            dG_cross[i, :, i, :] += 2.0 * dD_corr
+            dG_cross[:, i, :, i] += 2.0 * dD_corr
+            dG_cross[i, :, :, i] -= dD_corr.T
+            dG_cross[:, i, i, :] -= dD_corr
+        dG = dG + 0.5 * dG_cross
+
+        ERI = np.asarray(self.ci.H.ERI)
+        dX = c('jm,im->ij', dD_corr, zv['h_mo']) + c('jm,im->ij', zv['Q'], dh_mo)
+        dX = dX + 2.0 * c('jmkl,imkl->ij', dG, ERI) + 2.0 * c('jmkl,imkl->ij', zv['G'], dERI)
+
+        db = -(dX[v, o] - dX[o, v].T)
+
+        dL = 2.0 * dERI - dERI.swapaxes(2, 3)
+        dG_mat_vovo = (dL[v, o, o, v].transpose(0, 2, 3, 1)
+                       + dL[v, v, o, o].transpose(0, 2, 1, 3))
+        dG_mat_vovo = dG_mat_vovo + c('ab,ij->aibj', dF[v, v], np.eye(no))
+        dG_mat_vovo = dG_mat_vovo - c('ab,ij->aibj', np.eye(nv), dF[o, o])
+        dGz = c('aibj,bj->ai', dG_mat_vovo, z)
+
+        rhs = db - dGz
+        dz_ov = self.ci.cphf.solve(rhs.T)
+        dz = dz_ov.T
+        return dz, dD_corr
+
+
+    # Hessian
+
+    def _hess_build_Y(self):
+        """Y_ijkl double-UU tensor, correlation densities only (linear in Q/G,
+        so the HF part belongs to the SCF reference Hessian)."""
+        ct = self.contract
+        zv = self.ci._zvector()
+        Q, G, _ = self.ci._corr_QGX()
+        h_mo = zv['h_mo']
+        ERI = np.asarray(self.ci.H.ERI)
+        Y = ct('jl,ik->ijkl', Q, h_mo)
+        Y = Y + 2.0 * ct('jlmn,ikmn->ijkl', G, ERI)
+        Y = Y + 2.0 * ct('jmln,imkn->ijkl', G, ERI)
+        Y = Y + 2.0 * ct('jmnl,imnk->ijkl', G, ERI)
+        return Y
+
+    def _hess_X_tilde(self):
+        """Correlation-only X_tilde: X_corr (linear in the corr densities) with
+        the Z-vector-corrected vo block. z itself is solved from the FULL
+        Lagrangian in _zvector() (unchanged from the validated code); it is a
+        pure correlation quantity since the HF part of X satisfies Brillouin
+        (X_HF[v,o] - X_HF[o,v].T = 0) and contributes nothing to the rhs."""
+        ct = self.contract
+        o, v, no, nv = self.ci.o, self.ci.v, self.ci.no, self.ci.nv
+        zv = self.ci._zvector()
+        _, _, X_corr = self.ci._corr_QGX()
+        F, ERI = np.asarray(self.ci.H.F), np.asarray(self.ci.H.ERI)
+        A = (2.0 * ERI - ERI.swapaxes(2, 3)) + (2.0 * ERI - ERI.swapaxes(2, 3)).swapaxes(1, 3)
+        A = A.swapaxes(1, 2)
+        G_mat = (ct('ab,ij->aibj', np.eye(nv), np.eye(no)) * (F[v, v].reshape(nv, 1, nv, 1) - F[o, o].reshape(1, no, 1, no)) + A[v, o, v, o])
+        X_tilde = X_corr.copy()
+        X_tilde[v, o] += ct('aibj,bj->ai', G_mat, zv['z_ai'])
+        return X_tilde
+
+    def build_xi_ab(self, U_a, U_b, S_a, S_b, S_ab):
+        c = self.contract
+        xi = S_ab.copy()
+        xi = xi + c('im,jm->ij', U_a, U_b) + c('im,jm->ij', U_b, U_a)
+        xi = xi - c('im,jm->ij', S_a, S_b) - c('im,jm->ij', S_b, S_a)
+        return xi
+
+    def build_X_deriv(self, h_a_skel, g_a_skel):
+        """Skeleton-derivative Lagrangian, correlation densities only."""
+        ct = self.contract
+        Q, G, _ = self.ci._corr_QGX()
+        Xa = ct('jm,im->ij', Q, h_a_skel)
+        Xa = Xa + 2.0 * ct('jmkl,imkl->ij', G, g_a_skel)
+        return Xa
+
+    def build_cpci_term(self, dc1_a, dc2_a, dc1_b, dc2_b):
+        """The pure linear CI-Jacobian action on dc1_b/dc2_b."""
+        c = self.contract
+        o, v = self.ci.o, self.ci.v
+        F, ERI = np.asarray(self.ci.H.F), np.asarray(self.ci.H.ERI)
+        E_tot = self.ci.eci
+
+        sig1 = -E_tot * dc1_b
+        sig1 = sig1 - c('ji,ja->ia', F[o, o], dc1_b)
+        sig1 = sig1 + c('ab,ib->ia', F[v, v], dc1_b)
+        sig1 = sig1 + c('jabi,jb->ia', 2.0 * ERI[o, v, v, o] - ERI.swapaxes(2, 3)[o, v, v, o], dc1_b)
+        sig1 = sig1 + c('jb,ijab->ia', F[o, v], 2.0 * dc2_b - dc2_b.swapaxes(2, 3))
+        sig1 = sig1 + c('ajbc,ijbc->ia', 2.0 * ERI[v, o, v, v] - ERI.swapaxes(2, 3)[v, o, v, v], dc2_b)
+        sig1 = sig1 - c('kjib,kjab->ia', 2.0 * ERI[o, o, o, v] - ERI.swapaxes(2, 3)[o, o, o, v], dc2_b)
+
+        sig2 = -E_tot * dc2_b
+        sig2 = sig2 + c('abcj,ic->ijab', ERI[v, v, v, o], dc1_b)
+        sig2 = sig2 + c('abic,jc->ijab', ERI[v, v, o, v], dc1_b)
+        sig2 = sig2 - c('kbij,ka->ijab', ERI[o, v, o, o], dc1_b)
+        sig2 = sig2 - c('akij,kb->ijab', ERI[v, o, o, o], dc1_b)
+        sig2 = sig2 + c('ac,ijcb->ijab', F[v, v], dc2_b)
+        sig2 = sig2 + c('bc,ijac->ijab', F[v, v], dc2_b)
+        sig2 = sig2 - c('ki,kjab->ijab', F[o, o], dc2_b)
+        sig2 = sig2 - c('kj,ikab->ijab', F[o, o], dc2_b)
+        sig2 = sig2 + c('klij,klab->ijab', ERI[o, o, o, o], dc2_b)
+        sig2 = sig2 + c('abcd,ijcd->ijab', ERI[v, v, v, v], dc2_b)
+        sig2 = sig2 - c('kbcj,ikca->ijab', ERI[o, v, v, o], dc2_b)
+        sig2 = sig2 + c('kaci,kjcb->ijab', 2.0 * ERI[o, v, v, o] - ERI.swapaxes(2, 3)[o, v, v, o], dc2_b)
+        sig2 = sig2 - c('kbic,kjac->ijab', ERI[o, v, o, v], dc2_b)
+        sig2 = sig2 - c('kaci,kjbc->ijab', ERI[o, v, v, o], dc2_b)
+        sig2 = sig2 + c('kbcj,ikac->ijab', 2.0 * ERI[o, v, v, o] - ERI.swapaxes(2, 3)[o, v, v, o], dc2_b)
+        sig2 = sig2 - c('kajc,ikcb->ijab', ERI[o, v, o, v], dc2_b)
+
+        return -2.0 * (2.0 * c('ia,ia->', dc1_a, sig1) + c('ijab,ijab->', 2.0 * dc2_a - dc2_a.swapaxes(2, 3), sig2)).real
+
+    def hessian(self, route: str = 'explicit') -> np.ndarray:
+        """CISD CORRELATION-ONLY nuclear Hessian, shape (3*natom, 3*natom):
+        the T0-T5 assembly with the correlation densities in the density with linear
+        terms (T0, xi-X_tilde, T3, T4, the HF blocks of those terms are the
+        SCF reference Hessian) and the unchanged pure-correlation Z-vector (Bab.z)
+        and CPCI (T5) terms; nuclear-repulsion block dropped. Reference and
+        nuclear are supplied by the pycc.hessian facade, matching MPwfn's
+        contract."""
+        from .cphf import Perturbation
+        ct = self.contract
+        o, v, no = self.ci.o, self.ci.v, self.ci.no
+        mints, C_p4 = self.ci._psi4_mints()
+        mol = self.ci.ref.molecule()
+        natom = mol.natom()
+        ndof = 3 * natom
+        F = np.asarray(self.ci.H.F)
+        eps = np.diag(F)
+
+        zv = self.ci._zvector()
+        Q, G, _ = self.ci._corr_QGX()   # correlation densities (T0/T3/T4/xi-X)
+        X_t = self._hess_X_tilde()
+        Y = self._hess_build_Y()
+        ERI = np.asarray(self.ci.H.ERI)
+        z = zv['z_ai']
+        n0 = self.ci._normalized_amplitudes()[0]
+
+        ERI_M = ERI.transpose(0, 2, 1, 3)
+        W_M = 2 * ERI_M - ERI_M.transpose(0, 2, 1, 3)
+        A_M = 4 * ERI_M - ERI_M.transpose(0, 2, 1, 3) - ERI_M.transpose(0, 3, 2, 1)
+
+        def to_mulliken(g_dirac):
+            return g_dirac.transpose(0, 2, 1, 3)
+
+        h_skel_1, g_skel_1, S_skel_1 = {}, {}, {}
+        U_all, dT1_all, dT2_all = {}, {}, {}
+
+        for N1 in range(natom):
+            T_core = mints.mo_oei_deriv1('KINETIC', N1, C_p4, C_p4)
+            V_core = mints.mo_oei_deriv1('POTENTIAL', N1, C_p4, C_p4)
+            S_core = mints.mo_oei_deriv1('OVERLAP', N1, C_p4, C_p4)
+            E_core = mints.mo_tei_deriv1(N1, C_p4, C_p4, C_p4, C_p4)
+            for a in range(3):
+                la = 3 * N1 + a
+                h_skel_1[la] = T_core[a].np + V_core[a].np
+                S_skel_1[la] = S_core[a].np
+                g_skel_1[la] = E_core[a].np.swapaxes(1, 2)
+                pert = Perturbation('nuclear', (N1, a))
+                U_all[la] = np.asarray(self.ci.cphf.full_U(pert))
+                dT1_all[la], dT2_all[la] = self.ci._cpci_raw(pert)
+
+        X_deriv = {la: self.build_X_deriv(h_skel_1[la], g_skel_1[la]) for la in range(ndof)}
+
+        Fa_M, Aa_M = {}, {}
+        for la in range(ndof):
+            g_a_M = to_mulliken(g_skel_1[la])
+            Fa = h_skel_1[la].copy()
+            Fa += (ct('ijkk->ij', 2 * g_a_M[:, :, o, o]) - ct('ikjk->ij', g_a_M[:, o, :, o]))
+            Fa_M[la] = Fa
+            Aa_M[la] = (4 * g_a_M - g_a_M.transpose(0, 2, 1, 3) - g_a_M.transpose(0, 3, 2, 1))
+
+        Hessian = np.zeros((ndof, ndof))
+
+        def _assemble_ab(a, b, h_ab_sk, S_ab_sk, g_ab_sk, N1, N2):
+            la, lb = 3 * N1 + a, 3 * N2 + b
+            U_a, U_b = U_all[la], U_all[lb]
+
+            # T1: skeleton density contraction
+            t0_val = ct('ij,ij->', Q, h_ab_sk)
+            t0_val += ct('pqrs,pqrs->', G, g_ab_sk)
+
+            # T2: Z-vector replacement
+            xi = self.build_xi_ab(U_a, U_b, S_skel_1[la], S_skel_1[lb], S_ab_sk)
+            t2_xiXt = -ct('ij,ji->', xi, X_t)
+            g_ab_sk_M = to_mulliken(g_ab_sk)
+            F_ab_M = (h_ab_sk + ct('ijkk->ij', 2 * g_ab_sk_M[:, :, o, o]) - ct('ikjk->ij', g_ab_sk_M[:, o, :, o]))
+            Bab = F_ab_M.copy()
+            Bab -= ct('ij,j->ij', xi, eps)
+            Bab -= ct('kl,ijkl->ij', xi[o, o], W_M[:, :, o, o])
+            Bab += ct('ki,kj->ij', U_a, Fa_M[lb])
+            Bab += ct('ki,kj->ij', U_b, Fa_M[la])
+            Bab += ct('kj,ik->ij', U_a, Fa_M[lb])
+            Bab += ct('kj,ik->ij', U_b, Fa_M[la])
+            Bab += ct('ki,kj,k->ij', U_a, U_b, eps)
+            Bab += ct('ki,kj,k->ij', U_b, U_a, eps)
+            UaUbT = U_a[:, o] @ U_b[:, o].T
+            Bab += ct('kl,ijkl->ij', UaUbT, A_M)
+            temp5_b = ct('lm,kjlm->kj', U_b[:, o], A_M[:, :, :, o])
+            temp5_a = ct('lm,kjlm->kj', U_a[:, o], A_M[:, :, :, o])
+            Bab += ct('ki,kj->ij', U_a, temp5_b)
+            Bab += ct('ki,kj->ij', U_b, temp5_a)
+            temp6_b = ct('lm,iklm->ik', U_b[:, o], A_M[:, :, :, o])
+            temp6_a = ct('lm,iklm->ik', U_a[:, o], A_M[:, :, :, o])
+            Bab += ct('kj,ik->ij', U_a, temp6_b)
+            Bab += ct('kj,ik->ij', U_b, temp6_a)
+            Bab += ct('kl,ijkl->ij', U_a[:, o], Aa_M[lb][:, :, :, o])
+            Bab += ct('kl,ijkl->ij', U_b[:, o], Aa_M[la][:, :, :, o])
+            t2_zvec = 2.0 * ct('ai,ai->', Bab[v, o], z)
+            t2_val = t2_xiXt + t2_zvec
+
+            # T3+T4: orbital-response Lagrangian + Y tensor
+            t3_val = 2.0 * (ct('ij,ij->', U_b, X_deriv[la])+ ct('ij,ij->', U_a, X_deriv[lb]))
+            t4_val = 2.0 * ct('ij,kl,ijkl->', U_a, U_b, Y)
+
+            # T5: CPCI amplitude response
+            t5_val = n0**2 * self.build_cpci_term(
+                dT1_all[la], dT2_all[la], dT1_all[lb], dT2_all[lb]).real
+
+            return la, lb, (t0_val + t2_val + t3_val + t4_val + t5_val).real
+
+        for N1 in range(natom):
+            for N2 in range(natom):
+                T_ab = mints.mo_oei_deriv2('KINETIC', N1, N2, C_p4, C_p4)
+                V_ab = mints.mo_oei_deriv2('POTENTIAL', N1, N2, C_p4, C_p4)
+                S_ab = mints.mo_oei_deriv2('OVERLAP', N1, N2, C_p4, C_p4)
+                E_ab = mints.mo_tei_deriv2(N1, N2, C_p4, C_p4, C_p4, C_p4)
+
+                h_ab = {(a, b): T_ab[3 * a + b].np + V_ab[3 * a + b].np for a in range(3) for b in range(3)}
+                S_ab_np = {(a, b): S_ab[3 * a + b].np for a in range(3) for b in range(3)}
+                g_ab = {(a, b): E_ab[3 * a + b].np.swapaxes(1, 2) for a in range(3) for b in range(3)}
+
+                for a in range(3):
+                    for b in range(3):
+                        la, lb, val = _assemble_ab(
+                            a, b, h_ab[(a, b)], S_ab_np[(a, b)], g_ab[(a, b)], N1, N2)
+                        Hessian[la, lb] = val
+
+                del T_ab, V_ab, S_ab, E_ab, h_ab, S_ab_np, g_ab
+
+        Hessian = 0.5 * (Hessian + Hessian.T)
+        return Hessian
+
+    # CISD-specific properties (overlap formulations; not part of the base)
+    # AAT and the velocity-gauge APT are wave-function-overlap constructions (Krishnan, Shumberger &
+    # Crawford)
+
+    def _build_Dtilde(self, dc1, dc2, dc0):
+        c = self.contract
+        n0, n1, n2, tau_n = self.ci._normalized_amplitudes()
+        o, v, nmo = self.ci.o, self.ci.v, self.ci.nmo
+
+        R = np.zeros((nmo, nmo), dtype=complex)
+        R[o, o] -= 2.0 * c('ja,ia->ij', n1, dc1)
+        R[o, o] -= 2.0 * c('jkab,ikab->ij', tau_n, dc2)
+        R[v, v] += 2.0 * c('ia,ib->ab', n1, dc1)
+        R[v, v] += 2.0 * c('ijac,ijbc->ab', tau_n, dc2)
+        R[o, v] += 2.0 * n0 * dc1 + 2.0 * dc0 * n1
+        R[o, v] += 2.0 * c('jb,ijab->ia', n1, 2.0 * dc2 - dc2.swapaxes(2, 3))
+        R[v, o] += 2.0 * c('ijab,jb->ai', tau_n, dc1)
+        return R
+
+    def _aat_dc_normalized(self, pert):
+        dc1, dc2, dc0v = self.ci._solve_cpci(pert)
+        return dc0v, dc1, dc2
+
+    def compute_Icc_AATs(self):
+        """Term 1 of the AAT: direct state-vector overlap <dPsi_R|dPsi_H>."""
+        from .cphf import Perturbation
+        c = self.contract
+        natom = self.ci.derivatives.natom
+        I_cc = np.zeros((3 * natom, 3))
+        magH = {b: self._aat_dc_normalized(Perturbation('magnetic', b)) for b in range(3)}
+        for la in range(3 * natom):
+            A, beta_ = divmod(la, 3)
+            pR = Perturbation('nuclear', (A, beta_))
+            _, dn1_R, dn2_R = self._aat_dc_normalized(pR)
+            for beta in range(3):
+                _, dn1_H, dn2_H = magH[beta]
+                term = 2.0 * c('ia,ia->', dn1_R.conj(), dn1_H)
+                term = term + c('ijab,ijab->', (2.0 * dn2_R - dn2_R.swapaxes(2, 3)).conj(), dn2_H)
+                I_cc[la, beta] = term.real
+        return I_cc
+
+    def compute_Iphic_AATs(self):
+        from .cphf import Perturbation
+        c = self.contract
+        natom = self.ci.derivatives.natom
+        AAT_phic = np.zeros((3 * natom, 3), dtype=complex)
+        magH = {b: self._aat_dc_normalized(Perturbation('magnetic', b)) for b in range(3)}
+        for la in range(3 * natom):
+            A, beta_ = divmod(la, 3)
+            pR = Perturbation('nuclear', (A, beta_))
+            _, _, U_R = self.ci._cpci_ints(pR)
+            half_S = np.asarray(self.ci.derivatives.overlap_half(A)[beta_])
+            Ur_eff = U_R + half_S.T
+            for beta in range(3):
+                dn0_H, dn1_H, dn2_H = magH[beta]
+                R_pq = self._build_Dtilde(dn1_H, dn2_H, dn0_H)
+                AAT_phic[la, beta] = c('pq,qp->', R_pq, Ur_eff)
+        return AAT_phic.real
+
+    def compute_Iphiphi_AATs(self):
+        from .cphf import Perturbation
+        c = self.contract
+        natom = self.ci.derivatives.natom
+        _, D_pq, _ = self.ci._cisd_densities()   # correlation-only 1-PDM (true-normalized)
+        I_pp = np.zeros((3 * natom, 3))
+        for la in range(3 * natom):
+            A, beta_ = divmod(la, 3)
+            pR = Perturbation('nuclear', (A, beta_))
+            _, _, U_R = self.ci._cpci_ints(pR)
+            half_S = np.asarray(self.ci.derivatives.overlap_half(A)[beta_])
+            Ur_eff = U_R + half_S.T
+            for beta in range(3):
+                _, _, U_H = self.ci._cpci_ints(Perturbation('magnetic', beta))
+                I_pp[la, beta] = c('pq,pq->', D_pq, U_H.T @ Ur_eff).real
+        return I_pp
+
+    def compute_Icphi_AATs(self):
+        from .cphf import Perturbation
+        c = self.contract
+        natom = self.ci.derivatives.natom
+        AAT_cphi = np.zeros((3 * natom, 3), dtype=complex)
+        for la in range(3 * natom):
+            A, beta_ = divmod(la, 3)
+            pR = Perturbation('nuclear', (A, beta_))
+            dn0_R, dn1_R, dn2_R = self._aat_dc_normalized(pR)
+            R_pq = self._build_Dtilde(dn1_R, dn2_R, dn0_R)
+            for beta in range(3):
+                _, _, U_H = self.ci._cpci_ints(Perturbation('magnetic', beta))
+                AAT_cphi[la, beta] = c('pq,pq->', R_pq, U_H)
+        return AAT_cphi.real
+
+    def atomic_axial_tensors(self, gauge: str = 'canonical') -> np.ndarray:
+        """CISD correlation AAT, shape (natom, 3, 3): the four electronic overlap blocks with the
+        correlation 1-PDM in Iphiphi. The SCF reference and the nuclear term (Z_A/4) eps_abc R_c
+        are supplied by the pycc.aat facade (HFwfn.atomic_axial_tensors + _nuclear_aat), matching
+        MPderiv's contract."""
+        natom = self.ci.ref.molecule().natom()
+        total = (self.compute_Icc_AATs() + self.compute_Iphic_AATs() + self.compute_Iphiphi_AATs() + self.compute_Icphi_AATs())
+        return total.reshape(natom, 3, 3)
+
+    def compute_Icc_VG_APT(self):
+        from .cphf import Perturbation
+        c = self.contract
+        natom = self.ci.derivatives.natom
+        I_cc = np.zeros((3 * natom, 3), dtype=complex)
+        vecA = {g: self._aat_dc_normalized(Perturbation('vecpot', g)) for g in range(3)}
+        for la in range(3 * natom):
+            A, beta_ = divmod(la, 3)
+            _, dn1_R, dn2_R = self._aat_dc_normalized(Perturbation('nuclear', (A, beta_)))
+            for gamma in range(3):
+                _, dn1_A, dn2_A = vecA[gamma]
+                I_cc[la, gamma] = (2.0 * c('ia,ia->', dn1_R.conj(), dn1_A) + c('ijab,ijab->', (2.0 * dn2_R - dn2_R.swapaxes(2, 3)).conj(), dn2_A))
+        return I_cc
+
+    def compute_Icphi_VG_APT(self):
+        from .cphf import Perturbation
+        c = self.contract
+        natom = self.ci.derivatives.natom
+        Icphi = np.zeros((3 * natom, 3), dtype=complex)
+        for la in range(3 * natom):
+            A, beta_ = divmod(la, 3)
+            dn0_R, dn1_R, dn2_R = self._aat_dc_normalized(Perturbation('nuclear', (A, beta_)))
+            D_tilde_R = self._build_Dtilde(dn1_R, dn2_R, dn0_R)
+            for gamma in range(3):
+                _, _, U_A = self.ci._cpci_ints(Perturbation('vecpot', gamma))
+                Icphi[la, gamma] = c('pq,pq->', D_tilde_R, U_A)
+        return Icphi
+
+    def compute_Iphic_VG_APT(self):
+        from .cphf import Perturbation
+        c = self.contract
+        natom = self.ci.derivatives.natom
+        Iphic = np.zeros((3 * natom, 3), dtype=complex)
+        vecA = {g: self._aat_dc_normalized(Perturbation('vecpot', g)) for g in range(3)}
+        for la in range(3 * natom):
+            A, beta_ = divmod(la, 3)
+            pR = Perturbation('nuclear', (A, beta_))
+            _, _, U_R = self.ci._cpci_ints(pR)
+            half_S = np.asarray(self.ci.derivatives.overlap_half(A)[beta_])
+            Ur_eff = U_R + half_S.T
+            for gamma in range(3):
+                dn0_A, dn1_A, dn2_A = vecA[gamma]
+                D_tilde_A = self._build_Dtilde(dn1_A, dn2_A, dn0_A)
+                Iphic[la, gamma] = c('pq,qp->', D_tilde_A.conj(), Ur_eff)
+        return Iphic
+
+    def compute_Iphiphi_VG_APT(self):
+        from .cphf import Perturbation
+        c = self.contract
+        natom = self.ci.derivatives.natom
+        _, D_pq, _ = self.ci._cisd_densities()   # correlation-only 1-PDM (true-normalized)
+        I_pp = np.zeros((3 * natom, 3), dtype=complex)
+        for la in range(3 * natom):
+            A, beta_ = divmod(la, 3)
+            _, _, U_R = self.ci._cpci_ints(Perturbation('nuclear', (A, beta_)))
+            half_S = np.asarray(self.ci.derivatives.overlap_half(A)[beta_])
+            Ur_eff = U_R + half_S.T
+            for gamma in range(3):
+                _, _, U_A = self.ci._cpci_ints(Perturbation('vecpot', gamma))
+                I_pp[la, gamma] = c('pq,pq->', D_pq, U_A.T @ Ur_eff)
+        return I_pp
+
+    def velocity_dipole_derivatives(self, gauge: str = 'canonical') -> np.ndarray:
+        """CISD correlation velocity-gauge APT, shape (natom, 3, 3): -2 times the four overlap
+        blocks with the correlation 1-PDM in Iphiphi. The SCF reference and the Z_A delta nuclear
+        term are supplied by the pycc.apt(gauge='velocity') facade, matching MPderiv's contract."""
+        natom = self.ci.ref.molecule().natom()
+        overlap_total = (self.compute_Icc_VG_APT() + self.compute_Icphi_VG_APT() + self.compute_Iphic_VG_APT() + self.compute_Iphiphi_VG_APT())
+        return (-2.0 * overlap_total).real.reshape(natom, 3, 3)

--- a/pycc/ciwfn.py
+++ b/pycc/ciwfn.py
@@ -235,9 +235,8 @@ class CIwfn(Wavefunction):
     def _normalized_amplitudes(self):
         if getattr(self, '_ci_namp', None) is None:
             c = self.contract
-            t1, t2 = self.c1, self.c2      # CIwfn's intermediate-normalized amplitudes
-            norm2 = (2.0 * c('ia,ia->', t1.conj(), t1)
-                     + c('ijab,ijab->', t2.conj(), 2.0 * t2 - t2.swapaxes(2, 3)))
+            t1, t2 = self.c1, self.c2    
+            norm2 = (2.0 * c('ia,ia->', t1.conj(), t1) + c('ijab,ijab->', t2.conj(), 2.0 * t2 - t2.swapaxes(2, 3)))
             N = 1.0 / np.sqrt(1.0 + norm2)
             n0 = N.real if np.isrealobj(N) else N
             n1 = N * t1
@@ -329,7 +328,7 @@ class CIwfn(Wavefunction):
         L_AO = mints.ao_angular_momentum()
         h_mag = ct('mp,mn,nq->pq', C.conj(), -0.5 * L_AO[beta].np, C)
 
-        # U_H  (full 4-block solve - exactly as in working code)
+        # U_H  
         U_H = np.zeros((nbf, nbf), dtype=complex)
         B_vo = h_mag[v, o]
         U_H[v, o] += (G_mag @ B_vo.reshape(nv * no)).reshape(nv, no)
@@ -444,6 +443,11 @@ class CIwfn(Wavefunction):
             result = self._build_magnetic_ints(pert.comp)
         elif pert.kind == 'vecpot':
             result = self._build_vecpot_ints(pert.comp)
+        elif pert.kind == 'field':
+            dF = np.asarray(cphf.perturbed_fock(pert))
+            dERI = np.asarray(cphf.perturbed_eri(pert))   # zero for electric field
+            U = np.asarray(cphf.full_U(pert))
+            result = (dF, dERI, U)
         else:
             raise ValueError(f"unknown perturbation kind {pert.kind!r}")
         self._cpci_ints_cache[pert] = result
@@ -611,126 +615,11 @@ class CIwfn(Wavefunction):
             self._solve_cpci(pert)
         return self._cpci_raw_cache[pert]
 
-    # length-gauge APT  (cisd_apt_lg.py: _CISDAPTEngine)
 
-    def _zvector(self):
-        """CISD unperturbed Z-vector: relaxed density Q_relaxed, Lagrangian
-        X, h_mo, and the CPHF orbital-response z-amplitudes."""
-        if getattr(self, '_cizvec', None) is None:
-            c = self.contract
-            o, v, no, nmo = self.o, self.v, self.no, self.nmo
-            D_pq, D_pq_corr, D_pqrs = self._cisd_densities()
-
-            ERI = np.asarray(self.H.ERI)
-            F = np.asarray(self.H.F)
-            h_mo = F - c('piqi->pq', 2.0 * ERI[:, o, :, o] - ERI.swapaxes(2, 3)[:, o, :, o])
-
-            Q = D_pq_corr.copy()
-            for i in range(no):
-                Q[i, i] += 2.0
-
-            G_sym = 0.25 * (D_pqrs + D_pqrs.transpose(1, 0, 3, 2)
-                             + D_pqrs.transpose(2, 3, 0, 1) + D_pqrs.transpose(3, 2, 1, 0))
-            G = G_sym.copy()
-            for i in range(no):
-                for j in range(no):
-                    G[i, j, i, j] += 2.0
-                    G[i, j, j, i] -= 1.0
-            G_cross = np.zeros_like(G)
-            for i in range(no):
-                G_cross[i, :, i, :] += 2.0 * D_pq_corr
-                G_cross[:, i, :, i] += 2.0 * D_pq_corr
-                G_cross[i, :, :, i] -= D_pq_corr.T
-                G_cross[:, i, i, :] -= D_pq_corr
-            G = G + 0.5 * G_cross
-
-            X = c('jm,im->ij', Q, h_mo) + 2.0 * c('jmkl,imkl->ij', G, ERI)
-
-            rhs = -(X[v, o] - X[o, v].T)
-            z_ov = self.cphf.solve(rhs.T)
-            z_ai = z_ov.T
-
-            Q_relaxed = Q.copy()
-            Q_relaxed[v, o] += z_ai
-            Q_relaxed[o, v] += z_ai.T
-
-            self._cizvec = dict(Q=Q, G=G, Q_relaxed=Q_relaxed, X=X, h_mo=h_mo, z_ai=z_ai)
-        return self._cizvec
-
-    def _corr_QGX(self):
-        """Correlation-only (Q_corr, G_corr, X_corr): the full Z-vector
-        quantities with the pure-HF density blocks removed (Q minus 2*delta_oo;
-        G minus the closed-shell HF 2-RDM block 2*d_ik*d_jl - d_il*d_jk; X
-        rebuilt linearly from the corr densities). Cached. Used by the
-        correlation-only property assemblies; the FULL quantities in
-        _zvector() stay untouched (the perturbed-Lagrangian z response is a
-        full-density equation and remains as validated)."""
-        if getattr(self, '_ci_corr_qgx', None) is None:
-            ct = self.contract
-            no = self.no
-            zv = self._zvector()
-            ERI = np.asarray(self.H.ERI)
-            Q_corr = zv['Q'].copy()
-            for i in range(no):
-                Q_corr[i, i] -= 2.0
-            G_corr = zv['G'].copy()
-            for i in range(no):
-                for j in range(no):
-                    G_corr[i, j, i, j] -= 2.0
-                    G_corr[i, j, j, i] += 1.0
-            X_corr = (ct('jm,im->ij', Q_corr, zv['h_mo'])
-                      + 2.0 * ct('jmkl,imkl->ij', G_corr, ERI))
-            self._ci_corr_qgx = (Q_corr, G_corr, X_corr)
-        return self._ci_corr_qgx
-
-    def _reference_hf(self):
-        """The all-electron :class:`HFwfn` for the SCF reference (cached),
-        supplying the reference (electronic) contribution to the total CISD
-        properties via the pycc property facade - same pattern as
-        MPwfn._reference_hf."""
-        if getattr(self, '_ref_hf', None) is None:
-            from .hfwfn import HFwfn
-            self._ref_hf = HFwfn(self.ref, orbital_basis=self.orbital_basis)
-        return self._ref_hf
-
-    def dipole_derivatives(self, route: str = 'explicit') -> np.ndarray:
-        """CISD CORRELATION-ONLY LG-APT, shape (natom, 3, 3), [A, beta, alpha].
-        Port of _CISDAPTEngine.assemble() with the HF density block removed
-        from T1/T2 and the nuclear charge term dropped - both supplied by the
-        pycc.apt facade (HFwfn reference + _nuclear_apt), matching MPwfn's
-        contract."""
-        from .cphf import Perturbation
-        c = self.contract
-        o, v = self.o, self.v
-        zv = self._zvector()
-        # Correlation-only relaxed density: Q_relaxed minus the HF 2*delta_oo.
-        # T3/T3z are already pure correlation (amplitude/Z-vector response).
-        Qt = zv['Q_relaxed'].copy()
-        for i in range(self.no):
-            Qt[i, i] -= 2.0
-        natom = self.derivatives.natom
-        h_E = [np.asarray(self.H.mu[f]) for f in range(3)]
-
-        APT = np.zeros((natom, 3, 3))
-        for A in range(natom):
-            dip = self.derivatives.dipole(A)
-            for beta in range(3):
-                pert = Perturbation('nuclear', (A, beta))
-                U_R = np.asarray(self.cphf.full_U(pert))
-                dc1, dc2, dc0v = self._solve_cpci(pert)
-                dc1, dc2 = dc1.real, dc2.real
-                dc0v = dc0v.real if hasattr(dc0v, 'real') else dc0v
-                dz, dD_corr = self._solve_dz_dR(pert, dc1, dc2, dc0v)
-
-                for alpha in range(3):
-                    h_RE = np.asarray(dip[alpha * 3 + beta])
-                    T1 = c('ij,ij->', Qt, h_RE)
-                    T2 = (c('rp,pq,rq->', U_R, Qt, h_E[alpha])
-                          + c('pq,ps,sq->', Qt, h_E[alpha], U_R))
-                    T3 = c('pq,pq->', dD_corr, h_E[alpha])
-                    T3z = 2.0 * c('ai,ai->', dz, h_E[alpha][v, o])
-                    APT[A, beta, alpha] = (T1 + T2 + T3 + T3z).real
-        return APT
+    # raw perturbed correlation-density builders (true-normalized) 
+    # Used by CIderiv._perturbed_unrelaxed_densities; kept here as CISD-wavefunction-level
+    # primitives, the same pattern as _cisd_densities and the CPCI/magnetic/vecpot machinery
+    # above (see cideriv.py's module docstring for the rationale).
 
     def _perturbed_cisd_corr_opdm(self, dc1, dc2):
         c = self.contract
@@ -777,439 +666,143 @@ class CIwfn(Wavefunction):
         dG[o, o, o, v] = -2.0 * (c('kb,ijba->ijka', dc1, tau_n) + c('kb,ijba->ijka', n1, dtau_n))
         return dG
 
-    def _solve_dz_dR(self, pert, dc1, dc2, dc0v):
-        c = self.contract
-        o, v, no, nv = self.o, self.v, self.no, self.nv
-        zv = self._zvector()
-        z = zv['z_ai']
+    # unperturbed Z-vector (unused by CIderiv directly, but
+    # _corr_QGX below is CIderiv's density-hook source)
 
-        dF, dERI, _ = self._cpci_ints(pert)
-        dD_corr = self._perturbed_cisd_corr_opdm(dc1, dc2)
-        dD_pqrs = self._perturbed_cisd_tpdm(dc1, dc2, dc0v)
+    def _zvector(self):
+        """CISD unperturbed Z-vector: relaxed density Q_relaxed, Lagrangian
+        X, h_mo, and the CPHF orbital-response z-amplitudes."""
+        if getattr(self, '_cizvec', None) is None:
+            c = self.contract
+            o, v, no, nmo = self.o, self.v, self.no, self.nmo
+            D_pq, D_pq_corr, D_pqrs = self._cisd_densities()
 
-        o_ = self.o
-        dh_mo = dF - c('piqi->pq', 2.0 * dERI[:, o_, :, o_] - dERI.swapaxes(2, 3)[:, o_, :, o_])
-        dG_sym = 0.25 * (dD_pqrs + dD_pqrs.transpose(1, 0, 3, 2)
-                          + dD_pqrs.transpose(2, 3, 0, 1) + dD_pqrs.transpose(3, 2, 1, 0))
-        dG = dG_sym.copy()
-        dG_cross = np.zeros_like(dG)
-        for i in range(no):
-            dG_cross[i, :, i, :] += 2.0 * dD_corr
-            dG_cross[:, i, :, i] += 2.0 * dD_corr
-            dG_cross[i, :, :, i] -= dD_corr.T
-            dG_cross[:, i, i, :] -= dD_corr
-        dG = dG + 0.5 * dG_cross
+            ERI = np.asarray(self.H.ERI)
+            F = np.asarray(self.H.F)
+            h_mo = F - c('piqi->pq', 2.0 * ERI[:, o, :, o] - ERI.swapaxes(2, 3)[:, o, :, o])
 
-        ERI = np.asarray(self.H.ERI)
-        dX = c('jm,im->ij', dD_corr, zv['h_mo']) + c('jm,im->ij', zv['Q'], dh_mo)
-        dX = dX + 2.0 * c('jmkl,imkl->ij', dG, ERI) + 2.0 * c('jmkl,imkl->ij', zv['G'], dERI)
+            Q = D_pq_corr.copy()
+            for i in range(no):
+                Q[i, i] += 2.0
 
-        db = -(dX[v, o] - dX[o, v].T)
+            G_sym = 0.25 * (D_pqrs + D_pqrs.transpose(1, 0, 3, 2) + D_pqrs.transpose(2, 3, 0, 1) + D_pqrs.transpose(3, 2, 1, 0))
+            G = G_sym.copy()
+            for i in range(no):
+                for j in range(no):
+                    G[i, j, i, j] += 2.0
+                    G[i, j, j, i] -= 1.0
+            G_cross = np.zeros_like(G)
+            for i in range(no):
+                G_cross[i, :, i, :] += 2.0 * D_pq_corr
+                G_cross[:, i, :, i] += 2.0 * D_pq_corr
+                G_cross[i, :, :, i] -= D_pq_corr.T
+                G_cross[:, i, i, :] -= D_pq_corr
+            G = G + 0.5 * G_cross
 
-        dL = 2.0 * dERI - dERI.swapaxes(2, 3)
-        dG_mat_vovo = (dL[v, o, o, v].transpose(0, 2, 3, 1)
-                       + dL[v, v, o, o].transpose(0, 2, 1, 3))
-        dG_mat_vovo = dG_mat_vovo + c('ab,ij->aibj', dF[v, v], np.eye(no))
-        dG_mat_vovo = dG_mat_vovo - c('ab,ij->aibj', np.eye(nv), dF[o, o])
-        dGz = c('aibj,bj->ai', dG_mat_vovo, z)
+            X = c('jm,im->ij', Q, h_mo) + 2.0 * c('jmkl,imkl->ij', G, ERI)
 
-        rhs = db - dGz
-        dz_ov = self.cphf.solve(rhs.T)
-        dz = dz_ov.T
-        return dz, dD_corr
+            rhs = -(X[v, o] - X[o, v].T)
+            z_ov = self.cphf.solve(rhs.T)
+            z_ai = z_ov.T
 
-    # AAT
+            Q_relaxed = Q.copy()
+            Q_relaxed[v, o] += z_ai
+            Q_relaxed[o, v] += z_ai.T
 
-    def _build_Dtilde(self, dc1, dc2, dc0):
-        c = self.contract
-        n0, n1, n2, tau_n = self._normalized_amplitudes()
-        o, v, nmo = self.o, self.v, self.nmo
+            self._cizvec = dict(Q=Q, G=G, Q_relaxed=Q_relaxed, X=X, h_mo=h_mo, z_ai=z_ai)
+        return self._cizvec
 
-        R = np.zeros((nmo, nmo), dtype=complex)
-        R[o, o] -= 2.0 * c('ja,ia->ij', n1, dc1)
-        R[o, o] -= 2.0 * c('jkab,ikab->ij', tau_n, dc2)
-        R[v, v] += 2.0 * c('ia,ib->ab', n1, dc1)
-        R[v, v] += 2.0 * c('ijac,ijbc->ab', tau_n, dc2)
-        R[o, v] += 2.0 * n0 * dc1 + 2.0 * dc0 * n1
-        R[o, v] += 2.0 * c('jb,ijab->ia', n1, 2.0 * dc2 - dc2.swapaxes(2, 3))
-        R[v, o] += 2.0 * c('ijab,jb->ai', tau_n, dc1)
-        return R
+    def _corr_QGX(self):
+        """Correlation-only (Q_corr, G_corr, X_corr): the unperturbed Q/G from
+        _zvector() with the pure-HF density blocks removed (Q minus 2*delta_oo;
+        G minus the closed-shell HF 2-RDM block 2*d_ik*d_jl - d_il*d_jk; X
+        rebuilt linearly from the corr densities). Cached. THE SOURCE OF
+        CIderiv._unrelaxed_densities() - confirmed (via the energy-closing
+        identity Tr(Q_corr,h)+Tr(G_corr,ERI)=E_corr) to be the correct
+        correlation-only 1-/2-PDM convention."""
+        if getattr(self, '_ci_corr_qgx', None) is None:
+            ct = self.contract
+            no = self.no
+            zv = self._zvector()
+            ERI = np.asarray(self.H.ERI)
+            Q_corr = zv['Q'].copy()
+            for i in range(no):
+                Q_corr[i, i] -= 2.0
+            G_corr = zv['G'].copy()
+            for i in range(no):
+                for j in range(no):
+                    G_corr[i, j, i, j] -= 2.0
+                    G_corr[i, j, j, i] += 1.0
+            X_corr = (ct('jm,im->ij', Q_corr, zv['h_mo'])
+                      + 2.0 * ct('jmkl,imkl->ij', G_corr, ERI))
+            self._ci_corr_qgx = (Q_corr, G_corr, X_corr)
+        return self._ci_corr_qgx
 
-    def _aat_dc_normalized(self, pert):
-        dc1, dc2, dc0v = self._solve_cpci(pert)
-        return dc0v, dc1, dc2
 
-    def compute_Icc_AATs(self):
-        """Term 1 of the AAT: direct state-vector overlap <dPsi_R|dPsi_H>."""
-        from .cphf import Perturbation
-        c = self.contract
-        natom = self.derivatives.natom
-        I_cc = np.zeros((3 * natom, 3))
-        magH = {b: self._aat_dc_normalized(Perturbation('magnetic', b)) for b in range(3)}
-        for la in range(3 * natom):
-            A, beta_ = divmod(la, 3)
-            pR = Perturbation('nuclear', (A, beta_))
-            _, dn1_R, dn2_R = self._aat_dc_normalized(pR)
-            for beta in range(3):
-                _, dn1_H, dn2_H = magH[beta]
-                term = 2.0 * c('ia,ia->', dn1_R.conj(), dn1_H)
-                term = term + c('ijab,ijab->', (2.0 * dn2_R - dn2_R.swapaxes(2, 3)).conj(), dn2_H)
-                I_cc[la, beta] = term.real
-        return I_cc
+    # analytic derivative-property driver (see pycc.cideriv.CIderiv) 
+    # The analytic derivative-property code (gradient, relaxed dipole, polarizability, APT, Hessian,
+    # AAT, VG-APT) lives on CIderiv, reached through the cached `deriv` driver; the property methods
+    # below are thin delegators kept for the historical `ciwfn.<property>()` call sites - exactly
+    # mirroring MPwfn's own delegators to MPderiv.
 
-    def compute_Iphic_AATs(self):
-        from .cphf import Perturbation
-        c = self.contract
-        natom = self.derivatives.natom
-        AAT_phic = np.zeros((3 * natom, 3), dtype=complex)
-        magH = {b: self._aat_dc_normalized(Perturbation('magnetic', b)) for b in range(3)}
-        for la in range(3 * natom):
-            A, beta_ = divmod(la, 3)
-            pR = Perturbation('nuclear', (A, beta_))
-            _, _, U_R = self._cpci_ints(pR)
-            half_S = np.asarray(self.derivatives.overlap_half(A)[beta_])
-            Ur_eff = U_R + half_S.T
-            for beta in range(3):
-                dn0_H, dn1_H, dn2_H = magH[beta]
-                R_pq = self._build_Dtilde(dn1_H, dn2_H, dn0_H)
-                AAT_phic[la, beta] = c('pq,qp->', R_pq, Ur_eff)
-        return AAT_phic.real
+    @property
+    def deriv(self):
+        """The cached :class:`~pycc.cideriv.CIderiv` derivative-property driver for this
+        wavefunction (built lazily). `CIderiv` is the CISD leaf of
+        :class:`~pycc.correlatedderivs.CorrelatedDerivs` and carries the analytic derivative-property
+        code; the thin property methods below delegate to it so the historical
+        `ciwfn.<property>()` call sites keep working, and the :mod:`pycc.properties` facade routes
+        through the registry (`pycc/__init__.py`) to the same driver."""
+        if getattr(self, '_deriv', None) is None:
+            from .cideriv import CIderiv
+            self._deriv = CIderiv(self)
+        return self._deriv
 
-    def compute_Iphiphi_AATs(self):
-        from .cphf import Perturbation
-        c = self.contract
-        natom = self.derivatives.natom
-        _, D_pq, _ = self._cisd_densities()   # correlation-only 1-PDM
-        I_pp = np.zeros((3 * natom, 3))
-        for la in range(3 * natom):
-            A, beta_ = divmod(la, 3)
-            pR = Perturbation('nuclear', (A, beta_))
-            _, _, U_R = self._cpci_ints(pR)
-            half_S = np.asarray(self.derivatives.overlap_half(A)[beta_])
-            Ur_eff = U_R + half_S.T
-            for beta in range(3):
-                _, _, U_H = self._cpci_ints(Perturbation('magnetic', beta))
-                I_pp[la, beta] = c('pq,pq->', D_pq, U_H.T @ Ur_eff).real
-        return I_pp
+    def relaxed_dipole(self) -> np.ndarray:
+        """CISD correlation dipole - delegates to :meth:`CIderiv.relaxed_dipole`."""
+        return self.deriv.relaxed_dipole()
 
-    def compute_Icphi_AATs(self):
-        from .cphf import Perturbation
-        c = self.contract
-        natom = self.derivatives.natom
-        AAT_cphi = np.zeros((3 * natom, 3), dtype=complex)
-        for la in range(3 * natom):
-            A, beta_ = divmod(la, 3)
-            pR = Perturbation('nuclear', (A, beta_))
-            dn0_R, dn1_R, dn2_R = self._aat_dc_normalized(pR)
-            R_pq = self._build_Dtilde(dn1_R, dn2_R, dn0_R)
-            for beta in range(3):
-                _, _, U_H = self._cpci_ints(Perturbation('magnetic', beta))
-                AAT_cphi[la, beta] = c('pq,pq->', R_pq, U_H)
-        return AAT_cphi.real
+    def gradient(self) -> np.ndarray:
+        """CISD correlation nuclear gradient - delegates to :meth:`CIderiv.gradient`."""
+        return self.deriv.gradient()
 
-    def atomic_axial_tensors(self, gauge: str = 'canonical') -> np.ndarray:
-        """CISD CORRELATION-ONLY AAT, shape (natom, 3, 3): the four electronic
-        overlap blocks with the correlation 1-PDM in Iphiphi (the 2*delta_oo
-        HF block of Iphiphi is the SCF reference AAT; Icc/Icphi/Iphic are pure
-        correlation, vanishing with the amplitudes). The SCF reference and the
-        nuclear term (Z_A/4) eps_abc R_c are supplied by the pycc.aat facade
-        (HFwfn.atomic_axial_tensors + _nuclear_aat), matching MPwfn's
-        contract."""
-        natom = self.ref.molecule().natom()
-        total = (self.compute_Icc_AATs() + self.compute_Iphic_AATs()
-                 + self.compute_Iphiphi_AATs() + self.compute_Icphi_AATs())
-        return total.reshape(natom, 3, 3)
-
-    # velocity-gauge APT
-    def compute_Icc_VG_APT(self):
-        from .cphf import Perturbation
-        c = self.contract
-        natom = self.derivatives.natom
-        I_cc = np.zeros((3 * natom, 3), dtype=complex)
-        vecA = {g: self._aat_dc_normalized(Perturbation('vecpot', g)) for g in range(3)}
-        for la in range(3 * natom):
-            A, beta_ = divmod(la, 3)
-            _, dn1_R, dn2_R = self._aat_dc_normalized(Perturbation('nuclear', (A, beta_)))
-            for gamma in range(3):
-                _, dn1_A, dn2_A = vecA[gamma]
-                I_cc[la, gamma] = (2.0 * c('ia,ia->', dn1_R.conj(), dn1_A)
-                                   + c('ijab,ijab->', (2.0 * dn2_R - dn2_R.swapaxes(2, 3)).conj(), dn2_A))
-        return I_cc
-
-    def compute_Icphi_VG_APT(self):
-        from .cphf import Perturbation
-        c = self.contract
-        natom = self.derivatives.natom
-        Icphi = np.zeros((3 * natom, 3), dtype=complex)
-        for la in range(3 * natom):
-            A, beta_ = divmod(la, 3)
-            dn0_R, dn1_R, dn2_R = self._aat_dc_normalized(Perturbation('nuclear', (A, beta_)))
-            D_tilde_R = self._build_Dtilde(dn1_R, dn2_R, dn0_R)
-            for gamma in range(3):
-                _, _, U_A = self._cpci_ints(Perturbation('vecpot', gamma))
-                Icphi[la, gamma] = c('pq,pq->', D_tilde_R, U_A)
-        return Icphi
-
-    def compute_Iphic_VG_APT(self):
-        from .cphf import Perturbation
-        c = self.contract
-        natom = self.derivatives.natom
-        Iphic = np.zeros((3 * natom, 3), dtype=complex)
-        vecA = {g: self._aat_dc_normalized(Perturbation('vecpot', g)) for g in range(3)}
-        for la in range(3 * natom):
-            A, beta_ = divmod(la, 3)
-            pR = Perturbation('nuclear', (A, beta_))
-            _, _, U_R = self._cpci_ints(pR)
-            half_S = np.asarray(self.derivatives.overlap_half(A)[beta_])
-            Ur_eff = U_R + half_S.T
-            for gamma in range(3):
-                dn0_A, dn1_A, dn2_A = vecA[gamma]
-                D_tilde_A = self._build_Dtilde(dn1_A, dn2_A, dn0_A)
-                Iphic[la, gamma] = c('pq,qp->', D_tilde_A.conj(), Ur_eff)
-        return Iphic
-
-    def compute_Iphiphi_VG_APT(self):
-        from .cphf import Perturbation
-        c = self.contract
-        natom = self.derivatives.natom
-        _, D_pq, _ = self._cisd_densities()   # correlation-only 1-PDM
-        I_pp = np.zeros((3 * natom, 3), dtype=complex)
-        for la in range(3 * natom):
-            A, beta_ = divmod(la, 3)
-            _, _, U_R = self._cpci_ints(Perturbation('nuclear', (A, beta_)))
-            half_S = np.asarray(self.derivatives.overlap_half(A)[beta_])
-            Ur_eff = U_R + half_S.T
-            for gamma in range(3):
-                _, _, U_A = self._cpci_ints(Perturbation('vecpot', gamma))
-                I_pp[la, gamma] = c('pq,pq->', D_pq, U_A.T @ Ur_eff)
-        return I_pp
-
-    def velocity_dipole_derivatives(self, gauge: str = 'canonical') -> np.ndarray:
-        """CISD CORRELATION-ONLY VG-APT, shape (natom, 3, 3): -2 times the four
-        overlap blocks with the correlation 1-PDM in Iphiphi (the HF block of
-        Iphiphi is the SCF reference; the other three blocks are pure
-        correlation). The SCF reference and the Z_A delta nuclear term are
-        supplied by the pycc.apt(gauge='velocity') facade, matching MPwfn's
-        contract. """
-        natom = self.ref.molecule().natom()
-        overlap_total = (self.compute_Icc_VG_APT() + self.compute_Icphi_VG_APT()
-                          + self.compute_Iphic_VG_APT() + self.compute_Iphiphi_VG_APT())
-        return (-2.0 * overlap_total).real.reshape(natom, 3, 3)
-
-    # Hessian  (cisd_analytic_hessian.py)
-
-    def _hess_build_Y(self):
-        """Y_ijkl double-UU tensor, correlation densities only (linear in Q/G,
-        so the HF part belongs to the SCF reference Hessian)."""
-        ct = self.contract
-        zv = self._zvector()
-        Q, G, _ = self._corr_QGX()
-        h_mo = zv['h_mo']
-        ERI = np.asarray(self.H.ERI)
-        Y = ct('jl,ik->ijkl', Q, h_mo)
-        Y = Y + 2.0 * ct('jlmn,ikmn->ijkl', G, ERI)
-        Y = Y + 2.0 * ct('jmln,imkn->ijkl', G, ERI)
-        Y = Y + 2.0 * ct('jmnl,imnk->ijkl', G, ERI)
-        return Y
-
-    def _hess_X_tilde(self):
-        """Correlation-only X_tilde: X_corr (linear in the corr densities) with
-        the Z-vector-corrected vo block. z itself is solved from the FULL
-        Lagrangian in _zvector() (unchanged from the validated code); it is a
-        pure correlation quantity since the HF part of X satisfies Brillouin
-        (X_HF[v,o] - X_HF[o,v].T = 0) and contributes nothing to the rhs."""
-        ct = self.contract
-        o, v, no, nv = self.o, self.v, self.no, self.nv
-        zv = self._zvector()
-        _, _, X_corr = self._corr_QGX()
-        F, ERI = np.asarray(self.H.F), np.asarray(self.H.ERI)
-        A = (2.0 * ERI - ERI.swapaxes(2, 3)) + (2.0 * ERI - ERI.swapaxes(2, 3)).swapaxes(1, 3)
-        A = A.swapaxes(1, 2)
-        G_mat = (ct('ab,ij->aibj', np.eye(nv), np.eye(no))
-                  * (F[v, v].reshape(nv, 1, nv, 1) - F[o, o].reshape(1, no, 1, no))
-                  + A[v, o, v, o])
-        X_tilde = X_corr.copy()
-        X_tilde[v, o] += ct('aibj,bj->ai', G_mat, zv['z_ai'])
-        return X_tilde
-
-    def build_xi_ab(self, U_a, U_b, S_a, S_b, S_ab):
-        c = self.contract
-        xi = S_ab.copy()
-        xi = xi + c('im,jm->ij', U_a, U_b) + c('im,jm->ij', U_b, U_a)
-        xi = xi - c('im,jm->ij', S_a, S_b) - c('im,jm->ij', S_b, S_a)
-        return xi
-
-    def build_X_deriv(self, h_a_skel, g_a_skel):
-        """Skeleton-derivative Lagrangian, correlation densities only."""
-        ct = self.contract
-        Q, G, _ = self._corr_QGX()
-        Xa = ct('jm,im->ij', Q, h_a_skel)
-        Xa = Xa + 2.0 * ct('jmkl,imkl->ij', G, g_a_skel)
-        return Xa
-
-    def build_cpci_term(self, dc1_a, dc2_a, dc1_b, dc2_b):
-        """The pure linear CI-Jacobian action on dc1_b/dc2_b."""
-        c = self.contract
-        o, v = self.o, self.v
-        F, ERI = np.asarray(self.H.F), np.asarray(self.H.ERI)
-        E_tot = self.eci
-
-        sig1 = -E_tot * dc1_b
-        sig1 = sig1 - c('ji,ja->ia', F[o, o], dc1_b)
-        sig1 = sig1 + c('ab,ib->ia', F[v, v], dc1_b)
-        sig1 = sig1 + c('jabi,jb->ia', 2.0 * ERI[o, v, v, o] - ERI.swapaxes(2, 3)[o, v, v, o], dc1_b)
-        sig1 = sig1 + c('jb,ijab->ia', F[o, v], 2.0 * dc2_b - dc2_b.swapaxes(2, 3))
-        sig1 = sig1 + c('ajbc,ijbc->ia', 2.0 * ERI[v, o, v, v] - ERI.swapaxes(2, 3)[v, o, v, v], dc2_b)
-        sig1 = sig1 - c('kjib,kjab->ia', 2.0 * ERI[o, o, o, v] - ERI.swapaxes(2, 3)[o, o, o, v], dc2_b)
-
-        sig2 = -E_tot * dc2_b
-        sig2 = sig2 + c('abcj,ic->ijab', ERI[v, v, v, o], dc1_b)
-        sig2 = sig2 + c('abic,jc->ijab', ERI[v, v, o, v], dc1_b)
-        sig2 = sig2 - c('kbij,ka->ijab', ERI[o, v, o, o], dc1_b)
-        sig2 = sig2 - c('akij,kb->ijab', ERI[v, o, o, o], dc1_b)
-        sig2 = sig2 + c('ac,ijcb->ijab', F[v, v], dc2_b)
-        sig2 = sig2 + c('bc,ijac->ijab', F[v, v], dc2_b)
-        sig2 = sig2 - c('ki,kjab->ijab', F[o, o], dc2_b)
-        sig2 = sig2 - c('kj,ikab->ijab', F[o, o], dc2_b)
-        sig2 = sig2 + c('klij,klab->ijab', ERI[o, o, o, o], dc2_b)
-        sig2 = sig2 + c('abcd,ijcd->ijab', ERI[v, v, v, v], dc2_b)
-        sig2 = sig2 - c('kbcj,ikca->ijab', ERI[o, v, v, o], dc2_b)
-        sig2 = sig2 + c('kaci,kjcb->ijab', 2.0 * ERI[o, v, v, o] - ERI.swapaxes(2, 3)[o, v, v, o], dc2_b)
-        sig2 = sig2 - c('kbic,kjac->ijab', ERI[o, v, o, v], dc2_b)
-        sig2 = sig2 - c('kaci,kjbc->ijab', ERI[o, v, v, o], dc2_b)
-        sig2 = sig2 + c('kbcj,ikac->ijab', 2.0 * ERI[o, v, v, o] - ERI.swapaxes(2, 3)[o, v, v, o], dc2_b)
-        sig2 = sig2 - c('kajc,ikcb->ijab', ERI[o, v, o, v], dc2_b)
-
-        return -2.0 * (2.0 * c('ia,ia->', dc1_a, sig1) + c('ijab,ijab->', 2.0 * dc2_a - dc2_a.swapaxes(2, 3), sig2)).real
+    def polarizability(self, route: str = '2n+1') -> np.ndarray:
+        """CISD correlation polarizability - delegates to :meth:`CIderiv.polarizability`."""
+        return self.deriv.polarizability(route)
 
     def hessian(self, route: str = 'explicit') -> np.ndarray:
-        """CISD CORRELATION-ONLY nuclear Hessian, shape (3*natom, 3*natom):
-        the T0-T5 assembly with the correlation densities in the density with linear
-        terms (T0, xi-X_tilde, T3, T4, the HF blocks of those terms are the
-        SCF reference Hessian) and the unchanged pure-correlation Z-vector (Bab.z)
-        and CPCI (T5) terms; nuclear-repulsion block dropped. Reference and
-        nuclear are supplied by the pycc.hessian facade, matching MPwfn's
-        contract."""
-        from .cphf import Perturbation
-        ct = self.contract
-        o, v, no = self.o, self.v, self.no
-        mints, C_p4 = self._psi4_mints()
-        mol = self.ref.molecule()
-        natom = mol.natom()
-        ndof = 3 * natom
-        F = np.asarray(self.H.F)
-        eps = np.diag(F)
+        """CISD correlation Hessian - delegates to :meth:`CIderiv.hessian` (custom, migrated
+        verbatim from this method's original implementation; `route` is a vestigial argument
+        the body does not branch on, kept for call-site compatibility)."""
+        return self.deriv.hessian(route)
 
-        zv = self._zvector()
-        Q, G, _ = self._corr_QGX()   # correlation densities (T0/T3/T4/xi-X)
-        X_t = self._hess_X_tilde()
-        Y = self._hess_build_Y()
-        ERI = np.asarray(self.H.ERI)
-        z = zv['z_ai']
-        n0 = self._normalized_amplitudes()[0]
+    def dipole_derivatives(self, route: str = 'explicit') -> np.ndarray:
+        """CISD correlation length-gauge APT - delegates to :meth:`CIderiv.dipole_derivatives`
+        (custom, migrated verbatim from this method's original implementation; `route` is a
+        vestigial argument the body does not branch on, kept for call-site compatibility)."""
+        return self.deriv.dipole_derivatives(route)
 
-        ERI_M = ERI.transpose(0, 2, 1, 3)
-        W_M = 2 * ERI_M - ERI_M.transpose(0, 2, 1, 3)
-        A_M = 4 * ERI_M - ERI_M.transpose(0, 2, 1, 3) - ERI_M.transpose(0, 3, 2, 1)
+    def velocity_dipole_derivatives(self, gauge: str = 'canonical') -> np.ndarray:
+        """CISD correlation velocity-gauge APT - delegates to
+        :meth:`CIderiv.velocity_dipole_derivatives`."""
+        return self.deriv.velocity_dipole_derivatives(gauge)
 
-        def to_mulliken(g_dirac):
-            return g_dirac.transpose(0, 2, 1, 3)
+    def atomic_axial_tensors(self, gauge: str = 'canonical') -> np.ndarray:
+        """CISD correlation AAT - delegates to :meth:`CIderiv.atomic_axial_tensors`."""
+        return self.deriv.atomic_axial_tensors(gauge)
 
-        h_skel_1, g_skel_1, S_skel_1 = {}, {}, {}
-        U_all, dT1_all, dT2_all = {}, {}, {}
+    # reference for the total (reference + correlation) properties 
+    # The property methods above are the correlation contribution only. The full molecular property
+    # (nuclear + SCF reference + correlation) is assembled by the pycc property facade
+    # (pycc.dipole/gradient/polarizability/hessian/apt/aat), which pairs each correlation method
+    # with the SCF reference below and the separate nuclear term. Kept here (not just on the base
+    # CorrelatedDerivs) because the facade's transitional fallback path (register_deriv(CIwfn,
+    # CIderiv) still commented out) calls this directly on the wavefunction - matching MPwfn.
 
-        for N1 in range(natom):
-            T_core = mints.mo_oei_deriv1('KINETIC', N1, C_p4, C_p4)
-            V_core = mints.mo_oei_deriv1('POTENTIAL', N1, C_p4, C_p4)
-            S_core = mints.mo_oei_deriv1('OVERLAP', N1, C_p4, C_p4)
-            E_core = mints.mo_tei_deriv1(N1, C_p4, C_p4, C_p4, C_p4)
-            for a in range(3):
-                la = 3 * N1 + a
-                h_skel_1[la] = T_core[a].np + V_core[a].np
-                S_skel_1[la] = S_core[a].np
-                g_skel_1[la] = E_core[a].np.swapaxes(1, 2)
-                pert = Perturbation('nuclear', (N1, a))
-                U_all[la] = np.asarray(self.cphf.full_U(pert))
-                dT1_all[la], dT2_all[la] = self._cpci_raw(pert)
-
-        X_deriv = {la: self.build_X_deriv(h_skel_1[la], g_skel_1[la])
-                   for la in range(ndof)}
-
-        Fa_M, Aa_M = {}, {}
-        for la in range(ndof):
-            g_a_M = to_mulliken(g_skel_1[la])
-            Fa = h_skel_1[la].copy()
-            Fa += (ct('ijkk->ij', 2 * g_a_M[:, :, o, o]) - ct('ikjk->ij', g_a_M[:, o, :, o]))
-            Fa_M[la] = Fa
-            Aa_M[la] = (4 * g_a_M - g_a_M.transpose(0, 2, 1, 3) - g_a_M.transpose(0, 3, 2, 1))
-
-        Hessian = np.zeros((ndof, ndof))
-
-        def _assemble_ab(a, b, h_ab_sk, S_ab_sk, g_ab_sk, N1, N2):
-            la, lb = 3 * N1 + a, 3 * N2 + b
-            U_a, U_b = U_all[la], U_all[lb]
-
-            # T1: skeleton density contraction
-            t0_val = ct('ij,ij->', Q, h_ab_sk)
-            t0_val += ct('pqrs,pqrs->', G, g_ab_sk)
-
-            # T2: Z-vector replacement
-            xi = self.build_xi_ab(U_a, U_b, S_skel_1[la], S_skel_1[lb], S_ab_sk)
-            t2_xiXt = -ct('ij,ji->', xi, X_t)
-            g_ab_sk_M = to_mulliken(g_ab_sk)
-            F_ab_M = (h_ab_sk + ct('ijkk->ij', 2 * g_ab_sk_M[:, :, o, o]) - ct('ikjk->ij', g_ab_sk_M[:, o, :, o]))
-            Bab = F_ab_M.copy()
-            Bab -= ct('ij,j->ij', xi, eps)
-            Bab -= ct('kl,ijkl->ij', xi[o, o], W_M[:, :, o, o])
-            Bab += ct('ki,kj->ij', U_a, Fa_M[lb])
-            Bab += ct('ki,kj->ij', U_b, Fa_M[la])
-            Bab += ct('kj,ik->ij', U_a, Fa_M[lb])
-            Bab += ct('kj,ik->ij', U_b, Fa_M[la])
-            Bab += ct('ki,kj,k->ij', U_a, U_b, eps)
-            Bab += ct('ki,kj,k->ij', U_b, U_a, eps)
-            UaUbT = U_a[:, o] @ U_b[:, o].T
-            Bab += ct('kl,ijkl->ij', UaUbT, A_M)
-            temp5_b = ct('lm,kjlm->kj', U_b[:, o], A_M[:, :, :, o])
-            temp5_a = ct('lm,kjlm->kj', U_a[:, o], A_M[:, :, :, o])
-            Bab += ct('ki,kj->ij', U_a, temp5_b)
-            Bab += ct('ki,kj->ij', U_b, temp5_a)
-            temp6_b = ct('lm,iklm->ik', U_b[:, o], A_M[:, :, :, o])
-            temp6_a = ct('lm,iklm->ik', U_a[:, o], A_M[:, :, :, o])
-            Bab += ct('kj,ik->ij', U_a, temp6_b)
-            Bab += ct('kj,ik->ij', U_b, temp6_a)
-            Bab += ct('kl,ijkl->ij', U_a[:, o], Aa_M[lb][:, :, :, o])
-            Bab += ct('kl,ijkl->ij', U_b[:, o], Aa_M[la][:, :, :, o])
-            t2_zvec = 2.0 * ct('ai,ai->', Bab[v, o], z)
-            t2_val = t2_xiXt + t2_zvec
-
-            # T3+T4: orbital-response Lagrangian + Y tensor
-            t3_val = 2.0 * (ct('ij,ij->', U_b, X_deriv[la])+ ct('ij,ij->', U_a, X_deriv[lb]))
-            t4_val = 2.0 * ct('ij,kl,ijkl->', U_a, U_b, Y)
-
-            # T5: CPCI amplitude response
-            t5_val = n0**2 * self.build_cpci_term(
-                dT1_all[la], dT2_all[la], dT1_all[lb], dT2_all[lb]).real
-
-            return la, lb, (t0_val + t2_val + t3_val + t4_val + t5_val).real
-
-        for N1 in range(natom):
-            for N2 in range(natom):
-                T_ab = mints.mo_oei_deriv2('KINETIC', N1, N2, C_p4, C_p4)
-                V_ab = mints.mo_oei_deriv2('POTENTIAL', N1, N2, C_p4, C_p4)
-                S_ab = mints.mo_oei_deriv2('OVERLAP', N1, N2, C_p4, C_p4)
-                E_ab = mints.mo_tei_deriv2(N1, N2, C_p4, C_p4, C_p4, C_p4)
-
-                h_ab = {(a, b): T_ab[3 * a + b].np + V_ab[3 * a + b].np for a in range(3) for b in range(3)}
-                S_ab_np = {(a, b): S_ab[3 * a + b].np for a in range(3) for b in range(3)}
-                g_ab = {(a, b): E_ab[3 * a + b].np.swapaxes(1, 2) for a in range(3) for b in range(3)}
-
-                for a in range(3):
-                    for b in range(3):
-                        la, lb, val = _assemble_ab(
-                            a, b, h_ab[(a, b)], S_ab_np[(a, b)], g_ab[(a, b)], N1, N2)
-                        Hessian[la, lb] = val
-
-                del T_ab, V_ab, S_ab, E_ab, h_ab, S_ab_np, g_ab
-
-        Hessian = 0.5 * (Hessian + Hessian.T)
-        return Hessian
+    def _reference_hf(self):
+        """The all-electron :class:`HFwfn` for the SCF reference (cached), supplying the reference
+        (electronic) contribution to the total CISD properties via the pycc property facade."""
+        if getattr(self, '_ref_hf', None) is None:
+            from .hfwfn import HFwfn
+            self._ref_hf = HFwfn(self.ref, orbital_basis=self.orbital_basis)
+        return self._ref_hf

--- a/pycc/tests/test_079_cisd_lg_apt.py
+++ b/pycc/tests/test_079_cisd_lg_apt.py
@@ -8,8 +8,7 @@ itself validated independently: the analytic Hessian against Psi4/Gaussian
 finite differences (~1e-6), the AATs against the determinant-based apyib
 reference (B. Shumberger; ~1e-11 a.u.), and the LG-APT (Z-vector route)
 against finite differences of the analytic dipole.  The CIwfn port
-reproduces these values to ~1e-10; the test tolerance (1e-6) absorbs the
-printed precision of the reference.  The references are TOTAL tensors, so
+reproduces these values to ~1e-10.  The references are TOTAL tensors, so
 the tests exercise the full facade decomposition (nuclear + HF reference +
 CISD correlation).  Spatial orbitals, all-electron only.
 """
@@ -36,15 +35,18 @@ LG_APT_REF = np.array([
 
 
 def test_cisd_lg_apt_vs_reference(cisd_h2o2):
-    """The facade total (nuclear + HF reference + CISD correlation) reproduces
-    the standalone validated reference, every element."""
+    """The facade total (nuclear + HF reference + CIderiv-driven CISD
+    correlation) reproduces the standalone validated reference, every
+    element. Primary correctness gate for the CIderiv migration."""
     P = np.asarray(pycc.apt(cisd_h2o2()).total).reshape(-1, 3)
     assert np.max(np.abs(P - LG_APT_REF)) < 1e-9, np.max(np.abs(P - LG_APT_REF))
 
+
 def test_cisd_lg_apt_translational_sum_rule(cisd_h2o2):
     """Acoustic sum rule: the total LG APT of neutral H2O2 sums to zero over
-    atoms; the correlation block alone also sums to zero (traceless corr
-    density)."""
+    atoms; the correlation block (from CIderiv, inherited from the base
+    CorrelatedDerivs 2n+1 assembly) alone also sums to zero (traceless corr
+    density) - FD-free, implementation-agnostic physics check."""
     comp = pycc.apt(cisd_h2o2())
     assert np.max(np.abs(np.sum(np.asarray(comp.total), axis=0))) < 1e-9
     assert np.max(np.abs(np.sum(np.asarray(comp.correlation), axis=0))) < 1e-9

--- a/pycc/tests/test_080_cisd_vg_apt.py
+++ b/pycc/tests/test_080_cisd_vg_apt.py
@@ -8,8 +8,7 @@ itself validated independently: the analytic Hessian against Psi4/Gaussian
 finite differences (~1e-6), the AATs against the determinant-based apyib
 reference (B. Shumberger; ~1e-11 a.u.), and the LG-APT (Z-vector route)
 against finite differences of the analytic dipole.  The CIwfn port
-reproduces these values to ~1e-10; the test tolerance (1e-6) absorbs the
-printed precision of the reference.  The references are TOTAL tensors, so
+reproduces these values to ~1e-10.  The references are TOTAL tensors, so
 the tests exercise the full facade decomposition (nuclear + HF reference +
 CISD correlation).  Spatial orbitals, all-electron only.
 """
@@ -36,7 +35,8 @@ VG_APT_REF = np.array([
 
 
 def test_cisd_vg_apt_vs_reference(cisd_h2o2):
-    """The facade total reproduces the standalone validated reference, every
-    element."""
+    """The facade total (via CIderiv.velocity_dipole_derivatives(), migrated
+    verbatim from the retired on-CIwfn overlap code) reproduces the
+    standalone validated reference, every element."""
     P = np.asarray(pycc.apt(cisd_h2o2(), gauge='velocity').total).reshape(-1, 3)
     assert np.max(np.abs(P - VG_APT_REF)) < 1e-9, np.max(np.abs(P - VG_APT_REF))

--- a/pycc/tests/test_081_cisd_aat.py
+++ b/pycc/tests/test_081_cisd_aat.py
@@ -8,8 +8,7 @@ itself validated independently: the analytic Hessian against Psi4/Gaussian
 finite differences (~1e-6), the AATs against the determinant-based apyib
 reference (B. Shumberger; ~1e-11 a.u.), and the LG-APT (Z-vector route)
 against finite differences of the analytic dipole.  The CIwfn port
-reproduces these values to ~1e-10; the test tolerance (1e-6) absorbs the
-printed precision of the reference.  The references are TOTAL tensors, so
+reproduces these values to ~1e-10.  The references are TOTAL tensors, so
 the tests exercise the full facade decomposition (nuclear + HF reference +
 CISD correlation).  Spatial orbitals, all-electron only.
 """
@@ -34,7 +33,7 @@ AAT_REF = np.array([
  [ 0.2035256536,-2.2788945997,-0.0000010340],
 ])
 
-# Same, (P)-H2O2/cc-pVDZ - a real virtual space (virtuals in every irrep,
+# (P)-H2O2/cc-pVDZ - a real virtual space (virtuals in every irrep,
 # polarization functions) that STO-3G's two virtuals cannot provide.
 AAT_REF_CCPVDZ = np.array([
  [-0.0086864882,  0.0460210947, -0.2786642140],
@@ -53,8 +52,9 @@ AAT_REF_CCPVDZ = np.array([
 
 
 def test_cisd_aat_vs_reference(cisd_h2o2):
-    """The facade total reproduces the standalone validated reference, every
-    element (STO-3G)."""
+    """The facade total (via CIderiv.atomic_axial_tensors(), migrated
+    verbatim from the retired on-CIwfn overlap code) reproduces the
+    standalone validated reference, every element (STO-3G)."""
     P = np.asarray(pycc.aat(cisd_h2o2()).total).reshape(-1, 3)
     print(P)
     assert np.max(np.abs(P - AAT_REF)) < 1e-8, np.max(np.abs(P - AAT_REF))

--- a/pycc/tests/test_082_cisd_hessian.py
+++ b/pycc/tests/test_082_cisd_hessian.py
@@ -8,8 +8,7 @@ itself validated independently: the analytic Hessian against Psi4/Gaussian
 finite differences (~1e-6), the AATs against the determinant-based apyib
 reference (B. Shumberger; ~1e-11 a.u.), and the LG-APT (Z-vector route)
 against finite differences of the analytic dipole.  The CIwfn port
-reproduces these values to ~1e-10; the test tolerance (1e-6) absorbs the
-printed precision of the reference.  The references are TOTAL tensors, so
+reproduces these values to ~1e-10.  The references are TOTAL tensors, so
 the tests exercise the full facade decomposition (nuclear + HF reference +
 CISD correlation).  Spatial orbitals, all-electron only.
 """
@@ -36,16 +35,18 @@ HESS_REF = np.array([
 
 
 def test_cisd_hessian_vs_reference(cisd_h2o2):
-    """The facade total (nuclear repulsion + HF reference + CISD correlation)
-    reproduces the standalone validated reference, every element."""
+    """The facade total (nuclear repulsion + HF reference + CIderiv-driven
+    CISD correlation) reproduces the standalone validated reference, every
+    element. Primary correctness gate for the CIderiv migration."""
     H = np.asarray(pycc.hessian(cisd_h2o2()).total)
     assert np.max(np.abs(H - HESS_REF)) < 1e-8, np.max(np.abs(H - HESS_REF))
 
 
 def test_cisd_hessian_symmetry_sum_rule(cisd_h2o2):
-    """The total Hessian is symmetric and
-    translationally invariant (sum over the second atom vanishes); the
-    correlation block obeys both on its own."""
+    """The total Hessian is symmetric and translationally invariant (sum
+    over the second atom vanishes); the correlation block (from CIderiv,
+    inherited from the base CorrelatedDerivs 2n+1 assembly) obeys both on
+    its own - FD-free, implementation-agnostic physics check."""
     comp = pycc.hessian(cisd_h2o2())
     for H in (np.asarray(comp.total), np.asarray(comp.correlation)):
         assert np.max(np.abs(H - H.T)) < 1e-9

--- a/pycc/tests/test_091_cisd_polarizability.py
+++ b/pycc/tests/test_091_cisd_polarizability.py
@@ -1,0 +1,88 @@
+"""
+test_091_cisd_polarizability.py
+
+CISD static electric-dipole polarizability (correlation contribution),
+alpha_corr[a,b] = -d^2 E_corr / dF_a dF_b, omega = 0 - cross-checks the two
+implementation routes against each other (no finite-difference oracle here.
+
+Routes (CIwfn.polarizability(route=...)):
+  * '2n+1'     -- base-driven (CorrelatedDerivs.polarizability), from
+                  CIderiv's _unrelaxed_densities/_perturbed_unrelaxed_densities
+                  hooks. Confirmed via the energy-closing identity and
+                  consistency with dipole_derivatives/hessian.
+  * 'explicit' -- independent cross-check reusing the SAME T0-T5 / Z-vector
+                  machinery as hessian() (Yamaguchi Ch. 18) with field-field
+                  skeleton integrals. 
+                  This test is exactly the check needed to establish whether
+                  it agrees with the trusted '2n+1' route.
+
+Both routes eliminate the second-order CPHF response U^{fg} via the
+Z-vector and never compute it, so if they are both implemented correctly,
+agreement is a genuine algebraic identity, not a numerical coincidence.
+"""
+
+import psi4
+import pycc
+import numpy as np
+
+
+WATER = """
+O  0.00000  0.00000  0.00000
+H  0.00000  1.43121 -1.10664
+H  0.00000 -1.43121 -1.10664
+units bohr
+no_com
+no_reorient
+"""
+
+
+def _ciwfn(basis='6-31G'):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(WATER)
+    psi4.set_options({'basis': basis, 'scf_type': 'pk', 'freeze_core': False, 'e_convergence': 1e-14, 'd_convergence': 1e-14})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    ci = pycc.CIwfn(wfn, model='CISD')
+    ci.solve_ci(e_conv=1e-13, r_conv=1e-13, maxiter=150)
+    return ci
+
+
+def test_cisd_polarizability_explicit_vs_2n1_631g():
+    """The two polarizability routes agree with each other, H2O/6-31G,
+    every element. '2n+1' is the trusted route (energy-closing identity +
+    consistency with dipole_derivatives/hessian); this test checks whether
+    'explicit' reproduces it."""
+    ci = _ciwfn('6-31G')
+    a_2n1 = np.asarray(ci.polarizability(route='2n+1'))
+    a_exp = np.asarray(ci.polarizability(route='explicit'))
+    diff = np.max(np.abs(a_2n1 - a_exp))
+    assert diff < 1e-9, (diff, a_2n1, a_exp)
+
+
+def test_cisd_polarizability_symmetric_631g():
+    """Both routes give a symmetric tensor (alpha_ab = alpha_ba) - an
+    FD-free structural check, run for both routes independently."""
+    ci = _ciwfn('6-31G')
+    for route in ('2n+1', 'explicit'):
+        alpha = np.asarray(ci.polarizability(route=route))
+        assert np.max(np.abs(alpha - alpha.T)) < 1e-8, (route, alpha)
+
+
+def test_cisd_polarizability_off_diagonal_zero_by_symmetry_631g():
+    """H2O/6-31G is C2v (z along C2, molecular plane yz): the correlation
+    polarizability must be diagonal. Checked for both routes."""
+    ci = _ciwfn('6-31G')
+    for route in ('2n+1', 'explicit'):
+        alpha = np.asarray(ci.polarizability(route=route))
+        assert abs(alpha[0, 1]) < 1e-7, (route, 'xy', alpha[0, 1])
+        assert abs(alpha[0, 2]) < 1e-7, (route, 'xz', alpha[0, 2])
+        assert abs(alpha[1, 2]) < 1e-7, (route, 'yz', alpha[1, 2])
+
+
+def test_cisd_polarizability_guards():
+    """An unknown route raises ValueError rather than silently doing
+    something wrong."""
+    import pytest
+    ci = _ciwfn('6-31G')
+    with pytest.raises(ValueError):
+        ci.polarizability(route='bogus')


### PR DESCRIPTION
## Description

Adds CISD static electric-dipole polarizability (`CIwfn.polarizability()`, correlation-only) and refactors CISD's derivative-property code into a `CIwfn`/`CIderiv` split mirroring the existing `MPwfn`/`MPderiv` pattern:
`CIwfn` holds the CI amplitude/energy machinery, `CIderiv` carries the derivative-property code, reached through a cached `.deriv` property.

Two polarizability routes (2n+1 and explicit hessian like), cross-validated against each other to ~1e-9 (H2O/6-31G).

## Tests

- `test_091_cisd_polarizability.py` (new): 2n+1 vs explicit cross-check,
  symmetry, C2v off-diagonal vanishing, route guard.
- `test_079`-`082` (updated): docstrings updated to describe the new
  `CIwfn` -> `.deriv` -> `CIderiv` dispatch path; reference tensors and
  tolerances unchanged.

## Status

- [x] Ready to go