### PR TITLE
Key the nuclear-Hessian 2nd-derivative cache on the canonical atom pair

### DIFF
--- a/pycc/correlatedderivs.py
+++ b/pycc/correlatedderivs.py
@@ -852,7 +852,7 @@ class CorrelatedDerivs:
         per nucleus (:meth:`_perturbed_relaxed_density`), plus ``U^Y`` (:meth:`CPHF.full_U`).
 
         The field-derivatives of the nuclear skeletons carry (i) the full second integral skeletons
-        ``f^(XY)``/``<>^(XY)``/``S^(XY)`` (:meth:`CPHF.nuclear_hessian_skeletons`, cached per atom pair -- all
+        ``f^(XY)``/``<>^(XY)``/``S^(XY)`` (:meth:`Derivatives.nuclear_hessian_skeletons`, cached per atom pair -- all
         nonzero here, unlike the field case where only ``-mu^(X)`` survived), and (ii) the ``U^Y``
         orbital rotation of the ``X`` skeletons.  The rotations are hoisted off the ``O(N^2)`` pair
         loop onto the (per-``Y``) densities via ``sum A rot(U,B) = sum rot(U^T,A) B``:
@@ -929,7 +929,7 @@ class CorrelatedDerivs:
             Ay, cy = py.comp
             for ix, px in enumerate(pert):
                 Ax, cx = px.comp
-                blk = cphf.nuclear_hessian_skeletons(Ax, Ay)             # raw second skeletons (no U^{XY})
+                blk = d.nuclear_hessian_skeletons(Ax, Ay)                # raw second skeletons (no U^{XY})
                 core2 = blk['core'][cx * 3 + cy]
                 ov2 = blk['overlap'][cx * 3 + cy]
                 e2 = blk['eri'][cx * 3 + cy]

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -143,10 +143,6 @@ class CPHF(object):
         self._skel: dict = {}     # Perturbation -> (fx, Sx, gx) skeleton derivatives
         self._dfock: dict = {}    # (pert, ncore, canonical) -> (nmo, nmo) full perturbed Fock deriv
         self._deri: dict = {}     # (pert, ncore, canonical) -> (nmo^4) full perturbed <pq||rs> deriv
-        # Nuclear-nuclear skeleton second-derivative integrals, keyed by atom pair (atom1,
-        # atom2): the expensive mo_*_deriv2 calls are shared across the 3x3 Cartesian blocks
-        # of a pair, so memoize per pair rather than recompute per coordinate pair.
-        self._d2int: dict = {}    # (a1, a2) -> {'eri','core','overlap'}: 9-block lists
 
     # ---- orbital (MO) Hessian ----
     def _mo_hessian(self, kind: str = "electric") -> np.ndarray:
@@ -516,57 +512,6 @@ class CPHF(object):
                 + self.contract('tq,ptrs->pqrs', U, T)
                 + self.contract('tr,pqts->pqrs', U, T)
                 + self.contract('ts,pqrt->pqrs', U, T))
-
-    # ---- nuclear-nuclear skeleton second-derivative integrals (for the 2n+1 molecular Hessian) ----
-
-    def nuclear_hessian_skeletons(self, a1: int, a2: int) -> dict:
-        r"""Cached nuclear-nuclear skeleton second-derivative integrals for the atom pair
-        ``(a1, a2)``: the 9 ``(cart1, cart2)`` blocks of the core Hamiltonian ``h^{XY}``, the
-        overlap ``S^{XY}``, and the two-electron ``<pq||rs>^{XY}`` (in the basis's ERI
-        convention). The ``mo_*_deriv2`` calls -- ``mo_tei_deriv2`` especially -- are shared
-        across a pair's 3x3 Cartesian blocks, so compute once per atom pair (not per coordinate
-        pair). Returns ``{'core','overlap','eri'}`` -> lists of 9 arrays (indexed ``c1*3+c2``)::
-
-            core -> h^(XY)_pq,   overlap -> S^(XY)_pq,   eri -> <pq||rs>^(XY)
-
-        .. math::
-
-            h^{(XY)}_{pq}, \qquad S^{(XY)}_{pq}, \qquad \langle pq\Vert rs\rangle^{(XY)}
-
-        The mixed second derivative is symmetric under the atom-pair swap
-        (``d^2/dA_i dB_j = d^2/dB_j dA_i``), so the cache is keyed on the canonical ``(min, max)``
-        pair; a reversed request ``(a2, a1)`` returns the stored arrays with the ``3x3`` Cartesian
-        grid transposed (``comp c1*3+c2 -> c2*3+c1``) -- no tensor is copied. Only the upper
-        triangle of atom pairs is stored and computed (halving both). For a diagonal pair
-        (``a1 == a2``) the two derivatives are on one atom, so only the 6 ``c1 <= c2`` Cartesian
-        components are unique and the 3 lower-triangle components alias their partners.
-        """
-        lo, hi = (a1, a2) if a1 <= a2 else (a2, a1)
-        key = (lo, hi)
-        if key not in self._d2int:
-            so = self.wfn.orbital_basis == 'spinorbital'
-            d = self.wfn.derivatives
-            if so:
-                core = [np.asarray(m) for m in d.so_core2(lo, hi)]
-                overlap = [np.asarray(m) for m in d.so_overlap2(lo, hi)]
-                eri = [np.asarray(m) for m in d.so_eri2(lo, hi)]     # <pq||rs>^{XY} (antisym)
-            else:
-                core = [np.asarray(m) for m in d.core2(lo, hi)]
-                overlap = [np.asarray(m) for m in d.overlap2(lo, hi)]
-                eri = [np.asarray(m) for m in d.eri2(lo, hi)]        # physicist <pq|rs>^{XY}
-            blk = {'core': core, 'overlap': overlap, 'eri': eri}
-            if lo == hi:                        # same atom: comp (c1,c2) == (c2,c1), alias the dupes
-                for arrs in blk.values():
-                    for c1 in range(3):
-                        for c2 in range(c1):
-                            arrs[c1 * 3 + c2] = arrs[c2 * 3 + c1]
-            self._d2int[key] = blk
-        blk = self._d2int[key]
-        if a1 <= a2:
-            return blk
-        # reversed request: d^2/d(a1,c1)d(a2,c2) is the stored d^2/d(lo,c2)d(hi,c1) -- transpose comps
-        return {name: [arrs[c2 * 3 + c1] for c1 in range(3) for c2 in range(3)]
-                for name, arrs in blk.items()}
 
     # ---- magnetic-field perturbation (imaginary; for AATs) ----
     def _magnetic_dipole_ov(self, axis: int) -> np.ndarray:

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -532,21 +532,41 @@ class CPHF(object):
         .. math::
 
             h^{(XY)}_{pq}, \qquad S^{(XY)}_{pq}, \qquad \langle pq\Vert rs\rangle^{(XY)}
+
+        The mixed second derivative is symmetric under the atom-pair swap
+        (``d^2/dA_i dB_j = d^2/dB_j dA_i``), so the cache is keyed on the canonical ``(min, max)``
+        pair; a reversed request ``(a2, a1)`` returns the stored arrays with the ``3x3`` Cartesian
+        grid transposed (``comp c1*3+c2 -> c2*3+c1``) -- no tensor is copied. Only the upper
+        triangle of atom pairs is stored and computed (halving both). For a diagonal pair
+        (``a1 == a2``) the two derivatives are on one atom, so only the 6 ``c1 <= c2`` Cartesian
+        components are unique and the 3 lower-triangle components alias their partners.
         """
-        key = (a1, a2)
+        lo, hi = (a1, a2) if a1 <= a2 else (a2, a1)
+        key = (lo, hi)
         if key not in self._d2int:
             so = self.wfn.orbital_basis == 'spinorbital'
             d = self.wfn.derivatives
             if so:
-                core = [np.asarray(m) for m in d.so_core2(a1, a2)]
-                overlap = [np.asarray(m) for m in d.so_overlap2(a1, a2)]
-                eri = [np.asarray(m) for m in d.so_eri2(a1, a2)]     # <pq||rs>^{XY} (antisym)
+                core = [np.asarray(m) for m in d.so_core2(lo, hi)]
+                overlap = [np.asarray(m) for m in d.so_overlap2(lo, hi)]
+                eri = [np.asarray(m) for m in d.so_eri2(lo, hi)]     # <pq||rs>^{XY} (antisym)
             else:
-                core = [np.asarray(m) for m in d.core2(a1, a2)]
-                overlap = [np.asarray(m) for m in d.overlap2(a1, a2)]
-                eri = [np.asarray(m) for m in d.eri2(a1, a2)]        # physicist <pq|rs>^{XY}
-            self._d2int[key] = {'core': core, 'overlap': overlap, 'eri': eri}
-        return self._d2int[key]
+                core = [np.asarray(m) for m in d.core2(lo, hi)]
+                overlap = [np.asarray(m) for m in d.overlap2(lo, hi)]
+                eri = [np.asarray(m) for m in d.eri2(lo, hi)]        # physicist <pq|rs>^{XY}
+            blk = {'core': core, 'overlap': overlap, 'eri': eri}
+            if lo == hi:                        # same atom: comp (c1,c2) == (c2,c1), alias the dupes
+                for arrs in blk.values():
+                    for c1 in range(3):
+                        for c2 in range(c1):
+                            arrs[c1 * 3 + c2] = arrs[c2 * 3 + c1]
+            self._d2int[key] = blk
+        blk = self._d2int[key]
+        if a1 <= a2:
+            return blk
+        # reversed request: d^2/d(a1,c1)d(a2,c2) is the stored d^2/d(lo,c2)d(hi,c1) -- transpose comps
+        return {name: [arrs[c2 * 3 + c1] for c1 in range(3) for c2 in range(3)]
+                for name, arrs in blk.items()}
 
     # ---- magnetic-field perturbation (imaginary; for AATs) ----
     def _magnetic_dipole_ov(self, axis: int) -> np.ndarray:

--- a/pycc/derivatives.py
+++ b/pycc/derivatives.py
@@ -103,6 +103,9 @@ class Derivatives(object):
         # Cartesians and its several callers, without growing the deliberate one-atom footprint.
         self._d1_atom: Any = None
         self._d1_cache: dict = {}
+        # Accumulating cache of nuclear-nuclear second-derivative skeletons, keyed by the canonical
+        # atom pair (see :meth:`nuclear_hessian_skeletons`); persists for the whole molecular Hessian.
+        self._d2int: dict = {}
 
     # ---- nuclear repulsion ----
 
@@ -550,6 +553,56 @@ class Derivatives(object):
             phys = _complete_deriv2(ch).swapaxes(1, 2)   # complete over bra<->ket, then physicist
             out.append(phys - phys.swapaxes(2, 3))
         return out
+
+    # ---- nuclear-nuclear skeleton second-derivative integrals (for the 2n+1 molecular Hessian) ----
+
+    def nuclear_hessian_skeletons(self, a1: int, a2: int) -> dict:
+        r"""Cached nuclear-nuclear skeleton second-derivative integrals for the atom pair
+        ``(a1, a2)``: the 9 ``(cart1, cart2)`` blocks of the core Hamiltonian ``h^{XY}``, the
+        overlap ``S^{XY}``, and the two-electron ``<pq||rs>^{XY}`` (in the basis's ERI
+        convention). The ``mo_*_deriv2`` calls -- ``mo_tei_deriv2`` especially -- are shared
+        across a pair's 3x3 Cartesian blocks, so compute once per atom pair (not per coordinate
+        pair). Returns ``{'core','overlap','eri'}`` -> lists of 9 arrays (indexed ``c1*3+c2``)::
+
+            core -> h^(XY)_pq,   overlap -> S^(XY)_pq,   eri -> <pq||rs>^(XY)
+
+        .. math::
+
+            h^{(XY)}_{pq}, \qquad S^{(XY)}_{pq}, \qquad \langle pq\Vert rs\rangle^{(XY)}
+
+        The mixed second derivative is symmetric under the atom-pair swap
+        (``d^2/dA_i dB_j = d^2/dB_j dA_i``), so the cache is keyed on the canonical ``(min, max)``
+        pair; a reversed request ``(a2, a1)`` returns the stored arrays with the ``3x3`` Cartesian
+        grid transposed (``comp c1*3+c2 -> c2*3+c1``) -- no tensor is copied. Only the upper
+        triangle of atom pairs is stored and computed (halving both). For a diagonal pair
+        (``a1 == a2``) the two derivatives are on one atom, so only the 6 ``c1 <= c2`` Cartesian
+        components are unique and the 3 lower-triangle components alias their partners.
+        """
+        lo, hi = (a1, a2) if a1 <= a2 else (a2, a1)
+        key = (lo, hi)
+        if key not in self._d2int:
+            so = self.wfn.orbital_basis == 'spinorbital'
+            if so:
+                core = [np.asarray(m) for m in self.so_core2(lo, hi)]
+                overlap = [np.asarray(m) for m in self.so_overlap2(lo, hi)]
+                eri = [np.asarray(m) for m in self.so_eri2(lo, hi)]     # <pq||rs>^{XY} (antisym)
+            else:
+                core = [np.asarray(m) for m in self.core2(lo, hi)]
+                overlap = [np.asarray(m) for m in self.overlap2(lo, hi)]
+                eri = [np.asarray(m) for m in self.eri2(lo, hi)]        # physicist <pq|rs>^{XY}
+            blk = {'core': core, 'overlap': overlap, 'eri': eri}
+            if lo == hi:                        # same atom: comp (c1,c2) == (c2,c1), alias the dupes
+                for arrs in blk.values():
+                    for c1 in range(3):
+                        for c2 in range(c1):
+                            arrs[c1 * 3 + c2] = arrs[c2 * 3 + c1]
+            self._d2int[key] = blk
+        blk = self._d2int[key]
+        if a1 <= a2:
+            return blk
+        # reversed request: d^2/d(a1,c1)d(a2,c2) is the stored d^2/d(lo,c2)d(hi,c1) -- transpose comps
+        return {name: [arrs[c2 * 3 + c1] for c1 in range(3) for c2 in range(3)]
+                for name, arrs in blk.items()}
 
     # ---- MO block selection & caching (private helpers) ----
 


### PR DESCRIPTION
# Key the nuclear-Hessian 2nd-derivative cache on the canonical atom pair

Cuts the dominant four-index memory term of the molecular Hessian by exploiting
the atom-pair-swap symmetry of the second-derivative integrals. No behavior change
beyond roundoff.

## The problem

`CPHF.nuclear_hessian_skeletons(a1, a2)` caches the nuclear-nuclear second-
derivative skeletons (`core`/`overlap`/`eri`, the 9 Cartesian blocks of nmo^4
each) keyed on the ORDERED atom pair, and never evicts. So a molecular Hessian
ends up holding all natom^2 ordered pairs at once -- the dominant four-index term
(768.5 MB of ~1065 MB total for HOF/cc-pVDZ, all-electron).

## The change

The mixed second derivative is symmetric under the atom-pair swap
(`d^2/dA_i dB_j = d^2/dB_j dA_i`), so `blk(a1,a2)` component `(c1,c2)` is exactly
`blk(a2,a1)` component `(c2,c1)` -- the *same* tensor. So:

- key the cache on the canonical `(min, max)` pair;
- for a reversed request, return the stored arrays with the 3x3 Cartesian grid
  transposed (`c1*3+c2 -> c2*3+c1`) -- a reference reindex, no tensor copied;
- for a diagonal pair (`a1 == a2`) the two derivatives are on one atom, so only
  the 6 `c1 <= c2` Cartesian components are unique (libmints even mirrors them
  bitwise); the 3 lower-triangle components alias their partners.

Localized entirely to `nuclear_hessian_skeletons`; nothing else changes.

## Effect (HOF/cc-pVDZ, all-electron, natom=3)

- `_d2int` holds the upper triangle only: 45 arrays instead of 81,
  **768.5 -> 427 MB (44%)**; approaches 50% asymptotically as natom grows.
- Halves the expensive `mo_tei_deriv2` / `so_eri2` calls (only upper-triangle
  pairs are computed).
- Retrieval is free (reference reindex). A reversed pair now reuses the forward
  pair's integral, so `H[ix,iy]` and `H[iy,ix]` share it -- if anything the
  Hessian's numerical symmetry improves rather than degrades.

## Safety

No behavior change beyond ~1e-12 roundoff (a reversed pair now uses one
computation instead of an independently-rounded second one, below the ~1e-10
CFOUR anchors). Verified: 19 Hessian tests pass unchanged -- HF spatial + SO,
MP2, CISD, CCSD, CCSD(T).

## Second commit: move `nuclear_hessian_skeletons` to `Derivatives`

Follow-up cleanup (pure relocation, no behavior change). The method and its
`_d2int` cache are pure derivative-integral provision -- the body only ever read
`self.wfn.derivatives` and its own cache, no CPHF response state. They lived on
`CPHF` for historical cohesion, but `Derivatives` is the integral provider and
already owns the analogous first-derivative cache (`_d1_cache`/`_eri_cached`).
Moving them there co-locates the first- and second-derivative integral caches on
one class; `CPHF`/the Hessian assembly now *consume* the skeletons via
`wfn.derivatives.nuclear_hessian_skeletons(...)`. 19 Hessian tests pass unchanged.

## Not included (possible follow-ups)

- Restructuring the `H[ix,iy]` assembly to an atom-pair-outer loop would take
  `_d2int` down to a single live pair (~85 MB) but touches the core assembly.
- The per-perturbation first-derivative lists (`eriX`/`dGamN`/`Gamrot`, ~256 MB)
  could be recomputed on the fly instead of hoisted -- a memory-for-compute swap.
