### PR TITLE
Velocity-gauge and origin-independent IR/VCD (LGOI)

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -130,6 +130,12 @@ supports HF, MP2, and CISD sources (CCSD AATs are not yet available). Pass ``che
 to archive the computed tensors, then re-run the analysis later straight from the file with
 ``pycc.vcd("mol.npz")`` (nothing is recomputed).
 
+Pass ``velocity_gauge=True`` to also compute the velocity-gauge APT: the analysis then reports the
+length-, velocity-, and mixed-gauge IR intensities (a basis-set completeness check) and, for VCD,
+the velocity-gauge and origin-independent (length-gauge origin-invariant) rotatory strengths with a
+degree-of-symmetry diagnostic, under the ``*_velocity`` / ``*_origin_independent`` /
+``degree_of_symmetry`` result keys.
+
 Frequency-dependent response (CCSD)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The static polarizability above has dynamic (frequency-dependent) counterparts from CCSD linear

--- a/pycc/checkpoint.py
+++ b/pycc/checkpoint.py
@@ -137,12 +137,12 @@ class Checkpoint:
     ``orbital_basis``, ``nfzc``, ``scf_energy``, ``correlation_energy``, ``total_energy``,
     ``charge``, ``multiplicity``), the geometry data (``geometry`` bohr, ``atomic_numbers``,
     ``masses`` u, ``symbols``), the full ``PropertyComponents`` per property in ``components``,
-    and convenience total-tensor accessors (``hessian``, ``apt``, ``aat``, ``gradient``,
-    ``polarizability``, ``dipole``) that return the ``.total`` array or ``None`` if absent.
+    and convenience total-tensor accessors (``hessian``, ``apt``, ``apt_velocity``, ``aat``,
+    ``gradient``, ``polarizability``, ``dipole``) that return the ``.total`` array or ``None`` if absent.
     ``molecule`` rebuilds the psi4 molecule lazily at the stored frame and masses.
     """
 
-    _TOTALS = ('gradient', 'hessian', 'apt', 'polarizability', 'dipole', 'aat')
+    _TOTALS = ('gradient', 'hessian', 'apt', 'apt_velocity', 'polarizability', 'dipole', 'aat')
 
     def __init__(self, meta: dict, geometry: np.ndarray, atomic_numbers: np.ndarray,
                  masses: np.ndarray, components: dict) -> None:

--- a/pycc/tests/test_095_vcd.py
+++ b/pycc/tests/test_095_vcd.py
@@ -81,6 +81,34 @@ def test_vcd_scf_h2o2(rhf_wfn):
     psi4.core.clean()
 
 
+def test_vcd_scf_h2o2_velocity_gauge(rhf_wfn):
+    """SCF/STO-3G velocity-gauge and origin-independent VCD via ``pycc.vcd(..., velocity_gauge=True)``.
+    The velocity-gauge IR intensity, velocity-gauge rotatory strength, and origin-independent (LGOI)
+    rotatory strength reproduce the independent apyib reference (its ``compute_LGOI_vcd_from_input``,
+    fed pycc's own Hessian/APTs/AAT) for the six vibrations.  The length-gauge values are checked
+    separately in :func:`test_vcd_scf_h2o2`; here the velocity-gauge / origin-independent additions."""
+    # apyib compute_LGOI reference (10^-44 cgs for rotatory strengths, km/mol for IR), highest
+    # wavenumber to lowest, six vibrations.  pycc reproduces these to ~1e-5.
+    ir_velocity_ref  = np.array([175.0022,   57.7631,  21.8054, 505.6315,   4.2627, 154.9648])
+    rot_velocity_ref = np.array([121.4069, -114.0951, -92.7869,  31.1204, -17.4754, 108.9395])
+    rot_oi_ref       = np.array([ 50.5198,  -53.5278, -28.6068,   9.3948,  -1.0985, 101.3780])
+
+    wfn = rhf_wfn(H2O2_SCF, "STO-3G", freeze_core="false")
+    hf = pycc.HFwfn(wfn, quiet=True)
+    res = pycc.vcd(hf, project_trans=True, project_rot=True, velocity_gauge=True)
+
+    ir_v = np.asarray(res['ir_intensities_velocity'])[:6]
+    r_v = np.asarray(res['rotatory_strengths_velocity'])[:6]
+    r_oi = np.asarray(res['rotatory_strengths_origin_independent'])[:6]
+    assert np.max(np.abs(ir_v - ir_velocity_ref)) < 1e-2, ir_v
+    assert np.max(np.abs(r_v - rot_velocity_ref)) < 1e-2, r_v
+    assert np.max(np.abs(r_oi - rot_oi_ref)) < 1e-2, r_oi
+    # the degree-of-symmetry diagnostic is a fraction in [0, 1] for the vibrations
+    dos = np.asarray(res['degree_of_symmetry'])[:6]
+    assert np.all(dos >= -1e-9) and np.all(dos <= 1.0 + 1e-9), dos
+    psi4.core.clean()
+
+
 def test_vcd_mp2_h2o2(rhf_wfn):
     """MP2/STO-6G VCD (all-electron): pycc's analytic MP2 APT + AAT with an external CID/6-31G*
     Hessian, versus CFOUR frequencies and magpy's finite-difference MP2 IR/VCD.  Looser tolerance

--- a/pycc/vibanalysis.py
+++ b/pycc/vibanalysis.py
@@ -97,6 +97,43 @@ def _print_report(frequencies: np.ndarray, ir_intensities, rotatory_strengths,
     print("=" * width)
 
 
+def _print_velocity_gauge_report(frequencies: np.ndarray, ir_length, ir_velocity, ir_mixed,
+                                 rotatory_length, rotatory_velocity,
+                                 rotatory_origin_independent, degree_of_symmetry) -> None:
+    """Print the velocity-gauge / origin-independent supplement (only when a velocity-gauge APT was
+    supplied).  Shows the length-, velocity-, and mixed-gauge IR intensities (km/mol) and, when an
+    AAT was also supplied, the length-, velocity-, and origin-independent rotatory strengths
+    (1e-44 cgs) with the degree-of-symmetry diagnostic.  The velocity and mixed intensities equal
+    the length-gauge value in the basis-set limit; the origin-independent rotatory strength removes
+    the gauge-origin dependence of the length-gauge VCD."""
+    n_mode = frequencies.shape[0]
+    has_rot = rotatory_velocity is not None
+    width = 104 if has_rot else 58
+
+    print("\n" + "=" * width)
+    print("Velocity-Gauge and Origin-Independent Analysis")
+    print("=" * width)
+    h1 = "   Mode    Frequency        IR Intensity [km/mol]  "
+    h2 = "            [cm^-1]      length  velocity     mixed "
+    if has_rot:
+        h1 += "     Rotatory Strength [1e-44 cgs]        DoS"
+        h2 += "    length  velocity  origin-indep.        "
+    print(h1)
+    print(h2)
+    print("  " + "-" * (width - 4))
+    for k in range(n_mode):
+        nu = frequencies[k]
+        freq_str = ("%9.2fi" % abs(nu)) if nu < 0.0 else ("%9.2f " % nu)
+        row = ("   %4d  %s  %9.3f %9.3f %9.3f"
+               % (k + 1, freq_str, ir_length[k], ir_velocity[k], ir_mixed[k]))
+        if has_rot:
+            row += ("   %8.3f %8.3f %11.3f    %7.3f"
+                    % (rotatory_length[k], rotatory_velocity[k],
+                       rotatory_origin_independent[k], degree_of_symmetry[k]))
+        print(row)
+    print("=" * width)
+
+
 def _translation_rotation_projector(masses: np.ndarray, geom: np.ndarray,
                                     project_trans: bool, project_rot: bool,
                                     linear_tol: float):
@@ -193,7 +230,8 @@ def _translation_rotation_projector(masses: np.ndarray, geom: np.ndarray,
 
 
 def harmonic_analysis(source: Any, hessian: np.ndarray = None, apt: np.ndarray = None,
-                      aat: np.ndarray = None, project_trans: bool = False,
+                      aat: np.ndarray = None, apt_velocity: np.ndarray = None,
+                      project_trans: bool = False,
                       project_rot: bool = False, linear_tol: float = 1e-8) -> dict:
     r"""Harmonic frequencies, normal modes, and (with an APT) IR intensities and (with an APT and
     AAT) VCD rotatory strengths from a Cartesian Hessian.
@@ -272,6 +310,14 @@ def harmonic_analysis(source: Any, hessian: np.ndarray = None, apt: np.ndarray =
         the nuclear Cartesian and ``beta`` the magnetic component, a.u., e.g. ``pycc.aat(d).total``.
         When given together with ``apt``, VCD rotatory strengths are computed; otherwise
         ``rotatory_strengths`` is ``None``.  Pulled from a checkpoint ``source`` when present.
+    apt_velocity : np.ndarray, optional
+        velocity-gauge (momentum) APT, same shape/indexing as ``apt``, e.g.
+        ``pycc.apt(d, gauge='velocity').total``.  When given with ``apt``, the velocity- and
+        mixed-gauge IR intensities are added (a basis-set completeness check); when ``aat`` is also
+        given, the velocity-gauge and origin-independent rotatory strengths and the
+        degree-of-symmetry diagnostic are added.  Fed into the same normal-coordinate contraction as
+        the length gauge, with no frequency weighting.  Pulled from a checkpoint ``source`` when
+        present (stored key ``apt_velocity``).
     project_trans, project_rot : bool
         remove translations / rotations before diagonalizing (both off by default; opt in for a
         loose geometry).
@@ -284,7 +330,11 @@ def harmonic_analysis(source: Any, hessian: np.ndarray = None, apt: np.ndarray =
     ``frequencies`` (cm^-1), ``ir_intensities`` (km/mol, or ``None``), ``rotatory_strengths``
     (10^-44 esu^2 cm^2, or ``None`` if no AAT), ``force_constants`` (mDyne/A), ``reduced_masses``
     (u), ``modes`` (mass-weighted, columns), ``cartesian_modes`` (normalized un-mass-weighted
-    displacements, columns), and ``n_tr`` (rigid-body modes removed).
+    displacements, columns), and ``n_tr`` (rigid-body modes removed).  With ``apt_velocity`` also
+    supplied: ``ir_intensities_velocity`` and ``ir_intensities_mixed`` (km/mol), and, when an AAT is
+    present, ``rotatory_strengths_velocity`` and ``rotatory_strengths_origin_independent``
+    (10^-44 esu^2 cm^2) plus ``degree_of_symmetry`` (dimensionless, in ``[0, 1]``); each is ``None``
+    when ``apt_velocity`` (or the AAT) is absent.
 
     Returns
     -------
@@ -304,6 +354,8 @@ def harmonic_analysis(source: Any, hessian: np.ndarray = None, apt: np.ndarray =
             apt = source.apt
         if aat is None:
             aat = source.aat
+        if apt_velocity is None:
+            apt_velocity = source.apt_velocity
     else:
         molecule = source
     if hessian is None:
@@ -344,14 +396,51 @@ def harmonic_analysis(source: Any, hessian: np.ndarray = None, apt: np.ndarray =
     # rotatory strengths when an AAT is also supplied (magnetic-dipole gradient dotted with it).
     ir_intensities = None
     rotatory_strengths = None
+    ir_intensities_velocity = None
+    ir_intensities_mixed = None
+    rotatory_strengths_velocity = None
+    rotatory_strengths_origin_independent = None
+    degree_of_symmetry = None
     if apt is not None:
         dipder = apt.transpose(2, 0, 1).reshape(3, 3 * natom)     # [dipole, 3A+nuclear]
-        dmu_dQ = dipder @ cart_modes                              # [dipole, mode] = d mu_c / d Q
+        dmu_dQ = dipder @ cart_modes                              # [dipole, mode] = d mu_c / d Q (length)
         ir_intensities = np.einsum('cm,cm->m', dmu_dQ, dmu_dQ) * IR_KM_MOL_PER_AU
+
+        if apt_velocity is not None:
+            # Velocity-gauge (momentum) dipole gradient along the normal coordinates, fed into the
+            # same contraction as the length gauge (no frequency weighting).  The velocity-gauge IR
+            # intensity and the mixed (length x velocity) intensity are the length-gauge basis-set
+            # completeness checks; the velocity gauge is the ingredient for origin-independent VCD.
+            velder = apt_velocity.transpose(2, 0, 1).reshape(3, 3 * natom)
+            dp_dQ = velder @ cart_modes                          # [dipole, mode] = d p_c / d Q (velocity)
+            ir_intensities_velocity = np.einsum('cm,cm->m', dp_dQ, dp_dQ) * IR_KM_MOL_PER_AU
+            ir_intensities_mixed = np.einsum('cm,cm->m', dmu_dQ, dp_dQ) * IR_KM_MOL_PER_AU
+
         if aat is not None:
             mdip = aat.transpose(2, 0, 1).reshape(3, 3 * natom)   # [magnetic, 3A+nuclear]
             dm_dQ = mdip @ cart_modes                             # [magnetic, mode] = d m_c / d Q
             rotatory_strengths = np.einsum('cm,cm->m', dmu_dQ, dm_dQ) * VCD_ROT_STRENGTH_CGS_PER_AU
+
+            if apt_velocity is not None:
+                # Velocity-gauge rotatory strength, and the length-gauge origin-independent value:
+                # per mode, rotate the length-gauge rotatory-strength tensor R = (d mu/d Q)(d m/d Q)
+                # into the frame set by the SVD of the mixed dipole-strength tensor
+                # D = (d mu/d Q)(d p/d Q), R_oi = Tr(U^T R V) (Nafie's origin-independent formulation).
+                rotatory_strengths_velocity = (np.einsum('cm,cm->m', dp_dQ, dm_dQ)
+                                               * VCD_ROT_STRENGTH_CGS_PER_AU)
+                n_mode = cart_modes.shape[1]
+                rotatory_strengths_origin_independent = np.empty(n_mode)
+                degree_of_symmetry = np.empty(n_mode)
+                for k in range(n_mode):
+                    D_mix = np.outer(dmu_dQ[:, k], dp_dQ[:, k])   # mixed dipole-strength tensor
+                    R_len = np.outer(dmu_dQ[:, k], dm_dQ[:, k])   # length-gauge rotatory-strength tensor
+                    U, _, Vt = np.linalg.svd(D_mix)
+                    rotatory_strengths_origin_independent[k] = (
+                        np.trace(U.T @ R_len @ Vt.T) * VCD_ROT_STRENGTH_CGS_PER_AU)
+                    antisym = 0.5 * (D_mix - D_mix.T)
+                    norm = np.linalg.norm(D_mix)
+                    degree_of_symmetry[k] = (1.0 - np.linalg.norm(antisym) / norm
+                                             if norm > 1e-30 else np.nan)
 
     # Reorder everything highest wavenumber to lowest (matches the printed mode numbering).
     order = np.argsort(frequencies)[::-1]
@@ -364,15 +453,32 @@ def harmonic_analysis(source: Any, hessian: np.ndarray = None, apt: np.ndarray =
         ir_intensities = ir_intensities[order]
     if rotatory_strengths is not None:
         rotatory_strengths = rotatory_strengths[order]
+    if ir_intensities_velocity is not None:
+        ir_intensities_velocity = ir_intensities_velocity[order]
+        ir_intensities_mixed = ir_intensities_mixed[order]
+    if rotatory_strengths_velocity is not None:
+        rotatory_strengths_velocity = rotatory_strengths_velocity[order]
+        rotatory_strengths_origin_independent = rotatory_strengths_origin_independent[order]
+        degree_of_symmetry = degree_of_symmetry[order]
 
     n_trans = 3 if project_trans else 0
     _print_report(frequencies, ir_intensities, rotatory_strengths, force_constants,
                   reduced_masses, natom, n_trans, n_tr - n_trans)
+    if ir_intensities_velocity is not None:
+        _print_velocity_gauge_report(frequencies, ir_intensities, ir_intensities_velocity,
+                                     ir_intensities_mixed, rotatory_strengths,
+                                     rotatory_strengths_velocity,
+                                     rotatory_strengths_origin_independent, degree_of_symmetry)
 
     return {
         'frequencies': frequencies,
         'ir_intensities': ir_intensities,
         'rotatory_strengths': rotatory_strengths,
+        'ir_intensities_velocity': ir_intensities_velocity,
+        'ir_intensities_mixed': ir_intensities_mixed,
+        'rotatory_strengths_velocity': rotatory_strengths_velocity,
+        'rotatory_strengths_origin_independent': rotatory_strengths_origin_independent,
+        'degree_of_symmetry': degree_of_symmetry,
         'force_constants': force_constants,
         'reduced_masses': reduced_masses,
         'modes': modes,
@@ -409,9 +515,13 @@ def _checkpoint_for_driver(source: Any, driver: str, need_apt: bool = False,
 
 
 def ir(source: Any, checkpoint: str = None, project_trans: bool = False,
-       project_rot: bool = False, linear_tol: float = 1e-8) -> dict:
+       project_rot: bool = False, linear_tol: float = 1e-8, velocity_gauge: bool = False) -> dict:
     """IR driver: the one-call path to a printed IR spectrum, from either a live driver or a
     checkpoint.
+
+    With ``velocity_gauge=True`` the velocity-gauge APT is also computed (driver source only), and
+    the analysis reports the length-, velocity-, and mixed-gauge IR intensities (a basis-set
+    completeness check; they coincide in the complete-basis limit).
 
     * ``source`` is a **derivative driver** (``CCderiv``/``MPderiv``/``CIderiv``): compute the
       molecular Hessian and the length-gauge APT (each printing its property report and recording
@@ -452,20 +562,28 @@ def ir(source: Any, checkpoint: str = None, project_trans: bool = False,
     deriv = source
     hess = np.asarray(properties.hessian(deriv).total)
     apt = np.asarray(properties.apt(deriv).total)
+    apt_velocity = (np.asarray(properties.apt(deriv, gauge='velocity').total)
+                    if velocity_gauge else None)
     molecule = properties._wfn_of(deriv).ref.molecule()
 
     if checkpoint is not None:
         from .checkpoint import save_checkpoint
         save_checkpoint(deriv, checkpoint)
 
-    return harmonic_analysis(molecule, hess, apt=apt, project_trans=project_trans,
+    return harmonic_analysis(molecule, hess, apt=apt, apt_velocity=apt_velocity,
+                             project_trans=project_trans,
                              project_rot=project_rot, linear_tol=linear_tol)
 
 
 def vcd(source: Any, checkpoint: str = None, project_trans: bool = False,
-        project_rot: bool = False, linear_tol: float = 1e-8) -> dict:
+        project_rot: bool = False, linear_tol: float = 1e-8, velocity_gauge: bool = False) -> dict:
     """VCD driver: like :func:`ir`, but also computes and archives the atomic axial tensors (AATs)
     needed for VCD rotatory strengths.
+
+    With ``velocity_gauge=True`` the velocity-gauge APT is also computed (driver source only), and
+    the analysis adds the velocity-gauge rotatory strength and the origin-independent (length-gauge
+    origin-invariant) rotatory strength, together with the length/velocity/mixed IR intensities and
+    the degree-of-symmetry diagnostic.
 
     * ``source`` is a **derivative driver**: compute the Hessian, length-gauge APT, and AAT (each
       printing its report and recording itself), optionally archive everything to the
@@ -491,11 +609,14 @@ def vcd(source: Any, checkpoint: str = None, project_trans: bool = False,
     hess = np.asarray(properties.hessian(deriv).total)
     apt = np.asarray(properties.apt(deriv).total)
     aat = np.asarray(properties.aat(deriv).total)
+    apt_velocity = (np.asarray(properties.apt(deriv, gauge='velocity').total)
+                    if velocity_gauge else None)
     molecule = properties._wfn_of(deriv).ref.molecule()
 
     if checkpoint is not None:
         from .checkpoint import save_checkpoint
         save_checkpoint(deriv, checkpoint)
 
-    return harmonic_analysis(molecule, hess, apt=apt, aat=aat, project_trans=project_trans,
+    return harmonic_analysis(molecule, hess, apt=apt, aat=aat, apt_velocity=apt_velocity,
+                             project_trans=project_trans,
                              project_rot=project_rot, linear_tol=linear_tol)


### PR DESCRIPTION
# Velocity-gauge and origin-independent IR/VCD (LGOI)

## What this does

Adds a `velocity_gauge` option to `pycc.ir` and `pycc.vcd`. When enabled, the velocity-gauge
(momentum) APT is computed alongside the length-gauge APT and the analysis reports the full
length-gauge origin-independent (LGOI) set, following the apyib formulation
(Shumberger/Crawford):

- **IR**: length, velocity, and mixed (length x velocity) intensities. The gauges coincide in
  the complete-basis limit, so this is a basis-set completeness check.
- **VCD**: length, velocity, and origin-independent rotatory strengths, plus a degree-of-symmetry
  diagnostic. The origin-independent value comes from the SVD of the mixed dipole-strength tensor
  rotating the length-gauge rotatory-strength tensor, removing the gauge-origin dependence of the
  length-gauge VCD.

The velocity-gauge APT feeds the **same** normal-coordinate contraction as the length gauge, with
**no frequency weighting** (matching apyib).

## API

    pycc.ir(deriv, velocity_gauge=True)     # + length/velocity/mixed IR
    pycc.vcd(deriv, velocity_gauge=True)    # + velocity & origin-independent VCD, DoS

- `harmonic_analysis` gains an `apt_velocity` argument.
- Five new result keys (populated only when `apt_velocity` is given): `ir_intensities_velocity`,
  `ir_intensities_mixed`, `rotatory_strengths_velocity`, `rotatory_strengths_origin_independent`,
  `degree_of_symmetry`. The existing `ir_intensities` / `rotatory_strengths` remain the
  length-gauge values.
- A supplementary report table prints the new columns.
- The checkpoint stores/reads the velocity APT (`apt_velocity` added to `Checkpoint._TOTALS`), so
  a `vcd(..., checkpoint=..., velocity_gauge=True)` round-trip carries the velocity analysis.

## Validation

Checked against apyib's `compute_LGOI_vcd_from_input` driven with pycc's own Hessian/APTs/AAT:
agreement ~1e-8 (length and origin-independent) and ~1e-5 (velocity, tracking a ~2e-6 cm^-1
difference between the two mode solvers), for both the manuscript geometry and the SCF-optimized
H2O2/STO-3G geometry.

`test_095` adds `test_vcd_scf_h2o2_velocity_gauge`, anchoring the velocity and origin-independent
quantities to the apyib reference for SCF/STO-3G H2O2 (six vibrations). The length-gauge values
continue to reproduce the DALTON reference (existing `test_vcd_scf_h2o2`). test_095 (3) and the
checkpoint suite test_096 (4) pass; docs build clean.

## Touched

- `pycc/vibanalysis.py` -- `apt_velocity` in `harmonic_analysis`; LGOI computation; a supplementary
  report printer; `velocity_gauge` on `ir`/`vcd`.
- `pycc/checkpoint.py` -- `apt_velocity` added to the total-tensor accessors.
- `pycc/tests/test_095_vcd.py` -- the velocity-gauge/LGOI regression test.
- `docs/getting_started.rst` -- documents the option.
