### PR TITLE
CC linear-response reformulation (Phases 1-3) + correct T1/T2 residual source blocks

### DIFF
--- a/docs/ccresponse_reformulation_plan.md
+++ b/docs/ccresponse_reformulation_plan.md
@@ -1,6 +1,6 @@
 # CC linear-response reformulation — design plan
 
-**Status:** Phases 1-2 complete (static + dynamic unrelaxed CCSD polarizability); Phases 3-4 to follow. Living document.
+**Status:** Phases 1-3 complete (static + dynamic unrelaxed CCSD polarizability; optical rotation); Phase 4 (CC3) to follow. Living document.
 
 ## Goal
 
@@ -123,9 +123,23 @@ has spurious poles at the SCF excitation frequencies.
    `response_polarizability(omega)` reproduces `ccresponse.polarizability(omega)` to ~1e-11 at
    omega != 0 (test_092; spatial and spin-orbital, positive and negative frequency, with the static
    tensor recovered as omega -> 0 and normal dispersion away from it).
-3. **Optical rotation.** Operators are the electric dipole `mu` and the magnetic dipole `m` (the
-   `<<mu; m>>` tensor) — not angular momentum. **omega != 0 only** (there is no static optical
-   rotation). Antisymmetric combination + mixed `(1+Lambda)` terms.
+3. **Optical rotation. DONE.** `optical_rotation(omega)` = the `<<mu; m>>_omega` tensor, electric
+   dipole `mu` and magnetic dipole `m` (not angular momentum), `omega != 0`. Two findings:
+   - **The magnetic dipole is anti-Hermitian, which exposed a source bug in the perturbed-amplitude
+     solvers.** `cc.residuals` builds the singles source from the `[o,v]` block (the ground-state
+     `f_ia` convention, valid only because the Fock is symmetric); the correct similarity-transform
+     source is the `[v,o]` block `A_ai` (what `ccresponse.pertbar.Avo` uses). For a symmetric
+     perturbation (Fock derivative, electric dipole) the two blocks are equal, so Phases 1-2 were
+     unaffected; for the anti-Hermitian magnetic dipole they differ by a sign. Fixed in
+     `_perturbed_amplitudes`/`_so_perturbed_amplitudes` by `B1 += (df[v,o].T - df[o,v])` (zero for a
+     symmetric perturbation). Confirmed at the amplitude level: our `dt`/`dl` now reproduce
+     `ccresponse`'s `X`/`Y` for BOTH `mu` and `m` to ~1e-14.
+   - **Optical rotation is the odd-in-omega combination**, not a single density evaluation: a single
+     `Tr(d_m D(omega).mu)` is the asymmetric `<<mu; m>>` and differs from the trusted symmetric value.
+     `ccresponse.optrot` (via `linresp_sym`) is `0.5*(S1 - S2)` with `S1 = linresp_sym(mu@-omega,
+     m@+omega)` and `S2` its frequency-swap; this equals `0.5*[Tr(d_m D(+omega).mu) -
+     Tr(d_m D(-omega).mu)]`. Matches `ccresponse.optrot` to ~1e-13 (test_093; spatial + SO, chiral
+     H2O2, nonzero trace).
 4. **CC3.** Deferred; scope TBD.
 
 ## Validation

--- a/docs/ccresponse_reformulation_plan.md
+++ b/docs/ccresponse_reformulation_plan.md
@@ -1,6 +1,6 @@
 # CC linear-response reformulation — design plan
 
-**Status:** Phase 1 complete (static unrelaxed CCSD polarizability); Phases 2-4 to follow. Living document.
+**Status:** Phases 1-2 complete (static + dynamic unrelaxed CCSD polarizability); Phases 3-4 to follow. Living document.
 
 ## Goal
 
@@ -113,8 +113,16 @@ has spurious poles at the SCF excitation frequencies.
    - the FD-of-unrelaxed-dipole check was dropped in favor of the `ccresponse` oracle: the two routes
      (symmetric right-amplitude response vs asymmetric density contraction) share no machinery, so the
      match is a stronger, machine-precision cross-check than a truncation-limited finite difference.
-2. **Dynamic (omega != 0).** Reproduce `ccresponse` at several frequencies; same amplitude-level +
-   tensor checks.
+2. **Dynamic (omega != 0). DONE.** The frequency is threaded through the shared solvers as an `omega`
+   argument (default `0`, leaving the derivative path untouched): the `-omega dt` right-hand residual
+   shift in `_perturbed_amplitudes`/`_so_perturbed_amplitudes`, the `+omega dl` left-hand shift in
+   `_perturbed_lambda`/`_so_perturbed_lambda`, and `(D + omega)` denominators throughout. The left
+   (multiplier) frequency term is the full `+omega dl` (no 1/2 on the doubles): the perturbed-Lambda
+   solver is built on `cclambda`'s `r_L`, whose doubles normalization differs from `ccresponse`'s
+   `r_Y` (which carries `0.5*omega*Y2`) -- verified by the tensor match, not assumed.
+   `response_polarizability(omega)` reproduces `ccresponse.polarizability(omega)` to ~1e-11 at
+   omega != 0 (test_092; spatial and spin-orbital, positive and negative frequency, with the static
+   tensor recovered as omega -> 0 and normal dispersion away from it).
 3. **Optical rotation.** Operators are the electric dipole `mu` and the magnetic dipole `m` (the
    `<<mu; m>>` tensor) — not angular momentum. **omega != 0 only** (there is no static optical
    rotation). Antisymmetric combination + mixed `(1+Lambda)` terms.

--- a/docs/ccresponse_reformulation_plan.md
+++ b/docs/ccresponse_reformulation_plan.md
@@ -1,6 +1,6 @@
 # CC linear-response reformulation — design plan
 
-**Status:** Phases 1-3 complete (static + dynamic unrelaxed CCSD polarizability; optical rotation); Phase 4 (CC3) to follow. Living document.
+**Status:** Phases 1-3 complete (static + dynamic unrelaxed CCSD polarizability; optical rotation), in PR #214 (CI running); Phase 4 (CC3) to follow. The anti-Hermitian source fix that Phase 3 surfaced is now implemented at the source (the T1/T2 residual leading blocks in `ccwfn.py`), which also corrects the complex-ERI real-time CC path; the downstream perturbed-amplitude correction is removed. Living document.
 
 ## Goal
 
@@ -125,15 +125,22 @@ has spurious poles at the SCF excitation frequencies.
    tensor recovered as omega -> 0 and normal dispersion away from it).
 3. **Optical rotation. DONE.** `optical_rotation(omega)` = the `<<mu; m>>_omega` tensor, electric
    dipole `mu` and magnetic dipole `m` (not angular momentum), `omega != 0`. Two findings:
-   - **The magnetic dipole is anti-Hermitian, which exposed a source bug in the perturbed-amplitude
-     solvers.** `cc.residuals` builds the singles source from the `[o,v]` block (the ground-state
-     `f_ia` convention, valid only because the Fock is symmetric); the correct similarity-transform
-     source is the `[v,o]` block `A_ai` (what `ccresponse.pertbar.Avo` uses). For a symmetric
-     perturbation (Fock derivative, electric dipole) the two blocks are equal, so Phases 1-2 were
-     unaffected; for the anti-Hermitian magnetic dipole they differ by a sign. Fixed in
-     `_perturbed_amplitudes`/`_so_perturbed_amplitudes` by `B1 += (df[v,o].T - df[o,v])` (zero for a
-     symmetric perturbation). Confirmed at the amplitude level: our `dt`/`dl` now reproduce
-     `ccresponse`'s `X`/`Y` for BOTH `mu` and `m` to ~1e-14.
+   - **The magnetic dipole is anti-Hermitian, which exposed a mis-blocked leading term in the CC
+     amplitude residuals.** The T1 residual took its leading singles source from the `[o,v]` Fock
+     block (`f_ia`, the ground-state convention, valid only because the Fock is symmetric); the
+     correct similarity-transform source `<Phi_i^a|F|0>` is the `[v,o]` block `f_ai` (= `A_ai`, what
+     `ccresponse.pertbar.Avo` uses). The T2 residual has the analogous swap: its leading term was
+     `<ij|ab>` (`ERI[o,o,v,v]`) but should be `<ab|ij>` = `<Phi_ij^ab|V|0>` (`ERI[v,v,o,o]`). For a
+     symmetric perturbation (Fock derivative, electric dipole), and more generally for real
+     (Hermitian) integrals, the swapped blocks are equal, so Phases 1-2, all ground-state CC, and
+     every real calculation are unaffected; they differ for the anti-Hermitian magnetic dipole and
+     for complex ERI (real-time CC). **Fixed at the source** (`ccwfn.py`): `r_T1`/`_so_r_T1` lead with
+     `F[v,o]` and `r_T2`/`_so_r_T2` (plus the spatial `_r_T2_ccsd`/`_cc2`/`_ccd`) lead with `<ab|ij>`,
+     so the perturbed-amplitude solvers need no special case. (It was first patched downstream by
+     `B1 += (df[v,o].T - df[o,v])` in `_perturbed_amplitudes`/`_so_perturbed_amplitudes`, then
+     relocated to the residuals; that correction is now removed.) Confirmed at the amplitude level:
+     our `dt`/`dl` reproduce `ccresponse`'s `X`/`Y` for BOTH `mu` and `m` to ~1e-14, and no-op across
+     the real suites while the complex path is exercised by the RT-CCSD/RT-CC3/Pade tests.
    - **Optical rotation is the odd-in-omega combination**, not a single density evaluation: a single
      `Tr(d_m D(omega).mu)` is the asymmetric `<<mu; m>>` and differs from the trusted symmetric value.
      `ccresponse.optrot` (via `linresp_sym`) is `0.5*(S1 - S2)` with `S1 = linresp_sym(mu@-omega,
@@ -162,8 +169,11 @@ has spurious poles at the SCF excitation frequencies.
 - `ccresponse.py`: `linresp_asym` (:1627, the asymmetric response function this mirrors),
   `linresp_sym` (:641), `solve_right` (:217) / `r_X1` (:325) / `r_X2` (:384),
   `solve_left` (:1694) / `r_Y1` (:1908) / `r_Y2` (:2102), `_build_pertbar` (:74).
-- `ccderiv.py`: `_perturbed_amplitudes` (:209), `_perturbed_lambda` (:498),
-  `_perturbed_unrelaxed_densities` (:188).
+- `ccwfn.py`: `r_T1`/`_so_r_T1` (leading `F[v,o]` = `f_ai`) and `r_T2`/`_so_r_T2` + the spatial
+  `_r_T2_ccsd`/`_cc2`/`_ccd` (leading `ERI[v,v,o,o]` swap-axed = `<ab|ij>`) -- the corrected residual
+  source blocks.
+- `ccderiv.py`: `_perturbed_amplitudes`, `_perturbed_lambda`, `_perturbed_unrelaxed_densities`
+  (the `[v,o]` source correction removed; now supplied by the fixed residuals).
 - `correlatedderivs.py`: `_perturbed_relaxed_density` (:439), `polarizability` (:667).
 - `docs/cc_gradients_orbital_response.tex`: eq. `eq:polarizability` (the derivative assembly the
   response strips the orbital terms from); pertbar per Crawford, cc_response.pdf eqn 78.

--- a/docs/ccresponse_reformulation_plan.md
+++ b/docs/ccresponse_reformulation_plan.md
@@ -1,6 +1,6 @@
 # CC linear-response reformulation — design plan
 
-**Status:** design/discussion (not started). Living document.
+**Status:** Phase 1 complete (static unrelaxed CCSD polarizability); Phases 2-4 to follow. Living document.
 
 ## Goal
 
@@ -99,12 +99,20 @@ has spurious poles at the SCF excitation frequencies.
 
 ## Phasing
 
-1. **CCSD static unrelaxed polarizability (omega = 0).** Isolates the unrelaxed-density step with no
-   frequency. Validate three ways:
-   - **amplitude-level:** our `dT`/`dL` vs `ccresponse`'s `X`/`Y` from `solve_right`/`solve_left`
-     at omega = 0 (the earliest, sharpest check — before any density contraction);
-   - **tensor:** vs `ccresponse.linresp_asym` / `linresp_sym`;
-   - **finite difference of the unrelaxed dipole** (`d mu_unrelaxed / dF`).
+1. **CCSD static unrelaxed polarizability (omega = 0). DONE.** `CCderiv.response_polarizability(0)`
+   plus the general `linear_response('mu','mu',0)` engine and the `_response_density`/
+   `_perturbation_ints` helpers; spatial and spin-orbital, all-electron and frozen core. The mechanism
+   is exactly as designed: the existing `_perturbed_amplitudes`/`_perturbed_lambda` fed the bare dipole
+   (`df = mu`, `deri = 0`, `dL = 0`, no CPHF) reproduce the response amplitudes with no changes to those
+   solvers. Validated:
+   - **amplitude-level:** our `dt1`/`dt2` reproduce `ccresponse.solve_right`'s `X1`/`X2` at omega = 0 to
+     ~1e-13 (the sharpest check, before any density contraction) -- confirmed during development;
+   - **tensor:** `response_polarizability(0)` vs `ccresponse.polarizability(0)` to ~1e-11
+     (test_092; spatial, SO, off-diagonal HOF, and frozen core), and confirmed distinct from the
+     relaxed derivative `polarizability`;
+   - the FD-of-unrelaxed-dipole check was dropped in favor of the `ccresponse` oracle: the two routes
+     (symmetric right-amplitude response vs asymmetric density contraction) share no machinery, so the
+     match is a stronger, machine-precision cross-check than a truncation-limited finite difference.
 2. **Dynamic (omega != 0).** Reproduce `ccresponse` at several frequencies; same amplitude-level +
    tensor checks.
 3. **Optical rotation.** Operators are the electric dipole `mu` and the magnetic dipole `m` (the

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -918,3 +918,124 @@ class CCderiv(CorrelatedDerivs):
         dG[v, o, v, v] = 0.5 * dDvvvo.transpose(2, 3, 0, 1)
         dG = 0.25 * (dG + dG.transpose(1, 0, 3, 2) + dG.transpose(2, 3, 0, 1) + dG.transpose(3, 2, 1, 0))
         return dD, dG
+
+    # ---- CC linear response: orbital-unrelaxed (dynamic) properties ------
+    # The frequency-dependent response properties (dipole polarizability, optical
+    # rotation) are the SAME perturbed-amplitude machinery as the static derivative
+    # properties above, in a different configuration: orbital relaxation OFF and a
+    # frequency shift ON.  Two differences from the derivative path:
+    #   (1) the field enters the amplitude equations as the BARE MO dipole
+    #       (df = mu, deri = 0, dL = 0) -- no CPHF folding -- so the perturbed
+    #       T/Lambda are the orbital-unrelaxed field derivatives, i.e. exactly
+    #       ccresponse's right/left perturbed amplitudes X/Y.  (cc.residuals with the
+    #       bare dipole and zeroed two-electron integrals IS the similarity-transformed
+    #       dipole, ccresponse's pertbar source; verified dt == X, dl == Y to ~1e-13
+    #       at omega = 0.)
+    #   (2) the tensor contracts the UNRELAXED perturbed 1-PDM (the leaf density hook,
+    #       no Z-vector / dependent pairs) with the bare MO dipole,
+    #       alpha_ab(omega) = Tr(d_b D(omega) . mu_a), no U.mu orbital terms.
+    # Because there is no CPHF response the whole quantity lands in the correlation
+    # block; the reference (SCF) block is zero.  This is the CC RESPONSE (orbital-
+    # unrelaxed) property, distinct from the relaxed static `polarizability` above
+    # even at omega = 0 -- validate against ccresponse, not the derivative path.  See
+    # docs/ccresponse_reformulation_plan.md.  Phase 1: static (omega = 0) CCSD; the
+    # dynamic case (omega != 0), optical rotation, and CCSD(T) are staged to follow.
+
+    def linear_response(self, a, b, omega=0.0):
+        r"""Orbital-unrelaxed CC linear response function ``<<a; b>>_omega`` -- the
+        general engine behind :meth:`response_polarizability` / :meth:`optical_rotation`.
+        The 3x3 tensor is assembled by the density route::
+
+            <<a; b>>_omega[i,j] = Tr(d_bj D(omega) . a_i)
+
+        .. math::
+
+            \langle\langle a; b \rangle\rangle_\omega^{ij}
+                = \mathrm{Tr}\big(\partial_{b_j} D(\omega)\,a_i\big)
+
+        where ``d_bj D`` is the orbital-unrelaxed 1-PDM perturbed by component ``j`` of
+        operator ``b`` (:meth:`_response_density`) and ``a_i`` is the bare MO integral of
+        component ``i`` of operator ``a``.  ``a``/``b`` are operator keys following
+        ``ccresponse``'s idiom (``'mu'`` = electric dipole, ``'m'`` = magnetic dipole);
+        ``omega`` is a single field frequency (a sweep loops at the call site).  This is
+        the CC response (unrelaxed) value, not the relaxed derivative :meth:`polarizability`."""
+        a_ints = self._perturbation_ints(a)
+        dD = [self._response_density(self._perturbation_ints(b)[j], omega) for j in range(3)]
+        tensor = np.zeros((3, 3))
+        for i in range(3):
+            for j in range(3):
+                tensor[i, j] = self.contract('pq,qp->', dD[j], a_ints[i])
+        return tensor
+
+    def response_polarizability(self, omega=0.0):
+        r"""Orbital-unrelaxed dynamic dipole polarizability ``alpha(omega)``, a 3x3 array::
+
+            alpha_ab(omega) = -<<mu; mu>>_omega = -Tr(d_b D(omega) . mu_a)
+
+        .. math::
+
+            \alpha_{ab}(\omega) = -\langle\langle \mu; \mu \rangle\rangle_\omega
+                = -\mathrm{Tr}\big(\partial_{b} D(\omega)\,\mu_a\big)
+
+        ``omega = 0`` gives the static orbital-unrelaxed polarizability (the CC response
+        value, distinct from the relaxed derivative :meth:`polarizability`).  The overall
+        sign is the ``alpha = -<<mu; mu>>`` convention of ``ccresponse.polarizability``."""
+        return -self.linear_response('mu', 'mu', omega)
+
+    def optical_rotation(self, omega):
+        r"""Orbital-unrelaxed optical-rotation tensor ``G'(omega) = <<mu; m>>_omega``
+        (electric dipole ``mu`` and magnetic dipole ``m``), a 3x3 array; ``omega != 0``
+        (there is no static optical rotation).  Not yet implemented -- staged after the
+        dynamic (omega != 0) polarizability; see docs/ccresponse_reformulation_plan.md."""
+        raise NotImplementedError(
+            "Optical rotation (<<mu; m>>) is a later phase of the CC linear-response "
+            "reformulation; only the static polarizability is implemented so far.")
+
+    def _perturbation_ints(self, key):
+        """Bare MO integrals of a one-electron perturbation operator, as a list of three
+        (nmo x nmo) arrays (Cartesian x, y, z).  ``'mu'`` returns the electric-dipole
+        integrals (``H.mu``); ``'m'`` the magnetic-dipole integrals (``H.m``, stored pure
+        imaginary in :mod:`pycc.hamiltonian` for the RT-CC code -- the ``i`` is factored
+        out here as in :meth:`ccresponse._build_pertbar`, since the response values are
+        bilinear in the perturbation)."""
+        cc = self.ccwfn
+        if key == 'mu':
+            return [np.asarray(cc.H.mu[x]) for x in range(3)]
+        if key == 'm':
+            return [np.real(-1.0j * np.asarray(cc.H.m[x])) for x in range(3)]
+        raise KeyError(f"Unknown perturbation operator key: {key!r} (expected 'mu' or 'm').")
+
+    def _response_density(self, op_ints, omega=0.0):
+        r"""Orbital-unrelaxed perturbed 1-PDM ``d_op D(omega)`` for a bare one-electron
+        operator ``op_ints`` (full-MO ``nmo x nmo``).  Solves the perturbed amplitudes and
+        multipliers with the BARE operator as the perturbation (``df = op_ints``, no
+        perturbed two-electron integrals, no CPHF folding -- the orbital-unrelaxed field
+        derivative), reusing the converged ``self.hbar``/``self.cclambda`` from ``__init__``,
+        then builds the unrelaxed perturbed correlation 1-PDM
+        (:meth:`_perturbed_correlation_densities`; no Z-vector, no dependent pairs)::
+
+            (HBAR -/+ omega) . dt = -B(op),    dl similarly,    d_op D = dD(dt, dl)
+
+        CCSD only for now; the dynamic case (``omega != 0``, the ``-/+ omega`` residual
+        shift) and CCSD(T) (perturbed (T) sources) are later phases."""
+        cc = self.ccwfn
+        lam = self.cclambda
+        hbar = self.hbar
+        if cc.model.upper() != 'CCSD':
+            raise NotImplementedError(
+                "CC linear response is implemented for CCSD only (Phase 1); "
+                f"not {cc.model}.")
+        if omega != 0.0:
+            raise NotImplementedError(
+                "Dynamic CC response (omega != 0) is a later phase; only the static "
+                "(omega = 0) polarizability is implemented so far.")
+        zero_eri = np.zeros_like(np.asarray(cc.H.ERI))
+        if cc.orbital_basis == 'spinorbital':
+            dt1, dt2 = self._so_perturbed_amplitudes(op_ints, zero_eri, hbar)
+            dl1, dl2 = self._so_perturbed_lambda(op_ints, zero_eri, dt1, dt2, hbar, lam)
+        else:
+            zero_L = np.zeros_like(np.asarray(cc.H.L))
+            dt1, dt2 = self._perturbed_amplitudes(op_ints, zero_eri, zero_L, hbar)
+            dl1, dl2 = self._perturbed_lambda(op_ints, zero_eri, zero_L, dt1, dt2, hbar, lam)
+        dD, _ = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam)
+        return dD

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -224,11 +224,11 @@ class CCderiv(CorrelatedDerivs):
         ``d_x HBAR``, whose ``[HBAR, d_x t]`` piece is the Jacobian LHS.)  ``B^x`` is computed by
         evaluating ``cc.residuals`` with the perturbed **bare** integrals (``df`` and the CPHF-folded
         ``deri``/``dL`` swapped into ``cc.H``, carrying the orbital relaxation), the residual formula
-        supplying the ``e^-T ( ) e^T`` transform.  The singles source's leading term is taken from the
-        ``[v,o]`` block (the correct ``A_ai``), not ``cc.residuals``'s ``[o,v]`` (the ground-state
-        ``f_ia`` convention, which assumes a symmetric perturbation): the two agree for a Hermitian
-        operator (the Fock derivative, the electric dipole) but differ for an anti-Hermitian one (the
-        magnetic dipole), where ``[v,o]`` is the correct similarity-transform source.  Iterate
+        supplying the ``e^-T ( ) e^T`` transform.  The singles source's leading term is the ``[v,o]``
+        block ``A_ai`` -- ``<Phi_i^a|(d_x H)|0> = (d_x f)_{ai}`` -- supplied directly by ``r_T1``'s
+        leading ``F[v,o]`` term (\S ``ccwfn.r_T1``).  This matters only for an anti-Hermitian
+        perturbation (the magnetic dipole): for a Hermitian one (the Fock derivative, the electric
+        dipole) ``[v,o] == [o,v]`` and it is the ordinary ``f_ia``.  Iterate
         ``dt += (B + HBAR.dt - omega dt)/(D + omega)``
         with DIIS.  ``omega`` is the CC linear-response frequency (the ``-omega dt`` residual shift and
         ``(D + omega)`` denominators; default ``0`` reproduces the static derivative equation exactly
@@ -246,11 +246,9 @@ class CCderiv(CorrelatedDerivs):
             B1, B2 = cc.residuals(df, cc.t1, cc.t2)
         finally:
             cc.H.ERI, cc.H.L = saveERI, saveL
-        B1, B2 = np.asarray(B1), np.asarray(B2)
-        dfa = np.asarray(df)
-        B1 = B1 + (dfa[v, o].T - dfa[o, v])         # singles source = the vo block A_ai (see docstring):
-        X1, X2 = B1 / Dia, B2 / Dijab               # zero for a symmetric perturbation, the leading term
-        diis = helper_diis(X1, X2, 8)               # for an anti-Hermitian one (e.g. the magnetic dipole)
+        B1, B2 = np.asarray(B1), np.asarray(B2)      # singles source's leading term is r_T1's f_ai
+        X1, X2 = B1 / Dia, B2 / Dijab                # ([v,o] block A_ai), correct for anti-Hermitian df
+        diis = helper_diis(X1, X2, 8)
         for _ in range(maxiter):
             j1, j2 = self._ccsd_jacobian(X1, X2, hbar)
             r1 = B1 + j1 - omega * X1
@@ -277,9 +275,10 @@ class CCderiv(CorrelatedDerivs):
             B^{x}_\mu = \langle\mu|\, e^{-T}(\partial_x H)\, e^{T}\,|0\rangle
 
         ``B^x`` (fixed-``t``) is ``cc.residuals`` evaluated with the perturbed **bare** integrals
-        (``df``, ``deri`` swapped in), the singles source's leading term taken from the ``[v,o]`` block
-        (``A_ai``; correct for an anti-Hermitian perturbation like the magnetic dipole, and identical
-        to ``cc.residuals``'s ``[o,v]`` for a symmetric one -- see :meth:`_perturbed_amplitudes`).
+        (``df``, ``deri`` swapped in); the singles source's leading term is the ``[v,o]`` block ``A_ai``
+        supplied by ``_so_r_T1``'s leading ``F[v,o]`` term (correct for an anti-Hermitian perturbation
+        like the magnetic dipole, identical to ``[o,v]`` for a symmetric one -- see
+        :meth:`_perturbed_amplitudes`).
         ``omega`` is the CC linear-response frequency (``-omega dt``
         residual shift, ``(D + omega)`` denominators; default ``0`` = the static derivative equation).
         ``maxiter``/``rconv`` default to the wavefunction's convergence (``ccwfn.maxiter``/``r_conv``)."""
@@ -295,11 +294,9 @@ class CCderiv(CorrelatedDerivs):
             B1, B2 = cc.residuals(df, cc.t1, cc.t2)
         finally:
             cc.H.ERI = saveERI
-        B1, B2 = np.asarray(B1), np.asarray(B2)
-        dfa = np.asarray(df)
-        B1 = B1 + (dfa[v, o].T - dfa[o, v])         # singles source = the vo block A_ai (see docstring):
-        X1, X2 = B1 / Dia, B2 / Dijab               # zero for a symmetric perturbation, the leading term
-        diis = helper_diis(X1, X2, 8)               # for an anti-Hermitian one (e.g. the magnetic dipole)
+        B1, B2 = np.asarray(B1), np.asarray(B2)      # singles source's leading term is r_T1's f_ai
+        X1, X2 = B1 / Dia, B2 / Dijab                # ([v,o] block A_ai), correct for anti-Hermitian df
+        diis = helper_diis(X1, X2, 8)
         for _ in range(maxiter):
             j1, j2 = self._so_ccsd_jacobian(X1, X2, hbar)
             r1, r2 = B1 + j1 - omega * X1, B2 + j2 - omega * X2

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -224,7 +224,12 @@ class CCderiv(CorrelatedDerivs):
         ``d_x HBAR``, whose ``[HBAR, d_x t]`` piece is the Jacobian LHS.)  ``B^x`` is computed by
         evaluating ``cc.residuals`` with the perturbed **bare** integrals (``df`` and the CPHF-folded
         ``deri``/``dL`` swapped into ``cc.H``, carrying the orbital relaxation), the residual formula
-        supplying the ``e^-T ( ) e^T`` transform.  Iterate ``dt += (B + HBAR.dt - omega dt)/(D + omega)``
+        supplying the ``e^-T ( ) e^T`` transform.  The singles source's leading term is taken from the
+        ``[v,o]`` block (the correct ``A_ai``), not ``cc.residuals``'s ``[o,v]`` (the ground-state
+        ``f_ia`` convention, which assumes a symmetric perturbation): the two agree for a Hermitian
+        operator (the Fock derivative, the electric dipole) but differ for an anti-Hermitian one (the
+        magnetic dipole), where ``[v,o]`` is the correct similarity-transform source.  Iterate
+        ``dt += (B + HBAR.dt - omega dt)/(D + omega)``
         with DIIS.  ``omega`` is the CC linear-response frequency (the ``-omega dt`` residual shift and
         ``(D + omega)`` denominators; default ``0`` reproduces the static derivative equation exactly
         -- see the CC linear-response section).  ``maxiter``/``rconv`` default to the wavefunction's
@@ -234,6 +239,7 @@ class CCderiv(CorrelatedDerivs):
         maxiter = cc.maxiter if maxiter is None else maxiter
         rconv = cc.r_conv if rconv is None else rconv
         Dia, Dijab = cc.Dia + omega, cc.Dijab + omega
+        o, v = cc.o, cc.v
         saveERI, saveL = cc.H.ERI, cc.H.L
         cc.H.ERI, cc.H.L = deri, dL
         try:
@@ -241,8 +247,10 @@ class CCderiv(CorrelatedDerivs):
         finally:
             cc.H.ERI, cc.H.L = saveERI, saveL
         B1, B2 = np.asarray(B1), np.asarray(B2)
-        X1, X2 = B1 / Dia, B2 / Dijab
-        diis = helper_diis(X1, X2, 8)
+        dfa = np.asarray(df)
+        B1 = B1 + (dfa[v, o].T - dfa[o, v])         # singles source = the vo block A_ai (see docstring):
+        X1, X2 = B1 / Dia, B2 / Dijab               # zero for a symmetric perturbation, the leading term
+        diis = helper_diis(X1, X2, 8)               # for an anti-Hermitian one (e.g. the magnetic dipole)
         for _ in range(maxiter):
             j1, j2 = self._ccsd_jacobian(X1, X2, hbar)
             r1 = B1 + j1 - omega * X1
@@ -269,13 +277,17 @@ class CCderiv(CorrelatedDerivs):
             B^{x}_\mu = \langle\mu|\, e^{-T}(\partial_x H)\, e^{T}\,|0\rangle
 
         ``B^x`` (fixed-``t``) is ``cc.residuals`` evaluated with the perturbed **bare** integrals
-        (``df``, ``deri`` swapped in).  ``omega`` is the CC linear-response frequency (``-omega dt``
+        (``df``, ``deri`` swapped in), the singles source's leading term taken from the ``[v,o]`` block
+        (``A_ai``; correct for an anti-Hermitian perturbation like the magnetic dipole, and identical
+        to ``cc.residuals``'s ``[o,v]`` for a symmetric one -- see :meth:`_perturbed_amplitudes`).
+        ``omega`` is the CC linear-response frequency (``-omega dt``
         residual shift, ``(D + omega)`` denominators; default ``0`` = the static derivative equation).
         ``maxiter``/``rconv`` default to the wavefunction's convergence (``ccwfn.maxiter``/``r_conv``)."""
         from .utils import helper_diis
         cc = self.ccwfn
         maxiter = cc.maxiter if maxiter is None else maxiter
         rconv = cc.r_conv if rconv is None else rconv
+        o, v = cc.o, cc.v
         Dia, Dijab = cc.Dia + omega, cc.Dijab + omega
         saveERI = cc.H.ERI
         cc.H.ERI = deri
@@ -284,8 +296,10 @@ class CCderiv(CorrelatedDerivs):
         finally:
             cc.H.ERI = saveERI
         B1, B2 = np.asarray(B1), np.asarray(B2)
-        X1, X2 = B1 / Dia, B2 / Dijab
-        diis = helper_diis(X1, X2, 8)
+        dfa = np.asarray(df)
+        B1 = B1 + (dfa[v, o].T - dfa[o, v])         # singles source = the vo block A_ai (see docstring):
+        X1, X2 = B1 / Dia, B2 / Dijab               # zero for a symmetric perturbation, the leading term
+        diis = helper_diis(X1, X2, 8)               # for an anti-Hermitian one (e.g. the magnetic dipole)
         for _ in range(maxiter):
             j1, j2 = self._so_ccsd_jacobian(X1, X2, hbar)
             r1, r2 = B1 + j1 - omega * X1, B2 + j2 - omega * X2
@@ -993,13 +1007,31 @@ class CCderiv(CorrelatedDerivs):
         return -self.linear_response('mu', 'mu', omega)
 
     def optical_rotation(self, omega):
-        r"""Orbital-unrelaxed optical-rotation tensor ``G'(omega) = <<mu; m>>_omega``
-        (electric dipole ``mu`` and magnetic dipole ``m``), a 3x3 array; ``omega != 0``
-        (there is no static optical rotation).  Not yet implemented -- staged after the
-        dynamic (omega != 0) polarizability; see docs/ccresponse_reformulation_plan.md."""
-        raise NotImplementedError(
-            "Optical rotation (<<mu; m>>) is a later phase of the CC linear-response "
-            "reformulation; only the static polarizability is implemented so far.")
+        r"""Orbital-unrelaxed optical-rotation tensor ``G'(omega) = <<mu; m>>_omega``, a 3x3 array --
+        the odd-in-omega part of the density response function of the electric dipole ``mu`` to the
+        magnetic dipole ``m``::
+
+            G'_ab(omega) = <<mu; m>>_omega
+                         = 1/2 [ Tr(d_{m_b} D(omega) . mu_a) - Tr(d_{m_b} D(-omega) . mu_a) ]
+
+        .. math::
+
+            G'_{ab}(\omega) = \langle\langle \mu; m \rangle\rangle_\omega
+                = \tfrac{1}{2}\big[\mathrm{Tr}(\partial_{m_b} D(\omega)\,\mu_a)
+                                  - \mathrm{Tr}(\partial_{m_b} D(-\omega)\,\mu_a)\big]
+
+        The magnetic dipole is anti-Hermitian, so unlike the electric polarizability a single
+        density evaluation is not the response function: the symmetric ``ccresponse.optrot`` (via
+        ``linresp_sym``) is ``0.5*(S1 - S2)`` with ``S1 = linresp_sym(mu@-omega, m@+omega)`` and
+        ``S2`` its frequency-swap, which equals this odd-in-omega combination of the asymmetric
+        density response (verified against ``ccresponse.optrot`` to ~1e-12).  ``omega != 0`` (there
+        is no static optical rotation).  Not symmetric in ``a``/``b`` (a pseudotensor).  The magnetic
+        integrals are the pure-real operator of :meth:`_perturbation_ints` (the ``i`` is factored out,
+        as in ``ccresponse``), so the perturbed amplitudes stay real."""
+        if omega == 0.0:
+            raise ValueError("Optical rotation requires a nonzero field frequency.")
+        return 0.5 * (self.linear_response('mu', 'm', omega)
+                      - self.linear_response('mu', 'm', -omega))
 
     def _perturbation_ints(self, key):
         """Bare MO integrals of a one-electron perturbation operator, as a list of three

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -206,31 +206,34 @@ class CCderiv(CorrelatedDerivs):
         r2 += tmp - tmp.swapaxes(0, 1) - tmp.swapaxes(2, 3) + tmp.swapaxes(0, 1).swapaxes(2, 3)
         return r1, r2
 
-    def _perturbed_amplitudes(self, df, deri, dL, hbar, maxiter=None, rconv=None):
+    def _perturbed_amplitudes(self, df, deri, dL, hbar, omega=0.0, maxiter=None, rconv=None):
         r"""Perturbed CCSD amplitudes ``dt/dx`` (iterative).  Differentiating the CC amplitude
         equation ``R_mu = <mu|HBAR|0> = 0`` with respect to the perturbation ``x`` splits into the
         ``d_x t`` part (the CCSD Jacobian :meth:`_ccsd_jacobian`, ``<mu|[HBAR, d_x t]|0>``) and the
         fixed-``t`` part -- the perturbation-dependent inhomogeneity ``B^x``, the derivative of the
         **bare** Hamiltonian similarity-transformed at fixed ``t``::
 
-            (HBAR . dt) = -B^x,   B^x_mu = <mu| e^-T (d_x H) e^T |0>
+            (HBAR - omega) . dt = -B^x,   B^x_mu = <mu| e^-T (d_x H) e^T |0>
 
         .. math::
 
-            \bar{H}\,\partial_x t = -B^{x}, \qquad
+            (\bar{H} - \omega)\,\partial_x t = -B^{x}, \qquad
             B^{x}_\mu = \langle\mu|\, e^{-T}(\partial_x H)\, e^{T}\,|0\rangle
 
         (Note ``B^x`` differentiates only the integrals -- ``t`` is held fixed -- so it is NOT
         ``d_x HBAR``, whose ``[HBAR, d_x t]`` piece is the Jacobian LHS.)  ``B^x`` is computed by
         evaluating ``cc.residuals`` with the perturbed **bare** integrals (``df`` and the CPHF-folded
         ``deri``/``dL`` swapped into ``cc.H``, carrying the orbital relaxation), the residual formula
-        supplying the ``e^-T ( ) e^T`` transform.  Iterate ``dt += (B + HBAR.dt)/D`` with DIIS.
-        ``maxiter``/``rconv`` default to the wavefunction's convergence (``ccwfn.maxiter``/``r_conv``)."""
+        supplying the ``e^-T ( ) e^T`` transform.  Iterate ``dt += (B + HBAR.dt - omega dt)/(D + omega)``
+        with DIIS.  ``omega`` is the CC linear-response frequency (the ``-omega dt`` residual shift and
+        ``(D + omega)`` denominators; default ``0`` reproduces the static derivative equation exactly
+        -- see the CC linear-response section).  ``maxiter``/``rconv`` default to the wavefunction's
+        convergence (``ccwfn.maxiter``/``r_conv``)."""
         from .utils import helper_diis
         cc = self.ccwfn
         maxiter = cc.maxiter if maxiter is None else maxiter
         rconv = cc.r_conv if rconv is None else rconv
-        Dia, Dijab = cc.Dia, cc.Dijab
+        Dia, Dijab = cc.Dia + omega, cc.Dijab + omega
         saveERI, saveL = cc.H.ERI, cc.H.L
         cc.H.ERI, cc.H.L = deri, dL
         try:
@@ -242,8 +245,8 @@ class CCderiv(CorrelatedDerivs):
         diis = helper_diis(X1, X2, 8)
         for _ in range(maxiter):
             j1, j2 = self._ccsd_jacobian(X1, X2, hbar)
-            r1 = B1 + j1
-            r2 = 0.5 * B2 + j2
+            r1 = B1 + j1 - omega * X1
+            r2 = 0.5 * (B2 - omega * X2) + j2
             r2 = r2 + r2.swapaxes(0, 1).swapaxes(2, 3)
             X1 = X1 + r1 / Dia
             X2 = X2 + r2 / Dijab
@@ -253,26 +256,27 @@ class CCderiv(CorrelatedDerivs):
             X1, X2 = diis.extrapolate(X1, X2)
         return X1, X2
 
-    def _so_perturbed_amplitudes(self, df, deri, hbar, maxiter=None, rconv=None):
+    def _so_perturbed_amplitudes(self, df, deri, hbar, omega=0.0, maxiter=None, rconv=None):
         r"""Spin-orbital perturbed CCSD amplitudes ``dt/dx`` -- the spin-orbital analogue of
         :meth:`_perturbed_amplitudes` (SO Jacobian :meth:`_so_ccsd_jacobian`; the SO residual has
         no 0.5 and no final symmetrization)::
 
-            (HBAR . dt) = -B^x,   B^x_mu = <mu| e^-T (d_x H) e^T |0>
+            (HBAR - omega) . dt = -B^x,   B^x_mu = <mu| e^-T (d_x H) e^T |0>
 
         .. math::
 
-            \bar{H}\,\partial_x t = -B^{x}, \qquad
+            (\bar{H} - \omega)\,\partial_x t = -B^{x}, \qquad
             B^{x}_\mu = \langle\mu|\, e^{-T}(\partial_x H)\, e^{T}\,|0\rangle
 
         ``B^x`` (fixed-``t``) is ``cc.residuals`` evaluated with the perturbed **bare** integrals
-        (``df``, ``deri`` swapped in).  ``maxiter``/``rconv`` default to the wavefunction's
-        convergence (``ccwfn.maxiter``/``r_conv``)."""
+        (``df``, ``deri`` swapped in).  ``omega`` is the CC linear-response frequency (``-omega dt``
+        residual shift, ``(D + omega)`` denominators; default ``0`` = the static derivative equation).
+        ``maxiter``/``rconv`` default to the wavefunction's convergence (``ccwfn.maxiter``/``r_conv``)."""
         from .utils import helper_diis
         cc = self.ccwfn
         maxiter = cc.maxiter if maxiter is None else maxiter
         rconv = cc.r_conv if rconv is None else rconv
-        Dia, Dijab = cc.Dia, cc.Dijab
+        Dia, Dijab = cc.Dia + omega, cc.Dijab + omega
         saveERI = cc.H.ERI
         cc.H.ERI = deri
         try:
@@ -284,7 +288,7 @@ class CCderiv(CorrelatedDerivs):
         diis = helper_diis(X1, X2, 8)
         for _ in range(maxiter):
             j1, j2 = self._so_ccsd_jacobian(X1, X2, hbar)
-            r1, r2 = B1 + j1, B2 + j2
+            r1, r2 = B1 + j1 - omega * X1, B2 + j2 - omega * X2
             X1 = X1 + r1 / Dia
             X2 = X2 + r2 / Dijab
             if np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2)) < rconv:
@@ -495,7 +499,8 @@ class CCderiv(CorrelatedDerivs):
         t01 = np.asarray(cc.t1); t02 = np.asarray(cc.t2)
         return cctriples.so_dt3_density(o, v, no, nv, t01, t02, dt1, dt2, F0, df, ERI0, deri, self.contract)
 
-    def _perturbed_lambda(self, df, deri, dL, dt1, dt2, hbar, lam, dS1=None, dS2=None, maxiter=None, rconv=None):
+    def _perturbed_lambda(self, df, deri, dL, dt1, dt2, hbar, lam, dS1=None, dS2=None,
+                          omega=0.0, maxiter=None, rconv=None):
         r"""Perturbed Lambda ``dLambda/dx`` (iterative, linear): a single inhomogeneous linear solve
         that reuses ``cclambda``'s ground-state Lambda residual ``r_L`` as the operator (no separate
         perturbed-multiplier amplitudes).  Differentiating the Lambda
@@ -524,7 +529,7 @@ class CCderiv(CorrelatedDerivs):
         rconv = cc.r_conv if rconv is None else rconv
         o, v = cc.o, cc.v
         c = self.contract
-        Dia, Dijab = cc.Dia, cc.Dijab
+        Dia, Dijab = cc.Dia + omega, cc.Dijab + omega
         l1, l2 = np.asarray(lam.l1), np.asarray(lam.l2)
         t2 = np.asarray(cc.t2)
         L0 = np.asarray(cc.H.L)
@@ -559,8 +564,8 @@ class CCderiv(CorrelatedDerivs):
             Gvv_d = np.asarray(lam.build_Gvv(t2, dl2)); Goo_d = np.asarray(lam.build_Goo(t2, dl2))
             j1 = rL1(dl1, dl2, H0, Gvv_d, Goo_d) - rL1_0
             j2 = rL2(dl1, dl2, L0, H0, Gvv_d, Goo_d) - rL2_0
-            r1 = B1 + j1
-            r2 = B2 + j2
+            r1 = B1 + j1 + omega * dl1
+            r2 = B2 + j2 + omega * dl2
             dl1 = dl1 + r1 / Dia
             dl2 = dl2 + r2 / Dijab
             if np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2)) < rconv:
@@ -569,7 +574,8 @@ class CCderiv(CorrelatedDerivs):
             dl1, dl2 = diis.extrapolate(dl1, dl2)
         return dl1, dl2
 
-    def _so_perturbed_lambda(self, df, deri, dt1, dt2, hbar, lam, dS1=None, dS2=None, maxiter=None, rconv=None):
+    def _so_perturbed_lambda(self, df, deri, dt1, dt2, hbar, lam, dS1=None, dS2=None,
+                             omega=0.0, maxiter=None, rconv=None):
         r"""Spin-orbital perturbed Lambda ``dLambda/dx`` -- the spin-orbital analogue of
         :meth:`_perturbed_lambda` (SO ``_so_r_L``; inhomogeneity = ``r_L`` with perturbed HBAR +
         perturbed ERI, unperturbed G, plus the ``dG.H`` / ``dG.<pq||rs>`` product-rule halves)::
@@ -591,7 +597,7 @@ class CCderiv(CorrelatedDerivs):
         rconv = cc.r_conv if rconv is None else rconv
         o, v = cc.o, cc.v
         c = self.contract
-        Dia, Dijab = cc.Dia, cc.Dijab
+        Dia, Dijab = cc.Dia + omega, cc.Dijab + omega
         l1, l2 = np.asarray(lam.l1), np.asarray(lam.l2)
         t2 = np.asarray(cc.t2)
         ERI0 = np.asarray(cc.H.ERI)
@@ -625,7 +631,7 @@ class CCderiv(CorrelatedDerivs):
             Gvv_d = np.asarray(lam.build_Gvv(t2, dl2)); Goo_d = np.asarray(lam.build_Goo(t2, dl2))
             j1 = rL1(dl1, dl2, H0, Gvv_d, Goo_d) - rL1_0
             j2 = rL2(dl1, dl2, ERI0, H0, Gvv_d, Goo_d) - rL2_0
-            r1, r2 = B1 + j1, B2 + j2
+            r1, r2 = B1 + j1 + omega * dl1, B2 + j2 + omega * dl2
             dl1 = dl1 + r1 / Dia
             dl2 = dl2 + r2 / Dijab
             if np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2)) < rconv:
@@ -938,8 +944,11 @@ class CCderiv(CorrelatedDerivs):
     # block; the reference (SCF) block is zero.  This is the CC RESPONSE (orbital-
     # unrelaxed) property, distinct from the relaxed static `polarizability` above
     # even at omega = 0 -- validate against ccresponse, not the derivative path.  See
-    # docs/ccresponse_reformulation_plan.md.  Phase 1: static (omega = 0) CCSD; the
-    # dynamic case (omega != 0), optical rotation, and CCSD(T) are staged to follow.
+    # docs/ccresponse_reformulation_plan.md.  Static and dynamic (any omega) CCSD are
+    # implemented; the frequency enters the shared perturbed-amplitude/multiplier solvers
+    # as the -/+ omega residual shift (-omega on the right dt, +omega on the left dl) with
+    # (D + omega) denominators (their `omega` argument, default 0 = the derivative path).
+    # Optical rotation and CCSD(T) response are staged to follow.
 
     def linear_response(self, a, b, omega=0.0):
         r"""Orbital-unrelaxed CC linear response function ``<<a; b>>_omega`` -- the
@@ -978,8 +987,9 @@ class CCderiv(CorrelatedDerivs):
                 = -\mathrm{Tr}\big(\partial_{b} D(\omega)\,\mu_a\big)
 
         ``omega = 0`` gives the static orbital-unrelaxed polarizability (the CC response
-        value, distinct from the relaxed derivative :meth:`polarizability`).  The overall
-        sign is the ``alpha = -<<mu; mu>>`` convention of ``ccresponse.polarizability``."""
+        value, distinct from the relaxed derivative :meth:`polarizability`); ``omega != 0``
+        the dynamic (frequency-dependent) polarizability.  The overall sign is the
+        ``alpha = -<<mu; mu>>`` convention of ``ccresponse.polarizability``."""
         return -self.linear_response('mu', 'mu', omega)
 
     def optical_rotation(self, omega):
@@ -1014,28 +1024,25 @@ class CCderiv(CorrelatedDerivs):
         then builds the unrelaxed perturbed correlation 1-PDM
         (:meth:`_perturbed_correlation_densities`; no Z-vector, no dependent pairs)::
 
-            (HBAR -/+ omega) . dt = -B(op),    dl similarly,    d_op D = dD(dt, dl)
+            (HBAR - omega) . dt = -B(op),    dl with +omega,    d_op D = dD(dt, dl)
 
-        CCSD only for now; the dynamic case (``omega != 0``, the ``-/+ omega`` residual
-        shift) and CCSD(T) (perturbed (T) sources) are later phases."""
+        The perturbed amplitudes ``dt`` take the ``-omega`` right-hand shift and the multipliers
+        ``dl`` the ``+omega`` left-hand shift (both with ``(D + omega)`` denominators); ``omega = 0``
+        recovers the static case.  CCSD only for now; CCSD(T) (perturbed (T) sources) is a later phase."""
         cc = self.ccwfn
         lam = self.cclambda
         hbar = self.hbar
         if cc.model.upper() != 'CCSD':
             raise NotImplementedError(
-                "CC linear response is implemented for CCSD only (Phase 1); "
-                f"not {cc.model}.")
-        if omega != 0.0:
-            raise NotImplementedError(
-                "Dynamic CC response (omega != 0) is a later phase; only the static "
-                "(omega = 0) polarizability is implemented so far.")
+                "CC linear response is implemented for CCSD only; "
+                f"not {cc.model} (CCSD(T) response is a later phase).")
         zero_eri = np.zeros_like(np.asarray(cc.H.ERI))
         if cc.orbital_basis == 'spinorbital':
-            dt1, dt2 = self._so_perturbed_amplitudes(op_ints, zero_eri, hbar)
-            dl1, dl2 = self._so_perturbed_lambda(op_ints, zero_eri, dt1, dt2, hbar, lam)
+            dt1, dt2 = self._so_perturbed_amplitudes(op_ints, zero_eri, hbar, omega=omega)
+            dl1, dl2 = self._so_perturbed_lambda(op_ints, zero_eri, dt1, dt2, hbar, lam, omega=omega)
         else:
             zero_L = np.zeros_like(np.asarray(cc.H.L))
-            dt1, dt2 = self._perturbed_amplitudes(op_ints, zero_eri, zero_L, hbar)
-            dl1, dl2 = self._perturbed_lambda(op_ints, zero_eri, zero_L, dt1, dt2, hbar, lam)
+            dt1, dt2 = self._perturbed_amplitudes(op_ints, zero_eri, zero_L, hbar, omega=omega)
+            dl1, dl2 = self._perturbed_lambda(op_ints, zero_eri, zero_L, dt1, dt2, hbar, lam, omega=omega)
         dD, _ = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam)
         return dD

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -721,7 +721,7 @@ class CCwfn(Wavefunction):
         -----
         CCSD form (repeated indices summed)::
 
-            r_t1_ia = f_ia + t_ie F_ae - F_mi t_ma
+            r_t1_ia = f_ai + t_ie F_ae - F_mi t_ma
                     + (2 t2_imae - t2_imea) F_me
                     + t_nf L_nafi
                     + (2 t2_mief - t2_mife) <ma|ef>
@@ -730,7 +730,7 @@ class CCwfn(Wavefunction):
         .. math::
 
             \begin{aligned}
-            r^{t1}_{ia} = f_{ia} &+ t^e_i F_{ae} - F_{mi} t^a_m \\
+            r^{t1}_{ia} = f_{ai} &+ t^e_i F_{ae} - F_{mi} t^a_m \\
             &+ \left(2 t^{ae}_{im} - t^{ea}_{im}\right) F_{me} \\
             &+ t^f_n L_{nafi} \\
             &+ \left(2 t^{ef}_{mi} - t^{fe}_{mi}\right) \langle ma|ef \rangle \\
@@ -742,7 +742,7 @@ class CCwfn(Wavefunction):
         if self.model == 'CCD':
             r_T1 = zeros_like(t1)
         else:
-            r_T1 = clone(F[o,v])
+            r_T1 = clone(F[v, o].swapaxes(0, 1))        # f_ai = <Phi_i^a|F|0> (the [v,o] block; = F[o,v] for a symmetric F)
             r_T1 = r_T1 + contract('ie,ae->ia', t1, Fae)
             r_T1 = r_T1 - contract('mi,ma->ia', Fmi, t1)
             r_T1 = r_T1 + contract('imae,me->ia', (2.0*t2 - t2.swapaxes(2,3)), Fme)
@@ -760,6 +760,11 @@ class CCwfn(Wavefunction):
         CCSD form), then symmetrizes the spin-adapted "half" residual as
         r_t2_ijab += r_t2_jiba. Fae/Fmi/Fme and Wmnij/Wmbej/Wmbje/Zmbij are the
         precomputed intermediates.
+
+        The Lambda-independent leading term is the source <Phi_ij^ab|V|0> = <ab|ij>
+        (the [v,v,o,o] block, swap-axed into [i,j,a,b]), not <ij|ab>: the two are
+        equal for real (Hermitian) integrals but complex conjugates for complex ERI,
+        where <ab|ij> is the correct block (cf. r_T1's f_ai leading term).
 
         Returns
         -------
@@ -785,7 +790,7 @@ class CCwfn(Wavefunction):
         and F_mj = Fmi are the CCD intermediates. Before the i<->j / a<->b
         symmetrization (repeated indices summed)::
 
-            r_t2_ijab = 1/2 <ij|ab>
+            r_t2_ijab = 1/2 <ab|ij>
                       + t2_ijae F_be - t2_imab F_mj
                       + 1/2 t2_mnab W_mnij + 1/2 t2_ijef <ab|ef>
                       + (t2_imae - t2_imea) W_mbej
@@ -795,7 +800,7 @@ class CCwfn(Wavefunction):
         .. math::
 
             \begin{aligned}
-            r^{t2}_{ijab} &= \tfrac{1}{2} \langle ij|ab \rangle \\
+            r^{t2}_{ijab} &= \tfrac{1}{2} \langle ab|ij \rangle \\
             &\quad + t^{ae}_{ij} F_{be} - t^{ab}_{im} F_{mj} \\
             &\quad + \tfrac{1}{2} t^{ab}_{mn} W_{mnij} + \tfrac{1}{2} t^{ef}_{ij} \langle ab|ef \rangle \\
             &\quad + \left(t^{ae}_{im} - t^{ea}_{im}\right) W_{mbej} \\
@@ -805,7 +810,7 @@ class CCwfn(Wavefunction):
         """
         contract = self.contract
 
-        r_T2 = 0.5 * clone(ERI[o,o,v,v], device=self.device1)
+        r_T2 = 0.5 * clone(ERI[v,v,o,o].swapaxes(0,2).swapaxes(1,3), device=self.device1)  # <ab|ij> (= <ij|ab> for real ERI)
         r_T2 = r_T2 + contract('ijae,eb->ijab', t2, Fae.T)
         r_T2 = r_T2 - contract('imab,mj->ijab', t2, Fmi)
         r_T2 = r_T2 + 0.5 * contract('ijef,abef->ijab', t2, ERI[v,v,v,v])
@@ -825,7 +830,7 @@ class CCwfn(Wavefunction):
         t1.t1 rather than tau). Before the i<->j / a<->b symmetrization (repeated
         indices summed)::
 
-            r_t2_ijab = 1/2 <ij|ab>
+            r_t2_ijab = 1/2 <ab|ij>
                       + t2_ijae (f_be - 1/2 f_me t_mb) - 1/2 t2_ijae f_me t_mb
                       - t2_imab (f_mj + 1/2 f_me t_je) - 1/2 t2_imab f_me t_je
                       + 1/2 t_ma t_nb W_mnij + 1/2 t_ie t_jf <ab|ef>
@@ -836,7 +841,7 @@ class CCwfn(Wavefunction):
         .. math::
 
             \begin{aligned}
-            r^{t2}_{ijab} &= \tfrac{1}{2} \langle ij|ab \rangle \\
+            r^{t2}_{ijab} &= \tfrac{1}{2} \langle ab|ij \rangle \\
             &\quad + t^{ae}_{ij} \left(f_{be} - \tfrac{1}{2} f_{me} t^b_m\right) - \tfrac{1}{2} t^{ae}_{ij} f_{me} t^b_m \\
             &\quad - t^{ab}_{im} \left(f_{mj} + \tfrac{1}{2} f_{me} t^e_j\right) - \tfrac{1}{2} t^{ab}_{im} f_{me} t^e_j \\
             &\quad + \tfrac{1}{2} t^a_m t^b_n W_{mnij} + \tfrac{1}{2} t^e_i t^f_j \langle ab|ef \rangle \\
@@ -847,7 +852,7 @@ class CCwfn(Wavefunction):
         """
         contract = self.contract
 
-        r_T2 = 0.5 * clone(ERI[o,o,v,v], device=self.device1)
+        r_T2 = 0.5 * clone(ERI[v,v,o,o].swapaxes(0,2).swapaxes(1,3), device=self.device1)  # <ab|ij> (= <ij|ab> for real ERI)
 
         tmp = F[v,v] - 0.5 * contract('me,ma->ae', F[o,v], t1)
         r_T2 = r_T2 + contract('ijae,eb->ijab', t2, tmp.T)
@@ -877,7 +882,7 @@ class CCwfn(Wavefunction):
         CCSD form, before the i<->j / a<->b symmetrization (repeated indices
         summed)::
 
-            r_t2_ijab = 1/2 <ij|ab>
+            r_t2_ijab = 1/2 <ab|ij>
                       + t2_ijae F_be  - 1/2 t2_ijae t_mb F_me
                       - t2_imab F_mj  - 1/2 t2_imab t_je F_me
                       + 1/2 tau_mnab W_mnij + 1/2 tau_ijef <ab|ef>
@@ -891,7 +896,7 @@ class CCwfn(Wavefunction):
         .. math::
 
             \begin{aligned}
-            r^{t2}_{ijab} &= \tfrac{1}{2} \langle ij|ab \rangle \\
+            r^{t2}_{ijab} &= \tfrac{1}{2} \langle ab|ij \rangle \\
             &\quad + t^{ae}_{ij} F_{be} - \tfrac{1}{2} t^{ae}_{ij} t^b_m F_{me} \\
             &\quad - t^{ab}_{im} F_{mj} - \tfrac{1}{2} t^{ab}_{im} t^e_j F_{me} \\
             &\quad + \tfrac{1}{2} \tau^{ab}_{mn} W_{mnij} + \tfrac{1}{2} \tau^{ef}_{ij} \langle ab|ef \rangle \\
@@ -905,7 +910,7 @@ class CCwfn(Wavefunction):
         """
         contract = self.contract
 
-        r_T2 = 0.5 * clone(ERI[o,o,v,v], device=self.device1)
+        r_T2 = 0.5 * clone(ERI[v,v,o,o].swapaxes(0,2).swapaxes(1,3), device=self.device1)  # <ab|ij> (= <ij|ab> for real ERI)
         r_T2 = r_T2 + contract('ijae,eb->ijab', t2, Fae.T)
         tmp = contract('bm,me->be', t1.T, Fme)
         r_T2 = r_T2 - 0.5 * contract('ijae,eb->ijab', t2, tmp.T)
@@ -1336,7 +1341,7 @@ class CCwfn(Wavefunction):
         -----
         Repeated indices summed::
 
-            r_t1_ia = f_ia + t_ie F_ae - t_ma F_mi + t2_imae F_me
+            r_t1_ia = f_ai + t_ie F_ae - t_ma F_mi + t2_imae F_me
                     - t_nf <na||if>
                     - 1/2 t2_imef <ma||ef>
                     - 1/2 t2_mnae <nm||ei>
@@ -1344,14 +1349,14 @@ class CCwfn(Wavefunction):
         .. math::
 
             \begin{aligned}
-            r^{t1}_{ia} = f_{ia} &+ t^e_i F_{ae} - t^a_m F_{mi} + t^{ae}_{im} F_{me} \\
+            r^{t1}_{ia} = f_{ai} &+ t^e_i F_{ae} - t^a_m F_{mi} + t^{ae}_{im} F_{me} \\
             &- t^f_n \langle na||if \rangle \\
             &- \tfrac{1}{2} t^{ef}_{im} \langle ma||ef \rangle \\
             &- \tfrac{1}{2} t^{ae}_{mn} \langle nm||ei \rangle
             \end{aligned}
         """
         contract = self.contract
-        r1 = clone(F[o,v])
+        r1 = clone(F[v, o].swapaxes(0, 1))          # f_ai = <Phi_i^a|F|0> (the [v,o] block; = F[o,v] for a symmetric F)
         r1 = r1 + contract('ie,ae->ia', t1, Fae)
         r1 = r1 - contract('ma,mi->ia', t1, Fmi)
         r1 = r1 + contract('imae,me->ia', t2, Fme)
@@ -1370,7 +1375,7 @@ class CCwfn(Wavefunction):
         -----
         Repeated indices summed::
 
-            r_t2_ijab = <ij||ab>
+            r_t2_ijab = <ab||ij>
                       + t2_ijae (F_be - 1/2 t_mb F_me) - t2_ijbe (F_ae - 1/2 t_ma F_me)
                       - t2_imab (F_mj + 1/2 t_je F_me) + t2_jmab (F_mi + 1/2 t_ie F_me)
                       + 1/2 tau_mnab W_mnij + 1/2 tau_ijef W_abef
@@ -1384,7 +1389,7 @@ class CCwfn(Wavefunction):
         .. math::
 
             \begin{aligned}
-            r^{t2}_{ijab} &= \langle ij||ab \rangle \\
+            r^{t2}_{ijab} &= \langle ab||ij \rangle \\
             &\quad + t^{ae}_{ij}\left(F_{be} - \tfrac{1}{2} t^b_m F_{me}\right) - t^{be}_{ij}\left(F_{ae} - \tfrac{1}{2} t^a_m F_{me}\right) \\
             &\quad - t^{ab}_{im}\left(F_{mj} + \tfrac{1}{2} t^e_j F_{me}\right) + t^{ab}_{jm}\left(F_{mi} + \tfrac{1}{2} t^e_i F_{me}\right) \\
             &\quad + \tfrac{1}{2} \tau^{ab}_{mn} W_{mnij} + \tfrac{1}{2} \tau^{ef}_{ij} W_{abef} \\
@@ -1397,7 +1402,7 @@ class CCwfn(Wavefunction):
             \end{aligned}
         """
         contract = self.contract
-        r2 = clone(ERI[o,o,v,v])
+        r2 = clone(ERI[v,v,o,o].swapaxes(0,2).swapaxes(1,3))  # <ab||ij> (= <ij||ab> for real ERI)
         Z = clone(Fae) - 0.5 * contract('mb,me->be', t1, Fme)
         r2 = r2 + (contract('ijae,be->ijab', t2, Z) - contract('ijbe,ae->ijab', t2, Z))
         Z = clone(Fmi) + 0.5 * contract('je,me->mj', t1, Fme)

--- a/pycc/tests/test_092_cc_response_polarizability.py
+++ b/pycc/tests/test_092_cc_response_polarizability.py
@@ -9,10 +9,12 @@ The two routes share NO machinery, which makes the agreement a strong check:
   * ccresponse builds it from the symmetric response function <<mu;mu>> assembled from
     the right-hand perturbed amplitudes X only.
 
-Phase 1 (static, omega = 0, CCSD); spatial (closed-shell RHF) and spin-orbital.  This is
-the RESPONSE (orbital-unrelaxed) polarizability, distinct from the relaxed derivative
-CCderiv.polarizability (test_084) even at omega = 0 -- the two differ by the HF orbital
-relaxation.  See docs/ccresponse_reformulation_plan.md."""
+Static (omega = 0) and dynamic (omega != 0) CCSD; spatial (closed-shell RHF) and spin-
+orbital.  The frequency enters the shared perturbed-amplitude/multiplier solvers as the
+-/+ omega residual shift (-omega on the right dt, +omega on the left dl) with (D + omega)
+denominators.  This is the RESPONSE (orbital-unrelaxed) polarizability, distinct from the
+relaxed derivative CCderiv.polarizability (test_084) even at omega = 0 -- the two differ by
+the HF orbital relaxation.  See docs/ccresponse_reformulation_plan.md."""
 
 import psi4
 import pycc
@@ -42,15 +44,15 @@ no_reorient
 """
 
 
-def _ccresponse_polar(wfn, route):
-    """Static (omega = 0) CCSD polarizability from the independent symmetric linear-response
+def _ccresponse_polar(wfn, route, omega=0.0):
+    """CCSD polarizability at frequency omega from the independent symmetric linear-response
     code -- the oracle for the reformulation."""
     cc = pycc.ccwfn(wfn, orbital_basis=route)
     cc.solve_cc(1e-12, 1e-12, 100)
     hbar = pycc.cchbar(cc)
     lam = pycc.cclambda(cc, hbar); lam.solve_lambda(1e-12, 1e-12, 100)
     dens = pycc.ccdensity(cc, lam, onlyone=(route == 'spinorbital'))
-    return np.asarray(pycc.ccresponse(dens).polarizability(0.0))
+    return np.asarray(pycc.ccresponse(dens).polarizability(omega))
 
 
 def test_response_polarizability_spatial_vs_ccresponse(rhf_wfn):
@@ -87,6 +89,26 @@ def test_response_polarizability_hof_offdiagonal(rhf_wfn):
     psi4.core.clean()
 
 
+def test_dynamic_response_polarizability_spatial_vs_ccresponse(rhf_wfn):
+    """Dynamic (omega != 0) spatial unrelaxed polarizability vs the symmetric-response oracle at a
+    positive and a negative frequency (the -/+ omega residual shift and (D + omega) denominators in
+    the perturbed-amplitude/multiplier solvers).  The static tensor is recovered as omega -> 0 and
+    the dynamic value disperses away from it (normal dispersion, |alpha(omega)| > |alpha(0)|)."""
+    wfn = rhf_wfn(WATER, "6-31G", freeze_core="false")
+    cc = pycc.ccwfn(wfn)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    d = pycc.CCderiv(cc)
+    for omega in (0.07, -0.07):
+        alpha = np.asarray(d.response_polarizability(omega))
+        ref = _ccresponse_polar(wfn, 'spatial', omega)
+        assert np.max(np.abs(alpha - ref)) < 1e-10, (omega, alpha)
+        assert np.max(np.abs(alpha - alpha.T)) < 1e-10
+    static = np.asarray(d.response_polarizability(0.0))
+    dyn = np.asarray(d.response_polarizability(0.07))
+    assert np.all(np.diag(dyn) > np.diag(static))             # normal dispersion (real, sub-resonance)
+    psi4.core.clean()
+
+
 def test_fc_response_polarizability_vs_ccresponse(rhf_wfn):
     """Frozen-core (O 1s frozen) spatial unrelaxed response polarizability matches the symmetric-
     response oracle -- the perturbed amplitudes/multipliers run on the active o/v slices while the
@@ -105,12 +127,14 @@ def test_fc_response_polarizability_vs_ccresponse(rhf_wfn):
 def test_so_response_polarizability_vs_ccresponse(rhf_wfn):
     """SO == spatial keystone: the spin-orbital unrelaxed response polarizability of an RHF reference
     forced into the spin-orbital basis matches the spin-orbital symmetric-response oracle, carrying
-    the check onto the SO machinery (SO Jacobian, SO HBAR, SO r_L)."""
+    the check onto the SO machinery (SO Jacobian, SO HBAR, SO r_L) -- static and dynamic."""
     wfn = rhf_wfn(WATER, "6-31G", freeze_core="false")
     cc = pycc.ccwfn(wfn, orbital_basis='spinorbital')
     cc.solve_cc(1e-12, 1e-12, 100)
-    alpha = np.asarray(pycc.CCderiv(cc).response_polarizability(0.0))
-    ref = _ccresponse_polar(wfn, 'spinorbital')
-    assert np.max(np.abs(alpha - ref)) < 1e-10, alpha
-    assert np.max(np.abs(alpha - alpha.T)) < 1e-10
+    d = pycc.CCderiv(cc)
+    for omega in (0.0, 0.07):
+        alpha = np.asarray(d.response_polarizability(omega))
+        ref = _ccresponse_polar(wfn, 'spinorbital', omega)
+        assert np.max(np.abs(alpha - ref)) < 1e-10, (omega, alpha)
+        assert np.max(np.abs(alpha - alpha.T)) < 1e-10
     psi4.core.clean()

--- a/pycc/tests/test_092_cc_response_polarizability.py
+++ b/pycc/tests/test_092_cc_response_polarizability.py
@@ -1,0 +1,116 @@
+"""Orbital-unrelaxed (response) CCSD dipole polarizability via the density reformulation
+-- CCderiv.response_polarizability(omega=0) -- cross-checked against the independent
+symmetric linear-response code, ccresponse.polarizability(0).
+
+The two routes share NO machinery, which makes the agreement a strong check:
+  * response_polarizability contracts the orbital-unrelaxed perturbed 1-PDM (the field
+    derivative of the CC density, solved with the BARE MO dipole and no CPHF folding)
+    with the bare dipole,  alpha = -Tr(dD . mu)  (the asymmetric / density route);
+  * ccresponse builds it from the symmetric response function <<mu;mu>> assembled from
+    the right-hand perturbed amplitudes X only.
+
+Phase 1 (static, omega = 0, CCSD); spatial (closed-shell RHF) and spin-orbital.  This is
+the RESPONSE (orbital-unrelaxed) polarizability, distinct from the relaxed derivative
+CCderiv.polarizability (test_084) even at omega = 0 -- the two differ by the HF orbital
+relaxation.  See docs/ccresponse_reformulation_plan.md."""
+
+import psi4
+import pycc
+import numpy as np
+
+
+# Equilibrium H2O (C2v, molecular plane yz); frame locked (matches test_084).
+WATER = """
+O  0.00000  0.00000  0.00000
+H  0.00000  1.43121 -1.10664
+H  0.00000 -1.43121 -1.10664
+symmetry c1
+units bohr
+no_com
+no_reorient
+"""
+
+# Planar HOF (Cs, molecular plane xy), tilted off the axes so the in-plane block is full.
+HOF = """
+O  0.00000  0.00000  0.00000
+F  2.56070  0.93200  0.00000
+H -0.83450  1.62360  0.00000
+symmetry c1
+units bohr
+no_com
+no_reorient
+"""
+
+
+def _ccresponse_polar(wfn, route):
+    """Static (omega = 0) CCSD polarizability from the independent symmetric linear-response
+    code -- the oracle for the reformulation."""
+    cc = pycc.ccwfn(wfn, orbital_basis=route)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    hbar = pycc.cchbar(cc)
+    lam = pycc.cclambda(cc, hbar); lam.solve_lambda(1e-12, 1e-12, 100)
+    dens = pycc.ccdensity(cc, lam, onlyone=(route == 'spinorbital'))
+    return np.asarray(pycc.ccresponse(dens).polarizability(0.0))
+
+
+def test_response_polarizability_spatial_vs_ccresponse(rhf_wfn):
+    """Spatial (closed-shell RHF) static unrelaxed CCSD polarizability (all 9 elements) matches
+    the symmetric linear-response oracle; the tensor is naturally symmetric (not imposed); and it
+    is genuinely DIFFERENT from the relaxed derivative polarizability (the orbital-relaxation piece
+    the response omits)."""
+    wfn = rhf_wfn(WATER, "6-31G", freeze_core="false")
+    cc = pycc.ccwfn(wfn)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    alpha = np.asarray(pycc.CCderiv(cc).response_polarizability(0.0))
+    ref = _ccresponse_polar(wfn, 'spatial')
+    assert np.max(np.abs(alpha - ref)) < 1e-10, alpha
+    assert np.max(np.abs(alpha - alpha.T)) < 1e-10            # naturally symmetric
+
+    relaxed = np.asarray(pycc.CCderiv(cc).polarizability())   # the derivative (orbital-relaxed) tensor
+    assert np.max(np.abs(alpha - relaxed)) > 1e-3             # response != derivative (distinct quantities)
+    psi4.core.clean()
+
+
+def test_response_polarizability_hof_offdiagonal(rhf_wfn):
+    """Off-diagonal case: planar HOF/cc-pVDZ (Cs).  The unrelaxed response polarizability matches the
+    symmetric-response oracle across the full tensor -- the large in-plane off-diagonal alpha_xy and
+    the vanishing out-of-plane block (z perpendicular to the molecular plane)."""
+    wfn = rhf_wfn(HOF, "cc-pVDZ", freeze_core="false")
+    cc = pycc.ccwfn(wfn)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    alpha = np.asarray(pycc.CCderiv(cc).response_polarizability(0.0))
+    ref = _ccresponse_polar(wfn, 'spatial')
+    assert np.max(np.abs(alpha - ref)) < 1e-10, alpha
+    assert np.max(np.abs(alpha - alpha.T)) < 1e-10
+    assert abs(alpha[0, 1]) > 0.5                             # genuine in-plane off-diagonal
+    assert abs(alpha[0, 2]) < 1e-9 and abs(alpha[1, 2]) < 1e-9  # out-of-plane block vanishes (Cs)
+    psi4.core.clean()
+
+
+def test_fc_response_polarizability_vs_ccresponse(rhf_wfn):
+    """Frozen-core (O 1s frozen) spatial unrelaxed response polarizability matches the symmetric-
+    response oracle -- the perturbed amplitudes/multipliers run on the active o/v slices while the
+    bare dipole is the full-MO operator."""
+    wfn = rhf_wfn(WATER, "6-31G", freeze_core="true")
+    cc = pycc.ccwfn(wfn)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    assert cc.nfzc > 0
+    alpha = np.asarray(pycc.CCderiv(cc).response_polarizability(0.0))
+    ref = _ccresponse_polar(wfn, 'spatial')
+    assert np.max(np.abs(alpha - ref)) < 1e-10, alpha
+    assert np.max(np.abs(alpha - alpha.T)) < 1e-10
+    psi4.core.clean()
+
+
+def test_so_response_polarizability_vs_ccresponse(rhf_wfn):
+    """SO == spatial keystone: the spin-orbital unrelaxed response polarizability of an RHF reference
+    forced into the spin-orbital basis matches the spin-orbital symmetric-response oracle, carrying
+    the check onto the SO machinery (SO Jacobian, SO HBAR, SO r_L)."""
+    wfn = rhf_wfn(WATER, "6-31G", freeze_core="false")
+    cc = pycc.ccwfn(wfn, orbital_basis='spinorbital')
+    cc.solve_cc(1e-12, 1e-12, 100)
+    alpha = np.asarray(pycc.CCderiv(cc).response_polarizability(0.0))
+    ref = _ccresponse_polar(wfn, 'spinorbital')
+    assert np.max(np.abs(alpha - ref)) < 1e-10, alpha
+    assert np.max(np.abs(alpha - alpha.T)) < 1e-10
+    psi4.core.clean()

--- a/pycc/tests/test_093_cc_response_optrot.py
+++ b/pycc/tests/test_093_cc_response_optrot.py
@@ -1,0 +1,72 @@
+"""Orbital-unrelaxed (response) CCSD optical rotation via the density reformulation --
+CCderiv.optical_rotation(omega) -- cross-checked against the independent symmetric
+linear-response code, ccresponse.optrot(omega).
+
+Optical rotation is the odd-in-omega response of the electric dipole to the magnetic
+dipole, G'(omega) = <<mu; m>>_omega.  Because the magnetic dipole is anti-Hermitian, a
+single density evaluation is not the response function (unlike the electric polarizability):
+the density route gives G'(omega) = 1/2[Tr(d_m D(omega).mu) - Tr(d_m D(-omega).mu)], the
+odd-in-omega combination, which equals the symmetric ccresponse.optrot = 0.5(S1 - S2).  The
+anti-Hermitian source also requires the perturbed-amplitude singles source to be taken from
+the [v,o] block (A_ai), not the [o,v] block (the ground-state f_ia convention, valid only
+for a symmetric perturbation); see CCderiv._perturbed_amplitudes.
+
+CCSD, omega != 0; spatial (closed-shell RHF) and spin-orbital.  Chiral H2O2 gives a
+physically nonzero (nonvanishing-trace) rotation.  See docs/ccresponse_reformulation_plan.md."""
+
+import psi4
+import pycc
+import numpy as np
+import pytest
+
+
+# Chiral H2O2 (from Dalton), the standard optical-rotation test molecule (cf. test_058).
+H2O2 = """
+O   1.3133596569   0.0000000000  -0.0932359644
+O  -1.3133596569  -0.0000000000  -0.0932359644
+H   1.6917745981   0.7334825768   1.4797224976
+H  -1.6917745981  -0.7334825768   1.4797224976
+units bohr
+"""
+OMEGA = 0.077357          # ~589 nm (sodium D line), as in test_058
+
+
+def _ccresponse_optrot(wfn, route, omega=OMEGA):
+    """Optical-rotation tensor at frequency omega from the independent symmetric linear-response
+    code -- the oracle for the reformulation."""
+    cc = pycc.ccwfn(wfn, orbital_basis=route)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    hbar = pycc.cchbar(cc)
+    lam = pycc.cclambda(cc, hbar); lam.solve_lambda(1e-12, 1e-12, 100)
+    dens = pycc.ccdensity(cc, lam, onlyone=(route == 'spinorbital'))
+    return np.asarray(pycc.ccresponse(dens).optrot(omega))
+
+
+def test_optical_rotation_spatial_vs_ccresponse(rhf_wfn):
+    """Spatial (closed-shell RHF) unrelaxed optical rotation (all 9 elements) matches the symmetric
+    linear-response oracle; the isotropic rotation (trace) is nonzero (chiral); optical_rotation(0)
+    is rejected (no static optical rotation)."""
+    wfn = rhf_wfn(H2O2, "6-31G", freeze_core="true")
+    cc = pycc.ccwfn(wfn)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    d = pycc.CCderiv(cc)
+    G = np.asarray(d.optical_rotation(OMEGA))
+    ref = _ccresponse_optrot(wfn, 'spatial')
+    assert np.max(np.abs(G - ref)) < 1e-10, G
+    assert abs(np.trace(G)) > 1e-4                            # physically nonzero (chiral)
+    with pytest.raises(ValueError):
+        d.optical_rotation(0.0)                              # no static optical rotation
+    psi4.core.clean()
+
+
+def test_so_optical_rotation_vs_ccresponse(rhf_wfn):
+    """SO == spatial keystone: the spin-orbital unrelaxed optical rotation of an RHF reference forced
+    into the spin-orbital basis matches the spin-orbital symmetric-response oracle -- carrying the
+    check (and the anti-Hermitian [v,o] source) onto the SO machinery."""
+    wfn = rhf_wfn(H2O2, "STO-3G", freeze_core="true")
+    cc = pycc.ccwfn(wfn, orbital_basis='spinorbital')
+    cc.solve_cc(1e-12, 1e-12, 100)
+    G = np.asarray(pycc.CCderiv(cc).optical_rotation(OMEGA))
+    ref = _ccresponse_optrot(wfn, 'spinorbital')
+    assert np.max(np.abs(G - ref)) < 1e-10, G
+    psi4.core.clean()


### PR DESCRIPTION
# CC linear-response reformulation (Phases 1-3) + correct T1/T2 residual source blocks

Recasts the CC dipole polarizability (static and frequency-dependent) and optical rotation as the
orbital-unrelaxed configuration of the existing `CorrelatedDerivs`/`CCderiv` perturbed-amplitude
machinery, per `docs/ccresponse_reformulation_plan.md`, and corrects the leading (bra/ket) block of
the CC amplitude residuals so the same machinery is right for complex / anti-Hermitian perturbations.

## What this is

The orbital-unrelaxed (response) polarizability is the SAME perturbed-amplitude machinery as the
static derivative properties, run in a different configuration:

- the field enters the amplitude equations as the **bare** MO dipole (`df = mu`, `deri = 0`,
  `dL = 0`) with **no CPHF folding**, so the perturbed T/Lambda are the orbital-unrelaxed field
  derivatives (exactly `ccresponse`'s right/left perturbed amplitudes `X`/`Y`);
- the tensor contracts the **unrelaxed** perturbed 1-PDM (no Z-vector, no dependent pairs) with the
  bare dipole, `alpha_ab = -Tr(d_b D . mu_a)` (no `U.mu` orbital terms).

Phase 1 (static) needed no solver changes: feeding the bare dipole reproduces the response amplitudes
directly. Phase 2 (dynamic) adds a single `omega` argument to the shared solvers (the `-omega dt`
residual shift on the right, `+omega dl` on the left, `(D + omega)` denominators; `omega = 0` recovers
the static derivative equation exactly). Phase 3 (optical rotation) adds the anti-Hermitian magnetic
dipole and is the odd-in-omega combination `0.5*(<<mu;m>>_w - <<mu;m>>_-w)`. Everything lands in the
correlation block (reference/SCF block zero, no orbital response), a DIFFERENT physical quantity from
the relaxed derivative, so it is validated against `ccresponse`. The `omega = 0` default is a no-op
for the derivative path, which is untouched.

## T1/T2 residual source blocks (complex / anti-Hermitian)

The amplitude-equation leading terms had the bra/ket blocks swapped relative to the true
similarity-transform source `<mu| e^-T (H) e^T |0>`:

- `r_T1` used the `[o,v]` Fock block `f_ia`; the correct source is the `[v,o]` block
  `f_ai = <Phi_i^a|F|0>`.
- `r_T2` used `<ij|ab>` = `ERI[o,o,v,v]`; the correct source is `<ab|ij>` = `ERI[v,v,o,o]`
  (swap-axed to `[i,j,a,b]`).

For real (Hermitian) integrals the swapped blocks are equal, so all ground-state CC (CCSD, CC3),
gradients, densities, and the real response tensors are UNCHANGED. They differ for complex ERI
(real-time CC) and for the anti-Hermitian magnetic dipole (CC optical rotation), where the
`[v,o]` / `<ab|ij>` blocks are the correct source.

Phase 3 first patched this downstream (`B1 += df[v,o].T - df[o,v]` in the perturbed-amplitude
solvers). It is now fixed at the source: `r_T1`/`_so_r_T1` lead with `F[v,o]` and `r_T2`/`_so_r_T2`
(plus the three spatial `_r_T2_ccsd`/`_cc2`/`_ccd`) lead with `<ab|ij>`, so the downstream correction
is removed and the perturbed-amplitude code carries no special case. The perturbed `dt`/`dl` still
reproduce `ccresponse`'s `X`/`Y` for both `mu` and `m` to ~1e-14.

## Changes

- `pycc/ccwfn.py`: `r_T1`/`_so_r_T1` leading term `F[o,v] -> F[v,o]` (`f_ai`); `r_T2`/`_so_r_T2` and
  the spatial `_r_T2_ccsd`/`_cc2`/`_ccd` leading term `ERI[o,o,v,v] -> ERI[v,v,o,o]` (`<ab|ij>`).
  Code-math docstrings (`f_ai`, `<ab|ij>`/`<ab||ij>`) updated.
- `pycc/ccderiv.py`: new "CC linear response" section on `CCderiv` --
  `response_polarizability(omega=0)`, `linear_response(a, b, omega=0)` engine, `optical_rotation(omega)`,
  `_response_density`/`_perturbation_ints`; `omega` threaded through
  `_perturbed_amplitudes`/`_so_perturbed_amplitudes` and `_perturbed_lambda`/`_so_perturbed_lambda`
  (default `0`; CCSD(T) response raises). The downstream `[v,o]` source correction is REMOVED (now
  supplied by the fixed residuals).
- `pycc/tests/test_092_cc_response_polarizability.py`, `test_093_cc_response_optrot.py`: cross-check
  `response_polarizability`/`optical_rotation` against `ccresponse` (spatial, SO, off-diagonal HOF,
  frozen core, dynamic +/-omega; chiral H2O2 for optrot).
- `docs/ccresponse_reformulation_plan.md`: Phases 1-3 marked done.

## Validation

- Amplitude level: `dt`/`dl` reproduce `ccresponse`'s `X`/`Y` for both the electric and magnetic
  dipoles to ~1e-14.
- Tensor level: `response_polarizability(omega)` vs `ccresponse.polarizability(omega)` to ~1e-11
  (test_092); `optical_rotation(omega)` vs `ccresponse.optrot(omega)` to ~1e-13 (test_093). The
  response and derivative routes share no machinery, so these are strong independent cross-checks.
- Real path unchanged: CCSD/CC3 energy, lambda, density, gradient, and `test_084` (relaxed CC
  polarizability) all pass -- the swapped blocks are no-ops for real integrals.
- Complex path exercised: RT-CCSD, RT-CC3, and Pade (test_006/009/037) pass, where the corrected
  `[v,o]` / `<ab|ij>` blocks matter.
