### PR TITLE
Response frequency in nm; document the ccresponse route

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -152,11 +152,13 @@ rotation); its report also prints the specific rotation ``[alpha]``.
 These facade calls are the high-level route. The lower-level :class:`~pycc.ccresponse.ccresponse`
 object computes the same linear-response tensors and reaches further -- both spin paths (spatial
 and spin-orbital) and CC3, in addition to CCSD -- at the cost of assembling the intermediates by
-hand and returning raw arrays. It is built from the ``density`` created above::
+hand and returning raw arrays. It is built from the ``density`` created above and takes the same
+``units`` toggle::
 
     resp = pycc.ccresponse(density)
-    resp.polarizability(0.07)        # length-gauge alpha(omega)   (3, 3) ndarray
-    resp.optrot(0.07)                # length-gauge G'(omega); note the name is .optrot
+    resp.polarizability(0.07)              # length-gauge alpha(omega)   (3, 3) ndarray
+    resp.optrot(0.07)                      # length-gauge G'(omega); note the name is .optrot
+    resp.optrot(589, units='nm')           # omega as a wavelength, as on the facade
 
 GPU and mixed precision
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -135,16 +135,28 @@ Frequency-dependent response (CCSD)
 The static polarizability above has dynamic (frequency-dependent) counterparts from CCSD linear
 response, evaluated on a CCSD derivative driver::
 
-    dcc = pycc.CCderiv(cc)                       # CCSD derivative driver (cc solved above)
+    dcc = pycc.CCderiv(cc)                          # CCSD derivative driver (cc solved above)
 
-    pycc.polarizability(dcc, omega=0.07)         # dynamic polarizability alpha(omega)  (3, 3)
-    pycc.optical_rotation(dcc, omega=0.07)       # optical-rotation tensor G'(omega)    (3, 3)
+    pycc.polarizability(dcc, omega=0.07)            # dynamic polarizability alpha(omega)  (3, 3)
+    pycc.optical_rotation(dcc, omega=0.07)          # optical-rotation tensor G'(omega)    (3, 3)
 
-``omega`` is the field frequency in hartree (0 = static). The dynamic polarizability defaults to
-the unrelaxed linear-response value (it omits the orbital relaxation, which would introduce
-spurious poles), so it is correlation-only with a zero reference block. Optical rotation is
-CCSD-only and requires a nonzero ``omega`` (there is no static optical rotation); its report also
-prints the specific rotation ``[alpha]``.
+    pycc.optical_rotation(dcc, omega=589, units='nm')   # same, with omega given as a wavelength
+
+``omega`` is the field frequency in hartree (``0 = static``); pass ``units='nm'`` to give it as a
+wavelength in nm instead (a positive wavelength -- the static value has none). The dynamic
+polarizability defaults to the unrelaxed linear-response value (it omits the orbital relaxation,
+which would introduce spurious poles), so it is correlation-only with a zero reference block.
+Optical rotation is CCSD-only and requires a nonzero ``omega`` (there is no static optical
+rotation); its report also prints the specific rotation ``[alpha]``.
+
+These facade calls are the high-level route. The lower-level :class:`~pycc.ccresponse.ccresponse`
+object computes the same linear-response tensors and reaches further -- both spin paths (spatial
+and spin-orbital) and CC3, in addition to CCSD -- at the cost of assembling the intermediates by
+hand and returning raw arrays. It is built from the ``density`` created above::
+
+    resp = pycc.ccresponse(density)
+    resp.polarizability(0.07)        # length-gauge alpha(omega)   (3, 3) ndarray
+    resp.optrot(0.07)                # length-gauge G'(omega); note the name is .optrot
 
 GPU and mixed precision
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pycc/ccresponse.py
+++ b/pycc/ccresponse.py
@@ -534,7 +534,7 @@ class ccresponse(object):
     # ==================================================================
 
     def polarizability(self, omega, e_conv=1e-12, r_conv=1e-12, maxiter=200,
-                       max_diis=7, start_diis=1):
+                       max_diis=7, start_diis=1, units='Eh'):
         r"""Dipole polarizability tensor (length gauge) at frequency omega via the
         symmetric response function (right-hand perturbed amplitudes only)::
 
@@ -552,7 +552,12 @@ class ccresponse(object):
         assembled from the right-hand perturbed amplitudes X(mu,-w) and X(mu,+w).
         Returns a 3x3 array. Basis-agnostic: all basis-specific work lives in
         solve_right and linresp_sym.
+
+        ``omega`` is in hartree by default; set ``units='nm'`` to give it as a
+        wavelength in nm instead.
         """
+        from .properties import _omega_to_hartree   # single source of truth for frequency units
+        omega = _omega_to_hartree(omega, units)
         args = (e_conv, r_conv, maxiter, max_diis, start_diis)
         Xp, Xm = [], []
         # solve_right returns (X, pseudo) where X is the list [X1, X2] (CCSD) or
@@ -598,7 +603,7 @@ class ccresponse(object):
         print(field("isotropic (1/3 Tr)", "%.6f a.u.   %.6f Angstrom^3" % (iso, iso * _ANG3_PER_AU)))
 
     def optrot(self, omega, e_conv=1e-12, r_conv=1e-12, maxiter=200,
-               max_diis=7, start_diis=1):
+               max_diis=7, start_diis=1, units='Eh'):
         r"""Optical-rotation tensor (length gauge) at frequency omega via the symmetric
         response function (right-hand perturbed amplitudes only)::
 
@@ -619,7 +624,12 @@ class ccresponse(object):
         assembled from the right-hand perturbed amplitudes X(mu,-w), X(m,+w),
         X(mu,+w), X(m*,-w). Returns a 3x3 array. Basis-agnostic: all basis-specific
         work lives in solve_right and linresp_sym.
+
+        ``omega`` is in hartree by default; set ``units='nm'`` to give it as a
+        wavelength in nm instead.
         """
+        from .properties import _omega_to_hartree   # single source of truth for frequency units
+        omega = _omega_to_hartree(omega, units)
         if omega == 0.0:
             raise ValueError("Optical rotation requires a nonzero field frequency.")
         args = (e_conv, r_conv, maxiter, max_diis, start_diis)

--- a/pycc/properties.py
+++ b/pycc/properties.py
@@ -260,7 +260,26 @@ def gradient(wfn) -> PropertyComponents:
     return pc.report("%s gradient" % _method_name(wfn))
 
 
-def polarizability(wfn, omega: float = 0.0, relaxed: bool = None) -> PropertyComponents:
+def _omega_to_hartree(omega, units):
+    """Interpret a response frequency given in ``units`` and return it in hartree (Eh).
+
+    ``units='Eh'`` (aliases ``'hartree'`` / ``'au'``) leaves ``omega`` unchanged; ``units='nm'``
+    treats ``omega`` as a wavelength in nm and converts it (``omega_Eh = NM_PER_EH / lambda_nm``),
+    which requires a positive wavelength (there is no static ``omega = 0`` wavelength)."""
+    u = str(units).lower()
+    if u in ('eh', 'hartree', 'au', 'a.u.'):
+        return float(omega)
+    if u == 'nm':
+        if omega <= 0.0:
+            raise ValueError(
+                "a wavelength in nm must be positive; there is no static (omega=0) wavelength.  "
+                "For the static value use the default units='Eh' with omega=0.")
+        return NM_PER_EH / float(omega)
+    raise ValueError("unknown frequency units %r; use 'Eh' (hartree/au) or 'nm'." % (units,))
+
+
+def polarizability(wfn, omega: float = 0.0, relaxed: bool = None,
+                   units: str = 'Eh') -> PropertyComponents:
     """Electric-dipole polarizability as a :class:`PropertyComponents`, shape ``(3, 3)`` each.  A
     pure electronic response property: the nuclear block is zero.  The report also prints the field
     frequency (in Eh and nm) and the isotropic invariant ``(1/3) Tr(alpha)`` in a.u. and Angstrom^3.
@@ -277,9 +296,12 @@ def polarizability(wfn, omega: float = 0.0, relaxed: bool = None) -> PropertyCom
       MO response, there is no Hartree-Fock contribution: the value is correlation-only, so the SCF
       block is zero.
 
-    ``omega`` is the external-field frequency in Eh (0 = static).  ``relaxed`` overrides the route:
+    ``omega`` is the external-field frequency, in hartree by default (``0 = static``).  Set
+    ``units='nm'`` to give ``omega`` as a wavelength in nm instead (converted internally; a positive
+    wavelength only, since the static value has no wavelength).  ``relaxed`` overrides the route:
     the default (``None``) picks relaxed at ``omega = 0`` and unrelaxed otherwise; ``relaxed=False``
     takes the unrelaxed route at ``omega = 0`` too."""
+    omega = _omega_to_hartree(omega, units)
     if relaxed is None:
         relaxed = (omega == 0.0)
     if relaxed and omega != 0.0:
@@ -313,7 +335,7 @@ def polarizability(wfn, omega: float = 0.0, relaxed: bool = None) -> PropertyCom
         summary=[("isotropic (1/3 Tr)", "%.6f a.u.   %.6f Angstrom^3" % (iso_au, iso_au * ANG3_PER_AU))])
 
 
-def optical_rotation(wfn, omega) -> PropertyComponents:
+def optical_rotation(wfn, omega, units: str = 'Eh') -> PropertyComponents:
     """Optical-rotation (optical-activity) tensor ``G'(omega)`` as a :class:`PropertyComponents`,
     shape ``(3, 3)`` -- the unrelaxed CC linear response of the electric dipole to the magnetic
     dipole (:meth:`~pycc.ccderiv.CCderiv.optical_rotation`).
@@ -322,7 +344,11 @@ def optical_rotation(wfn, omega) -> PropertyComponents:
     no static optical rotation.  Like the dynamic polarizability it omits the orbital (MO) response,
     so it carries no Hartree-Fock contribution: the SCF block is zero and correlation = total.  The
     report prints the field frequency (Eh and nm), ``Tr(G')`` in a.u., and the specific rotation
-    ``[alpha]`` in deg/(dm (g/mL))."""
+    ``[alpha]`` in deg/(dm (g/mL)).
+
+    ``omega`` is in hartree by default; set ``units='nm'`` to give it as a wavelength in nm instead
+    (converted internally)."""
+    omega = _omega_to_hartree(omega, units)
     if omega == 0.0:
         raise ValueError("optical rotation requires a nonzero field frequency; there is no static "
                          "optical rotation.")

--- a/pycc/tests/test_094_optical_rotation.py
+++ b/pycc/tests/test_094_optical_rotation.py
@@ -85,3 +85,27 @@ def test_optical_rotation_ccresponse():
     G = np.asarray(pycc.ccresponse(dens).optrot(OMEGA))
     assert np.max(np.abs(G - G_REF)) < 1e-11, G
     psi4.core.clean()
+
+
+def test_response_frequency_units_nm():
+    """The field frequency may be given as a wavelength in nm (``units='nm'``): it must match the
+    equivalent hartree input for both optical rotation and the dynamic polarizability, and an
+    unusable frequency (a wavelength at the static point, or unknown units) is rejected."""
+    from pycc.properties import NM_PER_EH
+    wfn, cc = _h2o2_ccsd()
+    d = pycc.CCderiv(cc)
+    lam_nm = NM_PER_EH / OMEGA                            # the wavelength equivalent to OMEGA (Eh)
+
+    g_eh = np.asarray(pycc.optical_rotation(d, OMEGA).total)
+    g_nm = np.asarray(pycc.optical_rotation(d, lam_nm, units='nm').total)
+    assert np.max(np.abs(g_eh - g_nm)) < 1e-12, np.max(np.abs(g_eh - g_nm))
+
+    a_eh = np.asarray(pycc.polarizability(d, omega=OMEGA).total)
+    a_nm = np.asarray(pycc.polarizability(d, omega=lam_nm, units='nm').total)
+    assert np.max(np.abs(a_eh - a_nm)) < 1e-12, np.max(np.abs(a_eh - a_nm))
+
+    with pytest.raises(ValueError):
+        pycc.optical_rotation(d, 0.0, units='nm')        # the static point has no wavelength
+    with pytest.raises(ValueError):
+        pycc.polarizability(d, omega=OMEGA, units='THz')  # unknown frequency units
+    psi4.core.clean()

--- a/pycc/tests/test_094_optical_rotation.py
+++ b/pycc/tests/test_094_optical_rotation.py
@@ -89,13 +89,15 @@ def test_optical_rotation_ccresponse():
 
 def test_response_frequency_units_nm():
     """The field frequency may be given as a wavelength in nm (``units='nm'``): it must match the
-    equivalent hartree input for both optical rotation and the dynamic polarizability, and an
-    unusable frequency (a wavelength at the static point, or unknown units) is rejected."""
+    equivalent hartree input, on BOTH the facade (optical rotation and dynamic polarizability) and
+    the lower-level ``ccresponse`` object, and an unusable frequency (a wavelength at the static
+    point, or unknown units) is rejected on both."""
     from pycc.properties import NM_PER_EH
     wfn, cc = _h2o2_ccsd()
     d = pycc.CCderiv(cc)
     lam_nm = NM_PER_EH / OMEGA                            # the wavelength equivalent to OMEGA (Eh)
 
+    # --- facade (pycc.optical_rotation / pycc.polarizability) ---
     g_eh = np.asarray(pycc.optical_rotation(d, OMEGA).total)
     g_nm = np.asarray(pycc.optical_rotation(d, lam_nm, units='nm').total)
     assert np.max(np.abs(g_eh - g_nm)) < 1e-12, np.max(np.abs(g_eh - g_nm))
@@ -108,4 +110,14 @@ def test_response_frequency_units_nm():
         pycc.optical_rotation(d, 0.0, units='nm')        # the static point has no wavelength
     with pytest.raises(ValueError):
         pycc.polarizability(d, omega=OMEGA, units='THz')  # unknown frequency units
+
+    # --- lower-level ccresponse object honors the same units toggle ---
+    hbar = pycc.cchbar(cc)
+    clam = pycc.cclambda(cc, hbar); clam.solve_lambda(1e-12, 1e-12, 100)
+    dens = pycc.ccdensity(cc, clam)
+    rg_eh = np.asarray(pycc.ccresponse(dens).optrot(OMEGA))
+    rg_nm = np.asarray(pycc.ccresponse(dens).optrot(lam_nm, units='nm'))
+    assert np.max(np.abs(rg_eh - rg_nm)) < 1e-11, np.max(np.abs(rg_eh - rg_nm))
+    with pytest.raises(ValueError):
+        pycc.ccresponse(dens).optrot(0.0, units='nm')
     psi4.core.clean()


### PR DESCRIPTION
# Response frequency in nm; document the ccresponse route

## What this does

Two user-facing additions to the dynamic-response facade, plus docs.

### 1. omega in nm

`pycc.polarizability` and `pycc.optical_rotation` gain a `units` argument:

    pycc.polarizability(dcc, omega=0.07)                 # Eh (default, unchanged)
    pycc.polarizability(dcc, omega=651, units='nm')      # wavelength in nm
    pycc.optical_rotation(dcc, omega=589, units='nm')    # sodium D line

`units='Eh'` (aliases `'hartree'`/`'au'`) is the default and leaves behavior unchanged.
`units='nm'` reads `omega` as a wavelength and converts it internally
(`omega_Eh = NM_PER_EH / lambda_nm`) through a small `_omega_to_hartree` helper. A nm value
requires a positive wavelength (the static `omega=0` point has no wavelength) and an unknown
units string raises `ValueError`.

The same toggle is threaded through the lower-level `ccresponse` object's `polarizability` and
`optrot` methods (reusing `properties._omega_to_hartree` via a local import; no import cycle),
so nm input works on both entry points. `units` is appended to each signature, so existing
positional callers are unaffected.

### 2. getting_started: the ccresponse route

The "Frequency-dependent response" section now shows the nm example and points at the
lower-level `pycc.ccresponse` object, which computes the same linear-response tensors and
reaches further (CC3 and spin-orbital, in addition to CCSD) at the cost of assembling the
intermediates by hand and returning raw arrays.

## Tests

`test_094::test_response_frequency_units_nm` -- nm input matches the equivalent hartree input
for both properties, and the static-nm and unknown-units paths raise. The facade response
suite (test_074/084/091/094) passes; docs build clean and the new `ccresponse` xref resolves.

## Context: the two dynamic-response routes (timing)

The facade/`CCderiv` route and the `ccresponse` object compute the same length-gauge linear
response but solve different perturbed equations: `ccresponse` does right-hand solves at +/-omega,
`CCderiv` does left+right solves at +omega. Measured (aug-cc-pVDZ H2O, CCSD, omega=0.07, response
solve only): polarizability 3.24 s (CCderiv) vs 2.93 s (ccresponse); optical rotation 5.94 s vs
5.40 s -- CCderiv ~10% slower on the response step (the heavier left/multiplier solves), setup
equal. Not added to the docs (micro-benchmark), recorded here for reference.
