### PR TITLE
fix(deriv): gate CCSD(T) dependent-pair rotations on the MO-energy gap

### DIFF
--- a/pycc/correlatedderivs.py
+++ b/pycc/correlatedderivs.py
@@ -1025,19 +1025,31 @@ class CorrelatedDerivs:
 
             P_{mn} = \frac{I'_{mn} - I'_{nm}}{\epsilon_m - \epsilon_n}
 
-        Numerator-gated (``|Delta I'| < thresh`` -> 0), skipping the diagonal (``m=n``) and
-        near-degenerate pairs.  ``P`` is symmetric (numerator and denominator both antisymmetric).
+        Gated on the MO-energy **gap** (``|eps_m - eps_n| <= thresh`` -> 0), which skips the diagonal
+        (``m=n``) and any near-degenerate pair; the divide is taken for every other pair.  ``P`` is
+        symmetric (numerator and denominator both antisymmetric).
+
+        The gap gate (not a numerator gate) is required for consistency with the derivative
+        :meth:`_perturbed_dependent_pairs`, which gates the same way.  Gating instead on a small
+        *numerator* would hard-zero small-but-nonzero rotations whose derivative ``dP = dnum/gap`` is
+        nonzero, leaving ``P`` and ``dP`` inconsistent; that makes the (T) density non-smooth in
+        geometry/field and is a genuine gradient/Hessian error at low-symmetry (C1) references, where
+        such small-nonzero numerators occur (a numerator gate is only harmless at symmetric geometries,
+        where the affected pairs are symmetry-zero).  A near-degeneracy (small gap) is the one place the
+        divide is ill-conditioned; there the numerator vanishes by the same symmetry, so gating it to
+        zero is the correct regularization.
 
         Supplies the *redundant* active oo/vv canonical rotations of the canonical perturbed-MO gauge
         (:attr:`perturbed_mo_gauge`; used by :meth:`_orbital_response` / :meth:`_so_orbital_response`
-        and the Hessian ``_pair_augment``).  The same divide also fixes the *independent* (non-redundant)
+        and the Hessian :meth:`_augment_with_canonical_pair_rotations`).  The same divide also fixes the
+        *independent* (non-redundant)
         frozen-core core<->active-occupied rotation ``P_co``, but that off-diagonal block is built
-        separately as an ungated *direct* divide (its gap is large, so numerator-gating and the
-        degeneracy skip are unnecessary) -- see :meth:`_orbital_response`."""
+        separately as an ungated *direct* divide (its gap is always large, so the degeneracy skip is
+        unnecessary) -- see :meth:`_orbital_response`."""
         num = np.asarray(Iblock) - np.asarray(Iblock).T
         den = eps_block[:, None] - eps_block[None, :]
         P = np.zeros_like(num)
-        m = np.abs(num) > thresh
+        m = np.abs(den) > thresh
         P[m] = num[m] / den[m]
         return P
 
@@ -1106,12 +1118,16 @@ class CorrelatedDerivs:
 
         * the INDEPENDENT (non-redundant) core<->active-occupied rotation ``P^(x)_ci`` -- the energy is
           not invariant to core<->active mixing, so it is ALWAYS present when there is a frozen core
-          (doc lines 1739-1743); built here as an ungated *direct* divide (its gap is large, so the
-          numerator-gate and degeneracy skip are unnecessary), matching the density's ``Pco``;
+          (doc lines 1739-1743); built here as an ungated *direct* divide (its gap is always large, so
+          the degeneracy skip is unnecessary), matching the density's ``Pco``;
         * the REDUNDANT (dependent) active occ-occ / virt-virt rotations ``P^(x)_ij``/``P^(x)_ab`` --
           present only in the canonical gauge (CCSD(T)); for CCSD they vanish by invariance and the
-          non-canonical ``-1/2 S`` is used instead.  Built via the numerator-gated
-          :meth:`_dependent_pairs` (degeneracy-safe).
+          non-canonical ``-1/2 S`` is used instead.  Built via the gap-gated :meth:`_dependent_pairs`
+          -- the *same* routine that forms the unperturbed ``P``, here fed the perturbed (skeleton)
+          Lagrangian ``I'^(x)`` instead of ``I'``, so ``P`` and ``P^(x)`` share one gate on the MO-energy
+          gap (see :meth:`_dependent_pairs`; a numerator gate here would key ``P^(x)`` on the
+          *perturbed* numerator, inconsistent with both ``P`` and the ``dP`` of
+          :meth:`_perturbed_dependent_pairs`).
 
         ``P^(x)`` is folded into the three carriers of the doc's line 2 (occupied pair-sums ``k,l`` run
         over the full occupied space; ``A_pqrs = w_pqrs + w_psrq`` with ``w`` the unperturbed

--- a/pycc/tests/test_087_ccsdt_apt.py
+++ b/pycc/tests/test_087_ccsdt_apt.py
@@ -85,6 +85,27 @@ P   3   1.00
 P   1   1.00
       0.3581514             1.0000000
 ****
+C     0
+S   6   1.00
+   3047.5248800             0.0018347
+    457.3695180             0.0140373
+    103.9486850             0.0688426
+     29.2101553             0.2321844
+      9.2866630             0.4679413
+      3.1639270             0.3623120
+S   3   1.00
+      7.8682724            -0.1193324
+      1.8812885            -0.1608542
+      0.5442493             1.1434564
+S   1   1.00
+      0.1687145             1.0000000
+P   3   1.00
+      7.8682724             0.0689991
+      1.8812885             0.3164240
+      0.5442493             0.7443083
+P   1   1.00
+      0.1687145             1.0000000
+****
 """
 
 # Planar HOF (Cs, molecular plane xy), tilted off the axes so the in-plane APT block is full; the
@@ -197,6 +218,69 @@ CFOUR_APT_T_WATER_631G_TOTAL_FC = np.array(
       [0.0, -0.1972108654, 0.1331212723]]])
 
 
+# Ethylene, one CH2 twisted 0.2 deg about the C=C axis: a NEAR-symmetric geometry, run in C1.  The
+# tiny twist leaves the canonical CCSD(T) perturbed-MO oo/vv dependent-pair rotations with
+# tiny-but-nonzero (< 1e-8) (T)-Lagrangian numerators over near-degenerate gaps -- exactly the case
+# where the _dependent_pairs GATE matters.  This is the regression anchor for that gate: the old
+# NUMERATOR gate hard-zeroed those rotations and gave a wrong APT (off from CFOUR by ~6e-8 here),
+# while the GAP gate matches CFOUR to ~1e-10.  The existing symmetric molecules (water/HOF) cannot
+# catch a revert -- their cross-irrep numerators are exactly zero, so both gates agree there.  Frame
+# and atom order are CFOUR's (it reorients to principal axes); pycc runs at that frame under c1.
+ETHYLENE_TWIST = """
+C  -1.265000000000  0.000000000000  0.000000000000
+C   1.265000000000  0.000000000000  0.000000000000
+H  -2.331053217577  1.753346848929  0.003060170651
+H   2.331053217577 -1.753346848929  0.003060170652
+H  -2.331053217577 -1.753346848929 -0.003060170651
+H   2.331053217577  1.753346848929 -0.003060170652
+symmetry c1
+units bohr
+no_com
+no_reorient
+"""
+
+# CFOUR CCSD(T) APT oracles (a.u.), twisted ethylene (C, C, H, H, H, H) / CFOUR GENBAS 6-31G, indexed
+# [A, beta, alpha].  Correlation = DIPDER(CCSD(T)) - DIPDER(SCF); total = DIPDER(CCSD(T)).
+CFOUR_APT_T_ETHYLENE_TWIST_631G = np.array(
+    [[[1.86092944e-02, 0.0, 0.0],
+      [0.0, 6.05099580e-03, -4.22979000e-05],
+      [0.0, -4.34355000e-05, 6.07212215e-02]],
+     [[1.86092944e-02, 0.0, 0.0],
+      [0.0, 6.05099580e-03, 4.22979000e-05],
+      [0.0, 4.34355000e-05, 6.07212215e-02]],
+     [[-9.30464720e-03, 3.37710620e-03, 2.40413000e-05],
+      [-5.24072820e-03, -3.02549790e-03, -6.60630000e-06],
+      [-9.14680000e-06, 7.35210000e-06, -3.03606108e-02]],
+     [[-9.30464720e-03, 3.37710620e-03, -2.40413000e-05],
+      [-5.24072820e-03, -3.02549790e-03, 6.60630000e-06],
+      [9.14680000e-06, -7.35210000e-06, -3.03606108e-02]],
+     [[-9.30464720e-03, -3.37710620e-03, -2.40413000e-05],
+      [5.24072820e-03, -3.02549790e-03, -6.60630000e-06],
+      [9.14680000e-06, 7.35210000e-06, -3.03606108e-02]],
+     [[-9.30464720e-03, -3.37710620e-03, 2.40413000e-05],
+      [5.24072820e-03, -3.02549790e-03, 6.60630000e-06],
+      [-9.14680000e-06, -7.35210000e-06, -3.03606108e-02]]])
+CFOUR_APT_T_ETHYLENE_TWIST_631G_TOTAL = np.array(
+    [[[1.99678123e-02, 0.0, 0.0],
+      [0.0, 1.59978253e-01, 6.52847200e-04],
+      [0.0, 6.44087900e-04, -2.93791771e-01]],
+     [[1.99678123e-02, 0.0, 0.0],
+      [0.0, 1.59978253e-01, -6.52847200e-04],
+      [0.0, -6.44087900e-04, -2.93791771e-01]],
+     [[-9.98390610e-03, 6.77998677e-02, 7.07126000e-05],
+      [8.18439889e-02, -7.99891263e-02, -2.30329200e-04],
+      [1.42844900e-04, -2.63771300e-04, 1.46895885e-01]],
+     [[-9.98390610e-03, 6.77998677e-02, -7.07126000e-05],
+      [8.18439889e-02, -7.99891263e-02, 2.30329200e-04],
+      [-1.42844900e-04, 2.63771300e-04, 1.46895885e-01]],
+     [[-9.98390610e-03, -6.77998677e-02, -7.07126000e-05],
+      [-8.18439889e-02, -7.99891263e-02, -2.30329200e-04],
+      [-1.42844900e-04, -2.63771300e-04, 1.46895885e-01]],
+     [[-9.98390610e-03, -6.77998677e-02, 7.07126000e-05],
+      [-8.18439889e-02, -7.99891263e-02, 2.30329200e-04],
+      [1.42844900e-04, 2.63771300e-04, 1.46895885e-01]]])
+
+
 def _cfour_wfn(geom, freeze_core):
     """RHF reference in CFOUR's exact GENBAS 6-31G (via basis_helper), for the CFOUR-oracle tests."""
     psi4.core.clean()
@@ -269,6 +353,32 @@ def test_ccsdt_apt_cfour_water_spatial():
     psi4.core.clean()
     _check(_ccsdt_apt(WATER, 'true', 'spatial'),
            CFOUR_APT_T_WATER_631G_FC, CFOUR_APT_T_WATER_631G_TOTAL_FC, [8.0, 1.0, 1.0], perp=0)
+    psi4.core.clean()
+
+
+def test_ccsdt_apt_dependent_pair_gap_gate_ethylene_twist():
+    """Regression test for the canonical perturbed-MO dependent-pair GAP gate
+    (:meth:`correlatedderivs.CorrelatedDerivs._dependent_pairs`).  Ethylene with one CH2 twisted
+    0.2 deg is *near*-symmetric, so the (T) oo/vv dependent-pair rotations carry tiny-but-nonzero
+    numerators over near-degenerate MO gaps -- the regime where the gate choice matters.  The
+    discarded numerator gate (skip a pair if ``|I'_pq - I'_qp| < 1e-8``) disagrees there with the
+    gap gate (skip if ``|eps_p - eps_q| < 1e-8``): the gap gate reproduces the CFOUR DIPDER oracle
+    to ~1e-10, while the numerator gate was off by ~6e-8 and would fail this test.  The symmetric
+    molecules above (water/HOF) cannot catch a revert -- their cross-irrep numerators are exactly
+    zero, so the two gates agree.  All-electron spatial CCSD(T)."""
+    r = _ccsdt_apt(ETHYLENE_TWIST, 'false', 'spatial')
+    corr = np.asarray(r.correlation)
+    total = np.asarray(r.total)
+    assert np.max(np.abs(corr - CFOUR_APT_T_ETHYLENE_TWIST_631G)) < 1e-9, corr
+    assert np.max(np.abs(total - CFOUR_APT_T_ETHYLENE_TWIST_631G_TOTAL)) < 1e-9, total
+    # facade decomposition is exact; nuclear block is Z_A delta
+    parts = np.asarray(r.nuclear) + np.asarray(r.reference) + np.asarray(r.correlation)
+    assert np.max(np.abs(total - parts)) < 1e-12
+    Z = np.array([6.0, 6.0, 1.0, 1.0, 1.0, 1.0])
+    assert np.max(np.abs(np.asarray(r.nuclear) - Z[:, None, None] * np.eye(3))) < 1e-12
+    # translational (acoustic) sum rule: sum over atoms vanishes for a neutral molecule
+    assert np.max(np.abs(np.sum(total, axis=0))) < 1e-8
+    assert np.max(np.abs(np.sum(corr, axis=0))) < 1e-8
     psi4.core.clean()
 
 


### PR DESCRIPTION
# fix(deriv): gate CCSD(T) dependent-pair rotations on the MO-energy gap

Branch: `fix/ccsdt-dependent-pairs-gap-gate` -> `main`

## Summary
The canonical perturbed-MO dependent-pair rotation used in CCSD(T) analytic
derivatives was gated inconsistently with its own field/geometry derivative,
giving a wrong CCSD(T) gradient/Hessian/APT at low-symmetry or near-symmetric
(distorted) references. This flips one gate and adds a regression test that the
existing symmetric-geometry tests structurally cannot catch.

## The problem
`_dependent_pairs` builds the dependent-pair rotation

    P_mn = (I'_mn - I'_nm) / (eps_m - eps_n)

and gated it on the NUMERATOR (skip if |I'_mn - I'_nm| < 1e-8). Its
field/geometry derivative `_perturbed_dependent_pairs` gates on the MO-energy
GAP. The two are inconsistent: at a low-symmetry or near-symmetric geometry the
numerator takes small-but-nonzero values that the numerator gate hard-zeroed
while the derivative kept them, making the (T) density non-smooth and giving a
wrong CCSD(T) gradient/Hessian/APT. Symmetric geometries are unaffected (the
offending cross-irrep numerators are exactly zero there, so both gates agree) --
which is why the existing CFOUR-anchored water/HOF tests never caught it.

## The fix
Gate `_dependent_pairs` on the MO-energy gap, matching `_perturbed_dependent_pairs`.
The same routine also builds the perturbed dependent pair P^(x) = X^(x)/gap (via
`_augment_with_canonical_pair_rotations`, fed the skeleton Lagrangian I'^(x)), so
this single change makes P, P^(x), and dP all consistently gap-gated. A
near-degeneracy (small gap) is the one place the divide is genuinely
ill-conditioned; there the numerator vanishes by the same symmetry, so gating on
the gap is the correct regularization.

## Validation
Twisted ethylene (one CH2 twisted 0.2 deg about C=C -- near-symmetric, run in C1):

    check                            old numerator gate     gap gate
    -----------------------------    ------------------     ---------
    CCSD(T) APT vs CFOUR DIPDER      5.9e-8 off             1.4e-10
    gradient vs 7-pt energy-FD       3.5e-10 off            9e-13
    Hessian vs FD-of-gradient        explodes as h->0       clean (~5e-13)
    APT vs FD-of-relaxed-dipole      2.9e-6 off             4.8e-11

## Tests
- New CFOUR-anchored regression test (twisted-ethylene CCSD(T) APT in
  test_087) that FAILS under the numerator gate and passes with the fix; adds
  carbon to the test's exact GENBAS 6-31G.
- Full CCSD(T) derivative suite (gradient/polarizability/APT/Hessian, spatial +
  spin-orbital, AE + FC, fast + slow) passes.
- Verified compatible with #227 (orthogonal: CISD runs the non-canonical gauge
  and never calls `_dependent_pairs`).

Docstring updates in `_dependent_pairs` / `_augment_with_canonical_pair_rotations`
explain the gap gate and the shared P / P^(x) gate rationale.
