### PR TITLE
Move MO orbital energies to the Hamiltonian; drop CC/CI dependence on MPwfn

### DIFF
--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -21,7 +21,6 @@ from typing import Any
 
 from .utils import helper_diis, zeros_like, clone, sqrt, permute_triples
 from .wavefunction import Wavefunction
-from .mpwfn import MPwfn
 from .local import Local
 from . import cctriples
 from .cctriples import t_tjl, t3c_ijk, t3_pert_ijk
@@ -181,28 +180,26 @@ class CCwfn(Wavefunction):
                 self.Local.overlaps(self.Local.QL)
                 self.lccwfn = lccwfn(self.o, self.v,self.no, self.nv, self.H, self.local, self.model, self.eref, self.Local)
 
-        # The MP2 wavefunction supplies the energy denominators and the CC initial
-        # guess. from_wavefunction reuses this object's already-built base (no second
-        # integral transform), so the denominator/MP2-amplitude code lives only in
-        # MPwfn. CC's singles denominator (Dia) is built here from the MP2 wfn's
-        # orbital energies -- MP2 has no singles.
-        self.mp = MPwfn.from_wavefunction(self)
-        self.Dijab = self.mp.Dijab
-        self.Dia = self.mp.eps_occ.reshape(-1, 1) - self.mp.eps_vir
+        # Energy denominators from the orbital energies (the Fock diagonal). These
+        # precondition the CC update; the singles denominator Dia is needed for the
+        # spin-orbital t1 (canonical references have f_ia = 0, so t1 vanishes there).
+        eps_o, eps_v = self.H.eps[o], self.H.eps[v]
+        self.Dijab = (eps_o.reshape(-1, 1, 1, 1) + eps_o.reshape(-1, 1, 1)
+                      - eps_v.reshape(-1, 1) - eps_v)
+        self.Dia = eps_o.reshape(-1, 1) - eps_v
 
-        # CC initial-guess amplitudes. CC mutates t2 in place while iterating, so it
-        # takes its own copy of the MP2 doubles (the local path filters instead).
+        # Initial-guess amplitudes: the MP1 doubles t2 = <ij||ab>/Dijab (and, in the
+        # spin-orbital path, singles t1 = f_ia/Dia). CC mutates them in place while
+        # iterating, so each is its own array; the local path filters the raw ERI.
         if local is not None:
             self.t1, self.t2 = self.Local.filter_amps(np.zeros((self.no, self.nv)),
-                                                       self.H.ERI[o,o,v,v])
+                                                       self.H.ERI[o, o, v, v])
         elif self.orbital_basis == 'spinorbital':
-            # Start from the MP1 guess: doubles from MP2 and singles t1 = f_ia/Dia
-            # (zero for a canonical reference, nonzero for ROHF).
-            self.t1 = clone(self.mp.t1)
-            self.t2 = clone(self.mp.t2)
+            self.t1 = clone(self.H.F[o, v], device=self.device1) / self.Dia
+            self.t2 = clone(self.H.ERI[o, o, v, v], device=self.device1) / self.Dijab
         else:
             self.t1 = mgr.seed_compute(np.zeros((self.no, self.nv)))
-            self.t2 = clone(self.mp.t2)
+            self.t2 = clone(self.H.ERI[o, o, v, v], device=self.device1) / self.Dijab
 
         print("CCWFN object initialized in %.3f seconds." % (time.time() - time_init))
 

--- a/pycc/ciwfn.py
+++ b/pycc/ciwfn.py
@@ -10,7 +10,6 @@ from typing import Any, TYPE_CHECKING
 import numpy as np
 
 from .wavefunction import Wavefunction
-from .mpwfn import MPwfn
 from .utils import helper_diis, clone, sqrt, zeros_like
 from .exceptions import InvalidKeywordError
 
@@ -26,8 +25,6 @@ class CIwfn(Wavefunction):
     ----------
     model : str
         'CISD' (singles + doubles) or 'CID' (doubles only)
-    mp : MPwfn
-        composed MP2 wavefunction supplying ``Dijab`` and the MP1 guess
     Dia, Dijab : Tensor
         one- and two-electron energy denominators (from ``diag(F)``)
     c1, c2 : Tensor
@@ -48,17 +45,19 @@ class CIwfn(Wavefunction):
 
         super().__init__(scf_wfn, **kwargs)
         mgr = self.device_manager
+        o, v = self.o, self.v
 
-        # The MP2 wavefunction supplies the energy denominators and the CISD initial
-        # guess (MP1 doubles), reusing this object's base - the same pattern ccwfn
-        # uses. CI's singles denominator (Dia) is built from the MP2 orbital energies.
-        self.mp = MPwfn.from_wavefunction(self)
-        self.Dijab = self.mp.Dijab
-        self.Dia = self.mp.eps_occ.reshape(-1, 1) - self.mp.eps_vir
+        # Energy denominators from the orbital energies (the Fock diagonal); these
+        # precondition the CI update.
+        eps_o, eps_v = self.H.eps[o], self.H.eps[v]
+        self.Dijab = (eps_o.reshape(-1, 1, 1, 1) + eps_o.reshape(-1, 1, 1)
+                      - eps_v.reshape(-1, 1) - eps_v)
+        self.Dia = eps_o.reshape(-1, 1) - eps_v
 
-        # Initial guess: c1 = 0, c2 = MP1 doubles (CI mutates c2 in place, so copy).
+        # Initial guess: c1 = 0, c2 = MP1 doubles <ij||ab>/Dijab (CI mutates c2 in
+        # place while iterating, so it is its own array).
         self.c1 = mgr.seed_compute(np.zeros((self.no, self.nv)))
-        self.c2 = clone(self.mp.t2)
+        self.c2 = clone(self.H.ERI[o, o, v, v], device=self.device1) / self.Dijab
 
         print("CIWFN object initialized in %.3f seconds." % (time.time() - time_init))
 

--- a/pycc/correlatedderivs.py
+++ b/pycc/correlatedderivs.py
@@ -95,8 +95,7 @@ class CorrelatedDerivs:
         can't supply; building it here -- rather than borrowing an all-electron ``HFwfn`` -- keeps
         the spin-orbital ordering consistent with the densities.  For ``nfzc=0`` it coincides with
         ``wfn.cphf``.  CPHF depends only on the shared reference/orbitals/integrals, so building it on
-        ``self.wfn`` is equivalent for MP2 (``self.wfn`` is the MPwfn) and CC (the CCwfn shares those
-        with its ``cc.mp``)."""
+        ``self.wfn`` works uniformly for the MPwfn and the CCwfn."""
         if getattr(self, '_focphf', None) is None:
             from .cphf import CPHF
             self._focphf = CPHF(self.wfn, full_occ=True)

--- a/pycc/hamiltonian.py
+++ b/pycc/hamiltonian.py
@@ -58,6 +58,10 @@ class Hamiltonian(object):
         F_ao = np.asarray(ref.Fa_subset("AO"))
         self.F = npCp.T @ F_ao @ npCr
 
+        # MO orbital energies (the Fock diagonal), used by the correlated methods for
+        # their energy denominators and MP1 guess.
+        self.eps = np.diagonal(self.F).copy()
+
         # Get MO two-electron integrals in Dirac notation.
         # mo_eri() expects AO-basis C matrices, which Cp and Cr already are.
         mints = psi4.core.MintsHelper(ref.basisset())
@@ -184,6 +188,11 @@ class SpinOrbitalHamiltonian(object):
         F[np.ix_(a, a)] = Fa[np.ix_(sa, sa)]
         F[np.ix_(b, b)] = Fb[np.ix_(sb, sb)]
         self.F = F
+
+        # MO orbital energies (the diagonal of the canonical Fock, taken before any
+        # static field perturbs F below), used by the correlated methods for their
+        # energy denominators and MP1 guess.
+        self.eps = np.diagonal(self.F).copy()
 
         # All subsequent AO->MO transforms use the semicanonical MOs. Keep them (and the
         # spin/spatial maps) so consumers -- e.g. the spin-orbital MP2 gradient's

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -9,7 +9,7 @@ from typing import Any, TYPE_CHECKING
 import numpy as np
 
 from .wavefunction import Wavefunction
-from .utils import diag, clone
+from .utils import clone
 
 if TYPE_CHECKING:
     from ._typing import Tensor
@@ -20,14 +20,11 @@ class MPwfn(Wavefunction):
 
     Holds the energy denominators and the first-order (MP2) doubles amplitudes,
     derived from the base's seeded MO integrals, and computes the MP2 correlation
-    energy. It is also the canonical home for that denominator/amplitude code:
-    ``ccwfn`` composes one of these (via :meth:`from_wavefunction`) to obtain its
-    energy denominators and CC initial guess without building the Hamiltonian twice.
+    energy.
 
     The analytic derivative-property code (gradient, polarizability, APT, Hessian, AAT,
     VG-APT) lives on :class:`~pycc.mpderiv.MPderiv`, reached through the cached
-    :attr:`deriv` driver; the property methods here are thin delegators kept for the
-    historical ``mpwfn.<property>()`` call sites.
+    :attr:`deriv` driver; the property methods here are thin delegators.
 
     Attributes
     ----------
@@ -48,15 +45,6 @@ class MPwfn(Wavefunction):
     def __init__(self, scf_wfn: Any, **kwargs) -> None:
         super().__init__(scf_wfn, **kwargs)
         self._build_mp2()
-
-    @classmethod
-    def from_wavefunction(cls, wfn: "Wavefunction") -> "MPwfn":
-        """Build an MPwfn that reuses ``wfn``'s already-constructed base (reference,
-        orbitals, seeded integrals, device manager) -- no second integral transform.
-        """
-        mp = cls._from_shared_base(wfn)
-        mp._build_mp2()
-        return mp
 
     def _build_mp2(self) -> None:
         r"""Build the energy denominators and MP2 doubles amplitudes from the seeded
@@ -81,8 +69,8 @@ class MPwfn(Wavefunction):
         """
         o = self.o
         v = self.v
-        self.eps_occ = diag(self.H.F)[o]
-        self.eps_vir = diag(self.H.F)[v]
+        self.eps_occ = self.H.eps[o]
+        self.eps_vir = self.H.eps[v]
         self.Dijab = (self.eps_occ.reshape(-1, 1, 1, 1) + self.eps_occ.reshape(-1, 1, 1)
                       - self.eps_vir.reshape(-1, 1) - self.eps_vir)
         self.t2 = clone(self.H.ERI[o, o, v, v], device=self.device1) / self.Dijab
@@ -168,11 +156,10 @@ class MPwfn(Wavefunction):
         wavefunction (built lazily).  ``MPderiv`` is the MP2 leaf of
         :class:`~pycc.correlatedderivs.CorrelatedDerivs` and carries the analytic
         derivative-property code; the thin property methods below (:meth:`gradient`,
-        :meth:`polarizability`, :meth:`hessian`, ...) delegate to it so the historical
+        :meth:`polarizability`, :meth:`hessian`, ...) delegate to it so the
         ``mpwfn.<property>()`` call sites keep working, and the :mod:`pycc.properties` facade routes
         through the registry (``pycc/__init__.py``) to the same driver.  A single cached instance,
-        so its ``_full_occ_cphf`` / Z-vector caches are shared across the MP2 property calls and the
-        ``CCderiv`` cross-calls that reach it via ``cc.mp.deriv``."""
+        so its ``_full_occ_cphf`` / Z-vector caches are shared across the MP2 property calls."""
         if getattr(self, '_deriv', None) is None:
             from .mpderiv import MPderiv
             self._deriv = MPderiv(self)

--- a/pycc/tests/test_055_spinorbital_polar.py
+++ b/pycc/tests/test_055_spinorbital_polar.py
@@ -43,7 +43,9 @@ def _findiff_alpha_zz(cc, d=0.001):
     it does not contribute to the second derivative).  Restores cc.H.F on return."""
     F0 = np.asarray(cc.H.F).copy()
     muz = np.asarray(cc.H.mu[2])
-    g1, g2 = cc.mp.t1.copy(), cc.mp.t2.copy()
+    o, v = cc.o, cc.v
+    g1 = (np.asarray(cc.H.F)[o, v] / np.asarray(cc.Dia)).copy()
+    g2 = (np.asarray(cc.H.ERI)[o, o, v, v] / np.asarray(cc.Dijab)).copy()
 
     def ecc(Fstr):
         cc.H.F = F0 - Fstr * muz

--- a/pycc/wavefunction.py
+++ b/pycc/wavefunction.py
@@ -115,11 +115,6 @@ class Wavefunction(object):
             raise TypeError(
                 "the 'frozen_core' argument was removed; the frozen core is taken from "
                 "the psi4 reference -- set psi4's 'freeze_core' option when running the SCF.")
-        # A subclass may set its own attributes before calling super().__init__;
-        # snapshot them so _base_attrs (recorded at the end) captures only what the
-        # base itself adds -- which _from_shared_base then replicates.
-        _preexisting = set(vars(self))
-
         # The general kwargs (device/precision/localize_occ/local_mos) are owned
         # here; subclasses pop only their own kwargs and forward the rest, so this
         # is the single place they are parsed. local_mos is validated up front (a
@@ -163,13 +158,14 @@ class Wavefunction(object):
         # real-cast to float32; on GPU they become real torch tensors at the
         # matching width. The spin-adapted L exists only in the spatial path.
         self.H.F = mgr.seed_compute(self.H.F)
+        self.H.eps = mgr.seed_compute(self.H.eps)
         self.H.ERI = mgr.seed_store(self.H.ERI)
         if self.orbital_basis == 'spatial':
             self.H.L = mgr.seed_store(self.H.L)
 
         # Derivative-integral provider: built lazily on first access (see the
         # ``derivatives`` property), so methods that never take derivatives pay
-        # nothing. Recorded here as part of the base so _from_shared_base carries it.
+        # nothing.
         self._derivatives = None
         # Coupled-perturbed-HF orbital-response solver, likewise lazy (see ``cphf``).
         self._cphf = None
@@ -179,11 +175,6 @@ class Wavefunction(object):
         # unrecognized keyword -- flag it instead of silently ignoring it.
         if kwargs:
             raise PyCCError("Unexpected keyword argument(s): %s" % sorted(kwargs))
-
-        # Record exactly which attributes the base set (excluding anything the
-        # subclass set first), so _from_shared_base can replicate this base onto a
-        # new instance without re-running __init__ (and re-transforming integrals).
-        self._base_attrs = tuple(k for k in vars(self) if k not in _preexisting)
 
     def _resolve_orbital_basis(self, orbital_basis: Any) -> str:
         """Resolve the orbital basis from an explicit override or the reference.
@@ -389,18 +380,3 @@ class Wavefunction(object):
             self._cphf = CPHF(self)
         return self._cphf
 
-    @classmethod
-    def _from_shared_base(cls, source: "Wavefunction") -> "Wavefunction":
-        """Create a ``cls`` instance that REUSES ``source``'s already-built base --
-        reference, orbital spaces, seeded integrals, device manager -- by bypassing
-        ``__init__`` so the Hamiltonian is not transformed a second time. The caller
-        adds its own method-specific state afterward.
-
-        Lets one wavefunction compose another over the same base (e.g. ccwfn holds an
-        MPwfn for its MP2 guess/denominators) with a single integral build.
-        """
-        obj = cls.__new__(cls)
-        for name in source._base_attrs:
-            setattr(obj, name, getattr(source, name))
-        obj._base_attrs = source._base_attrs
-        return obj


### PR DESCRIPTION
# Move MO orbital energies to the Hamiltonian; drop CC/CI dependence on MPwfn

## What this does

The orbital energies (the Fock diagonal) are a property of the reference, not of
any one correlated method. They now live on `Hamiltonian` / `SpinOrbitalHamiltonian`
as `H.eps`, seeded on the `Wavefunction` base alongside `H.F`. Each correlated method
builds its own energy denominators (`Dijab`, `Dia`) and MP1 guess from `H.eps` /
`H.ERI` / `H.F` -- a few trivial lines -- instead of composing an `MPwfn` to obtain
them.

Result: `CCwfn` and `CIwfn` no longer construct an `MPwfn` for their denominators and
initial guess. `MPwfn` reverts to a peer method rather than a provider to the others,
and the CCwfn->MPwfn / CIwfn->MPwfn composition edges disappear.

## Changes

- **`hamiltonian.py`** -- both `Hamiltonian` and `SpinOrbitalHamiltonian` expose
  `self.eps` (MO orbital energies = Fock diagonal).
- **`wavefunction.py`** -- base seeds `H.eps` next to `H.F`; removes the now-dead
  `_from_shared_base` classmethod and `_base_attrs` bookkeeping (they existed solely
  to support the MPwfn composition).
- **`mpwfn.py`** -- reads `eps_occ`/`eps_vir` from `H.eps`; removes
  `MPwfn.from_wavefunction`; drops the unused `diag` import; scrubs docstrings of the
  composition references.
- **`ccwfn.py` / `ciwfn.py`** -- build their own `Dijab`, `Dia`, and MP1 guess from
  `H.eps` / `H.ERI` / `H.F`; drop the `MPwfn` import and composition.
- **`correlatedderivs.py`** -- docstring no longer references `cc.mp`.
- **`tests/test_055_spinorbital_polar.py`** -- the not-run FD regeneration helper
  rebuilds its guess from the CC-owned denominators instead of `cc.mp`.

## Canonical vs field-perturbed eps (behavior note)

For the spin-orbital Hamiltonian, `H.eps` is the diagonal of the **canonical** Fock,
taken before an optional static field perturbs `F`. Only `CCwfn` ever sets a field,
and its solver is iterative, so the denominators act purely as a preconditioner: at
convergence the residual is zero and the result is independent of the denominator, so
the canonical-vs-perturbed choice changes only the convergence path, not the converged
energy/amplitudes. `MPwfn` and `CIwfn` never receive a field, so their behavior is
unchanged. (Confirmed: the finite-field and CC3-response suites pass unchanged.)

## Validation

Full non-slow suite: **287 passed, 3 skipped, 1 xfailed, 19 deselected** (0 failures),
including the finite-field, CC3-response, local-CC, spin-orbital, and MP2/CISD/CCSD
derivative suites. The single warning is a pre-existing `ComplexWarning` in `utils.py`,
unrelated to this change.

## Notes

- Net architecture effect: orbital energies defined once (on the Hamiltonian, next to
  the Fock they come from); each `XXwfn` owns its trivial denominator/guess block. This
  removes the confusing "CC/CI contain an MP2 calculation" edge from the class diagram.
- `MPderiv`'s own `self.mp` alias (the MPwfn it wraps) is unrelated and untouched.
