### PR TITLE
Second-derivative orbital response: adopt the reference-doc form; remove the gamrot path

### DIFF
--- a/docs/cc_gradients_orbital_response.tex
+++ b/docs/cc_gradients_orbital_response.tex
@@ -16,6 +16,7 @@
 \newcommand{\so}{\text{all}}
 \newcommand{\occ}{\text{occ}}
 \newcommand{\vir}{\text{vir}}
+\newcommand{\alloc}{\text{all occ}}   % occupied summation over core + active (frozen-core aware)
 
 \begin{document}
 
@@ -56,7 +57,7 @@ elements and of the two-electron integrals are
 \begin{align}
 \frac{\partial f_{pq}}{\partial x}
 &= f^{(x)}_{pq} + U^x_{qp} f_{qq} + U^x_{pq} f_{pp}
-+ \sum_{t}^{\so}\sum_{m}^{\occ} U^x_{tm}A_{ptqm},
++ \sum_{t}^{\so}\sum_{m}^{\alloc} U^x_{tm}A_{ptqm},
 \label{eq:dfpq}\\[4pt]
 \frac{\partial \adb{pq}{rs}}{\partial x}
 &= \adb{pq}{rs}^{(x)}
@@ -77,7 +78,7 @@ the terms with and without $U^{x}$,
 + \sum_{pq} D_{pq}\left[U^x_{qp} f_{qq} + U^x_{pq} f_{pp}\right]
 \nonumber\\
 &\quad
-+ \sum_{pq}\sum_{t}^{\so}\sum_{m}^{\occ} D_{pq}\,U^x_{tm}A_{ptqm}
++ \sum_{pq}\sum_{t}^{\so}\sum_{m}^{\alloc} D_{pq}\,U^x_{tm}A_{ptqm}
 \nonumber\\
 &\quad
 + \sum_{pqrs}\sum_{t}^{\so}\Gamma_{pqrs}\left(U^x_{tp}\adb{tq}{rs}
@@ -204,7 +205,7 @@ The total gradient may therefore be written as
 \frac{\partial E}{\partial x}
 = \sum_{pq} D_{pq} f^{(x)}_{pq}
 + \sum_{pqrs}\Gamma_{pqrs}\adb{pq}{rs}^{(x)}
-+ 2\sum_{a}^{\vir}\sum_{i}^{\occ} U^x_{ai} X_{ai}
++ 2\sum_{a}^{\vir}\sum_{i}^{\alloc} U^x_{ai} X_{ai}
 + \sum_{pq} S^{(x)}_{pq} I''_{pq},
 \qquad X_{ai} \equiv I'_{ia} - I'_{ai}
 \label{eq:grad-U}
@@ -218,7 +219,7 @@ The first-order CPHF equations for $U^x_{ai}$ are
 \begin{equation}
 -f^{(x)}_{ai} + S^{(x)}_{ai}\varepsilon_i
 + \tfrac{1}{2}\sum_{jk} S^{(x)}_{jk}A_{ajik}
-= \sum_{b}^{\vir}\sum_{j}^{\occ} U^x_{bj}
+= \sum_{b}^{\vir}\sum_{j}^{\alloc} U^x_{bj}
 \left[(\varepsilon_a-\varepsilon_i)\delta_{ab}\delta_{ij} + A_{abij}\right].
 \end{equation}
 Defining
@@ -281,7 +282,7 @@ where
 \tilde{D}_{ai} &= D_{ai} - Z_{ai}, & \tilde{D}_{ia} &= D_{ia} - Z_{ai}, \\
 \tilde{D}_{ij} &= D_{ij}, & \tilde{D}_{ab} &= D_{ab}, \\
 I_{ai} &= I''_{ai} + Z_{ai}\varepsilon_i, & I_{ia} &= I''_{ia} + Z_{ai}\varepsilon_i, \\
-I_{ij} &= I''_{ij} + \sum_{a}^{\vir}\sum_{k}^{\occ} Z_{ak}A_{aikj}, & I_{ab} &= I''_{ab}.
+I_{ij} &= I''_{ij} + \sum_{a}^{\vir}\sum_{k}^{\alloc} Z_{ak}A_{aikj}, & I_{ab} &= I''_{ab}.
 \end{align}
 
 \noindent
@@ -359,8 +360,8 @@ determines $U^x_{ij}$ ($i\neq j$) fully:
 U^x_{ij}
 = \frac{1}{\varepsilon_i-\varepsilon_j}\left[
 -f^{(x)}_{ij} + S^{(x)}_{ij}\varepsilon_j
-+ \tfrac12\sum_{nm}^{\occ} S^{(x)}_{nm}\,A_{injm}
-- \sum_{c}^{\vir}\sum_{m}^{\occ} U^x_{cm}\,A_{icjm}
++ \tfrac12\sum_{nm}^{\alloc} S^{(x)}_{nm}\,A_{injm}
+- \sum_{d}^{\vir}\sum_{m}^{\alloc} U^x_{dm}\,A_{idjm}
 \right], \qquad i\neq j,
 \label{eq:canon-oo}
 \end{equation}
@@ -369,8 +370,8 @@ and, analogously, the virtual block
 U^x_{ab}
 = \frac{1}{\varepsilon_a-\varepsilon_b}\left[
 -f^{(x)}_{ab} + S^{(x)}_{ab}\varepsilon_b
-+ \tfrac12\sum_{nm}^{\occ} S^{(x)}_{nm}\,A_{anbm}
-- \sum_{c}^{\vir}\sum_{m}^{\occ} U^x_{cm}\,A_{acbm}
++ \tfrac12\sum_{nm}^{\alloc} S^{(x)}_{nm}\,A_{anbm}
+- \sum_{d}^{\vir}\sum_{m}^{\alloc} U^x_{dm}\,A_{adbm}
 \right], \qquad a\neq b.
 \label{eq:canon-vv}
 \end{equation}
@@ -428,18 +429,18 @@ P_{ij} \equiv \frac{X_{ij}}{\varepsilon_i-\varepsilon_j}
 \end{equation}
 the occupied block becomes
 \begin{equation}
--\sum_{ij}U^x_{ij}X_{ij}
-= \sum_{ij}P_{ij}f^{(x)}_{ij}
-- \sum_{ij}P_{ij}S^{(x)}_{ij}\varepsilon_j
-- \tfrac12\sum_{ij}\sum_{nm}^{\occ}P_{ij}S^{(x)}_{nm}A_{injm}
-+ \sum_{ij}\sum_{c}^{\vir}\sum_{m}^{\occ}P_{ij}U^x_{cm}A_{icjm}.
+-\sum_{ij}^{\alloc}U^x_{ij}X_{ij}
+= \sum_{ij}^{\alloc}P_{ij}f^{(x)}_{ij}
+- \sum_{ij}^{\alloc}P_{ij}S^{(x)}_{ij}\varepsilon_j
+- \tfrac12\sum_{ij}^{\alloc}\sum_{nm}^{\alloc}P_{ij}S^{(x)}_{nm}A_{injm}
++ \sum_{ij}^{\alloc}\sum_{d}^{\vir}\sum_{m}^{\alloc}P_{ij}U^x_{dm}A_{idjm}.
 \label{eq:oo-sub}
 \end{equation}
 The four terms have distinct
 destinations: the first adds $P_{ij}$ to the effective
 one-particle density that contracts the skeleton Fock derivative; the second and
 third are overlap-derivative contributions that join the energy-weighted density
-$I''$; and the fourth couples the occ-vir response $U^x_{cm}$, so it augments the
+$I''$; and the fourth couples the occ-vir response $U^x_{dm}$, so it augments the
 Z-vector right-hand side.
 
 \noindent
@@ -449,8 +450,8 @@ $P_{ab}\equiv X_{ab}/(\varepsilon_a-\varepsilon_b)$,
 -\sum_{ab}U^x_{ab}X_{ab}
 = \sum_{ab}P_{ab}f^{(x)}_{ab}
 - \sum_{ab}P_{ab}S^{(x)}_{ab}\varepsilon_b
-- \tfrac12\sum_{ab}\sum_{nm}^{\occ}P_{ab}S^{(x)}_{nm}A_{anbm}
-+ \sum_{ab}\sum_{c}^{\vir}\sum_{m}^{\occ}P_{ab}U^x_{cm}A_{acbm}.
+- \tfrac12\sum_{ab}\sum_{nm}^{\alloc}P_{ab}S^{(x)}_{nm}A_{anbm}
++ \sum_{ab}\sum_{d}^{\vir}\sum_{m}^{\alloc}P_{ab}U^x_{dm}A_{adbm}.
 \label{eq:vv-sub}
 \end{equation}
 
@@ -470,8 +471,8 @@ The terms carrying an overlap derivative $S^{(x)}$ match the energy-weighted
 density $\sum_{pq}S^{(x)}_{pq}I''_{pq}$, so they join $I''$,
 \begin{equation}
 \tilde{I}''_{ij} = I''_{ij} - P_{ij}\varepsilon_j
-- \tfrac12\sum_{kl}^{\occ}P_{kl}A_{kilj}
-- \tfrac12\sum_{cd}^{\vir}P_{cd}A_{cidj},
+- \tfrac12\sum_{kl}^{\alloc}P_{kl}A_{kilj}
+- \tfrac12\sum_{de}^{\vir}P_{de}A_{diej},
 \qquad
 \tilde{I}''_{ab} = I''_{ab} - P_{ab}\varepsilon_b
 \label{eq:Idouble-tilde}
@@ -480,19 +481,19 @@ density $\sum_{pq}S^{(x)}_{pq}I''_{pq}$, so they join $I''$,
 Eqs.~\eqref{eq:oo-sub} and \eqref{eq:vv-sub}, which multiply an
 occupied--occupied overlap $S^{(x)}_{nm}$).
 
-The final terms carry an occ-vir rotation coefficient $U^x_{cm}$ ($c$ virtual, $m$
+The final terms carry an occ-vir rotation coefficient $U^x_{dm}$ ($d$ virtual, $m$
 occupied).  Unlike the occ-occ and vir-vir rotations, which the canonical conditions fix
 in closed form through Eqs.~\eqref{eq:canon-oo} and \eqref{eq:canon-vv}, the
 occ-vir
 rotations remain the unknowns of the CPHF problem, so these terms cannot be
 evaluated directly and must instead be carried through the Z-vector.  Because
-$U^x_{cm}$ sits in the same occ-vir block as the orbital term
-$2\sum_{ai}U^x_{ai}X_{ai}$, renaming the dummy label $(c,m)\to(a,i)$ lets the two
+$U^x_{dm}$ sits in the same occ-vir block as the orbital term
+$2\sum_{ai}U^x_{ai}X_{ai}$, renaming the dummy label $(d,m)\to(a,i)$ lets the two
 be added under a single sum $\sum_{ai}U^x_{ai}(\cdots)$; factoring the common $2$
 then augments the Z-vector right-hand side $X_{ai}$ of \S\ref{sec:cphf-z} to
 \begin{equation}
 \tilde{X}_{ai} = X_{ai}
-+ \tfrac12\sum_{kl}^{\occ}P_{kl}\,A_{kali}
++ \tfrac12\sum_{kl}^{\alloc}P_{kl}\,A_{kali}
 + \tfrac12\sum_{de}^{\vir}P_{de}\,A_{daei}.
 \label{eq:Xtilde}
 \end{equation}
@@ -530,7 +531,7 @@ with $X_{ai}=I'_{ia}-I'_{ai}$.
 \begin{equation*}
 I_{ai}=I''_{ai}+Z_{ai}\varepsilon_i,\quad
 I_{ia}=I''_{ia}+Z_{ai}\varepsilon_i,\quad
-I_{ij}=I''_{ij}+\sum_{a}^{\vir}\sum_{k}^{\occ} Z_{ak}A_{aikj},\quad
+I_{ij}=I''_{ij}+\sum_{a}^{\vir}\sum_{k}^{\alloc} Z_{ak}A_{aikj},\quad
 I_{ab}=I''_{ab}.
 \end{equation*}
 \end{enumerate}
@@ -552,15 +553,15 @@ solve.  Augment the one-particle density,
 the energy-weighted density,
 \begin{equation*}
 \tilde{I}''_{ij} = I''_{ij} - P_{ij}\varepsilon_j
-- \tfrac12\sum_{kl}^{\occ}P_{kl}A_{kilj}
-- \tfrac12\sum_{cd}^{\vir}P_{cd}A_{cidj},
+- \tfrac12\sum_{kl}^{\alloc}P_{kl}A_{kilj}
+- \tfrac12\sum_{de}^{\vir}P_{de}A_{diej},
 \qquad
 \tilde{I}''_{ab} = I''_{ab} - P_{ab}\varepsilon_b;
 \end{equation*}
 and the Z-vector right-hand side,
 \begin{equation*}
 \tilde{X}_{ai} = X_{ai}
-+ \tfrac12\sum_{kl}^{\occ}P_{kl}A_{kali}
++ \tfrac12\sum_{kl}^{\alloc}P_{kl}A_{kali}
 + \tfrac12\sum_{de}^{\vir}P_{de}A_{daei}.
 \end{equation*}
 \item Solve the single Z-vector equation
@@ -573,7 +574,7 @@ blocks from step~3 and $\tilde{I}''$ in place of $I''$,
 \begin{equation*}
 I_{ai}=\tilde{I}''_{ai}+Z_{ai}\varepsilon_i,\quad
 I_{ia}=\tilde{I}''_{ia}+Z_{ai}\varepsilon_i,\quad
-I_{ij}=\tilde{I}''_{ij}+\sum_{a}^{\vir}\sum_{k}^{\occ} Z_{ak}A_{aikj},\quad
+I_{ij}=\tilde{I}''_{ij}+\sum_{a}^{\vir}\sum_{k}^{\alloc} Z_{ak}A_{aikj},\quad
 I_{ab}=\tilde{I}''_{ab}.
 \end{equation*}
 \end{enumerate}
@@ -673,7 +674,7 @@ the MO basis:
 \frac{\partial f^{(x)}_{pq}}{\partial y}
 &= f^{(xy)}_{pq}
 + \sum_{t}^{\so}\left(U^y_{tp} f^{(x)}_{tq} + U^y_{tq} f^{(x)}_{pt}\right)
-+ \sum_{t}^{\so}\sum_{m}^{\occ} U^y_{tm}\,A^{(x)}_{ptqm},
++ \sum_{t}^{\so}\sum_{m}^{\alloc} U^y_{tm}\,A^{(x)}_{ptqm},
 \label{eq:df-skel-dy}\\
 \frac{\partial \adb{pq}{rs}^{(x)}}{\partial y}
 &= \adb{pq}{rs}^{(xy)}
@@ -692,7 +693,7 @@ counterpart of the pair combination $A_{pqrs}$ of \S\ref{sec:first-derivs}, and 
 $\adb{pq}{rs}^{(xy)}$, and $S^{(xy)}$ are the doubly-skeleton integrals.  The
 occupied-sum term of \eqref{eq:df-skel-dy} arises from the $y$-rotation of the
 summed occupied index in the two-electron part of the skeleton Fock derivative
-$f^{(x)}_{pq}=h^{(x)}_{pq}+\sum_m^{\occ}\adb{pm}{qm}^{(x)}$.
+$f^{(x)}_{pq}=h^{(x)}_{pq}+\sum_m^{\alloc}\adb{pm}{qm}^{(x)}$.
 
 In the next three terms, the {\em first-order responses} of the densities,
 $\partial\tilde D/\partial y$, $\partial \Gamma/\partial y$, and
@@ -765,7 +766,7 @@ second derivative becomes
 + \sum_{pq} I_{pq} S^{(xy)}_{pq}
 \nonumber\\
 &\quad
-+ 2\sum_{a}^{\vir}\sum_{i}^{\occ} U^y_{ai}\,X^{(x)}_{ai}
++ 2\sum_{a}^{\vir}\sum_{i}^{\alloc} U^y_{ai}\,X^{(x)}_{ai}
 + \sum_{pq} S^{(y)}_{pq}\,I''^{(x)}_{pq}
 \nonumber\\
 &\quad
@@ -809,9 +810,9 @@ perturbation $y$.  In direct analogy to the canonical first-derivative gradient
 + \sum_{pq} I_{pq} S^{(xy)}_{pq}
 \nonumber\\
 &\quad
-- \sum_{ij} U^y_{ij} X^{(x)}_{ij}
+- \sum_{ij}^{\alloc} U^y_{ij} X^{(x)}_{ij}
 - \sum_{ab} U^y_{ab} X^{(x)}_{ab}
-+ 2\sum_{a}^{\vir}\sum_{i}^{\occ} U^y_{ai} X^{(x)}_{ai}
++ 2\sum_{a}^{\vir}\sum_{i}^{\alloc} U^y_{ai} X^{(x)}_{ai}
 + \sum_{pq} S^{(y)}_{pq} I''^{(x)}_{pq}
 \nonumber\\
 &\quad
@@ -825,7 +826,7 @@ $X^{(x)}_{ab}=I'^{(x)}_{ab}-I'^{(x)}_{ba}$ joining the $X^{(x)}_{ai}$ and
 $I''^{(x)}_{pq}$ of Eq.~\eqref{eq:d2E-noncanon}.  The occupied--occupied and
 virtual--virtual coefficients $U^y_{ij}$, $U^y_{ab}$ are now evaluated in closed
 form from Eqs.~\eqref{eq:canon-oo}--\eqref{eq:canon-vv} (in terms of $f^{(y)}$,
-$S^{(y)}$, and the occupied--virtual $U^y_{cm}$ that the CPHF solve supplies),
+$S^{(y)}$, and the occupied--virtual $U^y_{dm}$ that the CPHF solve supplies),
 while $U^y_{ai}$ is the same CPHF solution required in the non-canonical case.
 
 As in \S\ref{sec:cphf-z-canon}, the explicit $U^y_{ij}$ and $U^y_{ab}$ may be eliminated in favor of
@@ -834,13 +835,13 @@ for $U^y_{ij}$ and introducing the occupied--occupied dependent pair
 $P^{(x)}_{ij}=X^{(x)}_{ij}/(\varepsilon_i-\varepsilon_j)$ [cf.\ Eq.~\eqref{eq:Poo}],
 the occupied--occupied orbital-response term becomes
 \begin{align}
--\sum_{ij}U^y_{ij}X^{(x)}_{ij}
-&= \sum_{ij}P^{(x)}_{ij}f^{(y)}_{ij}
-- \sum_{ij}P^{(x)}_{ij}S^{(y)}_{ij}\varepsilon_j
+-\sum_{ij}^{\alloc}U^y_{ij}X^{(x)}_{ij}
+&= \sum_{ij}^{\alloc}P^{(x)}_{ij}f^{(y)}_{ij}
+- \sum_{ij}^{\alloc}P^{(x)}_{ij}S^{(y)}_{ij}\varepsilon_j
 \nonumber\\
 &\quad
-- \tfrac12\sum_{ij}\sum_{nm}^{\occ}P^{(x)}_{ij}S^{(y)}_{nm}A_{injm}
-+ \sum_{ij}\sum_{c}^{\vir}\sum_{m}^{\occ}P^{(x)}_{ij}U^y_{cm}A_{icjm},
+- \tfrac12\sum_{ij}^{\alloc}\sum_{nm}^{\alloc}P^{(x)}_{ij}S^{(y)}_{nm}A_{injm}
++ \sum_{ij}^{\alloc}\sum_{d}^{\vir}\sum_{m}^{\alloc}P^{(x)}_{ij}U^y_{dm}A_{idjm},
 \label{eq:oo-sub-2}
 \end{align}
 and the virtual block follows identically with
@@ -849,7 +850,7 @@ groups go where their \S\ref{sec:cphf-z-canon} counterparts did, now driven by $
 overlap and rotation coefficients of the {\em second} perturbation: the
 overlap-derivative terms (second and third) augment $I''^{(x)}$ to
 $\tilde I''^{(x)}$ [the analog of Eq.~\eqref{eq:Idouble-tilde}], and the term
-carrying $U^y_{cm}$ augments $X^{(x)}_{ai}$ to $\tilde X^{(x)}_{ai}$ [the analog
+carrying $U^y_{dm}$ augments $X^{(x)}_{ai}$ to $\tilde X^{(x)}_{ai}$ [the analog
 of Eq.~\eqref{eq:Xtilde}], which the CPHF solution $U^y_{ai}$ then multiplies.
 The leading group, however, has no first-derivative counterpart:
 $\sum_{ij}P^{(x)}_{ij}f^{(y)}_{ij}+\sum_{ab}P^{(x)}_{ab}f^{(y)}_{ab}$ contracts the
@@ -866,9 +867,9 @@ mixed second derivative is
 + \sum_{pq} I_{pq} S^{(xy)}_{pq}
 \nonumber\\
 &\quad
-+ \sum_{ij}P^{(x)}_{ij}f^{(y)}_{ij}
++ \sum_{ij}^{\alloc}P^{(x)}_{ij}f^{(y)}_{ij}
 + \sum_{ab}P^{(x)}_{ab}f^{(y)}_{ab}
-+ 2\sum_{a}^{\vir}\sum_{i}^{\occ} U^y_{ai}\,\tilde X^{(x)}_{ai}
++ 2\sum_{a}^{\vir}\sum_{i}^{\alloc} U^y_{ai}\,\tilde X^{(x)}_{ai}
 + \sum_{pq} S^{(y)}_{pq}\,\tilde I''^{(x)}_{pq}
 \nonumber\\
 &\quad
@@ -970,7 +971,7 @@ terms
 \begin{align}
 \frac{\partial\tilde X_{ai}}{\partial y}
 &= \frac{\partial X_{ai}}{\partial y}
-+ \tfrac12\sum_{kl}^{\occ}\left(\frac{\partial P_{kl}}{\partial y}A_{kali}
++ \tfrac12\sum_{kl}^{\alloc}\left(\frac{\partial P_{kl}}{\partial y}A_{kali}
    + P_{kl}\frac{\partial A_{kali}}{\partial y}\right)
 \nonumber\\
 &\quad
@@ -1119,7 +1120,7 @@ Take $U^y_{ij}=-\tfrac12 S^{(y)}_{ij}$ and $U^y_{ab}=-\tfrac12 S^{(y)}_{ab}$.
 \item The orbital-response term is
 \begin{equation*}
 (\text{orbital response}) =
-2\sum_{a}^{\vir}\sum_{i}^{\occ}U^y_{ai}\,X^{(x)}_{ai}
+2\sum_{a}^{\vir}\sum_{i}^{\alloc}U^y_{ai}\,X^{(x)}_{ai}
 + \sum_{pq}S^{(y)}_{pq}\,I''^{(x)}_{pq}.
 \end{equation*}
 \item Solve the perturbed Z-vector
@@ -1164,24 +1165,24 @@ P^{(x)}_{ab}=\frac{X^{(x)}_{ab}}{\varepsilon_a-\varepsilon_b};
 fold them into the energy-weighted density,
 \begin{equation*}
 \tilde I''^{(x)}_{ij} = I''^{(x)}_{ij} - P^{(x)}_{ij}\varepsilon_j
-- \tfrac12\sum_{kl}^{\occ}P^{(x)}_{kl}A_{kilj}
-- \tfrac12\sum_{cd}^{\vir}P^{(x)}_{cd}A_{cidj},
+- \tfrac12\sum_{kl}^{\alloc}P^{(x)}_{kl}A_{kilj}
+- \tfrac12\sum_{de}^{\vir}P^{(x)}_{de}A_{diej},
 \qquad
 \tilde I''^{(x)}_{ab} = I''^{(x)}_{ab} - P^{(x)}_{ab}\varepsilon_b,
 \end{equation*}
 and into the occupied--virtual combination,
 \begin{equation*}
 \tilde X^{(x)}_{ai} = X^{(x)}_{ai}
-+ \tfrac12\sum_{kl}^{\occ}P^{(x)}_{kl}A_{kali}
++ \tfrac12\sum_{kl}^{\alloc}P^{(x)}_{kl}A_{kali}
 + \tfrac12\sum_{de}^{\vir}P^{(x)}_{de}A_{daei}.
 \end{equation*}
 \item The orbital-response term is
 \begin{equation*}
 \begin{split}
 (\text{orbital response}) = {}&
-\sum_{ij}P^{(x)}_{ij}f^{(y)}_{ij}
+\sum_{ij}^{\alloc}P^{(x)}_{ij}f^{(y)}_{ij}
 + \sum_{ab}P^{(x)}_{ab}f^{(y)}_{ab} \\
-&+ 2\sum_{a}^{\vir}\sum_{i}^{\occ}U^y_{ai}\,\tilde X^{(x)}_{ai}
+&+ 2\sum_{a}^{\vir}\sum_{i}^{\alloc}U^y_{ai}\,\tilde X^{(x)}_{ai}
 + \sum_{pq}S^{(y)}_{pq}\,\tilde I''^{(x)}_{pq}.
 \end{split}
 \end{equation*}
@@ -1201,7 +1202,7 @@ $\mathbf{G}^{T}\,\partial\mathbf{Z}/\partial y
 with the dependent-pair-augmented source
 \begin{align*}
 \frac{\partial\tilde X_{ai}}{\partial y}=\frac{\partial X_{ai}}{\partial y}
-&+ \tfrac12\sum_{kl}^{\occ}\Big(\frac{\partial P_{kl}}{\partial y}A_{kali}
+&+ \tfrac12\sum_{kl}^{\alloc}\Big(\frac{\partial P_{kl}}{\partial y}A_{kali}
    + P_{kl}\frac{\partial A_{kali}}{\partial y}\Big)\\
 &+ \tfrac12\sum_{de}^{\vir}\Big(\frac{\partial P_{de}}{\partial y}A_{daei}
    + P_{de}\frac{\partial A_{daei}}{\partial y}\Big),
@@ -1731,6 +1732,7 @@ blocks vanishing.  As in the CCSD case the $\Gamma$ responses carry the overall
 $\frac14$; $\partial_x D$ needs no prefactor.
 
 \section{Frozen Core}
+\label{sec:frozen-core}
 
 The frozen-core approximation removes a set of low-lying (core) orbitals from
 the correlation treatment, splitting the occupied space into core
@@ -1762,7 +1764,10 @@ relaxed density as the occupied dependent pair of \S\ref{sec:cphf-z-canon} does,
 \end{equation}
 with the overlap-derivative terms folded into $\tilde{I}''$ and the occ-vir-response
 coupling into $\tilde{X}$ through Eqs.~\eqref{eq:Idouble-tilde} and
-\eqref{eq:Xtilde}, the pair-sum now running over $(c,i)$.  Two further
+\eqref{eq:Xtilde}.  No new terms appear: the occupied dependent-pair sums in those
+equations already carry the $\alloc$ limit (core plus active), so the
+core$\leftrightarrow$active pairs enter simply as the extra nonzero entries of $P$
+that the $\alloc$ range now covers.  Two further
 adjustments distinguish the frozen-core case: (1) 
 either the canonical or non-canonical perturbed MO conditions must be applied
 to the core-core block; and (2) the occupied$\leftrightarrow$virtual orbital

--- a/pycc/correlatedderivs.py
+++ b/pycc/correlatedderivs.py
@@ -84,6 +84,8 @@ class CorrelatedDerivs:
         a future non-canonical-(T) route (building the full (T) density) would override this.  The
         frozen-core core<->active-occupied divide ``P_co`` is always canonical, independent of this
         choice."""
+        if getattr(self, '_gauge_override', None) is not None:
+            return self._gauge_override   # test/validation override (e.g. force canonical for CCSD)
         return 'canonical' if getattr(self.wfn, 'model', '').upper() == 'CCSD(T)' else 'non-canonical'
 
     def _full_occ_cphf(self):
@@ -766,10 +768,13 @@ class CorrelatedDerivs:
 
         with the 3 field responses ``d_a D_rel``, ``d_a Gamma``, and the perturbed energy-weighted
         density ``d_a I`` all from one :class:`PerturbedResponse` per field
-        (:meth:`_perturbed_relaxed_density`).  The field-derivatives of the nuclear skeletons carry
-        the orbital rotation ``rotate(U^a, .)`` plus, for ``d_a f^(X)``, the occupied-sum response and
-        the ``-mu_a^(X)`` mixed skeleton (the field enters ``h``).  Both routes give the same tensor;
-        ``'2n+1-field'`` is cheaper (3 field responses vs ``3N`` nuclear)."""
+        (:meth:`_perturbed_relaxed_density`).  The orbital-response term ``D_rel d_a f^(X)`` is
+        assembled in the reference-doc form (eq:d2E-canon-final line 2): with the field skeleton
+        ``f^(a) = -mu``, ``S^(a) = 0``, ``<>^(a) = 0``, the only surviving pieces are ``2 U^a_bi
+        X~^(X)_bi`` and ``P^(X)_pq f^(a)_pq`` (from :meth:`_skeleton_lagrangian` and
+        :meth:`_augment_with_canonical_pair_rotations`), plus the fixed-density mixed skeleton
+        ``D_rel f^(Xa)`` with ``f^(Xa) = -mu^(X)`` (the field enters ``h``).  Both routes give the same
+        tensor; ``'2n+1-field'`` is cheaper (3 field responses vs ``3N`` nuclear)."""
         if route not in ('2n+1-nuclear', '2n+1-field'):
             raise ValueError(f"unknown dipole-derivative route {route!r} "
                              "(use '2n+1-nuclear' or '2n+1-field')")
@@ -777,7 +782,7 @@ class CorrelatedDerivs:
         wfn = self.wfn
         c = self.contract
         so = wfn.orbital_basis == 'spinorbital'
-        o = wfn.o
+        o, v = wfn.o, wfn.v
         ofull = slice(0, o.stop)
         ncore = o.stop - wfn.no
         canonical = self.perturbed_mo_gauge == 'canonical'
@@ -813,13 +818,6 @@ class CorrelatedDerivs:
         dI = [r.dI for r in resp]                                     # perturbed energy-weighted density
         U = [np.asarray(cphf.full_U(field[a], ncore, canonical=canonical)) for a in range(3)]
 
-        def rot1(Um, M):
-            return Um.T @ M + M @ Um
-
-        def rot4(Um, T):
-            return (c('tp,tqrs->pqrs', Um, T) + c('tq,ptrs->pqrs', Um, T)
-                    + c('tr,pqts->pqrs', Um, T) + c('ts,pqrt->pqrs', Um, T))
-
         for A in range(natom):
             hx = d.so_core(A) if so else d.core(A)
             Sx = d.so_overlap(A) if so else d.overlap(A)
@@ -835,16 +833,27 @@ class CorrelatedDerivs:
                 fX = np.asarray(hx[beta]) + c('pmqm->pq', eriL[beta][:, ofull, :, ofull])
                 SX = np.asarray(Sx[beta])
                 eriXb, eriLb = eriX[beta], eriL[beta]                 # this Cartesian's X-skeletons
+                # Reference-doc form (eq:d2E-canon-final): build the nuclear (X) orbital-response
+                # carriers once per (A, beta) from the X-skeletons, then contract with the field (F)
+                # per alpha.  The field skeleton is f^(F) = -mu, S^(F) = 0, <>^(F) = 0, so the only
+                # surviving orbital-response terms are 2 U^F X~^(X) and P^(X) f^(F); the fixed-density
+                # mixed skeleton is D~ f^(XF) with f^(XF) = d(-mu)/dX = -muX (no <>^(XF)/S^(XF)).
+                Ip, xov, i2 = self._skeleton_lagrangian(fX, SX, eriLb, eriXb, Drel, Gam, I)
+                if canonical or ncore:
+                    Xt, _, Pf = self._augment_with_canonical_pair_rotations(Ip, xov, i2)
+                else:
+                    Xt, Pf = xov, None
                 for alpha in range(3):
                     Um = U[alpha]
                     muX = np.asarray(dip[alpha * 3 + beta])
-                    occ = (c('rm,prqm->pq', Um[:, ofull], eriLb[:, :, :, ofull])
-                           + c('rm,pmqr->pq', Um[:, ofull], eriLb[:, ofull, :, :]))
-                    dfX = rot1(Um, fX) - muX + occ
-                    P[A, beta, alpha] = -(c('pq,pq->', dDrel[alpha], fX) + c('pq,pq->', Drel, dfX)
-                                          + c('pqrs,pqrs->', dGamF[alpha], eriXb)
-                                          + c('pqrs,pqrs->', Gam, rot4(Um, eriXb))
-                                          + c('pq,pq->', dI[alpha], SX) + c('pq,pq->', I, rot1(Um, SX)))
+                    orb = 2.0 * c('ai,ai->', Um[v, ofull], Xt[v, ofull])          # 2 U^F_ai X~^(X)_ai
+                    if Pf is not None:
+                        orb = orb - c('pq,pq->', Pf, mu[alpha])                   # P^(X)_pq f^(F)_pq, f^(F)=-mu
+                    P[A, beta, alpha] = -(c('pq,pq->', dDrel[alpha], fX)          # 2n+1 D response
+                                          + c('pqrs,pqrs->', dGamF[alpha], eriXb)   # 2n+1 Gamma response
+                                          + c('pq,pq->', dI[alpha], SX)           # 2n+1 I response
+                                          - c('pq,pq->', Drel, muX)               # D~ f^(XF), f^(XF) = -muX
+                                          + orb)
         return P
 
     def hessian(self) -> np.ndarray:
@@ -871,26 +880,26 @@ class CorrelatedDerivs:
         energy-weighted density ``d_Y I``, and ``d_Y Gamma`` all from one :class:`PerturbedResponse`
         per nucleus (:meth:`_perturbed_relaxed_density`), plus ``U^Y`` (:meth:`CPHF.full_U`).
 
-        The field-derivatives of the nuclear skeletons carry (i) the full second integral skeletons
-        ``f^(XY)``/``<>^(XY)``/``S^(XY)`` (:meth:`Derivatives.nuclear_hessian_skeletons`, cached per atom pair -- all
-        nonzero here, unlike the field case where only ``-mu^(X)`` survived), and (ii) the ``U^Y``
-        orbital rotation of the ``X`` skeletons.  The rotations are hoisted off the ``O(N^2)`` pair
-        loop onto the (per-``Y``) densities via ``sum A rot(U,B) = sum rot(U^T,A) B``:
-        ``Drot = U D + D U^T``, ``Irot`` likewise, ``Gamrot = rot4(U^T, Gamma)``, and the Fock
-        skeleton's occupied-sum response as the per-``X`` intermediate ``J^X`` contracted with
-        ``U^Y`` (so no ``O(N^2)`` four-index rotation).
+        The mixed second derivative assembles three groups (reference-doc eq:d2E-noncanon /
+        eq:d2E-canon-final): (i) the fixed-density second integral skeletons contracted with the
+        unperturbed relaxed densities, ``D~ f^(XY) + Gamma <>^(XY) + I S^(XY)``
+        (:meth:`Derivatives.nuclear_hessian_skeletons`, cached per atom pair -- all nonzero here,
+        unlike the field case where only ``-mu^(X)`` survives); (ii) the orbital response in the doc
+        form ``2 U^Y_ai X~^(X)_ai + S^(Y)_pq I~''^(X)_pq + P^(X)_pq f^(Y)_pq``, built per ``X`` from the
+        skeleton Lagrangian (:meth:`_skeleton_lagrangian`, :meth:`_augment_with_canonical_pair_rotations`);
+        and (iii) the 2n+1 density response ``d_Y D~ f^(X) + d_Y Gamma <>^(X) + d_Y I S^(X)``.
 
-        Local naming: a trailing ``X`` marks a *skeleton integral derivative* (``fX`` = ``f^(X)``,
-        ``SX`` = ``S^(X)``, ``eriX`` = ``<pq|rs>^(X)`` spatial / ``<pq||rs>^(X)`` spin-orbital) --
-        never a density derivative.  ``eriL``/``eL`` is the Fock-building companion of ``eriX``: the
-        spin-adapted ``L^(X) = 2<pq|rs>^(X) - <pq|sr>^(X)`` (closed-shell), or ``eriX`` itself when
-        the integrals are already antisymmetrized (spin-orbital).  A trailing ``rot`` marks a
-        ``U``-rotated *unperturbed* quantity
-        (``Drot``, ``Irot``, ``Gamrot``); this is the code's own rotation bookkeeping and is unrelated
-        to the tilde of the theory notes (which marks the relaxed 1-PDM ``D~`` = ``Drel`` and the
-        augmented ``I''~``).  A trailing ``N``/``F`` on a perturbed-response array names the
-        *perturbation* it responds to -- nuclear here (``dGamN`` = ``d_Y Gamma``), field in the
-        ``'2n+1-field'`` APT (``dGamF``); both are the ``dGam`` of :class:`PerturbedResponse`.
+        Local naming: a trailing ``X``/``x`` marks a *skeleton integral derivative* (``fX`` = ``f^(X)``,
+        ``SX`` = ``S^(X)``, ``erix``/``erX`` = ``<pq|rs>^(X)`` spatial / ``<pq||rs>^(X)`` spin-orbital) --
+        never a density derivative.  ``wx`` is the Fock-building companion of ``erix``: the
+        spin-adapted ``L^(X) = 2<pq|rs>^(X) - <pq|sr>^(X)`` (closed-shell), or ``erix`` itself when
+        the integrals are already antisymmetrized (spin-orbital).  (:meth:`dipole_derivatives` builds
+        the same two kernels under the names ``eriX``/``eriL``.)  ``X~``/``I~''`` (``Xx``/``I2x``) and
+        ``P^(x)`` (``Pf_x``) are the dependent-pair-augmented skeleton carriers from
+        :meth:`_augment_with_canonical_pair_rotations`; ``D~`` = ``Drel`` is the relaxed 1-PDM of the
+        theory notes.  A trailing ``N``/``F`` on a perturbed-response array names the *perturbation* it
+        responds to -- nuclear here (``dGamN`` = ``d_Y Gamma``), field in the ``'2n+1-field'`` APT
+        (``dGamF``); both are the ``dGam`` of :class:`PerturbedResponse`.
 
         The reference and nuclear parts are separate and summed with this correlation part by
         :func:`pycc.hessian`."""
@@ -898,8 +907,17 @@ class CorrelatedDerivs:
         wfn = self.wfn
         c = self.contract
         so = wfn.orbital_basis == 'spinorbital'
-        ofull = slice(0, wfn.o.stop)
+        o, v, ofull = wfn.o, wfn.v, slice(0, wfn.o.stop)
         ncore = wfn.o.stop - wfn.no
+        co = slice(0, ncore)                                  # frozen core (independent core<->active rot.)
+        eps = np.diag(np.asarray(wfn.H.F))                    # orbital energies (dependent pairs)
+        w = np.asarray(wfn.H.ERI if so else wfn.H.L)          # orbital-Hessian weight (<pq||rs> / L)
+        # The orbital response uses the reference-doc form (eq:d2E-noncanon line 2, or
+        # eq:d2E-canon-final when canonical) via the skeleton Lagrangian I'^(x).  The gauge follows
+        # perturbed_mo_gauge (canonical for CCSD(T)); the relaxed densities Drel/dDrel already fold in
+        # P_oo/P_vv (they are D~), so the canonical branch adds only the *orbital*-response
+        # augmentation (Sum P^(x) f^(y), X~^(x), I~''^(x)).  To exercise canonical for a CCSD wfn
+        # (valid, oo/vv-invariant) set self._gauge_override = 'canonical' on a fresh driver.
         canonical = self.perturbed_mo_gauge == 'canonical'
         cphf = self._full_occ_cphf()
         d = wfn.derivatives
@@ -910,41 +928,41 @@ class CorrelatedDerivs:
         I = self._lagrangian(Drel, Gam)
         pert = [Perturbation('nuclear', (A, ct)) for A in range(natom) for ct in range(3)]
 
-        def rot4(Um, T):
-            return (c('tp,tqrs->pqrs', Um, T) + c('tq,ptrs->pqrs', Um, T)
-                    + c('tr,pqts->pqrs', Um, T) + c('ts,pqrt->pqrs', Um, T))
-
-        # first-order responses + hoisted per-Y rotated densities (sum A rot(U,B) = sum rot(U^T,A) B).
-        # The large per-perturbation nmo^4 quantities live in the persistent store
-        # (wfn.derivatives.store): _relaxed_response persists each dGam and _eri_cached persists the
-        # per-atom eri stacks, so the assembly reads them back one atom pair at a time rather than
-        # holding 3*natom-long in-RAM lists.  Gamrot is recomputed per Y (not hoisted into a list).
-        # Only the small quantities (dDrel/dI/Drot/Irot/U and the nmo^2 fX/SX/JX) stay resident.
+        # first-order responses.  The large per-perturbation nmo^4 quantities live in the persistent
+        # store (wfn.derivatives.store): _relaxed_response persists each dGam and _eri_cached persists
+        # the per-atom eri stacks, so the assembly reads them back one atom pair at a time rather than
+        # holding 3*natom-long in-RAM lists.  Only the small quantities (dDrel/dI/U and the nmo^2
+        # fX/SX/Xx/I2x/Pf_x) stay resident.
         dDrel, dI, U = [], [], []
         for i, p in enumerate(pert):
             r = self._relaxed_response(p)                            # one perturbed solve; persists dGam
             dDrel.append(r.dDrel)
             dI.append(r.dI)
             U.append(np.asarray(cphf.full_U(p, ncore, canonical=canonical)))
-        Drot = [U[i] @ Drel + Drel @ U[i].T for i in range(nc)]
-        Irot = [U[i] @ I + I @ U[i].T for i in range(nc)]
 
-        # per-X first skeletons; J^X carries the Fock skeleton's occupied-sum rotation response.
-        # Reading d.eri/d.so_eri here also warms the store's per-atom eri stacks for the assembly.
-        fX, SX, JX = [], [], []
+        # per-X first skeletons.  wx = the 1-PDM two-electron kernel (L^(x) closed-shell /
+        # <pq||rs>^(x) spin-orbital); erix = the 2-PDM ERI skeleton (<pq|rs>^(x) closed-shell /
+        # <pq||rs>^(x) SO -- in SO the single antisymmetrized <pq||rs>^(x) serves both).  The per-X
+        # skeleton Lagrangian I'^(x) gives X^(x)/I''^(x) (X~^(x)/I~''^(x)/P^(x) when canonical or
+        # frozen-core).  Reading d.eri/d.so_eri here also warms the store.
+        fX, SX, Xx, I2x, Pf_x = [], [], [], [], []
         for i, p in enumerate(pert):
             A, ct = p.comp
             hx = np.asarray((d.so_core(A) if so else d.core(A))[ct])
             Sx = np.asarray((d.so_overlap(A) if so else d.overlap(A))[ct])
             if so:
-                eL = np.asarray(d.so_eri(A)[ct])
+                erix = np.asarray(d.so_eri(A)[ct]); wx = erix          # <pq||rs>^(X): both kernels
             else:
-                ph = np.asarray(d.eri(A)[ct])                           # <pq|rs>^(X) (Gamma)
-                eL = 2.0 * ph - ph.transpose(0, 1, 3, 2)                # L^X (Fock)
-            fX.append(hx + c('pmqm->pq', eL[:, ofull, :, ofull]))
+                erix = np.asarray(d.eri(A)[ct])                        # <pq|rs>^(X) (2-PDM / Gamma)
+                wx = 2.0 * erix - erix.transpose(0, 1, 3, 2)           # L^X (1-PDM / Fock)
+            fX.append(hx + c('pmqm->pq', wx[:, ofull, :, ofull]))
             SX.append(Sx)
-            JX.append(c('pq,prqm->rm', Drel, eL[:, :, :, ofull])
-                      + c('pq,pmqr->rm', Drel, eL[:, ofull, :, :]))
+            Ip, xov, i2 = self._skeleton_lagrangian(fX[i], Sx, wx, erix, Drel, Gam, I)
+            if canonical or ncore:        # independent core<->active (FC) and/or redundant oo/vv (canon.)
+                xt, it, pf = self._augment_with_canonical_pair_rotations(Ip, xov, i2)
+                Xx.append(xt); I2x.append(it); Pf_x.append(pf)
+            else:
+                Xx.append(xov); I2x.append(i2); Pf_x.append(None)
 
         # ---- assembly: atom-pair-outer contract-and-discard ----
         # Loop unique atom pairs, compute each pair's 2nd-deriv skeletons ONCE (cache=False, so
@@ -953,12 +971,16 @@ class CorrelatedDerivs:
         # I.ov2 uses only Drel/Gam/I and is symmetric in the pair (d2/dA dB = d2/dB dA), so it is
         # shared by H[ix,iy] and its transpose H[iy,ix]; only the response half differs.  The pair's
         # nmo^4 working set (dGam + eriX for its <= 6 perturbations) is read from the store here.
-        def _dGs(j):        # stored cumulant response dGam[j] + the per-Y rotation (recomputed)
-            return self._relaxed_response(pert[j]).dGam + rot4(U[j].T, Gam)
+        def _dGs(j):        # bare cumulant response dGam[j] (the doc form needs no U^y rotation)
+            return self._relaxed_response(pert[j]).dGam
 
-        def _resp(i, j, dGs_j, erX_i):     # perturbation-dependent half of H[i, j]
-            return (c('pq,pq->', dDrel[j] + Drot[j], fX[i]) + c('pqrs,pqrs->', dGs_j, erX_i)
-                    + c('pq,pq->', dI[j] + Irot[j], SX[i]) + float(np.sum(U[j][:, ofull] * JX[i])))
+        def _resp(i, j, dGam_j, erX_i):   # 2n+1 density response + doc orbital response (line 2)
+            orb = (2.0 * c('ai,ai->', U[j][v, ofull], Xx[i][v, ofull])  # 2 U^y_ai X(~)^(x)_ai
+                   + c('pq,pq->', SX[j], I2x[i]))                       # S^(y)_pq I(~)''^(x)_pq
+            if Pf_x[i] is not None:
+                orb = orb + c('pq,pq->', Pf_x[i], fX[j])               # + Sum P^(x)_pq f^(y)_pq
+            return (c('pq,pq->', dDrel[j], fX[i]) + c('pqrs,pqrs->', dGam_j, erX_i)
+                    + c('pq,pq->', dI[j], SX[i]) + orb)
 
         def _skel_scalar(blk, cx, cy):     # fixed-density second-skeleton scalar s for (cx, cy)
             core2 = blk['core'][cx * 3 + cy]
@@ -1007,9 +1029,12 @@ class CorrelatedDerivs:
         Numerator-gated (``|Delta I'| < thresh`` -> 0), skipping the diagonal (``m=n``) and
         near-degenerate pairs.  ``P`` is symmetric (numerator and denominator both antisymmetric).
 
-        This is the frozen-core core<->active-occupied divide generalized to an arbitrary square
-        block; it also supplies the active oo/vv rotations of the canonical perturbed-MO gauge
-        (:attr:`perturbed_mo_gauge`, used by :meth:`_orbital_response` / :meth:`_so_orbital_response`)."""
+        Supplies the *redundant* active oo/vv canonical rotations of the canonical perturbed-MO gauge
+        (:attr:`perturbed_mo_gauge`; used by :meth:`_orbital_response` / :meth:`_so_orbital_response`
+        and the Hessian ``_pair_augment``).  The same divide also fixes the *independent* (non-redundant)
+        frozen-core core<->active-occupied rotation ``P_co``, but that off-diagonal block is built
+        separately as an ungated *direct* divide (its gap is large, so numerator-gating and the
+        degeneracy skip are unnecessary) -- see :meth:`_orbital_response`."""
         num = np.asarray(Iblock) - np.asarray(Iblock).T
         den = eps_block[:, None] - eps_block[None, :]
         P = np.zeros_like(num)
@@ -1037,3 +1062,99 @@ class CorrelatedDerivs:
         m = np.abs(gap) > thresh
         dP[m] = (dnum[m] - np.asarray(Pblock0)[m] * dgap[m]) / gap[m]
         return dP
+
+    # ---- shared per-perturbation orbital-response builders (used by both hessian() and
+    #      dipole_derivatives() when they run in the reference-doc form) ----
+
+    def _skeleton_lagrangian(self, fXx, SXx, wx, erix, Drel, Gam, I):
+        r"""Skeleton-perturbed orbital Lagrangian ``I'^(x)`` for one perturbation ``x`` -- the
+        integral-derivative half of :meth:`_perturbed_lagrangian`, evaluated at *fixed* (unperturbed)
+        relaxed densities ``Drel``/``Gam``/``I``.  Returns the triple ``(I'^(x), X^(x), I''^(x))``
+        with the occupied-virtual orbital-response driver ``X^(x)_ai = I'^(x)_ia - I'^(x)_ai`` and the
+        energy-weighted rewrite ``I''^(x)`` (``I'^(x)`` with its virtual-occupied block transposed into
+        the occupied-virtual position)::
+
+            I'^(x)_pq = -1/2 [ Drel_qr f^(x)_pr + Drel_rq f^(x)_rp
+                               + delta_{q in ofull} Drel_rs ( w^(x)_rpsq + w^(x)_rqsp )
+                               + 4 <pr||st>^(x) Gam_qrst + I_qr S^(x)_pr + I_rq S^(x)_rp ]
+
+        The kernels are the per-perturbation skeleton integral derivatives: ``fXx`` = ``f^(x)``,
+        ``SXx`` = ``S^(x)``, ``wx`` = the 1-PDM two-electron kernel (spin-adapted ``L^(x)`` closed-shell
+        / antisymmetrized ``<pq||rs>^(x)`` spin-orbital), ``erix`` = the 2-PDM ERI skeleton
+        (``<pq|rs>^(x)`` closed-shell / ``<pq||rs>^(x)`` spin-orbital).  Perturbation-agnostic: the
+        caller supplies the nuclear or field skeletons."""
+        c = self.contract
+        wfn = self.wfn
+        v, ofull = wfn.v, slice(0, wfn.o.stop)
+        termA = c('qr,pr->pq', Drel, fXx) + c('rq,rp->pq', Drel, fXx)
+        termB = np.zeros_like(fXx)
+        termB[:, ofull] = (c('rs,rpsq->pq', Drel, wx[:, :, :, ofull])
+                           + c('rs,rqsp->pq', Drel, wx[:, ofull, :, :]))
+        termC = 4.0 * c('prst,qrst->pq', erix, Gam)
+        termD = c('qr,pr->pq', I, SXx) + c('rq,rp->pq', I, SXx)
+        Ip = -0.5 * (termA + termB + termC + termD)
+        I2 = Ip.copy(); I2[v, ofull] = Ip[ofull, v].T
+        return Ip, Ip.T - Ip, I2
+
+    def _augment_with_canonical_pair_rotations(self, Ip, Xov, I2):
+        r"""Add the closed-form (canonical Brillouin) orbital-rotation contributions to the skeleton
+        ``X^(x)``/``I''^(x)`` of :meth:`_skeleton_lagrangian`, for the rotations the CPHF
+        occupied-virtual solve does *not* provide (reference-doc eq:d2E-canon-final line 2, doc lines
+        862-882; the frozen-core (c,i) extension per the Frozen Core section, doc lines 1745-1776).
+
+        Two kinds of rotation enter, both fixed by the canonical condition ``d_x f_pq = 0`` and sharing
+        the divide ``P^(x)_pq = (I'^(x)_pq - I'^(x)_qp)/(eps_p - eps_q)``:
+
+        * the INDEPENDENT (non-redundant) core<->active-occupied rotation ``P^(x)_ci`` -- the energy is
+          not invariant to core<->active mixing, so it is ALWAYS present when there is a frozen core
+          (doc lines 1739-1743); built here as an ungated *direct* divide (its gap is large, so the
+          numerator-gate and degeneracy skip are unnecessary), matching the density's ``Pco``;
+        * the REDUNDANT (dependent) active occ-occ / virt-virt rotations ``P^(x)_ij``/``P^(x)_ab`` --
+          present only in the canonical gauge (CCSD(T)); for CCSD they vanish by invariance and the
+          non-canonical ``-1/2 S`` is used instead.  Built via the numerator-gated
+          :meth:`_dependent_pairs` (degeneracy-safe).
+
+        ``P^(x)`` is folded into the three carriers of the doc's line 2 (occupied pair-sums ``k,l`` run
+        over the full occupied space; ``A_pqrs = w_pqrs + w_psrq`` with ``w`` the unperturbed
+        orbital-Hessian weight, matching :meth:`cphf.CPHF.full_U`)::
+
+            X~^(x)_ai = X^(x)_ai + 1/2 [ Sum_kl P^(x)_kl A_kali + Sum_de P^(x)_de A_daei ]  (eq:Xtilde)
+            I~''^(x)_ij = I''^(x)_ij - P^(x)_ij eps_j
+                          - 1/2 [ Sum_kl P^(x)_kl A_kilj + Sum_de P^(x)_de A_diej ]         (eq:Idouble-tilde)
+            I~''^(x)_ab = I''^(x)_ab - P^(x)_ab eps_b
+
+        Returns ``(X~^(x), I~''^(x), P^(x))`` -- the augmented occupied-virtual Z-vector driver, the
+        augmented energy-weighted skeleton density, and the full-MO ``P^(x)`` (the latter for the
+        leading ``Sum P^(x)_pq f^(y)_pq`` term of eq:d2E-canon-final, which has no first-derivative
+        counterpart)."""
+        c = self.contract
+        wfn = self.wfn
+        so = wfn.orbital_basis == 'spinorbital'
+        o, v, ofull = wfn.o, wfn.v, slice(0, wfn.o.stop)
+        ncore = wfn.o.stop - wfn.no
+        co = slice(0, ncore)
+        eps = np.diag(np.asarray(wfn.H.F))
+        w = np.asarray(wfn.H.ERI if so else wfn.H.L)          # unperturbed orbital-Hessian weight
+        canonical = self.perturbed_mo_gauge == 'canonical'
+        Pof = np.zeros_like(Ip[ofull, ofull])                 # P^(x) over the full occupied space
+        Pvv = np.zeros_like(Ip[v, v])
+        if ncore:                                             # INDEPENDENT core<->active-occ (always)
+            Pof[co, o] = (Ip[co, o] - Ip[o, co].T) / (eps[co][:, None] - eps[o][None, :])
+            Pof[o, co] = Pof[co, o].T
+        if canonical:                                         # REDUNDANT active oo/vv (CCSD(T) gauge)
+            Pof[o, o] = self._dependent_pairs(Ip[o, o], eps[o])
+            Pvv = self._dependent_pairs(Ip[v, v], eps[v])
+        Pf = np.zeros_like(Ip); Pf[ofull, ofull] = Pof; Pf[v, v] = Pvv
+        # X~^(x)_ai (eq:Xtilde): occupied pair-sum over the FULL occupied space
+        Xk = (c('kl,kali->ai', Pof, w[ofull, v, ofull, ofull])
+              + c('kl,kila->ai', Pof, w[ofull, ofull, ofull, v]))
+        Xd = c('de,daei->ai', Pvv, w[v, v, v, ofull]) + c('de,diea->ai', Pvv, w[v, ofull, v, v])
+        Xt = Xov.copy(); Xt[v, ofull] = Xov[v, ofull] + 0.5 * (Xk + Xd)
+        # I~''^(x) (eq:Idouble-tilde): full occupied-occupied block
+        Aoo = (c('kl,kilj->ij', Pof, w[ofull, ofull, ofull, ofull])
+               + c('kl,kjli->ij', Pof, w[ofull, ofull, ofull, ofull]))
+        Avv = c('de,diej->ij', Pvv, w[v, ofull, v, ofull]) + c('de,djei->ij', Pvv, w[v, ofull, v, ofull])
+        It = I2.copy()
+        It[ofull, ofull] = I2[ofull, ofull] - Pof * eps[ofull][None, :] - 0.5 * (Aoo + Avv)
+        It[v, v] = I2[v, v] - Pvv * eps[v][None, :]
+        return Xt, It, Pf


### PR DESCRIPTION
# Second-derivative orbital response: adopt the reference-doc form; remove the gamrot path

Reformulate the molecular Hessian and the atomic polar tensors (APTs) so their
orbital-response term is assembled directly in the reference-document form
(`docs/cc_gradients_orbital_response.tex`, eq:d2E-canon-final), and remove the
temporary `gamrot` (rotate-the-densities) formulation once the doc form is fully
validated. Shared across MP2, CISD, CCSD, and CCSD(T) via `CorrelatedDerivs`.

## What changed

- `hessian()` and `dipole_derivatives()` now build the orbital response as
  `2 U^Y X~^(X) + S^(Y) I~''^(X) + P^(X) f^(Y)` (doc line 2), instead of
  distributing `U^Y` onto the densities via `rot4`/`Gamrot`.

- Two shared per-perturbation builders (promoted out of `hessian` so both drivers
  use them):
  - `_skeleton_lagrangian(fXx, SXx, wx, erix, Drel, Gam, I)` builds the
    skeleton-perturbed orbital Lagrangian `I'^(x)` and its combinations
    `X^(x)`, `I''^(x)`.
  - `_augment_with_canonical_pair_rotations(Ip, Xov, I2)` adds the closed-form
    (canonical Brillouin) contributions of the orbital rotations the CPHF solve
    does not provide, and returns `X~^(x)`, `I~''^(x)`, `P^(x)`.

- Frozen core: the independent (non-redundant) core<->active-occupied rotation
  `P_ci` now enters the doc-form orbital response (built over the full occupied
  space via a direct divide). The redundant active oo/vv pairs remain
  canonical-gauge-only (CCSD(T)).

- Removed the `gamrot` path from both drivers: deleted `rot4`, `rot1`, `Drot`,
  `Irot`, `Gamrot`, `JX`, and the temporary `_orbital_response` flag.

- Kept the APT `'2n+1-nuclear'` cross-check route (a distinct dipole-rotation
  formulation, not the `gamrot` orbital response) so the two APT routes can still
  be shown to agree.

- Reference document (`cc_gradients_orbital_response.tex`):
  - Added an explicit `all occ` summation limit (`\alloc`) on every occupied
    summation that runs over the full occupied space (core + active), removing the
    active-vs-all-occ ambiguity that the frozen-core term exposed.
  - Renamed the virtual dummy index `c -> d` in the canonical/dependent-pair
    equations so `c` is reserved for the frozen core, and labeled the Frozen Core
    section.

- Docstring corrections: `_dependent_pairs` (it supplies the redundant active
  oo/vv rotations; core<->active is a separate independent direct divide) and the
  `hessian` naming notes (removed the stale `Drot`/`Irot`/`Gamrot`/`eriL`
  descriptions).

## Validation

- Doc form vs the removed `gamrot` form is bit-exact across all four methods
  (MP2, CISD, CCSD, CCSD(T)), both drivers (hessian, APT), AE and frozen core
  (CISD all-electron only), spatial and spin-orbital: 1e-17 .. 5e-15.

- CFOUR / finite-difference anchored: full hessian + APT + dipole test suite
  passes with the doc form as the only path -- 84 passed, 2 skipped.
