### PR TITLE
ci: pin libxc-c to 7.0.0 (libxc 7.1.2 dropped XC_GGA_XC_TH_FL)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -61,7 +61,11 @@ jobs:
         conda list --show-channel-urls
         hash -r
         env
-        conda install psi4 python=${{ matrix.python-version }} pip numpy=2 -c conda-forge
+        # Pin libxc-c to 7.0.0: libxc 7.1.2 dropped the XC_GGA_XC_TH_FL functional that psi4's
+        # DFT table still references, which breaks `import psi4`. 7.0.0 still provides it and
+        # satisfies gauxc's exact requirement (per the psi4 devs). Temporary -- drop once
+        # conda-forge ships a psi4 build matched to libxc 7.1.x.
+        conda install psi4 "libxc-c=7.0.0" python=${{ matrix.python-version }} pip numpy=2 -c conda-forge
         ls -l $CONDA
 
     - name: Test Psi4 Python Loading


### PR DESCRIPTION
The unpinned `conda install psi4 ... -c conda-forge` pulls psi4 1.11 alongside libxc-c 7.1.2, which removed the XC_GGA_XC_TH_FL functional that psi4's DFT table still references, breaking `import psi4` (and hence every test at collection). Pin libxc-c to 7.0.0, which still provides that functional and satisfies gauxc's exact requirement, per the psi4 developers. psi4 and numpy stay unpinned/current. Temporary hold -- remove once conda-forge ships a psi4 build matched to libxc 7.1.x.

## Description
Provide a brief description of the PR's purpose here.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go