### PR TITLE
refactor(mp): remove the core MPwfn property shortcuts (facade-only, like CC/CI)

### DIFF
--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -142,7 +142,7 @@ class HFwfn(Wavefunction):
         same ``Tr(D mu)`` convention as :meth:`MPwfn.relaxed_dipole`, with the SCF density's occupied
         block). The prefactor is the orbital occupancy: ``k = 2`` on the spatial closed-shell path,
         ``k = 1`` for spin orbitals. Kept separate from the correlation dipole so the total MP2
-        dipole is ``HFwfn.dipole() + MPwfn.relaxed_dipole()`` (mirroring the gradient split).
+        dipole is ``HFwfn.dipole() + MPderiv.relaxed_dipole()`` (mirroring the gradient split).
         Basis-aware. The :func:`pycc.dipole` facade exposes the nuclear/reference/correlation
         pieces as :class:`pycc.PropertyComponents`."""
         mol = self.ref.molecule()

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -23,9 +23,12 @@ class MPwfn(Wavefunction):
     derived from the base's seeded MO integrals, and computes the MP2 correlation
     energy.
 
-    The analytic derivative-property code (gradient, polarizability, APT, Hessian, AAT,
-    VG-APT) lives on :class:`~pycc.mpderiv.MPderiv`, reached through the cached
-    :attr:`deriv` driver; the property methods here are thin delegators.
+    The analytic derivative-property code lives on :class:`~pycc.mpderiv.MPderiv`, a
+    :class:`~pycc.correlatedderivs.CorrelatedDerivs` driver.  Build it with
+    ``pycc.MPderiv(wfn)`` and pass it to the ``pycc`` property facade, e.g.
+    ``pycc.gradient(pycc.MPderiv(wfn))`` -- the same pattern as CCwfn/CIwfn.  (The cached
+    :attr:`deriv` accessor and the ``atomic_axial_tensors`` / ``velocity_dipole_derivatives``
+    wfn methods below remain only for the not-yet-migrated AAT / velocity-gauge-APT path.)
 
     Attributes
     ----------
@@ -168,26 +171,6 @@ class MPwfn(Wavefunction):
             from .mpderiv import MPderiv
             self._deriv = MPderiv(self)
         return self._deriv
-
-    def relaxed_dipole(self) -> np.ndarray:
-        """MP2 correlation dipole -- delegates to :meth:`MPderiv.relaxed_dipole`."""
-        return self.deriv.relaxed_dipole()
-
-    def gradient(self) -> np.ndarray:
-        """MP2 correlation nuclear gradient -- delegates to :meth:`MPderiv.gradient`."""
-        return self.deriv.gradient()
-
-    def polarizability(self) -> np.ndarray:
-        """MP2 correlation polarizability -- delegates to :meth:`MPderiv.polarizability`."""
-        return self.deriv.polarizability()
-
-    def hessian(self) -> np.ndarray:
-        """MP2 correlation Hessian -- delegates to :meth:`MPderiv.hessian`."""
-        return self.deriv.hessian()
-
-    def dipole_derivatives(self, route: str = '2n+1-field') -> np.ndarray:
-        """MP2 correlation length-gauge APT -- delegates to :meth:`MPderiv.dipole_derivatives`."""
-        return self.deriv.dipole_derivatives(route)
 
     def velocity_dipole_derivatives(self, gauge: str = 'non-canonical') -> np.ndarray:
         """MP2 correlation velocity-gauge APT -- delegates to

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -92,7 +92,7 @@ def _pycc_corr_dipole(geom, basis, orbital_basis='spinorbital', freeze_core='fal
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
-    return mp.relaxed_dipole()[2]
+    return pycc.MPderiv(mp).relaxed_dipole()[2]
 
 
 def test_mp2_relaxed_dipole_631g():
@@ -265,7 +265,7 @@ def test_fc_mp2_gradient_vs_energy_fd_631g():
 
 # ---- SCF dipole (HFwfn.dipole) and the total MP2 dipole ----
 # The reference dipole is kept separate from the correlation dipole (as for the gradient):
-# the total MP2 dipole is HFwfn.dipole() + MPwfn.relaxed_dipole().
+# the total MP2 dipole is HFwfn.dipole() + MPderiv.relaxed_dipole().
 
 def _scf_dipole(geom, basis):
     """PyCC HFwfn.dipole() (spatial + spin-orbital) and Psi4's analytic SCF dipole."""
@@ -311,7 +311,7 @@ def _ff_total_dipole(geom, basis, model, F=0.0005):
 
 
 def test_mp2_total_dipole_631g():
-    """Total MP2 dipole = HFwfn.dipole() + MPwfn.relaxed_dipole() vs the frozen finite-field
+    """Total MP2 dipole = HFwfn.dipole() + MPderiv.relaxed_dipole() vs the frozen finite-field
     oracle of the total MP2 energy, H2O/6-31G (C1) -- validates the reference/correlation split."""
     geom = WATER + "symmetry c1\n"
     psi4.core.clean()

--- a/pycc/tests/test_067_mp2_polarizability.py
+++ b/pycc/tests/test_067_mp2_polarizability.py
@@ -61,7 +61,7 @@ def _pycc_alpha(basis, orbital_basis='spatial', freeze_core='false', geom=WATER,
     _, wfn = psi4.energy('scf', return_wfn=True)
     mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
     mp.compute_energy()
-    return np.asarray(mp.polarizability())
+    return np.asarray(pycc.MPderiv(mp).polarizability())
 
 
 def _dipfd_alpha_diag(basis, axis, orbital_basis='spatial', freeze_core='false', h=0.002):
@@ -85,7 +85,7 @@ def _dipfd_alpha_diag(basis, axis, orbital_basis='spatial', freeze_core='false',
         _, wfn = psi4.energy('scf', return_wfn=True)
         mp = pycc.MPwfn(wfn, orbital_basis=orbital_basis)
         mp.compute_energy()
-        return mp.relaxed_dipole()[axis]
+        return pycc.MPderiv(mp).relaxed_dipole()[axis]
     d1 = (-mu(-3 * h) + 9 * mu(-2 * h) - 45 * mu(-h)
           + 45 * mu(h) - 9 * mu(2 * h) + mu(3 * h)) / (60 * h)
     return abs(d1)

--- a/pycc/tests/test_068_mp2_apt.py
+++ b/pycc/tests/test_068_mp2_apt.py
@@ -76,7 +76,7 @@ def _corr_dipfd(basis, orbital_basis, alpha, atom, cart, freeze_core='false', h=
     nuclear coordinate (atom, cart)."""
     def mu(delta):
         c = BASE.copy(); c[atom, cart] += delta
-        return _mpwfn(c, basis, orbital_basis, freeze_core).relaxed_dipole()[alpha]
+        return pycc.MPderiv(_mpwfn(c, basis, orbital_basis, freeze_core)).relaxed_dipole()[alpha]
     return (-mu(-3*h) + 9*mu(-2*h) - 45*mu(-h)
             + 45*mu(h) - 9*mu(2*h) + mu(3*h)) / (60*h)
 
@@ -124,31 +124,31 @@ def test_mp2_nuclear_t2_response_631g():
 def test_mp2_corr_apt_dipfd_631g():
     """Spatial correlation APT vs its frozen reference (validated once against a 7-point dipole-
     over-nuclear FD to ~1e-12), representative components, H2O/6-31G."""
-    P = _mpwfn(BASE, '6-31G', 'spatial').dipole_derivatives()
+    P = pycc.MPderiv(_mpwfn(BASE, '6-31G', 'spatial')).dipole_derivatives()
     for (alpha, atom, cart), ref in APT_631G.items():
         assert abs(P[atom, cart, alpha] - ref) < 1e-9
 
 
 def test_so_mp2_corr_apt_vs_spatial_631g():
     """Keystone (6-31G): closed-shell spin-orbital == spin-adapted correlation APT."""
-    P_so = _mpwfn(BASE, '6-31G', 'spinorbital').dipole_derivatives()
-    P_sa = _mpwfn(BASE, '6-31G', 'spatial').dipole_derivatives()
+    P_so = pycc.MPderiv(_mpwfn(BASE, '6-31G', 'spinorbital')).dipole_derivatives()
+    P_sa = pycc.MPderiv(_mpwfn(BASE, '6-31G', 'spatial')).dipole_derivatives()
     assert np.max(np.abs(P_so - P_sa)) < 1e-11
 
 
 def test_so_mp2_corr_apt_vs_spatial_ccpvdz():
     """Keystone (cc-pVDZ): spin-orbital == spin-adapted correlation APT."""
-    P_so = _mpwfn(BASE, 'cc-pVDZ', 'spinorbital').dipole_derivatives()
-    P_sa = _mpwfn(BASE, 'cc-pVDZ', 'spatial').dipole_derivatives()
+    P_so = pycc.MPderiv(_mpwfn(BASE, 'cc-pVDZ', 'spinorbital')).dipole_derivatives()
+    P_sa = pycc.MPderiv(_mpwfn(BASE, 'cc-pVDZ', 'spatial')).dipole_derivatives()
     assert np.max(np.abs(P_so - P_sa)) < 1e-11
 
 
 def test_mp2_apt_translational_sum_rule_631g():
     """Acoustic (translational) sum rule: for a neutral molecule the sum over atoms of the
     total APT vanishes (the correlation APT sums to zero on its own -- Tr(gamma_corr) = 0)."""
-    mp0 = _mpwfn(BASE, '6-31G', 'spatial')
-    P_corr = mp0.dipole_derivatives()
-    P_tot = np.asarray(pycc.apt(pycc.MPderiv(mp0)).total)
+    d0 = pycc.MPderiv(_mpwfn(BASE, '6-31G', 'spatial'))
+    P_corr = d0.dipole_derivatives()
+    P_tot = np.asarray(pycc.apt(d0).total)
     assert np.max(np.abs(np.sum(P_corr, axis=0))) < 1e-10
     assert np.max(np.abs(np.sum(P_tot, axis=0))) < 1e-10
 
@@ -162,24 +162,24 @@ def test_fc_mp2_corr_apt_dipfd_631g():
     Exercises the mixed field/nuclear core<->active response: the frozen-core nuclear density
     response over the active space, coupled to the core<->active orbital relaxation. Works with no
     APT-specific code change -- the ncore machinery carries over from the gradient/polarizability."""
-    P = _mpwfn(BASE, '6-31G', 'spatial', freeze_core='true').dipole_derivatives()
+    P = pycc.MPderiv(_mpwfn(BASE, '6-31G', 'spatial', freeze_core='true')).dipole_derivatives()
     for (alpha, atom, cart), ref in APT_631G_FC.items():
         assert abs(P[atom, cart, alpha] - ref) < 1e-9
 
 
 def test_fc_so_mp2_corr_apt_vs_spatial_631g():
     """Keystone (6-31G, frozen core): spin-orbital == spin-adapted correlation APT."""
-    P_so = _mpwfn(BASE, '6-31G', 'spinorbital', freeze_core='true').dipole_derivatives()
-    P_sa = _mpwfn(BASE, '6-31G', 'spatial', freeze_core='true').dipole_derivatives()
+    P_so = pycc.MPderiv(_mpwfn(BASE, '6-31G', 'spinorbital', freeze_core='true')).dipole_derivatives()
+    P_sa = pycc.MPderiv(_mpwfn(BASE, '6-31G', 'spatial', freeze_core='true')).dipole_derivatives()
     assert np.max(np.abs(P_so - P_sa)) < 1e-11
 
 
 def test_fc_mp2_apt_translational_sum_rule_631g():
     """Frozen-core acoustic sum rule: sum over atoms of the total (and correlation) APT
     vanishes for neutral water."""
-    mp0 = _mpwfn(BASE, '6-31G', 'spatial', freeze_core='true')
-    assert np.max(np.abs(np.sum(mp0.dipole_derivatives(), axis=0))) < 1e-10
-    assert np.max(np.abs(np.sum(np.asarray(pycc.apt(pycc.MPderiv(mp0)).total), axis=0))) < 1e-10
+    d0 = pycc.MPderiv(_mpwfn(BASE, '6-31G', 'spatial', freeze_core='true'))
+    assert np.max(np.abs(np.sum(d0.dipole_derivatives(), axis=0))) < 1e-10
+    assert np.max(np.abs(np.sum(np.asarray(pycc.apt(d0).total), axis=0))) < 1e-10
 
 
 # ---- the two 2n+1 routes agree with each other ----
@@ -194,9 +194,9 @@ def test_mp2_apt_2n1_routes_agree_631g():
     import pytest
     for ob in ('spinorbital', 'spatial'):
         for fc in ('false', 'true'):
-            mp = _mpwfn(BASE, '6-31G', ob, freeze_core=fc)
-            Pn = np.asarray(mp.dipole_derivatives(route='2n+1-nuclear'))
-            Pf = np.asarray(mp.dipole_derivatives(route='2n+1-field'))
+            d = pycc.MPderiv(_mpwfn(BASE, '6-31G', ob, freeze_core=fc))
+            Pn = np.asarray(d.dipole_derivatives(route='2n+1-nuclear'))
+            Pf = np.asarray(d.dipole_derivatives(route='2n+1-field'))
             assert np.max(np.abs(Pn - Pf)) < 1e-11
     with pytest.raises(ValueError):
-        _mpwfn(BASE, '6-31G', 'spatial').dipole_derivatives(route='bogus')
+        pycc.MPderiv(_mpwfn(BASE, '6-31G', 'spatial')).dipole_derivatives(route='bogus')

--- a/pycc/tests/test_069_mp2_hessian.py
+++ b/pycc/tests/test_069_mp2_hessian.py
@@ -60,7 +60,7 @@ def _gradfd_col(orbital_basis, atom, cart, freeze_core='false', h=0.002):
     coordinate (atom, cart)."""
     def g(delta):
         c = BASE.copy(); c[atom, cart] += delta
-        return np.asarray(_mpwfn(c, orbital_basis, freeze_core).gradient())
+        return np.asarray(pycc.MPderiv(_mpwfn(c, orbital_basis, freeze_core)).gradient())
     return ((-g(-3*h) + 9*g(-2*h) - 45*g(-h)
              + 45*g(h) - 9*g(2*h) + g(3*h)) / (60*h)).reshape(-1)
 
@@ -80,7 +80,7 @@ HESS_COL_631G_FC = {   # frozen core
 def test_mp2_corr_hessian_symmetry_sum_rule_631g():
     """All-electron correlation Hessian: symmetric, and translationally invariant
     (sum over the second atom vanishes), H2O/6-31G -- FD-free checks."""
-    H = _mpwfn(BASE, 'spatial').hessian()
+    H = pycc.MPderiv(_mpwfn(BASE, 'spatial')).hessian()
     assert H.shape == (9, 9)
     assert np.max(np.abs(H - H.T)) < 1e-10
     assert np.max(np.abs(H.reshape(3, 3, 3, 3).sum(axis=2))) < 1e-10
@@ -89,7 +89,7 @@ def test_mp2_corr_hessian_symmetry_sum_rule_631g():
 def test_mp2_corr_hessian_gradfd_631g():
     """All-electron correlation Hessian columns vs their frozen references (validated once against
     a 7-point FD of the analytic gradient to ~1e-13), H2O/6-31G."""
-    H = _mpwfn(BASE, 'spatial').hessian()
+    H = pycc.MPderiv(_mpwfn(BASE, 'spatial')).hessian()
     for (atom, cart), ref in HESS_COL_631G.items():
         j = atom * 3 + cart
         assert np.max(np.abs(H[:, j] - ref)) < 1e-9
@@ -97,8 +97,8 @@ def test_mp2_corr_hessian_gradfd_631g():
 
 def test_so_mp2_corr_hessian_vs_spatial_631g():
     """Keystone (6-31G): closed-shell spin-orbital == spin-adapted correlation Hessian."""
-    H_so = _mpwfn(BASE, 'spinorbital').hessian()
-    H_sa = _mpwfn(BASE, 'spatial').hessian()
+    H_so = pycc.MPderiv(_mpwfn(BASE, 'spinorbital')).hessian()
+    H_sa = pycc.MPderiv(_mpwfn(BASE, 'spatial')).hessian()
     assert np.max(np.abs(H_so - H_sa)) < 1e-11
 
 
@@ -107,7 +107,7 @@ def test_so_mp2_corr_hessian_vs_spatial_631g():
 def test_fc_mp2_corr_hessian_gradfd_631g():
     """Frozen-core correlation Hessian columns vs their frozen references (validated once against
     the 7-point gradient FD to ~1e-13), H2O/6-31G."""
-    H = _mpwfn(BASE, 'spatial', freeze_core='true').hessian()
+    H = pycc.MPderiv(_mpwfn(BASE, 'spatial', freeze_core='true')).hessian()
     for (atom, cart), ref in HESS_COL_631G_FC.items():
         j = atom * 3 + cart
         assert np.max(np.abs(H[:, j] - ref)) < 1e-9
@@ -115,13 +115,13 @@ def test_fc_mp2_corr_hessian_gradfd_631g():
 
 def test_fc_mp2_corr_hessian_symmetry_sum_rule_631g():
     """Frozen-core correlation Hessian: symmetric and translationally invariant."""
-    H = _mpwfn(BASE, 'spatial', freeze_core='true').hessian()
+    H = pycc.MPderiv(_mpwfn(BASE, 'spatial', freeze_core='true')).hessian()
     assert np.max(np.abs(H - H.T)) < 1e-10
     assert np.max(np.abs(H.reshape(3, 3, 3, 3).sum(axis=2))) < 1e-10
 
 
 def test_fc_so_mp2_corr_hessian_vs_spatial_631g():
     """Keystone (6-31G, frozen core): spin-orbital == spin-adapted correlation Hessian."""
-    H_so = _mpwfn(BASE, 'spinorbital', freeze_core='true').hessian()
-    H_sa = _mpwfn(BASE, 'spatial', freeze_core='true').hessian()
+    H_so = pycc.MPderiv(_mpwfn(BASE, 'spinorbital', freeze_core='true')).hessian()
+    H_sa = pycc.MPderiv(_mpwfn(BASE, 'spatial', freeze_core='true')).hessian()
     assert np.max(np.abs(H_so - H_sa)) < 1e-11

--- a/pycc/tests/test_074_property_facade.py
+++ b/pycc/tests/test_074_property_facade.py
@@ -115,11 +115,11 @@ def _facade_and_pieces(hf, mp):
     correlation method) that reconstruct the physical total, for the composition check."""
     d = pycc.MPderiv(mp)
     return [
-        ("dipole",         pycc.dipole(d),                hf.dipole(),                     mp.relaxed_dipole()),
-        ("gradient",       pycc.gradient(d),              hf.gradient(),                   mp.gradient()),
-        ("polarizability", pycc.polarizability(d),        hf.polarizability(),             mp.polarizability()),
-        ("hessian",        pycc.hessian(d),               hf.hessian(),                    mp.hessian()),
-        ("apt-length",     pycc.apt(d, 'length'),         hf.dipole_derivatives(),         mp.dipole_derivatives()),
+        ("dipole",         pycc.dipole(d),                hf.dipole(),                     d.relaxed_dipole()),
+        ("gradient",       pycc.gradient(d),              hf.gradient(),                   d.gradient()),
+        ("polarizability", pycc.polarizability(d),        hf.polarizability(),             d.polarizability()),
+        ("hessian",        pycc.hessian(d),               hf.hessian(),                    d.hessian()),
+        ("apt-length",     pycc.apt(d, 'length'),         hf.dipole_derivatives(),         d.dipole_derivatives()),
         ("apt-velocity",   pycc.apt(d, 'velocity'),       hf.velocity_dipole_derivatives(), mp.velocity_dipole_derivatives()),
     ]
 


### PR DESCRIPTION
# refactor(mp): remove the core MPwfn property shortcuts (facade-only, like CC/CI)

Branch: `refactor/remove-mp-property-shortcuts` -> `main`

## Summary
MPwfn carried thin wfn-level property methods -- `mp.gradient()`, `mp.hessian()`,
`mp.polarizability()`, `mp.relaxed_dipole()`, `mp.dipole_derivatives()` -- that
CCwfn/CIwfn never had. Besides the inconsistency, those shortcuts were broken two
ways: they returned the raw correlation-only array (not the decomposed
PropertyComponents the facade returns), and they bypassed the checkpoint recorder
(`pycc.hessian(d)` records to `wfn._property_results`; `mp.hessian()` did not, so
`save_checkpoint` after `mp.hessian()` saved nothing). This removes them; the core
derivative properties now go through `pycc.<prop>(pycc.MPderiv(wfn))`, uniformly
with CC/CI.

## Removed
`MPwfn.{relaxed_dipole, gradient, polarizability, hessian, dipole_derivatives}`.

## Kept (scoped out -- the not-yet-migrated AAT / velocity-gauge-APT path)
The cached `deriv` property, `atomic_axial_tensors`, and `velocity_dipole_derivatives`.
The `pycc.aat` facade still calls `wfn.atomic_axial_tensors()` directly
(properties.py:415/417), so these stay until the AAT/VG track is migrated (the
separate CC-AAT project). AAT/VG interfaces are untouched.

## Tests
Migrated the MP2 property test sites (test_061/067/068/069/074) to
`pycc.MPderiv(mp).<prop>()` -- the driver method returns the same correlation array
the removed shortcut did. test_072/073 (AAT/VG) untouched. HFwfn public methods
unchanged (separate concern). Fixed one stale `MPwfn.relaxed_dipole()` prose
reference in hfwfn.py. All affected tests pass (64).

Confirmed no downstream users: no pycc source calls the removed methods (only the
AAT path calls the kept ones), and magpy does not use them.

## Scope note
This is a clarity-of-implementation cleanup (one way to call the core properties).
The deeper clarity-of-use question -- the mandatory driver-wrapping, where
`pycc.hessian(ccwfn)` is rejected and you must write `pycc.hessian(pycc.CCderiv(wfn))`
-- is a separate, later step (the property-facade dispatch is the suggested starting
point).
