### PR TITLE
Coherent run output, and pycc.optical_rotation with specific rotation

### DIFF
--- a/pycc/__init__.py
+++ b/pycc/__init__.py
@@ -20,7 +20,7 @@ from .cceom import cceom
 from .ccderiv import CCderiv
 from .mpderiv import MPderiv
 from .cideriv import CIderiv
-from .properties import PropertyComponents, aat, apt, dipole, gradient, hessian, polarizability, register_deriv
+from .properties import PropertyComponents, aat, apt, dipole, gradient, hessian, polarizability, optical_rotation, register_deriv
 
 # Route the property facade's correlation-derivative calls for each wavefunction to its downstream
 # driver (the CorrelatedDerivs leaf carrying the correlation-property methods).
@@ -28,7 +28,7 @@ register_deriv(CCwfn, CCderiv)
 register_deriv(MPwfn, MPderiv)
 register_deriv(CIwfn, CIderiv)
 
-__all__ = ['CCwfn', 'ccwfn', 'MPwfn', 'HFwfn', 'CIwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom', 'CCderiv', 'MPderiv', 'CIderiv', 'PropertyComponents', 'aat', 'apt', 'dipole', 'gradient', 'hessian', 'polarizability']
+__all__ = ['CCwfn', 'ccwfn', 'MPwfn', 'HFwfn', 'CIwfn', 'cchbar', 'cclambda', 'ccdensity', 'ccresponse', 'pertbar', 'rtcc', 'cceom', 'CCderiv', 'MPderiv', 'CIderiv', 'PropertyComponents', 'aat', 'apt', 'dipole', 'gradient', 'hessian', 'polarizability', 'optical_rotation']
 
 # Handle versioneer
 from ._version import get_versions

--- a/pycc/ccdensity.py
+++ b/pycc/ccdensity.py
@@ -15,7 +15,7 @@ from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
 from .cctriples import t3c_ijk, t3c_abc, l3_ijk, l3_abc, t3c_bc, l3_bc, t3_pert_ijk, t3_pert_bc
-from .utils import zeros, zeros_like, clone
+from .utils import zeros, zeros_like, clone, timing
 
 if TYPE_CHECKING:
     from pycc.ccwfn import CCwfn
@@ -108,7 +108,7 @@ class ccdensity(object):
                 self.Dovov = self.build_Dovov(t1, t2, l1, l2)
                 self.Doovv = self.build_Doovv(t1, t2, l1, l2)
 
-        print("\nCCDENSITY constructed in %.3f seconds.\n" % (time.time() - time_init))
+        print(timing("CC density", time.time() - time_init))
 
     def compute_energy(self) -> float:
         r"""

--- a/pycc/ccderiv.py
+++ b/pycc/ccderiv.py
@@ -10,11 +10,14 @@ downstream of `ccwfn`, so the wavefunction never reaches forward to build them. 
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 from .correlatedderivs import CorrelatedDerivs
+from .cphf import perturbation_label
+from .utils import title, iteration, converged
 
 if TYPE_CHECKING:
     from .ccwfn import CCwfn
@@ -121,18 +124,19 @@ class CCderiv(CorrelatedDerivs):
         lam = self.cclambda
         hbar = self.hbar
         is_t = cc.model.upper() == 'CCSD(T)'
+        label = perturbation_label(pert, cc.ref.molecule())
         if cc.orbital_basis == 'spinorbital':
-            dt1, dt2 = self._so_perturbed_amplitudes(df, deri, hbar)
+            dt1, dt2 = self._so_perturbed_amplitudes(df, deri, hbar, label=label)
             dt3 = self._so_perturbed_t3_intermediates(df, deri, dt1, dt2) if is_t else None
             dl1, dl2 = self._so_perturbed_lambda(df, deri, dt1, dt2, hbar, lam,
                                                  dS1=(dt3['S1'] if is_t else None),
-                                                 dS2=(dt3['S2'] if is_t else None))
+                                                 dS2=(dt3['S2'] if is_t else None), label=label)
         else:
-            dt1, dt2 = self._perturbed_amplitudes(df, deri, dL, hbar)
+            dt1, dt2 = self._perturbed_amplitudes(df, deri, dL, hbar, label=label)
             dt3 = self._perturbed_t3_intermediates(df, deri, dL, dt1, dt2) if is_t else None
             dl1, dl2 = self._perturbed_lambda(df, deri, dL, dt1, dt2, hbar, lam,
                                               dS1=(dt3['S1'] if is_t else None),
-                                              dS2=(dt3['S2'] if is_t else None))
+                                              dS2=(dt3['S2'] if is_t else None), label=label)
         return self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam, dt3=dt3)
 
     def _ccsd_jacobian(self, X1, X2, hbar):
@@ -206,7 +210,7 @@ class CCderiv(CorrelatedDerivs):
         r2 += tmp - tmp.swapaxes(0, 1) - tmp.swapaxes(2, 3) + tmp.swapaxes(0, 1).swapaxes(2, 3)
         return r1, r2
 
-    def _perturbed_amplitudes(self, df, deri, dL, hbar, omega=0.0, maxiter=None, rconv=None):
+    def _perturbed_amplitudes(self, df, deri, dL, hbar, omega=0.0, maxiter=None, rconv=None, label=None):
         r"""Perturbed CCSD amplitudes ``dt/dx`` (iterative).  Differentiating the CC amplitude
         equation ``R_mu = <mu|HBAR|0> = 0`` with respect to the perturbation ``x`` splits into the
         ``d_x t`` part (the CCSD Jacobian :meth:`_ccsd_jacobian`, ``<mu|[HBAR, d_x t]|0>``) and the
@@ -249,20 +253,26 @@ class CCderiv(CorrelatedDerivs):
         B1, B2 = np.asarray(B1), np.asarray(B2)      # singles source's leading term is r_T1's f_ai
         X1, X2 = B1 / Dia, B2 / Dijab                # ([v,o] block A_ai), correct for anti-Hermitian df
         diis = helper_diis(X1, X2, 8)
-        for _ in range(maxiter):
+        name = "perturbed T-amplitudes" + (" (%s)" % label if label else "")
+        print(title(name))
+        t0 = time.time()
+        for niter in range(1, maxiter + 1):
             j1, j2 = self._ccsd_jacobian(X1, X2, hbar)
             r1 = B1 + j1 - omega * X1
             r2 = 0.5 * (B2 - omega * X2) + j2
             r2 = r2 + r2.swapaxes(0, 1).swapaxes(2, 3)
             X1 = X1 + r1 / Dia
             X2 = X2 + r2 / Dijab
-            if np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2)) < rconv:
+            rms = np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2))
+            print(iteration(niter, rms=rms))
+            if rms < rconv:
+                print(converged(name, time.time() - t0))
                 break
             diis.add_error_vector(X1, X2)
             X1, X2 = diis.extrapolate(X1, X2)
         return X1, X2
 
-    def _so_perturbed_amplitudes(self, df, deri, hbar, omega=0.0, maxiter=None, rconv=None):
+    def _so_perturbed_amplitudes(self, df, deri, hbar, omega=0.0, maxiter=None, rconv=None, label=None):
         r"""Spin-orbital perturbed CCSD amplitudes ``dt/dx`` -- the spin-orbital analogue of
         :meth:`_perturbed_amplitudes` (SO Jacobian :meth:`_so_ccsd_jacobian`; the SO residual has
         no 0.5 and no final symmetrization)::
@@ -297,12 +307,18 @@ class CCderiv(CorrelatedDerivs):
         B1, B2 = np.asarray(B1), np.asarray(B2)      # singles source's leading term is r_T1's f_ai
         X1, X2 = B1 / Dia, B2 / Dijab                # ([v,o] block A_ai), correct for anti-Hermitian df
         diis = helper_diis(X1, X2, 8)
-        for _ in range(maxiter):
+        name = "perturbed T-amplitudes" + (" (%s)" % label if label else "")
+        print(title(name))
+        t0 = time.time()
+        for niter in range(1, maxiter + 1):
             j1, j2 = self._so_ccsd_jacobian(X1, X2, hbar)
             r1, r2 = B1 + j1 - omega * X1, B2 + j2 - omega * X2
             X1 = X1 + r1 / Dia
             X2 = X2 + r2 / Dijab
-            if np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2)) < rconv:
+            rms = np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2))
+            print(iteration(niter, rms=rms))
+            if rms < rconv:
+                print(converged(name, time.time() - t0))
                 break
             diis.add_error_vector(X1, X2)
             X1, X2 = diis.extrapolate(X1, X2)
@@ -511,7 +527,7 @@ class CCderiv(CorrelatedDerivs):
         return cctriples.so_dt3_density(o, v, no, nv, t01, t02, dt1, dt2, F0, df, ERI0, deri, self.contract)
 
     def _perturbed_lambda(self, df, deri, dL, dt1, dt2, hbar, lam, dS1=None, dS2=None,
-                          omega=0.0, maxiter=None, rconv=None):
+                          omega=0.0, maxiter=None, rconv=None, label=None):
         r"""Perturbed Lambda ``dLambda/dx`` (iterative, linear): a single inhomogeneous linear solve
         that reuses ``cclambda``'s ground-state Lambda residual ``r_L`` as the operator (no separate
         perturbed-multiplier amplitudes).  Differentiating the Lambda
@@ -571,7 +587,10 @@ class CCderiv(CorrelatedDerivs):
         rL2_0 = rL2(zl1, zl2, L0, H0, zGvv, zGoo)       # = SYM[L]
         dl1, dl2 = B1 / Dia, B2 / Dijab
         diis = helper_diis(dl1, dl2, 8)
-        for _ in range(maxiter):
+        name = "perturbed Lambda" + (" (%s)" % label if label else "")
+        print(title(name))
+        t0 = time.time()
+        for niter in range(1, maxiter + 1):
             Gvv_d = np.asarray(lam.build_Gvv(t2, dl2)); Goo_d = np.asarray(lam.build_Goo(t2, dl2))
             j1 = rL1(dl1, dl2, H0, Gvv_d, Goo_d) - rL1_0
             j2 = rL2(dl1, dl2, L0, H0, Gvv_d, Goo_d) - rL2_0
@@ -579,14 +598,17 @@ class CCderiv(CorrelatedDerivs):
             r2 = B2 + j2 + omega * dl2
             dl1 = dl1 + r1 / Dia
             dl2 = dl2 + r2 / Dijab
-            if np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2)) < rconv:
+            rms = np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2))
+            print(iteration(niter, rms=rms))
+            if rms < rconv:
+                print(converged(name, time.time() - t0))
                 break
             diis.add_error_vector(dl1, dl2)
             dl1, dl2 = diis.extrapolate(dl1, dl2)
         return dl1, dl2
 
     def _so_perturbed_lambda(self, df, deri, dt1, dt2, hbar, lam, dS1=None, dS2=None,
-                             omega=0.0, maxiter=None, rconv=None):
+                             omega=0.0, maxiter=None, rconv=None, label=None):
         r"""Spin-orbital perturbed Lambda ``dLambda/dx`` -- the spin-orbital analogue of
         :meth:`_perturbed_lambda` (SO ``_so_r_L``; inhomogeneity = ``r_L`` with perturbed HBAR +
         perturbed ERI, unperturbed G, plus the ``dG.H`` / ``dG.<pq||rs>`` product-rule halves)::
@@ -638,14 +660,20 @@ class CCderiv(CorrelatedDerivs):
         rL2_0 = rL2(zl1, zl2, ERI0, H0, zGvv, zGoo)
         dl1, dl2 = B1 / Dia, B2 / Dijab
         diis = helper_diis(dl1, dl2, 8)
-        for _ in range(maxiter):
+        name = "perturbed Lambda" + (" (%s)" % label if label else "")
+        print(title(name))
+        t0 = time.time()
+        for niter in range(1, maxiter + 1):
             Gvv_d = np.asarray(lam.build_Gvv(t2, dl2)); Goo_d = np.asarray(lam.build_Goo(t2, dl2))
             j1 = rL1(dl1, dl2, H0, Gvv_d, Goo_d) - rL1_0
             j2 = rL2(dl1, dl2, ERI0, H0, Gvv_d, Goo_d) - rL2_0
             r1, r2 = B1 + j1 + omega * dl1, B2 + j2 + omega * dl2
             dl1 = dl1 + r1 / Dia
             dl2 = dl2 + r2 / Dijab
-            if np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2)) < rconv:
+            rms = np.sqrt(np.sum((r1 / Dia) ** 2) + np.sum((r2 / Dijab) ** 2))
+            print(iteration(niter, rms=rms))
+            if rms < rconv:
+                print(converged(name, time.time() - t0))
                 break
             diis.add_error_vector(dl1, dl2)
             dl1, dl2 = diis.extrapolate(dl1, dl2)
@@ -963,7 +991,7 @@ class CCderiv(CorrelatedDerivs):
 
     def linear_response(self, a, b, omega=0.0):
         r"""Orbital-unrelaxed CC linear response function ``<<a; b>>_omega`` -- the
-        general engine behind :meth:`response_polarizability` / :meth:`optical_rotation`.
+        general engine behind :meth:`dynamic_polarizability` / :meth:`optical_rotation`.
         The 3x3 tensor is assembled by the density route::
 
             <<a; b>>_omega[i,j] = Tr(d_bj D(omega) . a_i)
@@ -980,14 +1008,19 @@ class CCderiv(CorrelatedDerivs):
         ``omega`` is a single field frequency (a sweep loops at the call site).  This is
         the CC response (unrelaxed) value, not the relaxed derivative :meth:`polarizability`."""
         a_ints = self._perturbation_ints(a)
-        dD = [self._response_density(self._perturbation_ints(b)[j], omega) for j in range(3)]
+        b_ints = self._perturbation_ints(b)
+        xyz = 'xyz'
+        dD = []
+        for j in range(3):
+            label = "%s_%s" % (b, xyz[j]) + ("" if omega == 0.0 else ", omega=%.4f" % omega)
+            dD.append(self._response_density(b_ints[j], omega, label=label))
         tensor = np.zeros((3, 3))
         for i in range(3):
             for j in range(3):
                 tensor[i, j] = self.contract('pq,qp->', dD[j], a_ints[i])
         return tensor
 
-    def response_polarizability(self, omega=0.0):
+    def dynamic_polarizability(self, omega=0.0):
         r"""Orbital-unrelaxed dynamic dipole polarizability ``alpha(omega)``, a 3x3 array::
 
             alpha_ab(omega) = -<<mu; mu>>_omega = -Tr(d_b D(omega) . mu_a)
@@ -1044,7 +1077,7 @@ class CCderiv(CorrelatedDerivs):
             return [np.real(-1.0j * np.asarray(cc.H.m[x])) for x in range(3)]
         raise KeyError(f"Unknown perturbation operator key: {key!r} (expected 'mu' or 'm').")
 
-    def _response_density(self, op_ints, omega=0.0):
+    def _response_density(self, op_ints, omega=0.0, label=None):
         r"""Orbital-unrelaxed perturbed 1-PDM ``d_op D(omega)`` for a bare one-electron
         operator ``op_ints`` (full-MO ``nmo x nmo``).  Solves the perturbed amplitudes and
         multipliers with the BARE operator as the perturbation (``df = op_ints``, no
@@ -1067,11 +1100,11 @@ class CCderiv(CorrelatedDerivs):
                 f"not {cc.model} (CCSD(T) response is a later phase).")
         zero_eri = np.zeros_like(np.asarray(cc.H.ERI))
         if cc.orbital_basis == 'spinorbital':
-            dt1, dt2 = self._so_perturbed_amplitudes(op_ints, zero_eri, hbar, omega=omega)
-            dl1, dl2 = self._so_perturbed_lambda(op_ints, zero_eri, dt1, dt2, hbar, lam, omega=omega)
+            dt1, dt2 = self._so_perturbed_amplitudes(op_ints, zero_eri, hbar, omega=omega, label=label)
+            dl1, dl2 = self._so_perturbed_lambda(op_ints, zero_eri, dt1, dt2, hbar, lam, omega=omega, label=label)
         else:
             zero_L = np.zeros_like(np.asarray(cc.H.L))
-            dt1, dt2 = self._perturbed_amplitudes(op_ints, zero_eri, zero_L, hbar, omega=omega)
-            dl1, dl2 = self._perturbed_lambda(op_ints, zero_eri, zero_L, dt1, dt2, hbar, lam, omega=omega)
+            dt1, dt2 = self._perturbed_amplitudes(op_ints, zero_eri, zero_L, hbar, omega=omega, label=label)
+            dl1, dl2 = self._perturbed_lambda(op_ints, zero_eri, zero_L, dt1, dt2, hbar, lam, omega=omega, label=label)
         dD, _ = self._perturbed_correlation_densities(dt1, dt2, dl1, dl2, lam)
         return dD

--- a/pycc/cceom.py
+++ b/pycc/cceom.py
@@ -8,6 +8,7 @@ import pycc
 from pycc.data.molecules import *
 import numpy as np
 from pycc.exceptions import InvalidKeywordError
+from pycc.utils import title
 
 if TYPE_CHECKING:
     from pycc.ccwfn import CCwfn
@@ -122,6 +123,7 @@ class cceom(object):
         V = np.hstack((np.reshape(C1, (nguess, s1_len)), np.zeros((nguess, s2_len))))
         V = self._orthonormalize(V)
         W = np.empty((0, sigma_len), float)     # sigma vectors, in lockstep with V
+        print(title("EOM-CCSD (%s)" % eom_type))
         print("Guess vectors obtained from %s." % (guess))
 
         E = np.zeros((N))

--- a/pycc/cchbar.py
+++ b/pycc/cchbar.py
@@ -15,7 +15,7 @@ import numpy as np
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
-from pycc.utils import clone
+from pycc.utils import clone, timing
 
 if TYPE_CHECKING:
     from pycc.ccwfn import CCwfn
@@ -80,7 +80,7 @@ class cchbar(object):
 
         if ccwfn.orbital_basis == 'spinorbital':
             self._so_build(o, v, F, ERI, t1, t2)
-            print("\nHBAR constructed in %.3f seconds." % (time.time() - time_init))
+            print(timing("HBAR", time.time() - time_init))
             return
 
         self.Hov = self.build_Hov(o, v, F, L, t1)
@@ -95,7 +95,7 @@ class cchbar(object):
         self.Hvvvo = self.build_Hvvvo(o, v, ERI, L, self.Hov, self.Hvvvv, t1, t2)
         self.Hovoo = self.build_Hovoo(o, v, ERI, L, self.Hov, self.Hoooo, t1, t2)
 
-        print("\nHBAR constructed in %.3f seconds." % (time.time() - time_init))
+        print(timing("HBAR", time.time() - time_init))
 
     """
     For GPU implementation:

--- a/pycc/cclambda.py
+++ b/pycc/cclambda.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from opt_einsum import contract
-from .utils import helper_diis, zeros, zeros_like, clone, sqrt, permute_triples
+from .utils import helper_diis, zeros, zeros_like, clone, sqrt, permute_triples, title, iteration, converged
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
@@ -118,7 +118,9 @@ class cclambda(object):
 
         lecc = self.pseudoenergy(o, v, ERI, l2)
 
-        print("\nLCC Iter %3d: LCC PseudoE = %.15f  dE = % .5E" % (0, lecc, -lecc))
+        name = "Lambda-amplitudes (%s)" % self.ccwfn.model
+        print(title(name))
+        print(iteration(0, energy=lecc, de=-lecc, e_label="LCC PseudoE"))
 
         diis = helper_diis(l1, l2, max_diis, self.ccwfn.precision)
 
@@ -176,15 +178,15 @@ class cclambda(object):
 
             lecc = self.pseudoenergy(o, v, ERI, self.l2)
             ediff = lecc - lecc_last
-            print("LCC Iter %3d: LCC PseudoE = %.15f  dE = % .5E  rms = % .5E" % (niter, lecc, ediff, rms))
+            print(iteration(niter, energy=lecc, de=ediff, rms=rms, e_label="LCC PseudoE"))
 
             if HAS_TORCH and isinstance(self.l1, torch.Tensor):
                 if ((torch.abs(ediff) < e_conv) and torch.abs(rms) < r_conv):
-                    print("\nLambda-CC has converged in %.3f seconds.\n" % (time.time() - lambda_tstart))
+                    print(converged(name, time.time() - lambda_tstart))
                     return lecc
             else:
                 if ((abs(ediff) < e_conv) and abs(rms) < r_conv):
-                    print("\nLambda-CC has converged in %.3f seconds.\n" % (time.time() - lambda_tstart))
+                    print(converged(name, time.time() - lambda_tstart))
                     return lecc
 
             diis.add_error_vector(self.l1, self.l2)

--- a/pycc/ccresponse.py
+++ b/pycc/ccresponse.py
@@ -11,7 +11,8 @@ import time
 from typing import TYPE_CHECKING
 
 import numpy as np
-from .utils import helper_diis, permute_triples
+import qcelemental as qcel
+from .utils import helper_diis, permute_triples, title, iteration, converged, field
 from .cclambda import cclambda
 from .cctriples import t3c_ijk_so, t3c_abc_so, l3_ijk_so
 from ._typing import Tensor
@@ -19,6 +20,13 @@ from ._typing import Tensor
 if TYPE_CHECKING:
     from pycc.ccwfn import CCwfn
     from pycc.ccdensity import ccdensity
+
+# Physical constants for the polarizability report (repeated from pycc.properties -- minor, not worth
+# a shared import/module): field frequency omega (Eh) -> wavelength (nm), and dipole polarizability
+# atomic units (Bohr^3) -> Angstrom^3.  From qcelemental, for CODATA consistency with the rest of psi4.
+_NM_PER_EH = 1e7 / (qcel.constants.get('hartree-inverse meter relationship') / 100.0)
+_ANG3_PER_AU = (qcel.constants.get('bohr radius') * 1e10) ** 3
+
 
 class ccresponse(object):
     """
@@ -136,12 +144,10 @@ class ccresponse(object):
         for axis in range(3):
             pertkey = "MU_" + self.cart[axis]
             X_key = pertkey + "_" + f"{omega:0.6f}"
-            print("Solving right-hand perturbed wave function for %s:" % (X_key))
             X[X_key], polar = self.solve_right(self.pertbar[pertkey], omega, e_conv, r_conv, maxiter, max_diis, start_diis)
             check[X_key] = polar
             if (omega != 0.0):
                 X_key = pertkey + "_" + f"{-omega:0.6f}"
-                print("Solving right-hand perturbed wave function for %s:" % (X_key))
                 X[X_key], polar = self.solve_right(self.pertbar[pertkey], -omega, e_conv, r_conv, maxiter, max_diis, start_diis)
                 check[X_key] = polar
 
@@ -149,12 +155,10 @@ class ccresponse(object):
         for axis in range(3):
             pertkey = "M_" + self.cart[axis]
             X_key = pertkey + "_" + f"{omega:0.6f}"
-            print("Solving right-hand perturbed wave function for %s:" % (X_key))
             X[X_key], polar = self.solve_right(self.pertbar[pertkey], omega, e_conv, r_conv, maxiter, max_diis, start_diis)
             check[X_key] = polar
             if (omega != 0.0):
                 X_key = pertkey + "_" + f"{-omega:0.6f}"
-                print("Solving right-hand perturbed wave function for %s:" % (X_key))
                 X[X_key], polar = self.solve_right(self.pertbar[pertkey], -omega, e_conv, r_conv, maxiter, max_diis, start_diis)
                 check[X_key] = polar
 
@@ -162,12 +166,10 @@ class ccresponse(object):
         for axis in range(3):
             pertkey = "M*_" + self.cart[axis]
             X_key = pertkey + "_" + f"{omega:0.6f}"
-            print("Solving right-hand perturbed wave function for %s:" % (X_key))
             X[X_key], polar = self.solve_right(self.pertbar[pertkey], omega, e_conv, r_conv, maxiter, max_diis, start_diis)
             check[X_key] = polar
             if (omega != 0.0):
                 X_key = pertkey + "_" + f"{-omega:0.6f}"
-                print("Solving right-hand perturbed wave function for %s:" % (X_key))
                 X[X_key], polar = self.solve_right(self.pertbar[pertkey], -omega, e_conv, r_conv, maxiter, max_diis, start_diis)
                 check[X_key] = polar
 
@@ -175,12 +177,10 @@ class ccresponse(object):
         for axis in range(3):
             pertkey = "P_" + self.cart[axis]
             X_key = pertkey + "_" + f"{omega:0.6f}"
-            print("Solving right-hand perturbed wave function for %s:" % (X_key))
             X[X_key], polar = self.solve_right(self.pertbar[pertkey], omega, e_conv, r_conv, maxiter, max_diis, start_diis)
             check[X_key] = polar
             if (omega != 0.0):
                 X_key = pertkey + "_" + f"{-omega:0.6f}"
-                print("Solving right-hand perturbed wave function for %s:" % (X_key))
                 X[X_key], polar = self.solve_right(self.pertbar[pertkey], -omega, e_conv, r_conv, maxiter, max_diis, start_diis)
                 check[X_key] = polar
 
@@ -188,12 +188,10 @@ class ccresponse(object):
         for axis in range(3):
             pertkey = "P*_" + self.cart[axis]
             X_key = pertkey + "_" + f"{omega:0.6f}"
-            print("Solving right-hand perturbed wave function for %s:" % (X_key))
             X[X_key], polar = self.solve_right(self.pertbar[pertkey], omega, e_conv, r_conv, maxiter, max_diis, start_diis)
             check[X_key] = polar
             if (omega != 0.0):
                 X_key = pertkey + "_" + f"{-omega:0.6f}"
-                print("Solving right-hand perturbed wave function for %s:" % (X_key))
                 X[X_key], polar = self.solve_right(self.pertbar[pertkey], -omega, e_conv, r_conv, maxiter, max_diis, start_diis)
                 check[X_key] = polar
 
@@ -202,12 +200,10 @@ class ccresponse(object):
             for axis2 in range(3):
                 pertkey = "Q_" + self.cart[axis1] + self.cart[axis2]
                 X_key = pertkey + "_" + f"{omega:0.6f}"
-                print("Solving right-hand perturbed wave function for %s:" % (X_key))
                 X[X_key], polar = self.solve_right(self.pertbar[pertkey], omega, e_conv, r_conv, maxiter, max_diis, start_diis)
                 check[X_key] = polar
                 if (omega != 0.0):
                     X_key = pertkey + "_" + f"{-omega:0.6f}"
-                    print("Solving right-hand perturbed wave function for %s:" % (X_key))
                     X[X_key], polar = self.solve_right(self.pertbar[pertkey], -omega, e_conv, r_conv, maxiter, max_diis, start_diis)
                     check[X_key] = polar
 
@@ -259,8 +255,12 @@ class ccresponse(object):
         X1 = pertbar.Avo.T/(Dia + omega)
         X2 = pertbar.Avvoo/(Dijab + omega)
 
+        name = "right-hand perturbed amplitudes (%s)" % (
+            pertbar.name + ("" if omega == 0.0 else ", omega=%.4f" % omega))
+
         pseudo = self.pseudoresponse(pertbar, X1, X2)
-        print(f"Iter {0:3d}: CC Pseudoresponse = {pseudo.real:.15f} dP = {pseudo.real:.5E}")
+        print(title(name))
+        print(iteration(0, energy=pseudo, de=pseudo, e_label="pseudoresponse"))
 
         diis = helper_diis(X1, X2, max_diis)
         contract = self.ccwfn.contract
@@ -299,16 +299,16 @@ class ccresponse(object):
             self.X1 += r1/(Dia + omega)
             self.X2 += r2/(Dijab + omega)
 
-            rms = contract('ia,ia->', np.conj(r1/(Dia+omega)), r1/(Dia+omega))
-            rms += contract('ijab,ijab->', np.conj(r2/(Dijab+omega)), r2/(Dijab+omega))
+            rms = contract('ia,ia->', r1/(Dia+omega), r1/(Dia+omega))
+            rms += contract('ijab,ijab->', r2/(Dijab+omega), r2/(Dijab+omega))
             rms = np.sqrt(rms)
 
             pseudo = self.pseudoresponse(pertbar, self.X1, self.X2)
             pseudodiff = np.abs(pseudo - pseudo_last)
-            print(f"Iter {niter:3d}: CC Pseudoresponse = {pseudo.real:.15f} dP = {pseudodiff:.5E} rms = {rms.real:.5E}")
+            print(iteration(niter, energy=pseudo, de=pseudodiff, rms=rms, e_label="pseudoresponse"))
 
             if ((abs(pseudodiff) < e_conv) and abs(rms) < r_conv):
-                print("\nPerturbed wave function converged in %.3f seconds.\n" % (time.time() - solver_start))
+                print(converged(name, time.time() - solver_start))
                 if self.ccwfn.model == 'CC3':
                     if self.ccwfn.store_triples:
                         # full X3 was formed and stored each iteration
@@ -573,7 +573,29 @@ class ccresponse(object):
             for b in range(3):
                 B = self.pertbar["MU_" + self.cart[b]]
                 polar[a, b] = -1.0 * self.linresp_sym(A, Xm[a], B, Xp[b])
+        self._report_polarizability(polar, omega)
         return polar
+
+    def _report_polarizability(self, polar, omega):
+        """Print the symmetric-response polarizability report -- the same layout the
+        :func:`pycc.polarizability` facade prints (frequency in Eh and nm, the SCF/correlation/total
+        tensor, and the isotropic invariant).  The response route omits the orbital relaxation, so it
+        carries no Hartree-Fock contribution: the SCF block is zero and correlation = total."""
+        freq = "%.6f Eh   (static)" % omega if omega == 0.0 else \
+               "%.6f Eh   (%.2f nm)" % (omega, _NM_PER_EH / omega)
+        iso = float(np.trace(polar).real) / 3.0
+        pre = " " * 17
+        fmt = lambda a: np.array2string(np.asarray(a), precision=8, suppress_small=True,
+                                        separator=", ", prefix=pre)
+        print("\n" + "=" * 70)
+        print("%s polarizability  (a.u.)" % self.ccwfn.model)
+        print("=" * 70)
+        print(field("frequency (omega)", freq))
+        print(field("response", "symmetric linear response (unrelaxed)"))
+        print("  SCF          : " + fmt(np.zeros((3, 3))))
+        print("  correlation  : " + fmt(polar))
+        print("  total        : " + fmt(polar))
+        print(field("isotropic (1/3 Tr)", "%.6f a.u.   %.6f Angstrom^3" % (iso, iso * _ANG3_PER_AU)))
 
     def optrot(self, omega, e_conv=1e-12, r_conv=1e-12, maxiter=200,
                max_diis=7, start_diis=1):
@@ -628,7 +650,38 @@ class ccresponse(object):
             for b in range(3):
                 B = self.pertbar["M*_" + self.cart[b]]
                 tensor[a, b] += 0.5 * self.linresp_sym(A, Xmu_p[a], B, Xmstar_m[b])
+        self._report_optrot(tensor, omega)
         return tensor
+
+    def _report_optrot(self, tensor, omega):
+        """Print the symmetric-response optical-rotation (G') report: frequency (Eh and nm), the
+        SCF/correlation/total tensor (unrelaxed, so no HF term and SCF = 0), the trace Tr(G'), and
+        the specific rotation [alpha] in deg/(dm (g/mL)).  The specific-rotation conversion (Rosenfeld
+        expression; see pycc.properties._specific_rotation and the notes) is repeated inline here."""
+        mol = self.ccwfn.ref.molecule()
+        freq = "%.6f Eh   (%.2f nm)" % (omega, _NM_PER_EH / omega)
+        trace = float(np.trace(tensor).real)
+        tau = qcel.constants.get('atomic unit of time')
+        mu0 = qcel.constants.get('mag. constant')
+        n_a = qcel.constants.get('Avogadro constant')
+        e = qcel.constants.get('elementary charge')
+        a0 = qcel.constants.get('Bohr radius')
+        hbar = qcel.constants.get('Planck constant over 2 pi')
+        m_kg = sum(mol.mass(atom) for atom in range(mol.natom())) * 1e-3
+        alpha = -(3.60e4) / (6.0 * np.pi) * (omega / tau) * mu0 * n_a * (e ** 2 * a0 ** 3 / hbar) / m_kg * trace
+        pre = " " * 17
+        fmt = lambda a: np.array2string(np.asarray(a), precision=8, suppress_small=True,
+                                        separator=", ", prefix=pre)
+        print("\n" + "=" * 70)
+        print("%s optical rotation, G'  (a.u.)" % self.ccwfn.model)
+        print("=" * 70)
+        print(field("frequency (omega)", freq))
+        print(field("response", "symmetric linear response (unrelaxed)"))
+        print("  SCF          : " + fmt(np.zeros((3, 3))))
+        print("  correlation  : " + fmt(tensor))
+        print("  total        : " + fmt(tensor))
+        print(field("Tr(G')", "%.6f a.u." % trace))
+        print(field("specific rotation", "%.4f deg/(dm (g/mL))" % alpha))
 
     # ------------------------------------------------------------------
     # Symmetric linear-response assembly. Each component dispatches on
@@ -1714,9 +1767,12 @@ class ccresponse(object):
         Y2 = 4.0 * X2_guess.copy()
         Y2 -= 2.0 * X2_guess.copy().swapaxes(2,3)
 
-        # need to understand this
+        name = "left-hand perturbed amplitudes (%s)" % (
+            pertbar.name + ("" if omega == 0.0 else ", omega=%.4f" % omega))
+
         pseudo = self.pseudoresponse(pertbar, Y1, Y2)
-        print(f"Iter {0:3d}: CC Pseudoresponse = {pseudo.real:.15f} dP = {pseudo.real:.5E}")
+        print(title(name))
+        print(iteration(0, energy=pseudo, de=pseudo, e_label="pseudoresponse"))
 
         diis = helper_diis(Y1, Y2, max_diis)
         contract = self.ccwfn.contract
@@ -1740,16 +1796,16 @@ class ccresponse(object):
             self.Y1 += r1/(Dia + omega)
             self.Y2 += r2/(Dijab + omega)
 
-            rms = contract('ia,ia->', np.conj(r1/(Dia+omega)), r1/(Dia+omega))
-            rms += contract('ijab,ijab->', np.conj(r2/(Dijab+omega)), r2/(Dijab+omega))
+            rms = contract('ia,ia->', r1/(Dia+omega), r1/(Dia+omega))
+            rms += contract('ijab,ijab->', r2/(Dijab+omega), r2/(Dijab+omega))
             rms = np.sqrt(rms)
 
             pseudo = self.pseudoresponse(pertbar, self.Y1, self.Y2)
             pseudodiff = np.abs(pseudo - pseudo_last)
-            print(f"Iter {niter:3d}: CC Pseudoresponse = {pseudo.real:.15f} dP = {pseudodiff:.5E} rms = {rms.real:.5E}")
+            print(iteration(niter, energy=pseudo, de=pseudodiff, rms=rms, e_label="pseudoresponse"))
 
             if ((abs(pseudodiff) < e_conv) and abs(rms) < r_conv):
-                print("\nPerturbed wave function converged in %.3f seconds.\n" % (time.time() - solver_start))
+                print(converged(name, time.time() - solver_start))
                 return self.Y1, self.Y2 , pseudo
 
             diis.add_error_vector(self.Y1, self.Y2)
@@ -2298,5 +2354,6 @@ class _PertbarCache(dict):
         """Build the requested pertbar on first access via the owner's
         _build_pertbar, cache it under ``key``, and return it."""
         value = self._owner._build_pertbar(key)
+        value.name = key                        # its perturbation key (e.g. 'MU_X'), for solver labels
         self[key] = value
         return value

--- a/pycc/cctriples.py
+++ b/pycc/cctriples.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
 import numpy as np
 from pycc.ccwfn import HAS_TORCH
 if HAS_TORCH:
     import torch
-from pycc.utils import zeros_like, diag, clone, permute_triples
+from pycc.utils import zeros_like, diag, clone, permute_triples, title, iteration, converged
 
 if TYPE_CHECKING:
     from pycc.ccwfn import CCwfn
@@ -1031,7 +1032,10 @@ def t_invariant_so(o, v, t1, t2, F, ERI, contract, e_conv=1e-11, maxiter=100):
 
     t3 = source / denom
     eold = _t_energy_from_t3_so(o, v, t1, t2, F, ERI, t3, contract)
-    for _ in range(maxiter):
+    name = "(T) T3 (Jacobi)"
+    print(title(name))
+    t0 = time.time()
+    for niter in range(1, maxiter + 1):
         # <nu3|[F_offdiag,T3]|0>: virtual (c->d via Fvv) + occupied (k->l via Foo)
         tmp = contract('ijkabc,dc->ijkabd', t3, Fvv)
         comm = tmp - tmp.swapaxes(3, 5) - tmp.swapaxes(4, 5)
@@ -1039,7 +1043,9 @@ def t_invariant_so(o, v, t1, t2, F, ERI, contract, e_conv=1e-11, maxiter=100):
         comm = comm + (tmp - tmp.swapaxes(0, 2) - tmp.swapaxes(1, 2))
         t3 = (source + comm) / denom
         et = _t_energy_from_t3_so(o, v, t1, t2, F, ERI, t3, contract)
+        print(iteration(niter, energy=et, de=et - eold, e_label="E(T)"))
         if abs(et - eold) < e_conv:
+            print(converged(name, time.time() - t0))
             return et
         eold = et
     raise RuntimeError("t_invariant_so: T3 iteration did not converge in %d cycles "

--- a/pycc/ccwfn.py
+++ b/pycc/ccwfn.py
@@ -19,7 +19,7 @@ except ImportError:
 
 from typing import Any
 
-from .utils import helper_diis, zeros_like, clone, sqrt, permute_triples
+from .utils import helper_diis, zeros_like, clone, sqrt, permute_triples, title, iteration, converged, timing, solve_params
 from .wavefunction import Wavefunction
 from .local import Local
 from . import cctriples
@@ -84,6 +84,7 @@ class CCwfn(Wavefunction):
         if model not in valid_cc_models:
             raise InvalidKeywordError('model', model, valid_cc_models)
         self.model = model
+        self.method = model                 # preamble label (see Wavefunction._report_preamble)
 
         # Convergence criteria (overwritten by solve_cc with the values actually used); defaulted
         # here so downstream code that inherits them (the derivative drivers' Lambda / perturbed
@@ -201,7 +202,7 @@ class CCwfn(Wavefunction):
             self.t1 = mgr.seed_compute(np.zeros((self.no, self.nv)))
             self.t2 = clone(self.H.ERI[o, o, v, v], device=self.device1) / self.Dijab
 
-        print("CCWFN object initialized in %.3f seconds." % (time.time() - time_init))
+        print(timing("CCwfn", time.time() - time_init))
 
 
     def solve_cc(self, e_conv: float = 1e-7, r_conv: float = 1e-7, maxiter: int = 100, max_diis: int = 8, start_diis: int = 1) -> float:
@@ -249,7 +250,10 @@ class CCwfn(Wavefunction):
             self.t3 = np.zeros((self.no, self.no, self.no, self.nv, self.nv, self.nv))
 
         ecc = self.cc_energy(o, v, F, L, self.t1, self.t2)
-        print("CC Iter %3d: CC Ecorr = %.15f  dE = % .5E  MP2" % (0, ecc, -ecc))
+        name = "T-amplitudes (%s)" % self.model
+        print(solve_params(self.model, e_conv, r_conv, maxiter, max_diis, start_diis))
+        print(title(name))
+        print(iteration(0, energy=ecc, de=-ecc, e_label="CC Ecorr", note="MP2"))
 
         diis = helper_diis(self.t1, self.t2, max_diis, self.precision)
 
@@ -273,7 +277,7 @@ class CCwfn(Wavefunction):
 
             ecc = self.cc_energy(o, v, F, L, self.t1, self.t2)
             ediff = ecc - ecc_last
-            print("CC Iter %3d: CC Ecorr = %.15f  dE = % .5E  rms = % .5E" % (niter, ecc, ediff, rms))
+            print(iteration(niter, energy=ecc, de=ediff, rms=rms, e_label="CC Ecorr"))
 
             # check for convergence. abs() dispatches to __abs__ on both NumPy scalars
             # and 0-d torch tensors, so this single block (and the (T) correction below)
@@ -281,7 +285,7 @@ class CCwfn(Wavefunction):
             # silently skipped the (T) step, so CCSD(T) on a torch tensor returned the
             # bare CCSD energy.
             if ((abs(ediff) < e_conv) and abs(rms) < r_conv):
-                print("\nCCWFN converged in %.3f seconds.\n" % (time.time() - ccsd_tstart))
+                print(converged(name, time.time() - ccsd_tstart))
                 print("E(REF)  = %20.15f" % self.eref)
                 if (self.model == 'CCSD(T)'):
                     print("E(CCSD) = %20.15f" % ecc)

--- a/pycc/cideriv.py
+++ b/pycc/cideriv.py
@@ -37,9 +37,13 @@ used by the AAT/VG-APT overlap code (magnetic/vecpot/nuclear, via `_cpci_ints`).
 
 from __future__ import annotations
 
+import time
+
 import numpy as np
 
 from .correlatedderivs import CorrelatedDerivs
+from .cphf import perturbation_label
+from .utils import title, iteration, converged
 
 
 class CIderiv(CorrelatedDerivs):
@@ -67,7 +71,8 @@ class CIderiv(CorrelatedDerivs):
         """First-order response (d_x D, d_x Gam) of the CISD unrelaxed reduced densities to
         pert, in the same convention as _unrelaxed_densities. Solves the coupled-perturbed-CI
         response directly from the base's own canonical, full-occupied-space perturbed integrals. """
-        dc1, dc2, dc0v, _dt1, _dt2 = self._solve_cpci_ints(df, deri, imaginary=False)
+        label = perturbation_label(pert, self.ci.ref.molecule())
+        dc1, dc2, dc0v, _dt1, _dt2 = self._solve_cpci_ints(df, deri, imaginary=False, label=label)
         dD_corr = self._perturbed_cisd_corr_opdm(dc1, dc2)
         dG_raw = self._perturbed_cisd_tpdm(dc1, dc2, dc0v)
         dGam = self._cisd_symmetrize(dG_raw)
@@ -105,7 +110,7 @@ class CIderiv(CorrelatedDerivs):
         return result
 
     def _solve_cpci_ints(self, dF, dERI, imaginary=False, maxiter=100, diis_start=2, diis_max=8,
-                          e_convergence=1e-11, d_convergence=1e-11):
+                          e_convergence=1e-11, d_convergence=1e-11, label=None):
         """Core coupled-perturbed-CI iterative solve given already-built perturbed integrals
         (dF, dERI) - the CISD analog of CCderiv._perturbed_amplitudes, factored out so both
         CIderiv's own _cpci_ints-driven entry point (_solve_cpci, below) and the base's
@@ -166,7 +171,10 @@ class CIderiv(CorrelatedDerivs):
 
         diis = helper_diis(dt1, dt2, diis_max, getattr(ci, 'precision', 1e-12))
 
-        for iteration in range(1, maxiter + 1):
+        name = "CISD perturbed amplitudes" + (" (%s)" % label if label else "")
+        print(title(name))
+        t0 = time.time()
+        for niter in range(1, maxiter + 1):
             dE_proj_old = dE_proj
             dt1_old, dt2_old = dt1.copy(), dt2.copy()
 
@@ -230,7 +238,7 @@ class CIderiv(CorrelatedDerivs):
             dt2 = dt2 + dRt2 / Dijab
 
             diis.add_error_vector(dt1, dt2)
-            if iteration >= diis_start:
+            if niter >= diis_start:
                 dt1, dt2 = diis.extrapolate(dt1, dt2)
 
             dE_proj = (2.0 * c('ia,ia->', t1, dF[o, v])
@@ -241,8 +249,10 @@ class CIderiv(CorrelatedDerivs):
             delta_dE = abs(dE_proj - dE_proj_old)
             rms_dt1 = np.sqrt(np.sum((dt1 - dt1_old) ** 2))
             rms_dt2 = np.sqrt(np.sum((dt2 - dt2_old) ** 2))
-            if iteration > 1 and (delta_dE < e_convergence and rms_dt1 < d_convergence
-                                   and rms_dt2 < d_convergence):
+            print(iteration(niter, de=delta_dE, rms=np.sqrt(abs(rms_dt1) ** 2 + abs(rms_dt2) ** 2)))
+            if niter > 1 and (delta_dE < e_convergence and rms_dt1 < d_convergence
+                              and rms_dt2 < d_convergence):
+                print(converged(name, time.time() - t0))
                 break
 
         dc0 = ci._cisd_dn0(dt1, dt2)
@@ -277,7 +287,8 @@ class CIderiv(CorrelatedDerivs):
         imaginary = pert.kind in ('magnetic', 'vecpot')
         dc1, dc2, dc0v, dt1, dt2 = self._solve_cpci_ints(
             dF, dERI, imaginary=imaginary, maxiter=maxiter, diis_start=diis_start,
-            diis_max=diis_max, e_convergence=e_convergence, d_convergence=d_convergence)
+            diis_max=diis_max, e_convergence=e_convergence, d_convergence=d_convergence,
+            label=perturbation_label(pert, self.ci.ref.molecule()))
         if getattr(self, '_cpci_raw_cache', None) is None:
             self._cpci_raw_cache = {}
         self._cpci_raw_cache[key] = (dt1, dt2)

--- a/pycc/ciwfn.py
+++ b/pycc/ciwfn.py
@@ -10,7 +10,7 @@ from typing import Any, TYPE_CHECKING
 import numpy as np
 
 from .wavefunction import Wavefunction
-from .utils import helper_diis, clone, sqrt, zeros_like
+from .utils import helper_diis, clone, sqrt, zeros_like, title, iteration, converged, timing, solve_params
 from .exceptions import InvalidKeywordError
 
 if TYPE_CHECKING:
@@ -41,6 +41,7 @@ class CIwfn(Wavefunction):
         if model not in valid_ci_models:
             raise InvalidKeywordError('model', model, valid_ci_models)
         self.model = model
+        self.method = model                 # preamble label (see Wavefunction._report_preamble)
         self.need_singles = model in ['CISD']
 
         super().__init__(scf_wfn, **kwargs)
@@ -59,7 +60,7 @@ class CIwfn(Wavefunction):
         self.c1 = mgr.seed_compute(np.zeros((self.no, self.nv)))
         self.c2 = clone(self.H.ERI[o, o, v, v], device=self.device1) / self.Dijab
 
-        print("CIWFN object initialized in %.3f seconds." % (time.time() - time_init))
+        print(timing("CIwfn", time.time() - time_init))
 
     def solve_ci(self, e_conv: float = 1e-7, r_conv: float = 1e-7, maxiter: int = 100, max_diis: int = 8, start_diis: int = 1) -> "Tensor":
         """Iterate the projected CISD equations to convergence and return E_c.
@@ -73,7 +74,10 @@ class CIwfn(Wavefunction):
         contract = self.contract
 
         eci = self.ci_energy(o, v, F, L, self.c1, self.c2)
-        print("CI Iter %3d: CI Ecorr = %.15f  dE = % .5E  MP2" % (0, eci, -eci))
+        name = "CI-amplitudes (%s)" % self.model
+        print(solve_params(self.model, e_conv, r_conv, maxiter, max_diis, start_diis))
+        print(title(name))
+        print(iteration(0, energy=eci, de=-eci, e_label="CI Ecorr", note="MP2"))
 
         diis = helper_diis(self.c1, self.c2, max_diis, self.precision)
 
@@ -94,10 +98,10 @@ class CIwfn(Wavefunction):
 
             eci = self.ci_energy(o, v, F, L, self.c1, self.c2)
             ediff = eci - eci_last
-            print("CI Iter %3d: CI Ecorr = %.15f  dE = % .5E  rms = % .5E" % (niter, eci, ediff, rms))
+            print(iteration(niter, energy=eci, de=ediff, rms=rms, e_label="CI Ecorr"))
 
             if (abs(ediff) < e_conv) and abs(rms) < r_conv:
-                print("\nCIWFN converged in %.3f seconds.\n" % (time.time() - ci_tstart))
+                print(converged(name, time.time() - ci_tstart))
                 print("E(REF)   = %20.15f" % self.eref)
                 print("E(%s)  = %20.15f" % (self.model, eci))
                 print("E(TOT)   = %20.15f" % (eci + self.eref))

--- a/pycc/correlatedderivs.py
+++ b/pycc/correlatedderivs.py
@@ -65,7 +65,7 @@ class CorrelatedDerivs:
         and the CPHF orbital Hessian used by the Z-vector solve."""
         if self._ref_hf is None:
             from .hfwfn import HFwfn
-            self._ref_hf = HFwfn(self.wfn.ref, orbital_basis=self.wfn.orbital_basis)
+            self._ref_hf = HFwfn(self.wfn.ref, orbital_basis=self.wfn.orbital_basis, quiet=True)
         return self._ref_hf
 
     @property

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -75,6 +75,26 @@ from .utils import diag
 Perturbation = namedtuple('Perturbation', ['kind', 'comp'])
 
 
+def perturbation_label(pert, mol=None):
+    """A short human label for a :data:`Perturbation`, for solver output -- e.g. ``'O1y'``
+    (nuclear: atom 1, Cartesian y), ``'mu_x'`` (electric field), ``'m_z'`` (magnetic dipole),
+    ``'p_x'`` (vector potential / linear momentum).  ``mol`` supplies the element symbols for a
+    nuclear perturbation; without it the atom index is used."""
+    xyz = 'xyz'
+    kind, comp = pert.kind, pert.comp
+    if kind == 'nuclear':
+        atom, cart = comp
+        sym = mol.symbol(atom) if mol is not None else 'atom%d' % atom
+        return "%s%d%s" % (sym, atom + 1, xyz[cart])
+    if kind == 'field':
+        return "mu_%s" % xyz[comp]
+    if kind == 'magnetic':
+        return "m_%s" % xyz[comp]
+    if kind == 'vecpot':
+        return "p_%s" % xyz[comp]
+    return "%s(%s)" % (kind, comp)
+
+
 class CPHF(object):
     """RHF coupled-perturbed Hartree-Fock orbital-response solver (MO basis).
 

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -37,6 +37,7 @@ class HFwfn(Wavefunction):
     _all_electron = True
 
     def __init__(self, scf_wfn: Any, **kwargs) -> None:
+        self.method = 'HF'                  # preamble label (see Wavefunction._report_preamble)
         super().__init__(scf_wfn, **kwargs)
         # The derivative-integral provider and the CPHF orbital-response solver now live
         # on the base, built lazily (``self.derivatives`` / ``self.cphf``).

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -4,12 +4,13 @@ mpwfn.py: Moller-Plesset perturbation-theory (MP2) wavefunction.
 
 from __future__ import annotations
 
+import time
 from typing import Any, TYPE_CHECKING
 
 import numpy as np
 
 from .wavefunction import Wavefunction
-from .utils import clone
+from .utils import clone, timing
 
 if TYPE_CHECKING:
     from ._typing import Tensor
@@ -43,8 +44,11 @@ class MPwfn(Wavefunction):
     """
 
     def __init__(self, scf_wfn: Any, **kwargs) -> None:
+        time_init = time.time()
+        self.method = 'MP2'                 # preamble label (see Wavefunction._report_preamble)
         super().__init__(scf_wfn, **kwargs)
         self._build_mp2()
+        print(timing("MPwfn", time.time() - time_init))
 
     def _build_mp2(self) -> None:
         r"""Build the energy denominators and MP2 doubles amplitudes from the seeded
@@ -205,5 +209,5 @@ class MPwfn(Wavefunction):
         (electronic) contribution to the total MP2 properties via the pycc property facade."""
         if getattr(self, '_ref_hf', None) is None:
             from .hfwfn import HFwfn
-            self._ref_hf = HFwfn(self.ref, orbital_basis=self.orbital_basis)
+            self._ref_hf = HFwfn(self.ref, orbital_basis=self.orbital_basis, quiet=True)
         return self._ref_hf

--- a/pycc/properties.py
+++ b/pycc/properties.py
@@ -18,6 +18,18 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 import numpy as np
+import qcelemental as qcel
+
+from .utils import field
+
+#: Dipole polarizability atomic units (Bohr^3) to Angstrom^3 (= (a0 in Angstrom)^3), and the photon
+#: wavelength (nm) per field frequency omega (Eh): ``lambda = NM_PER_EH / omega`` (= 1e7 nm/cm over
+#: the Hartree-to-wavenumber relation).  Sourced from qcelemental so they track the same CODATA
+#: revision as every other constant psi4 uses.
+ANG3_PER_AU = (qcel.constants.get('bohr radius') * 1e10) ** 3
+NM_PER_EH = 1e7 / (qcel.constants.get('hartree-inverse meter relationship') / 100.0)
+#: Electric dipole moment atomic units (e a0) to Debye.
+DEBYE_PER_AU = qcel.constants.conversion_factor('e * bohr', 'debye')
 
 
 @dataclass(frozen=True)
@@ -60,6 +72,34 @@ class PropertyComponents:
     def hf(self) -> np.ndarray:
         """Alias of :attr:`reference`."""
         return self.reference
+
+    def report(self, name: str, unit: str = "a.u.", params=None, summary=None) -> "PropertyComponents":
+        """Print the property as an SCF / correlation / total breakdown and return ``self``
+        (so a facade can ``return components.report(...)``).  ``SCF`` is the full SCF-level value
+        ``nuclear + reference`` (what a bare Hartree-Fock calculation gives), ``correlation`` the
+        post-SCF correction, and ``total`` their sum -- so ``SCF + correlation = total``.
+
+        ``params`` is an optional list of ``(label, value)`` rows printed above the tensor (e.g. the
+        field frequency of a polarizability); ``summary`` an optional list printed below it (e.g. the
+        isotropic invariant)."""
+        scf = self.nuclear + self.reference
+        pre = " " * 17
+
+        def fmt(a):
+            return np.array2string(np.asarray(a), precision=8, suppress_small=True,
+                                   separator=", ", prefix=pre)
+
+        print("\n" + "=" * 70)
+        print("%s  (%s)" % (name, unit))
+        print("=" * 70)
+        for label, value in (params or []):
+            print(field(label, value))
+        print("  SCF          : " + fmt(scf))
+        print("  correlation  : " + fmt(self.correlation))
+        print("  total        : " + fmt(self.total))
+        for label, value in (summary or []):
+            print(field(label, value))
+        return self
 
 
 # ------------------------------------------------------------------------------------------------
@@ -151,6 +191,19 @@ def _wfn_of(obj):
     return obj.wfn if isinstance(obj, CorrelatedDerivs) else obj
 
 
+def _method_name(obj) -> str:
+    """The method label for a property report -- ``'SCF'``, ``'MP2'``, or the model of the
+    underlying wavefunction (``'CCSD'`` / ``'CCSD(T)'`` / ``'CISD'`` / ...)."""
+    from .hfwfn import HFwfn
+    from .mpwfn import MPwfn
+    if isinstance(obj, HFwfn):
+        return "SCF"
+    w = _wfn_of(obj)
+    if isinstance(w, MPwfn):
+        return "MP2"
+    return getattr(w, 'model', type(w).__name__)
+
+
 def _dispatch(obj, hf_method, corr_method, corr_kwargs=None):
     """Reference (SCF electronic) and correlation blocks of a property, computed apart.  ``obj`` is
     a derivative driver or (transitionally) a correlated wavefunction: the reference is the
@@ -169,9 +222,17 @@ def _dispatch(obj, hf_method, corr_method, corr_kwargs=None):
 
 def dipole(wfn) -> PropertyComponents:
     """Electric-dipole moment as a :class:`PropertyComponents` (``nuclear + reference +
-    correlation``, shape ``(3,)`` each) for any supported wavefunction type."""
+    correlation``, shape ``(3,)`` each) for any supported wavefunction type.  The report gives the
+    SCF/correlation/total vectors in a.u. and, for the total, the vector and magnitude in Debye."""
     reference, correlation = _dispatch(wfn, '_dipole_electronic', 'relaxed_dipole')
-    return PropertyComponents(_nuclear_dipole(_wfn_of(wfn).ref.molecule()), reference, correlation)
+    pc = PropertyComponents(_nuclear_dipole(_wfn_of(wfn).ref.molecule()), reference, correlation)
+    total = np.asarray(pc.total)
+    mag = float(np.linalg.norm(total))
+    debye = np.array2string(total * DEBYE_PER_AU, precision=8, suppress_small=True, separator=", ")
+    return pc.report(
+        "%s dipole moment" % _method_name(wfn),
+        summary=[("total (Debye)", debye),
+                 ("|mu|", "%.6f a.u.   %.6f Debye" % (mag, mag * DEBYE_PER_AU))])
 
 
 def gradient(wfn) -> PropertyComponents:
@@ -180,14 +241,89 @@ def gradient(wfn) -> PropertyComponents:
     derivative ``dV_NN/dX``."""
     reference, correlation = _dispatch(wfn, '_gradient_electronic', 'gradient')
     nuclear = np.asarray(_wfn_of(wfn).derivatives.nuclear_repulsion())
-    return PropertyComponents(nuclear, reference, correlation)
+    pc = PropertyComponents(nuclear, reference, correlation)
+    return pc.report("%s gradient" % _method_name(wfn))
 
 
-def polarizability(wfn) -> PropertyComponents:
-    """Static electric-dipole polarizability as a :class:`PropertyComponents`, shape ``(3, 3)``
-    each.  A pure electronic response property: the nuclear block is zero."""
-    reference, correlation = _dispatch(wfn, 'polarizability', 'polarizability')
-    return PropertyComponents(np.zeros((3, 3)), reference, correlation)
+def polarizability(wfn, omega: float = 0.0, relaxed: bool = None) -> PropertyComponents:
+    """Electric-dipole polarizability as a :class:`PropertyComponents`, shape ``(3, 3)`` each.  A
+    pure electronic response property: the nuclear block is zero.  The report also prints the field
+    frequency (in Eh and nm) and the isotropic invariant ``(1/3) Tr(alpha)`` in a.u. and Angstrom^3.
+
+    Two routes, selected by ``omega`` and ``relaxed``:
+
+    * **relaxed** -- the orbital-relaxed analytic second derivative (2n+1 route), the default at
+      ``omega = 0``.  Available for MP2 / CISD / CCSD.  Static only: a relaxed value at ``omega != 0``
+      is undefined and raises.
+    * **unrelaxed** -- the CC linear-response value (:meth:`CCderiv.dynamic_polarizability`), which
+      omits the orbital (MO) response.  This is the convention for *dynamic* response properties --
+      including the orbital relaxation introduces spurious poles -- so it is the default at
+      ``omega != 0``.  **CCSD only** (needs a :class:`~pycc.ccderiv.CCderiv`).  Because there is no
+      MO response, there is no Hartree-Fock contribution: the value is correlation-only, so the SCF
+      block is zero.
+
+    ``omega`` is the external-field frequency in Eh (0 = static).  ``relaxed`` overrides the route:
+    the default (``None``) picks relaxed at ``omega = 0`` and unrelaxed otherwise; ``relaxed=False``
+    takes the unrelaxed route at ``omega = 0`` too."""
+    if relaxed is None:
+        relaxed = (omega == 0.0)
+    if relaxed and omega != 0.0:
+        raise ValueError(
+            "a relaxed polarizability at omega != 0 is not defined: dynamic response omits the "
+            "orbital relaxation (which introduces spurious poles).  Use the default (relaxed=None) "
+            "or relaxed=False for the unrelaxed dynamic value.")
+
+    freq = "%.6f Eh   (static)" % omega if omega == 0.0 else \
+           "%.6f Eh   (%.2f nm)" % (omega, NM_PER_EH / omega)
+
+    if relaxed:
+        reference, correlation = _dispatch(wfn, 'polarizability', 'polarizability')
+        pc = PropertyComponents(np.zeros((3, 3)), reference, correlation)
+        route = "relaxed (orbital-relaxed derivative)"
+    else:
+        if not hasattr(wfn, 'dynamic_polarizability'):
+            raise NotImplementedError(
+                "the dynamic (unrelaxed) polarizability is implemented for CCSD only; pass a "
+                "pycc.CCderiv for a CCSD wavefunction (got %s)." % type(wfn).__name__)
+        # Correlation-only: no MO response, hence no HF/SCF contribution (see the docstring).
+        correlation = np.asarray(wfn.dynamic_polarizability(omega))
+        pc = PropertyComponents(np.zeros((3, 3)), np.zeros((3, 3)), correlation)
+        route = "unrelaxed (no orbital relaxation; correlation only)"
+
+    iso_au = float(np.trace(np.asarray(pc.total)).real) / 3.0
+    return pc.report(
+        "%s polarizability" % _method_name(wfn),
+        params=[("frequency (omega)", freq), ("response", route)],
+        summary=[("isotropic (1/3 Tr)", "%.6f a.u.   %.6f Angstrom^3" % (iso_au, iso_au * ANG3_PER_AU))])
+
+
+def optical_rotation(wfn, omega) -> PropertyComponents:
+    """Optical-rotation (optical-activity) tensor ``G'(omega)`` as a :class:`PropertyComponents`,
+    shape ``(3, 3)`` -- the unrelaxed CC linear response of the electric dipole to the magnetic
+    dipole (:meth:`~pycc.ccderiv.CCderiv.optical_rotation`).
+
+    **CCSD only** (needs a :class:`~pycc.ccderiv.CCderiv`), and ``omega`` must be nonzero -- there is
+    no static optical rotation.  Like the dynamic polarizability it omits the orbital (MO) response,
+    so it carries no Hartree-Fock contribution: the SCF block is zero and correlation = total.  The
+    report prints the field frequency (Eh and nm), ``Tr(G')`` in a.u., and the specific rotation
+    ``[alpha]`` in deg/(dm (g/mL))."""
+    if omega == 0.0:
+        raise ValueError("optical rotation requires a nonzero field frequency; there is no static "
+                         "optical rotation.")
+    if not hasattr(wfn, 'optical_rotation'):
+        raise NotImplementedError(
+            "optical rotation is implemented for CCSD only; pass a pycc.CCderiv for a CCSD "
+            "wavefunction (got %s)." % type(wfn).__name__)
+    g = np.asarray(wfn.optical_rotation(omega))
+    pc = PropertyComponents(np.zeros((3, 3)), np.zeros((3, 3)), g)
+    trace = float(np.trace(g).real)
+    alpha = _specific_rotation(trace, omega, _wfn_of(wfn).ref.molecule())
+    return pc.report(
+        "%s optical rotation, G'" % _method_name(wfn),
+        params=[("frequency (omega)", "%.6f Eh   (%.2f nm)" % (omega, NM_PER_EH / omega)),
+                ("response", "unrelaxed (no orbital relaxation; correlation only)")],
+        summary=[("Tr(G')", "%.6f a.u." % trace),
+                 ("specific rotation", "%.4f deg/(dm (g/mL))" % alpha)])
 
 
 def hessian(wfn) -> PropertyComponents:
@@ -196,7 +332,8 @@ def hessian(wfn) -> PropertyComponents:
     repulsion second derivative ``d^2 V_NN/dX dY``."""
     reference, correlation = _dispatch(wfn, '_hessian_electronic', 'hessian')
     nuclear = np.asarray(_wfn_of(wfn).derivatives.nuclear_repulsion2())
-    return PropertyComponents(nuclear, reference, correlation)
+    pc = PropertyComponents(nuclear, reference, correlation)
+    return pc.report("%s Hessian" % _method_name(wfn))
 
 
 def apt(wfn, gauge='length', route='2n+1-field', orbital_gauge='non-canonical') -> PropertyComponents:
@@ -222,7 +359,8 @@ def apt(wfn, gauge='length', route='2n+1-field', orbital_gauge='non-canonical') 
                                            'velocity_dipole_derivatives', {'gauge': orbital_gauge})
     else:
         raise ValueError(f"apt: gauge must be 'length' or 'velocity', got {gauge!r}")
-    return PropertyComponents(_nuclear_apt(_wfn_of(wfn).ref.molecule()), reference, correlation)
+    pc = PropertyComponents(_nuclear_apt(_wfn_of(wfn).ref.molecule()), reference, correlation)
+    return pc.report("%s APT (%s gauge)" % (_method_name(wfn), gauge))
 
 
 def aat(wfn, origin=None, orbital_gauge='non-canonical') -> PropertyComponents:
@@ -266,4 +404,26 @@ def aat(wfn, origin=None, orbital_gauge='non-canonical') -> PropertyComponents:
     else:
         raise TypeError(f"pycc.aat: unsupported wavefunction type {type(wfn).__name__!r}")
     o = (0.0, 0.0, 0.0) if origin is None else tuple(float(x) for x in origin)
-    return PropertyComponents(nuclear=nuclear, reference=reference, correlation=correlation, origin=o)
+    pc = PropertyComponents(nuclear=nuclear, reference=reference, correlation=correlation, origin=o)
+    return pc.report("%s AAT" % _method_name(wfn))
+
+
+def _specific_rotation(trace_G, omega, mol):
+    r"""Specific rotation ``[alpha]`` in deg/(dm (g/mL)) from the trace of the optical-activity
+    tensor ``G'`` (a.u.), the field frequency ``omega`` (Eh), and the molecule (for its molar mass),
+    via the Rosenfeld expression (Barron, *Molecular Light Scattering and Optical Activity*, 2nd ed.,
+    p. 143; see the specific-rotation-units derivation)::
+
+        [alpha] = -(3.60e4 / 6 pi) (omega/tau) mu0 N_A (e^2 a0^3 / hbar) Tr(G') / M
+
+    ``omega/tau`` is ``omega`` in rad/s (``tau`` = atomic unit of time = hbar/Eh, so Eh/hbar = 1/tau,
+    equivalently ``2 pi c / lambda``); ``M`` is the molar mass in kg/mol; ``Tr(G')`` is the full
+    trace (the 1/3 of the isotropic average is folded into the 3.60e4).  Constants from qcelemental."""
+    tau = qcel.constants.get('atomic unit of time')
+    mu0 = qcel.constants.get('mag. constant')
+    n_a = qcel.constants.get('Avogadro constant')
+    e = qcel.constants.get('elementary charge')
+    a0 = qcel.constants.get('Bohr radius')
+    hbar = qcel.constants.get('Planck constant over 2 pi')
+    m_kg = sum(mol.mass(atom) for atom in range(mol.natom())) * 1e-3
+    return -(3.60e4) / (6.0 * np.pi) * (omega / tau) * mu0 * n_a * (e ** 2 * a0 ** 3 / hbar) / m_kg * trace_G

--- a/pycc/tests/test_092_cc_response_polarizability.py
+++ b/pycc/tests/test_092_cc_response_polarizability.py
@@ -1,9 +1,9 @@
 """Orbital-unrelaxed (response) CCSD dipole polarizability via the density reformulation
--- CCderiv.response_polarizability(omega=0) -- cross-checked against the independent
+-- CCderiv.dynamic_polarizability(omega=0) -- cross-checked against the independent
 symmetric linear-response code, ccresponse.polarizability(0).
 
 The two routes share NO machinery, which makes the agreement a strong check:
-  * response_polarizability contracts the orbital-unrelaxed perturbed 1-PDM (the field
+  * dynamic_polarizability contracts the orbital-unrelaxed perturbed 1-PDM (the field
     derivative of the CC density, solved with the BARE MO dipole and no CPHF folding)
     with the bare dipole,  alpha = -Tr(dD . mu)  (the asymmetric / density route);
   * ccresponse builds it from the symmetric response function <<mu;mu>> assembled from
@@ -63,7 +63,7 @@ def test_response_polarizability_spatial_vs_ccresponse(rhf_wfn):
     wfn = rhf_wfn(WATER, "6-31G", freeze_core="false")
     cc = pycc.ccwfn(wfn)
     cc.solve_cc(1e-12, 1e-12, 100)
-    alpha = np.asarray(pycc.CCderiv(cc).response_polarizability(0.0))
+    alpha = np.asarray(pycc.CCderiv(cc).dynamic_polarizability(0.0))
     ref = _ccresponse_polar(wfn, 'spatial')
     assert np.max(np.abs(alpha - ref)) < 1e-10, alpha
     assert np.max(np.abs(alpha - alpha.T)) < 1e-10            # naturally symmetric
@@ -80,7 +80,7 @@ def test_response_polarizability_hof_offdiagonal(rhf_wfn):
     wfn = rhf_wfn(HOF, "cc-pVDZ", freeze_core="false")
     cc = pycc.ccwfn(wfn)
     cc.solve_cc(1e-12, 1e-12, 100)
-    alpha = np.asarray(pycc.CCderiv(cc).response_polarizability(0.0))
+    alpha = np.asarray(pycc.CCderiv(cc).dynamic_polarizability(0.0))
     ref = _ccresponse_polar(wfn, 'spatial')
     assert np.max(np.abs(alpha - ref)) < 1e-10, alpha
     assert np.max(np.abs(alpha - alpha.T)) < 1e-10
@@ -99,12 +99,12 @@ def test_dynamic_response_polarizability_spatial_vs_ccresponse(rhf_wfn):
     cc.solve_cc(1e-12, 1e-12, 100)
     d = pycc.CCderiv(cc)
     for omega in (0.07, -0.07):
-        alpha = np.asarray(d.response_polarizability(omega))
+        alpha = np.asarray(d.dynamic_polarizability(omega))
         ref = _ccresponse_polar(wfn, 'spatial', omega)
         assert np.max(np.abs(alpha - ref)) < 1e-10, (omega, alpha)
         assert np.max(np.abs(alpha - alpha.T)) < 1e-10
-    static = np.asarray(d.response_polarizability(0.0))
-    dyn = np.asarray(d.response_polarizability(0.07))
+    static = np.asarray(d.dynamic_polarizability(0.0))
+    dyn = np.asarray(d.dynamic_polarizability(0.07))
     assert np.all(np.diag(dyn) > np.diag(static))             # normal dispersion (real, sub-resonance)
     psi4.core.clean()
 
@@ -117,7 +117,7 @@ def test_fc_response_polarizability_vs_ccresponse(rhf_wfn):
     cc = pycc.ccwfn(wfn)
     cc.solve_cc(1e-12, 1e-12, 100)
     assert cc.nfzc > 0
-    alpha = np.asarray(pycc.CCderiv(cc).response_polarizability(0.0))
+    alpha = np.asarray(pycc.CCderiv(cc).dynamic_polarizability(0.0))
     ref = _ccresponse_polar(wfn, 'spatial')
     assert np.max(np.abs(alpha - ref)) < 1e-10, alpha
     assert np.max(np.abs(alpha - alpha.T)) < 1e-10
@@ -133,7 +133,7 @@ def test_so_response_polarizability_vs_ccresponse(rhf_wfn):
     cc.solve_cc(1e-12, 1e-12, 100)
     d = pycc.CCderiv(cc)
     for omega in (0.0, 0.07):
-        alpha = np.asarray(d.response_polarizability(omega))
+        alpha = np.asarray(d.dynamic_polarizability(omega))
         ref = _ccresponse_polar(wfn, 'spinorbital', omega)
         assert np.max(np.abs(alpha - ref)) < 1e-10, (omega, alpha)
         assert np.max(np.abs(alpha - alpha.T)) < 1e-10

--- a/pycc/tests/test_094_optical_rotation.py
+++ b/pycc/tests/test_094_optical_rotation.py
@@ -1,0 +1,87 @@
+"""Facade optical rotation (pycc.optical_rotation) and the specific rotation.
+
+Two routes to the CCSD optical-rotation (optical-activity) tensor G'(omega) for chiral H2O2, which
+must give identical results:
+  * pycc.optical_rotation(CCderiv(cc), omega) -- the facade over CCderiv.optical_rotation (the
+    orbital-unrelaxed density / 2n+1 route);
+  * ccresponse.optrot(omega)                  -- the independent symmetric linear-response code.
+
+The report/facade also converts the trace of G' to the specific rotation [alpha] in
+deg/(dm (g/mL)) via the Rosenfeld expression (pycc.properties._specific_rotation); that conversion
+factor was cross-checked against an independent Mathematica implementation.
+
+CCSD, spatial (closed-shell RHF), 6-31G, omega ~ 589 nm (sodium D line).  This complements the
+method-level cross-check in test_093.
+"""
+
+import psi4
+import pycc
+import numpy as np
+import pytest
+
+from pycc.properties import _specific_rotation
+
+
+# Chiral H2O2 (Dalton geometry), as in test_093 / test_058.
+H2O2 = """
+O   1.3133596569   0.0000000000  -0.0932359644
+O  -1.3133596569  -0.0000000000  -0.0932359644
+H   1.6917745981   0.7334825768   1.4797224976
+H  -1.6917745981  -0.7334825768   1.4797224976
+units bohr
+symmetry c1
+no_reorient
+no_com
+"""
+OMEGA = 0.077357          # ~589 nm (sodium D line)
+
+# CCSD/6-31G frozen-core, spatial route, at OMEGA.  G'(omega) is a pseudotensor (not symmetric).
+G_REF = np.array([[-1.681837431953e-02,  3.461783788385e-01,  0.0],
+                  [ 3.046945632411e-02,  2.025642104123e-01,  0.0],
+                  [ 0.0,                  0.0,                -1.895273738325e-01]])
+TRACE_REF = -0.003781537740       # Tr(G'), a.u.
+ALPHA_REF = 18.540192             # specific rotation, deg/(dm (g/mL))
+
+
+def _h2o2_ccsd():
+    """Converged CCSD/6-31G (frozen core) H2O2 wavefunction."""
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.geometry(H2O2)
+    psi4.set_options({'basis': '6-31G', 'scf_type': 'pk', 'freeze_core': 'true',
+                      'e_convergence': 1e-12, 'd_convergence': 1e-12})
+    _, wfn = psi4.energy('scf', return_wfn=True)
+    cc = pycc.ccwfn(wfn)
+    cc.solve_cc(1e-12, 1e-12, 100)
+    return wfn, cc
+
+
+def test_optical_rotation_facade():
+    """pycc.optical_rotation (facade -> CCderiv.optical_rotation) reproduces the reference G'; the
+    unrelaxed response carries no HF term (reference block zero); the reported specific rotation
+    matches the frozen value; and a static (omega = 0) call is rejected."""
+    wfn, cc = _h2o2_ccsd()
+    d = pycc.CCderiv(cc)
+    pc = pycc.optical_rotation(d, OMEGA)
+    G = np.asarray(pc.correlation)
+    assert np.max(np.abs(G - G_REF)) < 1e-11, G
+    assert np.allclose(np.asarray(pc.reference), 0.0)              # unrelaxed: no Hartree-Fock term
+    assert abs(np.trace(G) - TRACE_REF) < 1e-11
+    alpha = _specific_rotation(float(np.trace(G)), OMEGA, wfn.molecule())
+    assert abs(alpha - ALPHA_REF) < 1e-4, alpha
+    with pytest.raises(ValueError):
+        pycc.optical_rotation(d, 0.0)                             # no static optical rotation
+    psi4.core.clean()
+
+
+def test_optical_rotation_ccresponse():
+    """ccresponse.optrot reproduces the same reference G' -- the symmetric linear-response route
+    and the CCderiv density route are identical."""
+    wfn, cc = _h2o2_ccsd()
+    hbar = pycc.cchbar(cc)
+    lam = pycc.cclambda(cc, hbar)
+    lam.solve_lambda(1e-12, 1e-12, 100)
+    dens = pycc.ccdensity(cc, lam)
+    G = np.asarray(pycc.ccresponse(dens).optrot(OMEGA))
+    assert np.max(np.abs(G - G_REF)) < 1e-11, G
+    psi4.core.clean()

--- a/pycc/utils.py
+++ b/pycc/utils.py
@@ -191,6 +191,69 @@ def concatenate(arrays):
     return np.concatenate(arrays)
 
 
+# ---- iterative-solver output ----
+# Single source for the text every iterative solve prints, so the format lives in one place and
+# each solve is self-identifying.  A solve announces itself once with title(), then prints one
+# iteration() row per cycle, and (if it tracks a wall time) a converged() footer.  Plain string
+# builders -- the caller still print()s them; no logging, no verbosity state, no shared object.
+
+def title(text):
+    r"""A blank line then a solve title naming what an iterative sequence solves -- e.g.
+    ``'T-amplitudes (CCSD)'``, ``'perturbed Lambda'``, ``'EOM-CCSD (RIGHT)'``.  Printed once above
+    the iteration rows so a run that stacks many solves (the 3N perturbed solves behind a Hessian,
+    say) stays legible: each block says what it is rather than being an anonymous table of numbers."""
+    return "\n" + text
+
+
+def iteration(niter, energy=None, de=None, rms=None, e_label="Ecorr", note=None):
+    r"""One iteration row, e.g.::
+
+        Iter   3: Ecorr =   -0.070680088785123  dE = -1.20000E-07  rms =  3.40000E-08
+
+    Only the supplied columns print, so an energy-bearing solve (CC, CI) and a residual-only solve
+    (the perturbed-amplitude / Z-vector equations, which have no energy) share one formatter:
+    ``energy`` (labeled ``e_label``), ``de``, and ``rms`` are each shown only when given.  ``note``
+    (e.g. ``'MP2'``) is appended -- used on an initial-guess line in place of ``rms``."""
+    cols = []
+    if energy is not None:
+        cols.append("%s = %.15f" % (e_label, energy))
+    if de is not None:
+        cols.append("dE = % .5E" % de)
+    if rms is not None:
+        cols.append("rms = % .5E" % rms)
+    if note is not None:
+        cols.append(note)
+    return "Iter %3d: %s" % (niter, "  ".join(cols))
+
+
+def converged(name, elapsed):
+    r"""A convergence footer for a timed solve, e.g. ``'CCwfn converged in 0.420 seconds.'``."""
+    return "%s converged in %.3f seconds." % (name, elapsed)
+
+
+def timing(label, seconds):
+    r"""A build-timing line for a major component, e.g. ``'CCwfn built in 0.005 seconds.'`` --
+    a uniform report (one verb, one format) so a run's build steps read consistently and give the
+    user a sense of how long the calculation will take."""
+    return "%s built in %.3f seconds." % (label, seconds)
+
+
+def field(label, value, width=22):
+    r"""A colon-aligned ``label : value`` row for a preamble block, e.g.
+    ``'  SCF energy             : -74.959948270260 Eh'``."""
+    return "  %-*s : %s" % (width, label, value)
+
+
+def solve_params(method, e_conv, r_conv, maxiter, max_diis, start_diis):
+    r"""The wfn-specific solve preamble: the convergence limits and DIIS options a solve runs with,
+    printed above its iteration table."""
+    return "\n".join(("\n%s solve" % method,
+                      field("energy convergence", "%.2E" % e_conv),
+                      field("residual convergence", "%.2E" % r_conv),
+                      field("max iterations", "%d" % maxiter),
+                      field("DIIS max / start", "%d / %d" % (max_diis, start_diis))))
+
+
 class helper_diis(object):
     r"""DIIS (Pulay direct inversion of the iterative subspace) extrapolator for the CC / Lambda /
     response amplitude iterations.  Keeps a rolling window (``max_diis``) of amplitude iterates and
@@ -265,11 +328,14 @@ class helper_diis(object):
         B[-1, -1] = 0
 
         for n1, e1 in enumerate(self.diis_errors):
-            B[n1, n1] = dot(e1, e1)
+            # For complex amplitudes (e.g. ccresponse) the error overlaps are complex; B is the
+            # real overlap matrix by construction (see above), so take the real part explicitly
+            # rather than let the assignment truncate it (which numpy flags as a ComplexWarning).
+            B[n1, n1] = dot(e1, e1).real
             for n2, e2 in enumerate(self.diis_errors):
                 if n1 >= n2:
                     continue
-                B[n1, n2] = dot(e1, e2)
+                B[n1, n2] = dot(e1, e2).real
                 B[n2, n1] = B[n1, n2]
 
         B[:-1, :-1] /= absolute(B[:-1, :-1]).max()

--- a/pycc/wavefunction.py
+++ b/pycc/wavefunction.py
@@ -110,7 +110,7 @@ class Wavefunction(object):
 
     def __init__(self, scf_wfn: Any, *, device: str = 'CPU', precision: str = 'DP',
                  localize_occ: bool = False, local_mos: str = 'PIPEK_MEZEY',
-                 orbital_basis: Any = None, **kwargs) -> None:
+                 orbital_basis: Any = None, quiet: bool = False, **kwargs) -> None:
         if 'frozen_core' in kwargs:
             raise TypeError(
                 "the 'frozen_core' argument was removed; the frozen core is taken from "
@@ -127,6 +127,11 @@ class Wavefunction(object):
 
         self.ref = scf_wfn
         self.eref = self.ref.energy()
+
+        # Suppress the constructor's MO-summary print -- set for internally-built wavefunctions
+        # (e.g. the HFwfn reference the derivative machinery constructs) whose MO table would just
+        # duplicate the one the user's own wavefunction already printed.
+        self.quiet = quiet
 
         # Closed-shell RHF takes the spin-adapted spatial path; open-shell
         # (UHF/ROHF) takes the spin-orbital path. An explicit orbital_basis overrides
@@ -176,6 +181,98 @@ class Wavefunction(object):
         if kwargs:
             raise PyCCError("Unexpected keyword argument(s): %s" % sorted(kwargs))
 
+        # Everything is now set up (molecule, basis, orbital spaces, device, integrals), so the
+        # preamble can report the full computational setup.  Suppressed for internally-built
+        # wavefunctions (the HFwfn reference), whose preamble would duplicate the user's own.
+        if not self.quiet:
+            self._report_preamble()
+
+    def _report_preamble(self) -> None:
+        """Print the run preamble: molecule, basis, reference, and computation parameters, then the
+        MO-by-energy table.  Every value comes from state set during :meth:`__init__` (the psi4
+        reference / molecule / basis, the resolved orbital spaces, and the device manager) plus the
+        psi4 SCF options; coordinates and energies are shown to 12 decimals."""
+        import psi4
+        from . import __version__
+        from .utils import field
+        mol, bset = self.ref.molecule(), self.ref.basisset()
+        method = getattr(self, 'method', type(self).__name__)
+        ref_type = psi4.core.get_option('SCF', 'REFERENCE')
+        e_conv = float(psi4.core.get_option('SCF', 'E_CONVERGENCE'))
+        d_conv = float(psi4.core.get_option('SCF', 'D_CONVERGENCE'))
+        puream = 'spherical' if bset.has_puream() else 'cartesian'
+        geom = mol.geometry().np                          # computational frame, bohr
+        units = mol.units().lower()
+        rule = "=" * 68
+
+        print("\n" + rule)
+        print("PyCC %s  --  %s wavefunction" % (__version__, method))
+        print(rule)
+        print("Molecule")
+        print(field("charge, multiplicity", "%d, %d" % (mol.molecular_charge(), mol.multiplicity())))
+        print(field("point group", mol.point_group().symbol()))
+        print("  geometry (%s):" % units)
+        for A in range(mol.natom()):
+            x, y, z = geom[A]
+            print("      %-2s  %18.12f  %18.12f  %18.12f" % (mol.symbol(A), x, y, z))
+        print(field("nuclear repulsion", "%.12f Eh" % mol.nuclear_repulsion_energy()))
+        print("Basis")
+        print(field("set", bset.name()))
+        print(field("functions", "%d (%s)" % (bset.nbf(), puream)))
+        print("Reference")
+        print(field("type", ref_type))
+        print(field("SCF energy", "%.12f Eh" % self.eref))
+        print(field("frozen core", "%d" % self.nfzc))
+        print(field("active occ / vir", "%d / %d   (nmo = %d)" % (self.no, self.nv, self.nmo)))
+        print("Computation")
+        print(field("orbital basis", self.orbital_basis))
+        print(field("device, precision", "%s, %s" % (self.device, self.precision)))
+        print(field("SCF E/D convergence", "%.2E / %.2E" % (e_conv, d_conv)))
+        print(rule)
+        self._print_mo_table()
+
+    def _print_mo_table(self) -> None:
+        """The MO-by-energy table (orbital energies to 12 decimals), dispatched to the spatial
+        (single-column) or spin-orbital (alpha | beta) layout."""
+        ref = self.ref
+        nirrep = ref.nirrep()
+        irrep_labels = ref.molecule().irrep_labels()
+        nmopi = ref.nmopi()
+        mo_irreps = np.array([h for h in range(nirrep) for _ in range(nmopi[h])])
+
+        if self.orbital_basis == 'spatial':
+            eps_active_so = np.concatenate([np.array(ref.epsilon_a_subset("SO", "ALL").nph[h])
+                                            for h in range(nirrep)])
+            sort_idx = np.argsort(eps_active_so, kind='stable')
+            eps_active = eps_active_so[sort_idx]
+            labels = [irrep_labels[mo_irreps[sort_idx][i]] for i in range(len(sort_idx))]
+            ndocc = self.nfzc + self.no
+            print("\nMOs by energy:")
+            print(f"  {'#':>4}  {'Irrep':>6}  {'Energy':>18}")
+            print(f"  {'-'*4}  {'-'*6}  {'-'*18}")
+            for i, (eps, label) in enumerate(zip(eps_active, labels)):
+                if i == ndocc:
+                    print(f"  {'.'*4}  {'.'*6}  {'.'*18}")
+                idx = i if i < ndocc else i - ndocc
+                print(f"  {idx:>4}  {label:>6}  {eps:>18.12f}")
+        else:
+            def _spin_mos(eps_subset):
+                eps = np.concatenate([np.array(eps_subset.nph[h]) for h in range(nirrep)])
+                order = np.argsort(eps, kind='stable')
+                return eps[order], [irrep_labels[mo_irreps[i]] for i in order]
+
+            a_eps, a_lab = _spin_mos(ref.epsilon_a_subset("SO", "ALL"))
+            b_eps, b_lab = _spin_mos(ref.epsilon_b_subset("SO", "ALL"))
+            na, nb = ref.nalpha(), ref.nbeta()
+            print("\nMOs by energy (alpha | beta):")
+            print(f"  {'#':>4}   {'irr':>5} {'o':>1} {'energy':>18}    {'irr':>5} {'o':>1} {'energy':>18}")
+            print(f"  {'-'*4}   {'-'*5} {'-'*1} {'-'*18}    {'-'*5} {'-'*1} {'-'*18}")
+            for i in range(ref.nmo()):
+                aocc = 'o' if i < na else ' '
+                bocc = 'o' if i < nb else ' '
+                print(f"  {i:>4}   {a_lab[i]:>5} {aocc:>1} {a_eps[i]:>18.12f}"
+                      f"    {b_lab[i]:>5} {bocc:>1} {b_eps[i]:>18.12f}")
+
     def _resolve_orbital_basis(self, orbital_basis: Any) -> str:
         """Resolve the orbital basis from an explicit override or the reference.
 
@@ -210,37 +307,12 @@ class Wavefunction(object):
         self.nv   = self.nmo - self.no - self.nfzc
         self.nact = self.no + self.nv
 
-        print("NMO = %d; NACT = %d; NO = %d; NV = %d" % (self.nmo, self.nact, self.no, self.nv))
-
         ndocc = self.nfzc + self.no
         self.o = slice(self.nfzc, ndocc)
         self.v = slice(ndocc, self.nmo)
 
         # Full MO space, global energy order; the frozen core sits at columns [0:nfzc].
         self.C = self.ref.Ca_subset("AO", "ALL")
-
-        eps_so_blocked  = self.ref.epsilon_a_subset("SO", "ALL")
-        eps_active_so   = np.concatenate([np.array(eps_so_blocked.nph[h])
-                                          for h in range(self.ref.nirrep())])
-        sort_idx        = np.argsort(eps_active_so, kind='stable')
-
-        irrep_labels    = self.ref.molecule().irrep_labels()
-        nirrep          = self.ref.nirrep()
-        nmopi           = self.ref.nmopi()
-        mo_irreps       = np.array([h for h in range(nirrep) for _ in range(nmopi[h])])
-        mo_irreps       = mo_irreps[sort_idx]
-        mo_irrep_labels = [irrep_labels[h] for h in mo_irreps]
-        eps_active      = eps_active_so[sort_idx]
-
-        # Print MO summary
-        print("\nMOs by energy:")
-        print(f"  {'#':>4}  {'Irrep':>6}  {'Energy':>16}")
-        print(f"  {'-'*4}  {'-'*6}  {'-'*16}")
-        for i, (eps, label) in enumerate(zip(eps_active, mo_irrep_labels)):
-            if i == ndocc:
-                print(f"  {'.'*4}  {'.'*6}  {'.'*16}")
-            idx = i if i < ndocc else i - ndocc
-            print(f"  {idx:>4}  {label:>6}  {eps:>16.10f}")
 
         # Localize the occupied MOs if requested (used consistently for the single H
         # build below, so all methods share the same integrals). Only the ACTIVE
@@ -284,36 +356,6 @@ class Wavefunction(object):
         self.nv   = nav + nbv
         self.nmo  = 2 * ref.nmo()
         self.nact = self.no + self.nv
-
-        print("NMO = %d; NACT = %d; NO = %d; NV = %d" % (self.nmo, self.nact, self.no, self.nv))
-
-        # Reference MO summary, alpha and beta side by side -- the spin-orbital analog of
-        # the _init_spatial table. Shows the symmetry-adapted SCF MOs Psi4 produced (their
-        # irreps and energies) with an occupied marker per spin. These are the reference
-        # orbital energies; for ROHF the semicanonical energies actually used in the
-        # correlation are the diagonal of the (rotated) per-spin Fock, self.H.F.
-        nirrep = ref.nirrep()
-        irrep_labels = ref.molecule().irrep_labels()
-        nmopi = ref.nmopi()
-        mo_irreps = np.array([h for h in range(nirrep) for _ in range(nmopi[h])])
-
-        def _spin_mos(eps_subset):
-            eps = np.concatenate([np.array(eps_subset.nph[h]) for h in range(nirrep)])
-            order = np.argsort(eps, kind='stable')
-            return eps[order], [irrep_labels[mo_irreps[i]] for i in order]
-
-        a_eps, a_lab = _spin_mos(ref.epsilon_a_subset("SO", "ALL"))
-        b_eps, b_lab = _spin_mos(ref.epsilon_b_subset("SO", "ALL"))
-        na, nb = ref.nalpha(), ref.nbeta()
-
-        print("\nMOs by energy (alpha | beta):")
-        print(f"  {'#':>4}   {'irr':>5} {'o':>1} {'energy':>16}    {'irr':>5} {'o':>1} {'energy':>16}")
-        print(f"  {'-'*4}   {'-'*5} {'-'*1} {'-'*16}    {'-'*5} {'-'*1} {'-'*16}")
-        for i in range(ref.nmo()):
-            aocc = 'o' if i < na else ' '
-            bocc = 'o' if i < nb else ' '
-            print(f"  {i:>4}   {a_lab[i]:>5} {aocc:>1} {a_eps[i]:>16.10f}"
-                  f"    {b_lab[i]:>5} {bocc:>1} {b_eps[i]:>16.10f}")
 
         # Full spin-orbital MO space, ordered [a-core, b-core, a-occ, b-occ, a-vir, b-vir]
         # with the frozen core first (mirrors _init_spatial); the active slices skip it.


### PR DESCRIPTION
# Coherent run output, and pycc.optical_rotation with specific rotation

Turns a PyCC run into a uniform, readable record, and adds optical rotation to the
property facade. Two threads: an output overhaul across the whole solver/property
stack, and the `pycc.optical_rotation` feature (with the dynamic-polarizability
rewiring it builds on).

## Output overhaul

**One output layer** (`utils.py`): single-source formatters -- `title`, `iteration`,
`converged`, `timing`, `field`, `solve_params` -- replace ~150 ad-hoc `print()`s so
every component reads consistently.

**Preamble** (`Wavefunction._report_preamble`): once per user-built wavefunction
(suppressed via `quiet` for the internal HF reference so it isn't duplicated), a
version-stamped block:
- PyCC version (versioneer, so a dirty tree is flagged),
- molecule (charge/multiplicity, point group, computational-frame geometry, nuclear
  repulsion),
- basis (set, #functions, spherical/cartesian),
- reference (type, SCF energy, frozen core, active occ/vir),
- computation (orbital basis, device/precision, SCF convergence),
- then the MO-by-energy table (moved here from `_init_spatial`/`_init_spinorbital`).

Coordinates and energies to 12 places. `self.method` (set by each subclass) carries the
header label.

**Solvers**: every iterative sequence is titled, labeled with its perturbation, and timed
with a title-matching footer:
- ground-state T / Lambda / CI, EOM (RIGHT/LEFT),
- the perturbed T / Lambda / Z-vector solves (2n+1: `CCderiv`, `CIderiv`, the `cctriples`
  (T) T3 Jacobi), each carrying its perturbation label (`mu_x`, `O1y`, ...; the dynamic
  ones also carry `omega`),
- the `ccresponse` right-hand / left-hand perturbed wavefunctions (native uppercase keys
  `MU_X`, `M*_Z`, ... + signed omega).

Build timings (`CCwfn`/`CIwfn`/`MPwfn`/`HBAR`/`CC density`) go through `timing()`;
`solve_cc`/`solve_ci` print a convergence/DIIS preamble.

**Property reports**: the facade prints an SCF / correlation / total breakdown for every
property, with units:
- dipole -- a.u. and Debye,
- gradient / Hessian / APT / AAT -- a.u.,
- polarizability -- a.u., field frequency (Eh and nm), isotropic invariant (a.u. and
  Angstrom^3),
- optical rotation -- Tr(G') (a.u.) and the specific rotation (deg/(dm (g/mL))).

All physical constants come from `qcelemental` (CODATA-consistent with psi4).

## pycc.optical_rotation

- New facade `pycc.optical_rotation(wfn, omega)` over `CCderiv.optical_rotation`
  (CCSD-only, nonzero `omega`), mirroring the dynamic-polarizability wiring;
  correlation-only (unrelaxed, so no Hartree-Fock term -> SCF block zero).
- `CCderiv.response_polarizability` renamed `dynamic_polarizability` and wired into
  `pycc.polarizability`: `omega != 0` (or `relaxed=False`) routes the unrelaxed dynamic
  response (CCSD-only); the orbital-relaxed static derivative remains the default at
  `omega = 0`.
- The specific-rotation conversion (Rosenfeld/Barron expression) was cross-checked against
  an independent Mathematica implementation: conversion factor and total [alpha] agree to
  ~8 and ~6 significant figures respectively (residual = CODATA constant precision).

## Fixes folded in

- `helper_diis` ComplexWarning removed (explicit `.real`); `ccresponse` vestigial
  `.real`/`np.conj` dropped -- CC response amplitudes are genuinely real.
- MO-table duplication fixed (the internal HF reference no longer reprints it).

## Tests

- `test_094` -- H2O2 optical rotation via the facade (CCderiv route) vs `ccresponse.optrot`
  (identical G'), plus the specific-rotation value; `test_092` updated for the
  `dynamic_polarizability` rename.
- Full non-slow suite: **289 passed, 3 skipped, 1 xfailed** (0 failures).

## Notes

- Behavior-preserving where it matters: the numerics-touching change (dropping `np.conj`
  in the ccresponse rms) is bit-identical for real amplitudes; everything else is output
  formatting or new API.
- A scratch `demo_output.py` (not in the branch) exercises all of this end-to-end -- 10
  examples covering the preamble, timings, every solver, and every property report.
