### PR TITLE
Memoize the perturbed MP2 T2 in the DerivStore

### DIFF
--- a/pycc/mpderiv.py
+++ b/pycc/mpderiv.py
@@ -195,6 +195,28 @@ class MPderiv(CorrelatedDerivs):
                - c('ik,kjab->ijab', dfoo, t2) - c('jk,ikab->ijab', dfoo, t2))
         return num / np.asarray(self.mp.Dijab)
 
+    def _perturbed_t2_stored(self, pert):
+        r"""Store-memoized :meth:`_perturbed_t2`, shared across derivative properties on this
+        wavefunction.
+
+        The closed-form perturbed amplitudes are a pure function of ``pert`` and the
+        (wavefunction-bound) ``self.mp.t2``, so the record is keyed on ``(pert, ncore, route)``
+        and deliberately **omits** the driver instance id ``_uid`` that the relaxed-response
+        record (:meth:`CorrelatedDerivs._relaxed_response`) carries.  Dropping ``_uid`` is what
+        lets the AAT, the velocity-gauge APT, and the 2n+1 perturbed-density build all reuse one
+        nuclear ``d_x t2`` per perturbation: unlike the CC amplitudes (CCSD vs CCSD(T) on one
+        wavefunction), the MP2 amplitudes cannot differ between two drivers on the same
+        wavefunction, so the id is not needed to keep records apart.  The gauge is fixed (the
+        nuclear ``-1/2 S`` response of :meth:`CPHF.full_U`, ``canonical=False``), so it is not part
+        of the key; ``route`` ('sp'/'so') guards only the differing spin-adapted vs spin-orbital
+        amplitude shapes.  The heavy ``nmo^4`` perturbed ERI underneath is memoized on its own key
+        (:meth:`CPHF.perturbed_eri`, quantity ``'deri'``); this entry memoizes the remaining
+        closed-form divide and Fock fold on top of it."""
+        ncore = self.mp.o.stop - self.mp.no
+        route = 'so' if self.mp.orbital_basis == 'spinorbital' else 'sp'
+        return self.wfn.derivatives.store.get_or_compute(
+            'pt2', pert, lambda: self._perturbed_t2(pert), ctx=(ncore, route))
+
     def _perturbed_unrelaxed_densities(self, pert, df=None, deri=None, dL=None):
         r"""First-order response of the unrelaxed correlation densities to ``pert``: returns
         ``(d_x gamma, d_x Gamma)`` (full-MO arrays), from the perturbed amplitudes ``ta = d_x t2``
@@ -221,7 +243,7 @@ class MPderiv(CorrelatedDerivs):
         default to ``None`` so the closed form can also be called directly with just ``pert``."""
         o, v, nmo = self.mp.o, self.mp.v, self.mp.nmo
         t2 = np.asarray(self.mp.t2)
-        ta = self._perturbed_t2(pert)
+        ta = self._perturbed_t2_stored(pert)
         c = self.contract
         dgam = np.zeros((nmo, nmo))
         dGam = np.zeros((nmo, nmo, nmo, nmo))
@@ -357,7 +379,7 @@ class MPderiv(CorrelatedDerivs):
             hs = d.overlap_half(A)                             # 3 x (nmo, nmo), full
             for cart in range(3):
                 pX = Perturbation('nuclear', (A, cart))
-                dt2R = np.asarray(self._perturbed_t2(pX))      # -1/2 S gauge
+                dt2R = np.asarray(self._perturbed_t2_stored(pX))      # -1/2 S gauge
                 dc0R = -c0**3 * c('ijab,ijab->', tau, dt2R)
                 dc2R = dc0R * t2 + c0 * dt2R
                 tauR = 2.0 * dc2R - dc2R.swapaxes(2, 3)
@@ -448,7 +470,7 @@ class MPderiv(CorrelatedDerivs):
             hs = d.so_overlap_half(A)
             for cart in range(3):
                 pX = Perturbation('nuclear', (A, cart))
-                dt2R = np.asarray(self._perturbed_t2(pX))
+                dt2R = np.asarray(self._perturbed_t2_stored(pX))
                 dc0R = -0.25 * c0**3 * c('ijab,ijab->', t2, dt2R)
                 dc2R = dc0R * t2 + c0 * dt2R
                 UReff = np.asarray(cphf.full_U(pX, ncore)) + np.asarray(hs[cart]).T
@@ -527,7 +549,7 @@ class MPderiv(CorrelatedDerivs):
             hs = d.overlap_half(A)
             for beta in range(3):
                 pX = Perturbation('nuclear', (A, beta))
-                dt2R = np.asarray(self._perturbed_t2(pX))
+                dt2R = np.asarray(self._perturbed_t2_stored(pX))
                 dc0R = -c0**3 * c('ijab,ijab->', tau, dt2R)
                 dc2R = dc0R * t2 + c0 * dt2R
                 tauR = 2.0 * dc2R - dc2R.swapaxes(2, 3)
@@ -608,7 +630,7 @@ class MPderiv(CorrelatedDerivs):
             hs = d.so_overlap_half(A)
             for beta in range(3):
                 pX = Perturbation('nuclear', (A, beta))
-                dt2R = np.asarray(self._perturbed_t2(pX))
+                dt2R = np.asarray(self._perturbed_t2_stored(pX))
                 dc0R = -0.25 * c0**3 * c('ijab,ijab->', t2, dt2R)
                 dc2R = dc0R * t2 + c0 * dt2R
                 UReff = np.asarray(cphf.full_U(pX, ncore)) + np.asarray(hs[beta]).T


### PR DESCRIPTION
# Memoize the perturbed MP2 T2 in the DerivStore

## What this does

Adds `MPderiv._perturbed_t2_stored`, a store-memoized wrapper over `_perturbed_t2`,
and routes every caller through it so the closed-form nuclear perturbed amplitudes
are shared across derivative properties on one wavefunction instead of recomputed
per property.

Callers rerouted (all five):
- `atomic_axial_tensors` / `_so_atomic_axial_tensors` (AAT, spatial + SO)
- `velocity_dipole_derivatives` / `_so_velocity_dipole_derivatives` (VG-APT, spatial + SO)
- `_perturbed_unrelaxed_densities` (the base 2n+1 build feeding the regular APT,
  Hessian, and polarizability)

## Keying

The record is keyed on `(pert, ncore, route)` via `store.get_or_compute('pt2', ...)`.
It deliberately **omits** the driver instance id `_uid` that the relaxed-response
`'resp'` record carries: unlike the CC amplitudes (CCSD vs CCSD(T) on one
wavefunction), the MP2 amplitudes are a pure function of the perturbation and the
wavefunction-bound `t2`, so they cannot differ between two drivers on the same
wavefunction. Dropping `_uid` is exactly what lets the AAT, VG-APT, and 2n+1 build
reuse one nuclear `d_x t2` per perturbation.

- The gauge is fixed (nuclear `-1/2 S`, `canonical=False`), so it is not part of the key.
- `route` ('sp'/'so') guards only the differing spin-adapted vs spin-orbital amplitude shapes.
- The heavy `nmo^4` perturbed ERI underneath is memoized separately (`'deri'`, keyed on
  `(ncore, canonical)`); this new entry memoizes the remaining closed-form divide and
  Fock fold on top of it.

## Effect

Before, only the `nmo^4` `'deri'` tensor was shared across properties; the closed-form
divide/fold on top was recomputed by each property. Instrumented across
`pycc.aat` -> `pycc.hessian` on one water/STO-3G MP2 wavefunction:

- Hessian reuses all 9 nuclear `'pt2'` records the AAT built (0 rebuilt).
- Hessian `'deri'` lookups drop 18 -> 9 (the memoized `_perturbed_t2` no longer
  re-requests the ERI underneath on a hit).

This is a modest win by design -- the `nmo^4` ERI was already shared -- so it mainly
removes the redundant closed-form arithmetic and the AAT <-> VG-APT <-> Hessian
duplication of the nuclear perturbed amplitudes.

## Validation

- Results unchanged: 51 MP2 second-derivative tests pass (AAT, VG-APT, APT,
  polarizability, Hessian, relaxed density; spatial + SO, all-electron + frozen core).
- Store-sharing confirmed empirically by instrumenting the live `DerivStore` across an
  `aat` -> `hessian` sequence (`'pt2'`: 9 built in AAT, 9 hit in the Hessian, 0 rebuilt).

## Notes

- Source change on `MPderiv` only; no test or oracle changes.
- The imaginary field side (`magnetic_ints` / `momentum_ints` perturbed T2) is left
  untouched: those are 3 components precomputed once per call over a cheap inline ERI
  rotation, with nothing to reclaim.
- `aat` is still on the pre-driver `MPwfn` path (the deferred `aat`-onto-the-driver
  hoist); it reaches the same `mp.derivatives.store`, so the sharing holds regardless.
