### PR TITLE
Persistent HDF5 store for four-index derivative tensors

### DIFF
--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -2,3 +2,5 @@ name: p4env
 channels:
   - conda-forge
   - nodefaults
+dependencies:
+  - h5py     # on-disk persistent store for derivative tensors (DerivStore)

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -2,5 +2,3 @@ name: p4env
 channels:
   - conda-forge
   - nodefaults
-dependencies:
-  - h5py     # on-disk persistent store for derivative tensors (DerivStore)

--- a/pycc/correlatedderivs.py
+++ b/pycc/correlatedderivs.py
@@ -45,6 +45,10 @@ class CorrelatedDerivs:
     responses.
     """
 
+    #: process-lifetime counter yielding a distinct id per driver instance (deterministic, no RNG),
+    #: used to namespace this object's method-dependent perturbed responses in the shared store.
+    _obj_counter = 0
+
     def __init__(self, wfn) -> None:
         """Bind the converged correlated wavefunction and its (device-aware) contraction
         backend, and initialize the cached SCF-reference HFwfn handle (see
@@ -52,6 +56,8 @@ class CorrelatedDerivs:
         self.wfn = wfn
         self.contract = wfn.contract
         self._ref_hf = None
+        CorrelatedDerivs._obj_counter += 1
+        self._uid = CorrelatedDerivs._obj_counter
 
     def _reference_hf(self):
         """All-electron :class:`~pycc.hfwfn.HFwfn` for the SCF reference (cached) -- supplies the
@@ -565,6 +571,23 @@ class CorrelatedDerivs:
         dI = self._so_perturbed_lagrangian(df, deri, Drel0, dDrel, Gam0, dGam)
         return PerturbedResponse(dDrel, dGam, dI)
 
+    def _relaxed_response(self, pert):
+        """Per-perturbation :class:`PerturbedResponse` ``(dDrel, dGam, dI)`` for ``pert``,
+        dispatched to the spatial or spin-orbital solve and memoized in the persistent store
+        (:attr:`Derivatives.store`, disk when enabled, RAM otherwise).  The record is
+        method-dependent -- it consumes this driver's amplitudes through
+        :meth:`_perturbed_unrelaxed_densities` -- so it is keyed on the driver-instance id
+        ``_uid`` alongside the perturbation, gauge, and route.  A second property call on the
+        *same* driver then reads the record back (skipping the perturbed-amplitude / Z-vector
+        solve and the ``nmo^4`` cumulant-response build), while never colliding with a different
+        driver's response (e.g. CCSD vs CCSD(T)) on the same wavefunction."""
+        so = self.wfn.orbital_basis == 'spinorbital'
+        popdm = self._so_perturbed_relaxed_density if so else self._perturbed_relaxed_density
+        ctx = (self._uid, self.perturbed_mo_gauge, 'so' if so else 'sp')
+        parts = self.wfn.derivatives.store.get_or_compute_group(
+            'resp', pert, lambda: tuple(popdm(pert)), ('dDrel', 'dGam', 'dI'), ctx=ctx)
+        return PerturbedResponse(*parts)
+
     # ---- first-derivative properties: relaxed dipole and nuclear gradient ----
     # Both are contractions of the relaxed density against the property integrals, method-agnostic
     # given (Drel, Gam) and the energy-weighted density I = I'(Drel).  The reference (SCF) and
@@ -693,15 +716,13 @@ class CorrelatedDerivs:
         cphf = self._full_occ_cphf()
         if wfn.orbital_basis == 'spinorbital':
             Drel = self._so_orbital_response().Drel
-            popdm = self._so_perturbed_relaxed_density
         else:
             Drel = self._orbital_response().Drel
-            popdm = self._perturbed_relaxed_density
         mu = [np.asarray(wfn.H.mu[a]) for a in range(3)]
         alpha = np.zeros((3, 3))
         for b in range(3):
             pert = Perturbation('field', b)
-            dDrel = popdm(pert).dDrel
+            dDrel = self._relaxed_response(pert).dDrel
             Ub = np.asarray(cphf.full_U(pert, ncore, canonical=canonical))
             for a in range(3):
                 rot = Ub.T @ mu[a] + mu[a] @ Ub
@@ -765,7 +786,6 @@ class CorrelatedDerivs:
         natom = d.natom
         rec = self._so_orbital_response() if so else self._orbital_response()
         Drel = rec.Drel
-        popdm = self._so_perturbed_relaxed_density if so else self._perturbed_relaxed_density
         mu = [np.asarray(wfn.H.mu[a]) for a in range(3)]
         P = np.zeros((natom, 3, 3))
 
@@ -774,7 +794,7 @@ class CorrelatedDerivs:
                 dip = d.so_dipole(A) if so else d.dipole(A)          # [alpha*3 + beta]
                 for beta in range(3):
                     pX = Perturbation('nuclear', (A, beta))
-                    dDrel = popdm(pX).dDrel
+                    dDrel = self._relaxed_response(pX).dDrel
                     UX = np.asarray(cphf.full_U(pX, ncore, canonical=canonical))
                     for alpha in range(3):
                         dmu = np.asarray(dip[alpha * 3 + beta])       # skeleton d(mu_a)/dX_beta
@@ -787,7 +807,7 @@ class CorrelatedDerivs:
         Gam = rec.Gam
         I = self._lagrangian(Drel, Gam)
         field = [Perturbation('field', a) for a in range(3)]
-        resp = [popdm(field[a]) for a in range(3)]                    # one perturbed solve per field
+        resp = [self._relaxed_response(field[a]) for a in range(3)]   # one perturbed solve per field
         dDrel = [r.dDrel for r in resp]
         dGamF = [r.dGam for r in resp]                                # F = field-perturbation response
         dI = [r.dI for r in resp]                                     # perturbed energy-weighted density
@@ -888,57 +908,89 @@ class CorrelatedDerivs:
         rec = self._so_orbital_response() if so else self._orbital_response()
         Drel, Gam = rec.Drel, rec.Gam
         I = self._lagrangian(Drel, Gam)
-        popdm = self._so_perturbed_relaxed_density if so else self._perturbed_relaxed_density
         pert = [Perturbation('nuclear', (A, ct)) for A in range(natom) for ct in range(3)]
 
         def rot4(Um, T):
             return (c('tp,tqrs->pqrs', Um, T) + c('tq,ptrs->pqrs', Um, T)
                     + c('tr,pqts->pqrs', Um, T) + c('ts,pqrt->pqrs', Um, T))
 
-        # first-order responses + hoisted per-Y rotated densities (sum A rot(U,B) = sum rot(U^T,A) B)
-        resp = [popdm(p) for p in pert]                              # one perturbed solve per nucleus
-        dDrel = [r.dDrel for r in resp]
-        dGamN = [r.dGam for r in resp]
-        dI = [r.dI for r in resp]
-        U = [np.asarray(cphf.full_U(p, ncore, canonical=canonical)) for p in pert]
+        # first-order responses + hoisted per-Y rotated densities (sum A rot(U,B) = sum rot(U^T,A) B).
+        # The large per-perturbation nmo^4 quantities live in the persistent store
+        # (wfn.derivatives.store): _relaxed_response persists each dGam and _eri_cached persists the
+        # per-atom eri stacks, so the assembly reads them back one atom pair at a time rather than
+        # holding 3*natom-long in-RAM lists.  Gamrot is recomputed per Y (not hoisted into a list).
+        # Only the small quantities (dDrel/dI/Drot/Irot/U and the nmo^2 fX/SX/JX) stay resident.
+        dDrel, dI, U = [], [], []
+        for i, p in enumerate(pert):
+            r = self._relaxed_response(p)                            # one perturbed solve; persists dGam
+            dDrel.append(r.dDrel)
+            dI.append(r.dI)
+            U.append(np.asarray(cphf.full_U(p, ncore, canonical=canonical)))
         Drot = [U[i] @ Drel + Drel @ U[i].T for i in range(nc)]
         Irot = [U[i] @ I + I @ U[i].T for i in range(nc)]
-        Gamrot = [rot4(U[i].T, Gam) for i in range(nc)]
 
-        # per-X first skeletons; J^X carries the Fock skeleton's occupied-sum rotation response
-        fX, eriX, SX, JX = [], [], [], []
-        for p in pert:
+        # per-X first skeletons; J^X carries the Fock skeleton's occupied-sum rotation response.
+        # Reading d.eri/d.so_eri here also warms the store's per-atom eri stacks for the assembly.
+        fX, SX, JX = [], [], []
+        for i, p in enumerate(pert):
             A, ct = p.comp
             hx = np.asarray((d.so_core(A) if so else d.core(A))[ct])
             Sx = np.asarray((d.so_overlap(A) if so else d.overlap(A))[ct])
             if so:
                 eL = np.asarray(d.so_eri(A)[ct])
-                gm = eL
             else:
                 ph = np.asarray(d.eri(A)[ct])                           # <pq|rs>^(X) (Gamma)
                 eL = 2.0 * ph - ph.transpose(0, 1, 3, 2)                # L^X (Fock)
-                gm = ph
             fX.append(hx + c('pmqm->pq', eL[:, ofull, :, ofull]))
-            eriX.append(gm)
             SX.append(Sx)
             JX.append(c('pq,prqm->rm', Drel, eL[:, :, :, ofull])
                       + c('pq,pmqr->rm', Drel, eL[:, ofull, :, :]))
 
+        # ---- assembly: atom-pair-outer contract-and-discard ----
+        # Loop unique atom pairs, compute each pair's 2nd-deriv skeletons ONCE (cache=False, so
+        # _d2int never accumulates -- one pair's 9*nmo^4 resident at a time), contract the fixed-
+        # density scalar, and free the pair.  The second-skeleton scalar s = Drel.f2 + Gam.e2 +
+        # I.ov2 uses only Drel/Gam/I and is symmetric in the pair (d2/dA dB = d2/dB dA), so it is
+        # shared by H[ix,iy] and its transpose H[iy,ix]; only the response half differs.  The pair's
+        # nmo^4 working set (dGam + eriX for its <= 6 perturbations) is read from the store here.
+        def _dGs(j):        # stored cumulant response dGam[j] + the per-Y rotation (recomputed)
+            return self._relaxed_response(pert[j]).dGam + rot4(U[j].T, Gam)
+
+        def _resp(i, j, dGs_j, erX_i):     # perturbation-dependent half of H[i, j]
+            return (c('pq,pq->', dDrel[j] + Drot[j], fX[i]) + c('pqrs,pqrs->', dGs_j, erX_i)
+                    + c('pq,pq->', dI[j] + Irot[j], SX[i]) + float(np.sum(U[j][:, ofull] * JX[i])))
+
+        def _skel_scalar(blk, cx, cy):     # fixed-density second-skeleton scalar s for (cx, cy)
+            core2 = blk['core'][cx * 3 + cy]
+            ov2 = blk['overlap'][cx * 3 + cy]
+            e2 = blk['eri'][cx * 3 + cy]
+            L2 = e2 if so else 2.0 * e2 - e2.swapaxes(2, 3)
+            f2 = core2 + c('pmqm->pq', L2[:, ofull, :, ofull])          # f^(XY)
+            return c('pq,pq->', Drel, f2) + c('pqrs,pqrs->', Gam, e2) + c('pq,pq->', I, ov2)
+
+        def _erX_pair(a1, a2):             # both atoms' eriX, read once per atom (3-stack) and sliced
+            erX = {}
+            for A in {a1, a2}:
+                stk = d.so_eri(A) if so else d.eri(A)
+                for ct in range(3):
+                    erX[A * 3 + ct] = np.asarray(stk[ct])
+            return erX
+
         H = np.zeros((nc, nc))
-        for iy, py in enumerate(pert):
-            Ay, cy = py.comp
-            for ix, px in enumerate(pert):
-                Ax, cx = px.comp
-                blk = d.nuclear_hessian_skeletons(Ax, Ay)                # raw second skeletons (no U^{XY})
-                core2 = blk['core'][cx * 3 + cy]
-                ov2 = blk['overlap'][cx * 3 + cy]
-                e2 = blk['eri'][cx * 3 + cy]
-                L2 = e2 if so else 2.0 * e2 - e2.swapaxes(2, 3)
-                f2 = core2 + c('pmqm->pq', L2[:, ofull, :, ofull])       # f^(XY)
-                H[ix, iy] = (c('pq,pq->', dDrel[iy] + Drot[iy], fX[ix]) + c('pq,pq->', Drel, f2)
-                             + c('pqrs,pqrs->', dGamN[iy] + Gamrot[iy], eriX[ix]) + c('pqrs,pqrs->', Gam, e2)
-                             + c('pq,pq->', dI[iy] + Irot[iy], SX[ix]) + c('pq,pq->', I, ov2)
-                             + float(np.sum(U[iy][:, ofull] * JX[ix])))
+        for a1 in range(natom):
+            for a2 in range(a1, natom):
+                blk = d.nuclear_hessian_skeletons(a1, a2, cache=False)   # one pair, transient nmo^4
+                erX = _erX_pair(a1, a2)
+                need = sorted(set(range(a1 * 3, a1 * 3 + 3)) | set(range(a2 * 3, a2 * 3 + 3)))
+                dGs = {j: _dGs(j) for j in need}                        # per-pair working set (bounded)
+                for cx in range(3):
+                    for cy in range(3):
+                        s = _skel_scalar(blk, cx, cy)
+                        ix, iy = a1 * 3 + cx, a2 * 3 + cy
+                        H[ix, iy] = s + _resp(ix, iy, dGs[iy], erX[ix])
+                        if a1 != a2:
+                            H[iy, ix] = s + _resp(iy, ix, dGs[ix], erX[iy])
+                del blk, dGs, erX                                       # free the pair's nmo^4
         return H
 
     @staticmethod

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -142,7 +142,8 @@ class CPHF(object):
         self._U_field: dict = {}  # axis -> (no, nv) electric-field response U^a
         self._skel: dict = {}     # Perturbation -> (fx, Sx, gx) skeleton derivatives
         self._dfock: dict = {}    # (pert, ncore, canonical) -> (nmo, nmo) full perturbed Fock deriv
-        self._deri: dict = {}     # (pert, ncore, canonical) -> (nmo^4) full perturbed <pq||rs> deriv
+        # the (nmo^4) full perturbed <pq||rs> deriv now lives in wfn.derivatives.store (persistent,
+        # keyed on (pert, ncore, canonical)) rather than a per-CPHF RAM dict; see ``eri`` below.
 
     # ---- orbital (MO) Hessian ----
     def _mo_hessian(self, kind: str = "electric") -> np.ndarray:
@@ -483,14 +484,14 @@ class CPHF(object):
         ``('o','o','v','v')`` for the MP2 2PDM; the **default returns the full tensor** (CC
         consumers need the other blocks). ``canonical`` selects the canonical active-oo/vv
         perturbed orbitals (CCSD(T))."""
-        key = (pert, ncore, canonical)
-        full = self._deri.get(key)
-        if full is None:
+        def _build():
             ERI = np.asarray(self.wfn.H.ERI)
             _, _, gx = self._skeleton_derivatives(pert)
             U = self.full_U(pert, ncore, canonical)
-            full = gx + self._rotate_eri(U, ERI)
-            self._deri[key] = full
+            return gx + self._rotate_eri(U, ERI)
+        # persistent, perturbation-keyed store (disk when enabled, RAM when not) -- shared across
+        # property calls on this wavefunction, replacing the old per-CPHF ``_deri`` RAM dict.
+        full = self.wfn.derivatives.store.get_or_compute('deri', pert, _build, ctx=(ncore, canonical))
         if blocks is None:
             return full
         sl = tuple({'o': self.o, 'v': self.v}.get(b, slice(None)) for b in blocks)

--- a/pycc/derivatives.py
+++ b/pycc/derivatives.py
@@ -34,10 +34,125 @@ Lives on the Wavefunction base (lazy ``self.derivatives``); it depends only on b
 
 from __future__ import annotations
 
+import importlib.util
+import os
+import re
+import tempfile
+import warnings
 from typing import Any, List, Iterator, Tuple
 
 import psi4
 import numpy as np
+
+
+#: Persistent derivative-tensor store defaults.  Enabled by default (opt-out); set env var
+#: ``PYCC_DERIV_STORE=0`` (or ``derivatives.DERIV_STORE_ENABLED = False``) to disable, and
+#: ``PYCC_DERIV_STORE_DIR`` for the scratch directory (default: system temp, i.e. ``/tmp``).
+DERIV_STORE_ENABLED = os.environ.get('PYCC_DERIV_STORE', '1') != '0'
+DERIV_STORE_DIR = os.environ.get('PYCC_DERIV_STORE_DIR') or None
+
+
+class DerivStore:
+    """Persistent HDF5-backed store for four-index derivative tensors, keyed by
+    ``(quantity, perturbation, context)``.
+
+    Owned by :class:`Derivatives` (one per wavefunction), so a derivative tensor computed for one
+    property is read back by any later property on the same wavefunction rather than recomputed --
+    disk reads (~0.1 s for an ``nmo^4`` block) are far cheaper than re-derivation (seconds) and keep
+    the tensors off RAM.  The HDF5 file is created lazily on first write and removed on
+    :meth:`close` / deletion.  ``ctx`` is a hashable capturing everything the tensor depends on
+    beyond the perturbation (e.g. ``(ncore, canonical)`` for the perturbed ERI derivative, the
+    perturbed-MO gauge for amplitudes/densities)."""
+
+    def __init__(self, enabled: bool = True, path: str = None) -> None:
+        if enabled and importlib.util.find_spec('h5py') is None:
+            # No h5py: degrade to the in-memory memo path rather than fail.  Correctness is
+            # unchanged (RAM memo is bit-identical to the disk store); only the off-RAM /
+            # cross-property-persistence benefit is lost until h5py is installed.
+            warnings.warn("h5py not available; DerivStore is using in-memory memoization instead of "
+                          "the on-disk store (install h5py for the off-RAM / cross-property benefit).",
+                          RuntimeWarning, stacklevel=2)
+            enabled = False
+        self.enabled = enabled
+        self._dir = path
+        self._f = None                                  # lazy h5py.File
+        self._file = None                               # temp-file path
+        self._ram: dict = {}                            # in-memory memo when disabled
+
+    def _ensure(self):
+        if self._f is None:
+            import h5py
+            fd, self._file = tempfile.mkstemp(suffix='.h5', prefix='pycc_deriv_', dir=self._dir)
+            os.close(fd)
+            self._f = h5py.File(self._file, 'w')
+        return self._f
+
+    @staticmethod
+    def _name(quantity, pert, ctx) -> str:
+        raw = f"{quantity}|{pert!r}|{ctx!r}"
+        return re.sub(r'[^A-Za-z0-9_.-]', '_', raw)     # HDF5-safe dataset name
+
+    def get_or_compute(self, quantity, pert, builder, ctx=()):
+        """Return the tensor for ``(quantity, pert, ctx)``: on a hit read it back, else call
+        ``builder()`` and persist the result.  The store always memoizes -- to disk when enabled
+        (off RAM, persistent across property calls), to an in-memory dict when disabled (matching
+        the pre-store RAM caches).  Bit-identical either way."""
+        name = self._name(quantity, pert, ctx)
+        if not self.enabled:
+            if name not in self._ram:
+                self._ram[name] = np.asarray(builder())
+            return self._ram[name]
+        f = self._ensure()
+        dset = f.get(name)
+        if dset is not None:
+            return dset[()]
+        arr = np.asarray(builder())
+        f.create_dataset(name, data=arr)
+        return arr
+
+    def get_or_compute_group(self, quantity, pert, builder, names, ctx=()):
+        """Memoize a group of arrays produced together by a single ``builder()`` call (e.g. the
+        three components of a perturbed-response record, of differing shapes).  ``names`` labels the
+        components; ``builder()`` returns a tuple of arrays aligned with ``names``.  On a full hit
+        every component is read back; otherwise ``builder()`` runs **once** and each component is
+        persisted.  Returns the tuple.  All-or-nothing on the group, so a partial write never yields
+        a stale mix."""
+        full = [self._name(quantity, pert, tuple(ctx) + (n,)) for n in names]
+        if not self.enabled:
+            if all(n in self._ram for n in full):
+                return tuple(self._ram[n] for n in full)
+            vals = tuple(np.asarray(v) for v in builder())
+            for n, v in zip(full, vals):
+                self._ram[n] = v
+            return vals
+        f = self._ensure()
+        if all(n in f for n in full):
+            return tuple(f[n][()] for n in full)
+        vals = tuple(np.asarray(v) for v in builder())
+        for n, v in zip(full, vals):
+            if n in f:
+                del f[n]
+            f.create_dataset(n, data=v)
+        return vals
+
+    def has(self, quantity, pert, ctx=()) -> bool:
+        name = self._name(quantity, pert, ctx)
+        return name in self._ram if not self.enabled else (self._f is not None and name in self._f)
+
+    def close(self) -> None:
+        self._ram.clear()
+        if self._f is not None:
+            self._f.close()
+            self._f = None
+        if self._file is not None:
+            try:
+                os.remove(self._file)
+            except OSError:
+                pass
+            self._file = None
+
+    def __del__(self):
+        self.close()
 
 
 def _complete_deriv2(chem: np.ndarray) -> np.ndarray:
@@ -106,6 +221,10 @@ class Derivatives(object):
         # Accumulating cache of nuclear-nuclear second-derivative skeletons, keyed by the canonical
         # atom pair (see :meth:`nuclear_hessian_skeletons`); persists for the whole molecular Hessian.
         self._d2int: dict = {}
+        # Persistent, perturbation-keyed disk store for the large first-derivative four-index tensors
+        # (skeleton ERI^(X), perturbed 2-PDM, perturbed amplitudes/Lambda, perturbed ERI deriv),
+        # shared across property calls on this wavefunction (see :class:`DerivStore`).
+        self.store = DerivStore(enabled=DERIV_STORE_ENABLED, path=DERIV_STORE_DIR)
 
     # ---- nuclear repulsion ----
 
@@ -556,7 +675,7 @@ class Derivatives(object):
 
     # ---- nuclear-nuclear skeleton second-derivative integrals (for the 2n+1 molecular Hessian) ----
 
-    def nuclear_hessian_skeletons(self, a1: int, a2: int) -> dict:
+    def nuclear_hessian_skeletons(self, a1: int, a2: int, cache: bool = True) -> dict:
         r"""Cached nuclear-nuclear skeleton second-derivative integrals for the atom pair
         ``(a1, a2)``: the 9 ``(cart1, cart2)`` blocks of the core Hamiltonian ``h^{XY}``, the
         overlap ``S^{XY}``, and the two-electron ``<pq||rs>^{XY}`` (in the basis's ERI
@@ -577,10 +696,15 @@ class Derivatives(object):
         triangle of atom pairs is stored and computed (halving both). For a diagonal pair
         (``a1 == a2``) the two derivatives are on one atom, so only the 6 ``c1 <= c2`` Cartesian
         components are unique and the 3 lower-triangle components alias their partners.
+
+        ``cache=False`` computes the block and returns it WITHOUT storing it in ``_d2int`` -- for the
+        atom-pair-outer Hessian assembly, which visits each unique pair once and discards it, so the
+        (natom^2-scale) accumulating cache would only waste memory.
         """
         lo, hi = (a1, a2) if a1 <= a2 else (a2, a1)
         key = (lo, hi)
-        if key not in self._d2int:
+        blk = self._d2int.get(key) if cache else None
+        if blk is None:
             so = self.wfn.orbital_basis == 'spinorbital'
             if so:
                 core = [np.asarray(m) for m in self.so_core2(lo, hi)]
@@ -596,8 +720,8 @@ class Derivatives(object):
                     for c1 in range(3):
                         for c2 in range(c1):
                             arrs[c1 * 3 + c2] = arrs[c2 * 3 + c1]
-            self._d2int[key] = blk
-        blk = self._d2int[key]
+            if cache:
+                self._d2int[key] = blk
         if a1 <= a2:
             return blk
         # reversed request: d^2/d(a1,c1)d(a2,c2) is the stored d^2/d(lo,c2)d(hi,c1) -- transpose comps
@@ -642,7 +766,14 @@ class Derivatives(object):
         the MO blocks. The dominant cost is ``psi4.core.mo_tei_deriv1`` (the ``nmo^4`` MO
         transform), which every caller for a given atom otherwise re-runs; this reuses it
         across the atom's three Cartesians and callers. The cached arrays are treated
-        read-only (callers already build new arrays via swapaxes/arithmetic)."""
+        read-only (callers already build new arrays via swapaxes/arithmetic).
+
+        When the persistent :class:`DerivStore` is enabled the 3-Cartesian result is memoized
+        there instead (per atom + transform/blocks) -- off RAM and reused across property calls;
+        otherwise the 1-atom LRU (evict-on-atom-change) is used."""
+        if self.store.enabled:
+            stack = self.store.get_or_compute('eri1', atom, lambda: np.asarray(compute()), ctx=key)
+            return list(stack)
         if atom != self._d1_atom:
             self._d1_atom = atom
             self._d1_cache = {}

--- a/pycc/tests/test_094_deriv_store.py
+++ b/pycc/tests/test_094_deriv_store.py
@@ -88,14 +88,17 @@ def test_graceful_fallback_without_h5py(monkeypatch):
     assert store.enabled is False                                           # degraded to RAM memo
 
 
-def test_disk_matches_ram_hessian(rhf_wfn):
+@pytest.mark.parametrize("orbital_basis", ["spatial", "spinorbital"])
+def test_disk_matches_ram_hessian(rhf_wfn, orbital_basis):
     """The on-disk Hessian is bit-identical to the in-memory-memo Hessian (same driver machinery,
-    just disk vs RAM backing), and the disk path really is used (temp file created)."""
+    just disk vs RAM backing), and the disk path really is used (temp file created) -- checked on
+    both the spatial and spin-orbital routes, which the store keys distinctly (eri vs so_eri, and
+    the 'sp'/'so' response-context tag)."""
     pytest.importorskip("h5py")
     import pycc
 
     wfn = rhf_wfn("H2O", "STO-3G", freeze_core="false")
-    cc = pycc.ccwfn(wfn)
+    cc = pycc.ccwfn(wfn, orbital_basis=orbital_basis)
     cc.solve_cc(1e-10, 1e-10, 100)
     store = pycc.CCderiv(cc).wfn.derivatives.store                          # shared per-wfn store
 

--- a/pycc/tests/test_094_deriv_store.py
+++ b/pycc/tests/test_094_deriv_store.py
@@ -1,0 +1,109 @@
+"""DerivStore: the persistent HDF5-backed store for four-index derivative tensors.
+
+The derivative suite runs with the store ON by default (disk), so the on-disk path is exercised
+end-to-end throughout.  These tests add focused coverage for the store itself: the on-disk
+round-trip (single and grouped), the disabled/RAM-memo path, the graceful fallback when h5py is
+absent, and an explicit check that the on-disk Hessian is bit-identical to the in-memory one.
+"""
+import os
+
+import numpy as np
+import pytest
+
+from pycc.derivatives import DerivStore
+
+
+def test_roundtrip_disk():
+    """Enabled store: first call builds + persists, second reads back exactly, close removes file."""
+    pytest.importorskip("h5py")
+    store = DerivStore(enabled=True)
+    try:
+        calls = {"n": 0}
+
+        def build():
+            calls["n"] += 1
+            return np.arange(24, dtype=float).reshape(2, 3, 4)
+
+        a = store.get_or_compute("q", ("nuc", 0), build, ctx=(1, True))
+        assert calls["n"] == 1
+        assert store.has("q", ("nuc", 0), ctx=(1, True))
+        b = store.get_or_compute("q", ("nuc", 0), build, ctx=(1, True))     # hit: builder not re-run
+        assert calls["n"] == 1
+        assert np.array_equal(a, b)                                          # exact round-trip
+        assert store._file and os.path.exists(store._file)                  # disk file was created
+        path = store._file
+    finally:
+        store.close()
+    assert not os.path.exists(path)                                         # removed on close
+    assert store._f is None
+
+
+def test_group_roundtrip_disk():
+    """Grouped store: differing-shape components built once, read back exactly, all-or-nothing."""
+    pytest.importorskip("h5py")
+    store = DerivStore(enabled=True)
+    try:
+        calls = {"n": 0}
+
+        def build():
+            calls["n"] += 1
+            return (np.ones((2, 2)), np.arange(8.0).reshape(2, 2, 2), np.full((3,), 2.0))
+
+        names = ("dDrel", "dGam", "dI")
+        r1 = store.get_or_compute_group("resp", ("nuc", 1), build, names, ctx=("sp",))
+        assert calls["n"] == 1
+        r2 = store.get_or_compute_group("resp", ("nuc", 1), build, names, ctx=("sp",))  # full hit
+        assert calls["n"] == 1
+        for x, y in zip(r1, r2):
+            assert np.array_equal(x, y)
+    finally:
+        store.close()
+
+
+def test_ram_path_no_file():
+    """Disabled store memoizes in RAM and never touches disk."""
+    store = DerivStore(enabled=False)
+    calls = {"n": 0}
+
+    def build():
+        calls["n"] += 1
+        return np.zeros((4, 4))
+
+    store.get_or_compute("q", ("f", 0), build)
+    store.get_or_compute("q", ("f", 0), build)
+    assert calls["n"] == 1                                                  # memoized in RAM
+    assert store._file is None and store._f is None
+
+
+def test_graceful_fallback_without_h5py(monkeypatch):
+    """When h5py is unavailable, an enabled store degrades to the RAM path with a warning."""
+    import importlib.util as iu
+    import pycc.derivatives as D
+
+    real = iu.find_spec
+    monkeypatch.setattr(iu, "find_spec",
+                        lambda name, *a, **k: None if name == "h5py" else real(name, *a, **k))
+    with pytest.warns(RuntimeWarning):
+        store = D.DerivStore(enabled=True)
+    assert store.enabled is False                                           # degraded to RAM memo
+
+
+def test_disk_matches_ram_hessian(rhf_wfn):
+    """The on-disk Hessian is bit-identical to the in-memory-memo Hessian (same driver machinery,
+    just disk vs RAM backing), and the disk path really is used (temp file created)."""
+    pytest.importorskip("h5py")
+    import pycc
+
+    wfn = rhf_wfn("H2O", "STO-3G", freeze_core="false")
+    cc = pycc.ccwfn(wfn)
+    cc.solve_cc(1e-10, 1e-10, 100)
+    store = pycc.CCderiv(cc).wfn.derivatives.store                          # shared per-wfn store
+
+    store.enabled = False
+    H_ram = np.asarray(pycc.CCderiv(cc).hessian())
+
+    store.enabled = True
+    H_disk = np.asarray(pycc.CCderiv(cc).hessian())
+    assert store._file and os.path.exists(store._file)                      # disk path exercised
+    assert np.max(np.abs(H_ram - H_disk)) < 1e-12
+    store.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "numpy",
     "opt_einsum",
     "scipy",
+    "h5py",           # on-disk persistent store for derivative tensors (DerivStore); degrades to
+                      # in-memory memoization if absent, so this is a soft requirement
     # example: "numpy >=2.3.3; python_version >='3.14'",
 ]
 


### PR DESCRIPTION
# Persistent HDF5 store for four-index derivative tensors

## What

Adds `DerivStore`, a persistent per-wavefunction store that memoizes the large `nmo^4`
derivative tensors so they are computed once and read back across property calculations on
the same driver object, keeping them off RAM. The store is owned by `Derivatives` (reached as
`wfn.derivatives.store`), enabled by default (opt-out via `PYCC_DERIV_STORE=0`), with a
configurable scratch directory (`PYCC_DERIV_STORE_DIR`, system-temp default).

## Quantities routed through the store

- `deri` -- the perturbed `<pq||rs>` integral derivative (CPHF), keyed `(pert, ncore, canonical)`;
  method-independent (SCF orbital response), so shared wfn-wide.
- `eriX` -- the skeleton ERI first derivative, at the shared `Derivatives._eri_cached` chokepoint
  (both `eri` and `so_eri`); per-atom 3-Cartesian stack. Keeps the 1-atom LRU when disabled.
- `dt/dl` + `dGam` -- the perturbed-response record `PerturbedResponse(dDrel, dGam, dI)`, keyed by
  the driver instance id (`_uid`) in addition to `(pert, gauge, route)`. The response is
  method-dependent (it consumes the driver's amplitudes), so the `_uid` prevents a CCSD and a
  CCSD(T) object on the same wavefunction from colliding, while a second property call on the
  *same* driver reads it back (skipping the perturbed-amplitude solve).

## hessian()

The molecular Hessian now sources `dGam`/`eriX` from the store one atom pair at a time
(atom-pair-outer contract-and-discard), instead of holding `3*natom`-long in-RAM lists. The
intra-call `_DiskArrays` prototype is removed.

## Measured impact (HOF/cc-pVTZ CCSD, nmo=74)

- Peak-RSS ~17.5 GB (ru_maxrss), down from the pre-restructure ~29 GB.
- A nuclear APT after a Hessian on the same driver returns in **0.7 s** -- it reads the 9 nuclear
  responses back instead of re-solving. On DZ HOF the nuclear-APT-after-Hessian reuse is 0.04 s
  vs 6.34 s fresh (~160x).
- Store round-trip is bit-exact (`0.0`); disk and in-memory paths give identical results.

Note: a single Hessian is dominated (~90%) by `psi4.mo_tei_deriv2` (the second-derivative ERI
transform), which this change does not address. The wins here are memory (peak-RSS) and
cross-property reuse, not single-Hessian wall time.

## Robustness / packaging

- The store degrades gracefully to in-memory memoization (bit-identical) with a `RuntimeWarning`
  when `h5py` is unavailable, so correctness never depends on it.
- `h5py` is declared as a dependency (`pyproject.toml` and `devtools/conda-envs/psi.yaml`) so the
  disk path is present in CI/production.

## Both routes

The store is route-symmetric: `eriX` is keyed `eri` vs `so_eri`, and the perturbed-response
context carries a `'sp'`/`'so'` tag, so the spatial-MO and spin-orbital routes never collide. Both
are covered -- the broad suite passes SO derivative tests with the store ON, and the dedicated
disk-vs-RAM Hessian check is parametrized over `spatial` and `spinorbital` (bit-identical on both).

## Tests

- The derivative suite runs with the store ON by default, exercising the disk path end-to-end.
- `test_094_deriv_store.py` adds focused coverage: on-disk round-trip (single + grouped), the
  RAM-memo path, the h5py-absent graceful fallback, and a disk-vs-RAM bit-exactness check on a
  real Hessian parametrized over both the spatial and spin-orbital routes.
