### PR TITLE
Move MP2 AAT / VG-APT onto MPderiv, and route pycc.aat through the driver facade

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -88,12 +88,10 @@ once and reuse it across properties::
     pycc.polarizability(d)             # static dipole polarizability (3, 3)
     pycc.apt(d, gauge='length')        # atomic polar tensors         (natom, 3, 3)
     pycc.apt(d, gauge='velocity')      # velocity-gauge APTs          (natom, 3, 3)
-    pycc.aat(mp)                       # atomic axial tensors (VCD)   (natom, 3, 3)
+    pycc.aat(d)                        # atomic axial tensors (VCD)   (natom, 3, 3)
 
 The reference-only (SCF) property takes the :class:`~pycc.hfwfn.HFwfn` directly --
-``pycc.hessian(hf)`` -- with a zero ``correlation`` block. One current wrinkle:
-:func:`pycc.aat` still takes the *wavefunction* (``pycc.aat(mp)``), not the driver, pending
-its migration to the driver interface.
+``pycc.hessian(hf)`` -- with a zero ``correlation`` block.
 
 Every property is available for both spin paths (spin-adapted closed-shell RHF and
 spin-orbital, selected by ``orbital_basis`` on the wavefunction), all-electron and frozen

--- a/pycc/cphf.py
+++ b/pycc/cphf.py
@@ -617,7 +617,7 @@ class CPHF(object):
     def magnetic_ints(self, axis: int, ncore: int = 0, gauge: str = 'non-canonical'):
         """Magnetic-field-perturbed MO integrals for ``axis`` (0/1/2): returns the tuple
         ``(U^H, dF^H, dERI^H)`` used by the MP2 atomic axial tensors
-        (:meth:`MPwfn.atomic_axial_tensors`). Cached per ``(axis, ncore, gauge)``.
+        (:meth:`~pycc.mpderiv.MPderiv.atomic_axial_tensors`). Cached per ``(axis, ncore, gauge)``.
 
         The magnetic perturbation ``H' = -m.H`` (``m = -1/2 L``, the real antisymmetric
         magnetic-dipole matrix, stripped of the ``i`` carried in ``H.m``) is imaginary, so the
@@ -647,7 +647,7 @@ class CPHF(object):
     def momentum_ints(self, axis: int, ncore: int = 0, gauge: str = 'non-canonical'):
         """Linear-momentum-perturbed MO integrals for ``axis`` (0/1/2): returns the tuple
         ``(U^A, dF^A, dERI^A)`` used by the MP2 velocity-gauge atomic polar tensors
-        (:meth:`MPwfn.velocity_dipole_derivatives`). Cached per ``(axis, ncore, gauge)``.
+        (:meth:`~pycc.mpderiv.MPderiv.velocity_dipole_derivatives`). Cached per ``(axis, ncore, gauge)``.
 
         This is the magnetic engine (:meth:`magnetic_ints`) with the magnetic-dipole operator
         replaced by the linear-momentum operator ``p = -i nabla`` (stripped of the ``i`` carried

--- a/pycc/hfwfn.py
+++ b/pycc/hfwfn.py
@@ -139,7 +139,7 @@ class HFwfn(Wavefunction):
             \end{aligned}
 
         The electronic part is the occupied trace of the MO dipole integrals (``H.mu`` = ``-e r``;
-        same ``Tr(D mu)`` convention as :meth:`MPwfn.relaxed_dipole`, with the SCF density's occupied
+        same ``Tr(D mu)`` convention as :meth:`~pycc.correlatedderivs.CorrelatedDerivs.relaxed_dipole`, with the SCF density's occupied
         block). The prefactor is the orbital occupancy: ``k = 2`` on the spatial closed-shell path,
         ``k = 1`` for spin orbitals. Kept separate from the correlation dipole so the total MP2
         dipole is ``HFwfn.dipole() + MPderiv.relaxed_dipole()`` (mirroring the gradient split).

--- a/pycc/mpwfn.py
+++ b/pycc/mpwfn.py
@@ -26,9 +26,8 @@ class MPwfn(Wavefunction):
     The analytic derivative-property code lives on :class:`~pycc.mpderiv.MPderiv`, a
     :class:`~pycc.correlatedderivs.CorrelatedDerivs` driver.  Build it with
     ``pycc.MPderiv(wfn)`` and pass it to the ``pycc`` property facade, e.g.
-    ``pycc.gradient(pycc.MPderiv(wfn))`` -- the same pattern as CCwfn/CIwfn.  (The cached
-    :attr:`deriv` accessor and the ``atomic_axial_tensors`` / ``velocity_dipole_derivatives``
-    wfn methods below remain only for the not-yet-migrated AAT / velocity-gauge-APT path.)
+    ``pycc.gradient(pycc.MPderiv(wfn))`` -- the same pattern as CCwfn/CIwfn.  ``MPwfn`` carries
+    no derivative-property methods of its own.
 
     Attributes
     ----------
@@ -155,31 +154,6 @@ class MPwfn(Wavefunction):
         norm2 = 0.25 * self.contract('ijab,ijab->', t2, t2)
         return 1.0 / np.sqrt(1.0 + norm2)
 
-    # ---- analytic derivative-property driver (see pycc.mpderiv.MPderiv) ----
-
-    @property
-    def deriv(self):
-        """The cached :class:`~pycc.mpderiv.MPderiv` derivative-property driver for this
-        wavefunction (built lazily).  ``MPderiv`` is the MP2 leaf of
-        :class:`~pycc.correlatedderivs.CorrelatedDerivs` and carries the analytic
-        derivative-property code; the thin property methods below (:meth:`gradient`,
-        :meth:`polarizability`, :meth:`hessian`, ...) delegate to it so the
-        ``mpwfn.<property>()`` call sites keep working, and the :mod:`pycc.properties` facade routes
-        through the registry (``pycc/__init__.py``) to the same driver.  A single cached instance,
-        so its ``_full_occ_cphf`` / Z-vector caches are shared across the MP2 property calls."""
-        if getattr(self, '_deriv', None) is None:
-            from .mpderiv import MPderiv
-            self._deriv = MPderiv(self)
-        return self._deriv
-
-    def velocity_dipole_derivatives(self, gauge: str = 'non-canonical') -> np.ndarray:
-        """MP2 correlation velocity-gauge APT -- delegates to
-        :meth:`MPderiv.velocity_dipole_derivatives`."""
-        return self.deriv.velocity_dipole_derivatives(gauge)
-
-    def atomic_axial_tensors(self, gauge: str = 'non-canonical') -> np.ndarray:
-        """MP2 correlation AAT -- delegates to :meth:`MPderiv.atomic_axial_tensors`."""
-        return self.deriv.atomic_axial_tensors(gauge)
 
     # ---- reference for the total (reference + correlation) properties ----
     # The property methods above are the correlation contribution only.  The full molecular

--- a/pycc/properties.py
+++ b/pycc/properties.py
@@ -385,14 +385,16 @@ def apt(wfn, gauge='length', route='2n+1-field', orbital_gauge='non-canonical') 
 
 def aat(wfn, origin=None, orbital_gauge='non-canonical') -> PropertyComponents:
     """Atomic axial tensors (AATs, for VCD) as a :class:`PropertyComponents`
-    (``nuclear + reference + correlation``), shape ``(natom, 3, 3)`` each, for any supported
-    wavefunction type.
+    (``nuclear + reference + correlation``), shape ``(natom, 3, 3)`` each.  Like the other property
+    facades, ``wfn`` is a derivative driver (:class:`~pycc.mpderiv.MPderiv` /
+    :class:`~pycc.cideriv.CIderiv`) for a correlated method, or an :class:`~pycc.hfwfn.HFwfn` for the
+    SCF reference; a bare correlated wavefunction is rejected.
 
-    The correlation block is the genuine correlation contribution
-    (:meth:`MPwfn.atomic_axial_tensors`, which excludes the reference density), the reference
-    block is the independent SCF AAT (:meth:`HFwfn.atomic_axial_tensors`), and the nuclear block
-    is ``(Z_A/4) eps R``.  Each block is orbital-gauge invariant, so the decomposition is well
-    defined independent of the magnetic oo/vv gauge.
+    The correlation block is the genuine correlation contribution (the driver's
+    ``atomic_axial_tensors``, which excludes the reference density), the reference block is the
+    independent SCF AAT (:meth:`HFwfn.atomic_axial_tensors`), and the nuclear block is
+    ``(Z_A/4) eps R``.  Each block is orbital-gauge invariant, so the decomposition is well defined
+    independent of the magnetic oo/vv gauge.
 
     ``origin`` is the coordinate origin for the nuclear term; ``None`` (default) uses the current
     coordinate origin ``(0, 0, 0)`` in the molecule's input frame (honoring ``no_com`` /
@@ -404,25 +406,10 @@ def aat(wfn, origin=None, orbital_gauge='non-canonical') -> PropertyComponents:
     the correlation AAT (MP2 or CISD), ``'non-canonical'`` (default, numerically stable) or
     ``'canonical'``.  The AAT is invariant to this choice, so it exists only for
     verification/debugging; it is ignored for an ``HFwfn`` (no correlation)."""
-    from .hfwfn import HFwfn
-    from .mpwfn import MPwfn
-    from .ciwfn import CIwfn
-
-    mol = wfn.ref.molecule()
+    mol = _wfn_of(wfn).ref.molecule()
     nuclear = _nuclear_aat(mol, origin)
-    if isinstance(wfn, MPwfn):
-        reference = np.asarray(wfn._reference_hf().atomic_axial_tensors())
-        correlation = np.asarray(wfn.atomic_axial_tensors(gauge=orbital_gauge))
-    elif isinstance(wfn, HFwfn):
-        reference = np.asarray(wfn.atomic_axial_tensors())
-        correlation = np.zeros_like(reference)
-    elif isinstance(wfn, CIwfn):
-        from .cideriv import CIderiv
-        cd = CIderiv(wfn)
-        reference = np.asarray(cd._reference_hf().atomic_axial_tensors())
-        correlation = np.asarray(cd.atomic_axial_tensors(gauge=orbital_gauge))
-    else:
-        raise TypeError(f"pycc.aat: unsupported wavefunction type {type(wfn).__name__!r}")
+    reference, correlation = _dispatch(wfn, 'atomic_axial_tensors', 'atomic_axial_tensors',
+                                       {'gauge': orbital_gauge})
     o = (0.0, 0.0, 0.0) if origin is None else tuple(float(x) for x in origin)
     pc = PropertyComponents(nuclear=nuclear, reference=reference, correlation=correlation, origin=o)
     _record(wfn, 'aat', pc)

--- a/pycc/tests/test_061_mp2_relaxed_density.py
+++ b/pycc/tests/test_061_mp2_relaxed_density.py
@@ -80,7 +80,7 @@ def _ff_corr_dipole(geom, basis, F=0.0005, freeze_core='false', reference='rhf',
 
 def _pycc_corr_dipole(geom, basis, orbital_basis='spinorbital', freeze_core='false', reference='rhf', occ=None):
     """PyCC relaxed-MP2 electronic correlation mu_z (spin-orbital or spin-adapted),
-    via the user-API :meth:`MPwfn.relaxed_dipole`."""
+    via the user-API :meth:`~pycc.correlatedderivs.CorrelatedDerivs.relaxed_dipole`."""
     psi4.core.clean()
     psi4.core.clean_options()
     psi4.geometry(geom)

--- a/pycc/tests/test_068_mp2_apt.py
+++ b/pycc/tests/test_068_mp2_apt.py
@@ -60,7 +60,7 @@ def _mpwfn(coords, basis, orbital_basis='spatial', freeze_core='false'):
 def _dens_invariants(mp):
     """Gauge-invariant Tr(gamma^2), ||Gamma||^2 (orthogonal orbital rotations preserve both)."""
     o, v, nmo = mp.o, mp.v, mp.nmo
-    d = mp.deriv
+    d = pycc.MPderiv(mp)
     if mp.orbital_basis == 'spinorbital':
         Doo, Dvv = d._so_mp2_opdm(); Gam = np.asarray(d._so_mp2_tpdm())
     else:
@@ -109,7 +109,7 @@ def test_mp2_nuclear_t2_response_631g():
     from pycc.cphf import Perturbation
     mp0 = _mpwfn(BASE, '6-31G', 'spatial')
     o, v, nmo = mp0.o, mp0.v, mp0.nmo
-    d = mp0.deriv
+    d = pycc.MPderiv(mp0)
     Doo, Dvv = d._mp2_opdm(); Gam = np.asarray(d._mp2_tpdm())
     g = np.zeros((nmo, nmo)); g[o, o] = np.asarray(Doo); g[v, v] = np.asarray(Dvv)
     for (atom, cart) in [(0, 2), (2, 1)]:

--- a/pycc/tests/test_072_mp2_aat.py
+++ b/pycc/tests/test_072_mp2_aat.py
@@ -1,5 +1,5 @@
 """
-MP2 atomic axial tensors (AATs) -- MPwfn.atomic_axial_tensors(), the density/wave-function-
+MP2 atomic axial tensors (AATs) -- MPderiv.atomic_axial_tensors(), the density/wave-function-
 overlap formulation (Krishnan, Shumberger & Crawford, in prep.), built on the diagonal
 Born-Oppenheimer correction of Gauss, Tajti, Kallay, Stanton & Szalay, J. Chem. Phys. 125,
 144111 (2006) [Eqs. (16), (18), (19)].
@@ -73,7 +73,7 @@ def _mpwfn(orbital_basis='spatial', freeze_core='false', geom=H2O2, basis='STO-3
 def test_mp2_aat_all_electron():
     """All-electron spatial MP2 electronic AAT (SCF reference + correlation, via the pycc.aat
     facade) reproduces the apyib reference for (P)-H2O2/STO-3G."""
-    P = np.asarray(pycc.aat(_mpwfn()).electronic).reshape(-1, 3)
+    P = np.asarray(pycc.aat(pycc.MPderiv(_mpwfn())).electronic).reshape(-1, 3)
     for (row, col), ref in AAT_REF['false'].items():
         assert abs(P[row, col] - ref) < 1e-6, (row, col, P[row, col], ref)
 
@@ -81,7 +81,7 @@ def test_mp2_aat_all_electron():
 def test_mp2_aat_frozen_core():
     """Frozen-core spatial MP2 electronic AAT reproduces the independent apyib frozen-core
     reference (all-electron SCF reference + frozen-core correlation)."""
-    P = np.asarray(pycc.aat(_mpwfn(freeze_core='true')).electronic).reshape(-1, 3)
+    P = np.asarray(pycc.aat(pycc.MPderiv(_mpwfn(freeze_core='true'))).electronic).reshape(-1, 3)
     for (row, col), ref in AAT_REF['true'].items():
         assert abs(P[row, col] - ref) < 1e-6, (row, col, P[row, col], ref)
 
@@ -90,10 +90,10 @@ def test_mp2_aat_so_equals_spatial():
     """Spin-orbital MP2 correlation AAT == spin-adapted (the keystone), all-electron and
     frozen-core; the electronic total also matches the apyib reference."""
     for fc in ('false', 'true'):
-        P = np.asarray(_mpwfn(freeze_core=fc).atomic_axial_tensors()).reshape(-1, 3)
-        P_so = np.asarray(_mpwfn('spinorbital', fc).atomic_axial_tensors()).reshape(-1, 3)
+        P = np.asarray(pycc.MPderiv(_mpwfn(freeze_core=fc)).atomic_axial_tensors()).reshape(-1, 3)
+        P_so = np.asarray(pycc.MPderiv(_mpwfn('spinorbital', fc)).atomic_axial_tensors()).reshape(-1, 3)
         assert np.max(np.abs(P_so - P)) < 1e-9, (fc, np.max(np.abs(P_so - P)))
-        E_so = np.asarray(pycc.aat(_mpwfn('spinorbital', fc)).electronic).reshape(-1, 3)
+        E_so = np.asarray(pycc.aat(pycc.MPderiv(_mpwfn('spinorbital', fc))).electronic).reshape(-1, 3)
         for (row, col), ref in AAT_REF[fc].items():
             assert abs(E_so[row, col] - ref) < 1e-6, (fc, row, col, E_so[row, col], ref)
 
@@ -102,8 +102,8 @@ def test_mp2_aat_ccpvdz_vs_apyib():
     """Larger basis (cc-pVDZ): the electronic MP2 AAT (H2O -- a real virtual space with polarization
     functions and several virtuals per irrep, unlike STO-3G/H2O) reproduces the independent apyib
     reference, for BOTH the spin-adapted and the spin-orbital paths (so SO == spatial as well)."""
-    P = np.asarray(pycc.aat(_mpwfn('spatial', 'false', WATER, 'cc-pVDZ')).electronic).reshape(-1, 3)
-    P_so = np.asarray(pycc.aat(_mpwfn('spinorbital', 'false', WATER, 'cc-pVDZ')).electronic).reshape(-1, 3)
+    P = np.asarray(pycc.aat(pycc.MPderiv(_mpwfn('spatial', 'false', WATER, 'cc-pVDZ'))).electronic).reshape(-1, 3)
+    P_so = np.asarray(pycc.aat(pycc.MPderiv(_mpwfn('spinorbital', 'false', WATER, 'cc-pVDZ'))).electronic).reshape(-1, 3)
     for (row, col), ref in AAT_REF_CCPVDZ.items():
         assert abs(P[row, col] - ref) < 1e-6, ('spatial', row, col, P[row, col], ref)
         assert abs(P_so[row, col] - ref) < 1e-6, ('SO', row, col, P_so[row, col], ref)
@@ -115,9 +115,9 @@ def test_mp2_aat_gauge_invariance():
     (The dropped SCF-reference block is itself gauge invariant, so the correlation is too.)"""
     for fc in ('false', 'true'):
         for ob in ('spatial', 'spinorbital'):
-            mp = _mpwfn(ob, fc)
-            nc = np.asarray(mp.atomic_axial_tensors(gauge='non-canonical'))
-            ca = np.asarray(mp.atomic_axial_tensors(gauge='canonical'))
+            d = pycc.MPderiv(_mpwfn(ob, fc))
+            nc = np.asarray(d.atomic_axial_tensors(gauge='non-canonical'))
+            ca = np.asarray(d.atomic_axial_tensors(gauge='canonical'))
             assert np.max(np.abs(nc - ca)) < 1e-9, (fc, ob, np.max(np.abs(nc - ca)))
 
 

--- a/pycc/tests/test_073_mp2_vg_apt.py
+++ b/pycc/tests/test_073_mp2_vg_apt.py
@@ -1,5 +1,5 @@
 """
-MP2 velocity-gauge (VG) atomic polar tensors -- MPwfn.velocity_dipole_derivatives(), the
+MP2 velocity-gauge (VG) atomic polar tensors -- MPderiv.velocity_dipole_derivatives(), the
 density/wave-function-overlap formulation.  This is the atomic-axial-tensor machinery
 (test_072_mp2_aat) with the magnetic-dipole operator replaced by the linear momentum p = -i nabla
 and the Levi-Civita nuclear term replaced by the length-gauge Z_A delta.
@@ -88,8 +88,8 @@ def test_mp2_vg_apt_so_equals_spatial():
     """Spin-orbital MP2 VG APT correlation == spin-adapted (the keystone), all-electron and
     frozen-core."""
     for fc in ('false', 'true'):
-        P = np.asarray(_mpwfn(freeze_core=fc)[0].velocity_dipole_derivatives())
-        P_so = np.asarray(_mpwfn('spinorbital', fc)[0].velocity_dipole_derivatives())
+        P = np.asarray(pycc.MPderiv(_mpwfn(freeze_core=fc)[0]).velocity_dipole_derivatives())
+        P_so = np.asarray(pycc.MPderiv(_mpwfn('spinorbital', fc)[0]).velocity_dipole_derivatives())
         assert np.max(np.abs(P_so - P)) < 1e-9, (fc, np.max(np.abs(P_so - P)))
 
 
@@ -97,8 +97,8 @@ def test_mp2_vg_apt_so_equals_spatial_ccpvdz():
     """Larger basis (cc-pVDZ): the spin-orbital MP2 VG APT equals the spin-adapted, for a real
     virtual space (polarization functions, several virtuals per irrep) that STO-3G lacks.  Analytic
     keystone (H2O; molecule-agnostic) -- apyib provides no MP2 VG APT oracle at this basis."""
-    P = np.asarray(_mpwfn('spatial', 'false', WATER, 'cc-pVDZ')[0].velocity_dipole_derivatives())
-    P_so = np.asarray(_mpwfn('spinorbital', 'false', WATER, 'cc-pVDZ')[0].velocity_dipole_derivatives())
+    P = np.asarray(pycc.MPderiv(_mpwfn('spatial', 'false', WATER, 'cc-pVDZ')[0]).velocity_dipole_derivatives())
+    P_so = np.asarray(pycc.MPderiv(_mpwfn('spinorbital', 'false', WATER, 'cc-pVDZ')[0]).velocity_dipole_derivatives())
     assert np.max(np.abs(P_so - P)) < 1e-9, np.max(np.abs(P_so - P))
 
 
@@ -107,7 +107,7 @@ def test_mp2_vg_apt_gauge_invariance():
     (non-canonical default vs canonical), all-electron and frozen-core, both spin paths."""
     for fc in ('false', 'true'):
         for ob in ('spatial', 'spinorbital'):
-            mp = _mpwfn(ob, fc)[0]
-            nc = np.asarray(mp.velocity_dipole_derivatives(gauge='non-canonical'))
-            ca = np.asarray(mp.velocity_dipole_derivatives(gauge='canonical'))
+            d = pycc.MPderiv(_mpwfn(ob, fc)[0])
+            nc = np.asarray(d.velocity_dipole_derivatives(gauge='non-canonical'))
+            ca = np.asarray(d.velocity_dipole_derivatives(gauge='canonical'))
             assert np.max(np.abs(nc - ca)) < 1e-9, (fc, ob, np.max(np.abs(nc - ca)))

--- a/pycc/tests/test_074_property_facade.py
+++ b/pycc/tests/test_074_property_facade.py
@@ -40,7 +40,7 @@ def test_aat_decomposition_identities():
     """total == nuclear + reference + correlation; electronic == reference + correlation; the
     derived accessors and the scf/hf aliases are self-consistent."""
     _, mp = _wfns()
-    r = pycc.aat(mp)
+    r = pycc.aat(pycc.MPderiv(mp))
     assert np.max(np.abs(r.total - (r.nuclear + r.reference + r.correlation))) < 1e-14
     assert np.max(np.abs(r.electronic - (r.reference + r.correlation))) < 1e-14
     assert np.array_equal(r.scf, r.reference) and np.array_equal(r.hf, r.reference)
@@ -51,16 +51,16 @@ def test_aat_genuine_separation():
     """The reference block is exactly the independent SCF AAT, and the correlation block is a
     real, nonzero contribution computed apart from it."""
     hf, mp = _wfns()
-    r = pycc.aat(mp)
+    r = pycc.aat(pycc.MPderiv(mp))
     assert np.max(np.abs(r.reference - np.asarray(hf.atomic_axial_tensors()))) < 1e-12
-    assert np.max(np.abs(r.correlation - np.asarray(mp.atomic_axial_tensors()))) < 1e-12
+    assert np.max(np.abs(r.correlation - np.asarray(pycc.MPderiv(mp).atomic_axial_tensors()))) < 1e-12
     assert np.max(np.abs(r.correlation)) > 1e-4      # correlation really present
 
 
 def test_aat_nuclear_term():
     """The nuclear block is (Z_A/4) eps_{alpha,beta,gamma} R_{A,gamma}."""
     _, mp = _wfns()
-    r = pycc.aat(mp)
+    r = pycc.aat(pycc.MPderiv(mp))
     mol = mp.ref.molecule()
     R = mol.geometry().np
     for A in range(mol.natom()):
@@ -84,9 +84,9 @@ def test_aat_origin_argument():
     """A non-default origin shifts only the nuclear block (electronic terms unchanged), by the
     expected -(Z_A/4) eps O."""
     _, mp = _wfns()
-    r0 = pycc.aat(mp)
+    r0 = pycc.aat(pycc.MPderiv(mp))
     O = (0.5, -0.3, 0.1)
-    rO = pycc.aat(mp, origin=O)
+    rO = pycc.aat(pycc.MPderiv(mp), origin=O)
     assert np.max(np.abs(rO.electronic - r0.electronic)) < 1e-14
     mol = mp.ref.molecule()
     ox, oy, oz = O
@@ -101,7 +101,7 @@ def test_aat_frozen_core_total():
     reference is unaffected by freezing (it is the all-electron SCF AAT)."""
     _, mp_ae = _wfns('false')
     _, mp_fc = _wfns('true')
-    r_ae, r_fc = pycc.aat(mp_ae), pycc.aat(mp_fc)
+    r_ae, r_fc = pycc.aat(pycc.MPderiv(mp_ae)), pycc.aat(pycc.MPderiv(mp_fc))
     assert np.max(np.abs(r_fc.reference - r_ae.reference)) < 1e-12
     assert np.max(np.abs(r_fc.nuclear - r_ae.nuclear)) < 1e-14
     # freezing changes the correlation (and hence the total) a little, but not wildly
@@ -120,7 +120,7 @@ def _facade_and_pieces(hf, mp):
         ("polarizability", pycc.polarizability(d),        hf.polarizability(),             d.polarizability()),
         ("hessian",        pycc.hessian(d),               hf.hessian(),                    d.hessian()),
         ("apt-length",     pycc.apt(d, 'length'),         hf.dipole_derivatives(),         d.dipole_derivatives()),
-        ("apt-velocity",   pycc.apt(d, 'velocity'),       hf.velocity_dipole_derivatives(), mp.velocity_dipole_derivatives()),
+        ("apt-velocity",   pycc.apt(d, 'velocity'),       hf.velocity_dipole_derivatives(), d.velocity_dipole_derivatives()),
     ]
 
 
@@ -201,10 +201,9 @@ def test_facade_orbital_gauge_option():
     """orbital_gauge (expert-only) is exposed on aat / apt(velocity); the tensor is invariant to
     it (the knob reaches the correlation method, which is gauge invariant), ignored for HF."""
     hf, mp = _wfns()
-    # aat keeps its wavefunction-based interface for now (pending the AAT/VG-APT hoist)
-    assert np.max(np.abs(pycc.aat(mp, orbital_gauge='non-canonical').total
-                         - pycc.aat(mp, orbital_gauge='canonical').total)) < 1e-9
     d = pycc.MPderiv(mp)
+    assert np.max(np.abs(pycc.aat(d, orbital_gauge='non-canonical').total
+                         - pycc.aat(d, orbital_gauge='canonical').total)) < 1e-9
     assert np.max(np.abs(pycc.apt(d, 'velocity', orbital_gauge='non-canonical').total
                          - pycc.apt(d, 'velocity', orbital_gauge='canonical').total)) < 1e-9
     assert np.all(pycc.apt(hf, 'velocity', orbital_gauge='canonical').correlation == 0.0)

--- a/pycc/tests/test_081_cisd_aat.py
+++ b/pycc/tests/test_081_cisd_aat.py
@@ -61,7 +61,7 @@ AAT_REF_CCPVDZ = np.array([
 def test_cisd_aat_vs_reference(cisd_h2o2):
     """The facade total reproduces the standalone validated reference, every
     element (STO-3G)."""
-    P = np.asarray(pycc.aat(cisd_h2o2()).total).reshape(-1, 3)
+    P = np.asarray(pycc.aat(pycc.CIderiv(cisd_h2o2())).total).reshape(-1, 3)
     print(P)
     assert np.max(np.abs(P - AAT_REF)) < 1e-8, np.max(np.abs(P - AAT_REF))
 
@@ -69,7 +69,7 @@ def test_cisd_aat_vs_reference(cisd_h2o2):
 def test_cisd_aat_ccpvdz_vs_reference(cisd_h2o2):
     """Larger basis (cc-pVDZ): the facade total reproduces the standalone
     validated reference, every element."""
-    P = np.asarray(pycc.aat(cisd_h2o2(basis='cc-pVDZ')).total).reshape(-1, 3)
+    P = np.asarray(pycc.aat(pycc.CIderiv(cisd_h2o2(basis='cc-pVDZ'))).total).reshape(-1, 3)
     print(P)
     assert np.max(np.abs(P - AAT_REF_CCPVDZ)) < 1e-9, np.max(np.abs(P - AAT_REF_CCPVDZ))
 
@@ -138,8 +138,9 @@ def test_cisd_aat_all_electron_vs_apyib():
     """All-electron spatial CISD electronic AAT (SCF reference + correlation, via the pycc.aat
     facade) reproduces the apyib reference for (P)-H2O2/STO-3G, in both orbital gauges."""
     ci = _ciwfn()
+    cd = pycc.CIderiv(ci)
     for gauge in GAUGES:
-        P = np.asarray(pycc.aat(ci, orbital_gauge=gauge).electronic).reshape(-1, 3)
+        P = np.asarray(pycc.aat(cd, orbital_gauge=gauge).electronic).reshape(-1, 3)
         d = np.max(np.abs(P - AAT_APYIB_H2O2['false']))
         assert d < APYIB_TOL_H2O2, (gauge, d)
 
@@ -149,8 +150,9 @@ def test_cisd_aat_frozen_core_vs_apyib():
     reference (all-electron SCF reference + frozen-core correlation), in both orbital gauges."""
     ci = _ciwfn(freeze_core='true')
     assert ci.nfzc == 2, ci.nfzc
+    cd = pycc.CIderiv(ci)
     for gauge in GAUGES:
-        P = np.asarray(pycc.aat(ci, orbital_gauge=gauge).electronic).reshape(-1, 3)
+        P = np.asarray(pycc.aat(cd, orbital_gauge=gauge).electronic).reshape(-1, 3)
         d = np.max(np.abs(P - AAT_APYIB_H2O2['true']))
         assert d < APYIB_TOL_H2O2, (gauge, d)
 

--- a/pycc/tests/test_095_vcd.py
+++ b/pycc/tests/test_095_vcd.py
@@ -92,7 +92,7 @@ def test_vcd_mp2_h2o2(rhf_wfn):
 
     hessian = np.genfromtxt(_HESSIAN_FILE, skip_header=1).reshape(12, 12)
     apt = np.asarray(pycc.apt(d).total)
-    aat = np.asarray(pycc.aat(mp).total)
+    aat = np.asarray(pycc.aat(d).total)
 
     res = pycc.harmonic_analysis(wfn.molecule(), hessian, apt=apt, aat=aat,
                                  project_trans=True, project_rot=True)

--- a/pycc/vibanalysis.py
+++ b/pycc/vibanalysis.py
@@ -490,7 +490,7 @@ def vcd(source: Any, checkpoint: str = None, project_trans: bool = False,
     deriv = source
     hess = np.asarray(properties.hessian(deriv).total)
     apt = np.asarray(properties.apt(deriv).total)
-    aat = np.asarray(properties.aat(properties._wfn_of(deriv)).total)
+    aat = np.asarray(properties.aat(deriv).total)
     molecule = properties._wfn_of(deriv).ref.molecule()
 
     if checkpoint is not None:


### PR DESCRIPTION
# Move MP2 AAT / VG-APT onto MPderiv, and route pycc.aat through the driver facade

## What this does

Two related interface cleanups that finish moving MP2 derivative-property code off the
wavefunction and onto the derivative driver, and make the `pycc.aat` facade consistent with
the rest of the property facade.

### 1. MP2 AAT / VG-APT live on MPderiv, not MPwfn

`MPwfn.atomic_axial_tensors()` and `MPwfn.velocity_dipole_derivatives()` are removed.  The
computations now live only on `MPderiv` (they already did; the wfn methods were thin
forwarders).  This matches CCwfn/CIwfn, which carry no derivative-property methods, and gives
MP2 exactly the CISD interface: `pycc.MPderiv(wfn).atomic_axial_tensors(...)`.  After this,
`MPwfn` has no derivative-property methods of its own.

### 2. pycc.aat takes the driver (the "AAT hoist")

`pycc.aat` was the one property facade that still took a bare wavefunction.  Its formulation is
the same family as `pycc.apt(gauge='velocity')` (both are magnetic/momentum
wavefunction-overlap properties computed on the driver), yet the two had different signatures.

`pycc.aat` now goes through the shared `_dispatch` machinery, so it takes a derivative driver
(`MPderiv` / `CIderiv`) or an `HFwfn`, and rejects a bare correlated wavefunction with a
TypeError, identical to `apt` / `hessian` / `gradient` / `polarizability`:

    pycc.aat(pycc.MPderiv(mp))     # MP2
    pycc.aat(pycc.CIderiv(ci))     # CISD
    pycc.aat(hf)                   # SCF reference
    pycc.aat(mp)                   # TypeError: construct the driver first

The nuclear term and the `origin` argument are unchanged.  CC AATs remain unimplemented
(passing a CCderiv raises AttributeError, a bare CCwfn TypeError) exactly as before.

## Also fixed

Six now-broken `:meth:`MPwfn.<method>`` doc cross-references left behind when these methods
moved onto the driver (four from this change: `atomic_axial_tensors`,
`velocity_dipole_derivatives`; two `relaxed_dipole` leftovers from #231).  All repointed to
`MPderiv`.  The tree now has zero broken `MPwfn.<removed-method>` references.

## Touched

- `pycc/mpwfn.py` -- remove the two forwarder methods + docstring note.
- `pycc/properties.py` -- `aat` facade rewritten onto `_dispatch`; docstring updated.
- `pycc/vibanalysis.py` -- `aat(deriv)` (driver), like the hessian/apt siblings.
- `pycc/cphf.py`, `pycc/hfwfn.py` -- repointed doc xrefs.
- `docs/getting_started.rst` -- `pycc.aat(d)`; dropped the "wrinkle" note about aat taking the wfn.
- tests: `test_068`, `test_072`, `test_073`, `test_074`, `test_081`, `test_095` -- callers pass the driver; stale prose fixed.

## Validation

MP2/CISD AAT + VG-APT + property-facade + VCD suites pass
(test_072/073/074/081/095), plus the getting_started example.
